### PR TITLE
Issue with the `matchedCount` field of CRUD tests that upsert

### DIFF
--- a/source/crud/tests/write/updateMany.json
+++ b/source/crud/tests/write/updateMany.json
@@ -148,7 +148,7 @@
       },
       "outcome": {
         "result": {
-          "matchedCount": 0,
+          "matchedCount": 1,
           "modifiedCount": 0,
           "upsertedId": 4
         },

--- a/source/crud/tests/write/updateMany.yml
+++ b/source/crud/tests/write/updateMany.yml
@@ -9,9 +9,9 @@ tests:
         operation:
             name: "updateMany"
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -29,7 +29,7 @@ tests:
             name: "updateMany"
             arguments:
                 filter: {_id: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -47,7 +47,7 @@ tests:
             name: "updateMany"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -65,13 +65,13 @@ tests:
             name: "updateMany"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 upsert: true
 
         outcome:
             result:
-                matchedCount: 0
+                matchedCount: 1
                 modifiedCount: 0
                 upsertedId: 4
             collection:

--- a/source/crud/tests/write/updateOne.json
+++ b/source/crud/tests/write/updateOne.json
@@ -132,7 +132,7 @@
       },
       "outcome": {
         "result": {
-          "matchedCount": 0,
+          "matchedCount": 1,
           "modifiedCount": 0,
           "upsertedId": 4
         },

--- a/source/crud/tests/write/updateOne.yml
+++ b/source/crud/tests/write/updateOne.yml
@@ -9,9 +9,9 @@ tests:
         operation:
             name: "updateOne"
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -26,7 +26,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -44,7 +44,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -62,13 +62,13 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 upsert: true
 
         outcome:
             result:
-                matchedCount: 0
+                matchedCount: 1
                 modifiedCount: 0
                 upsertedId: 4
             collection:


### PR DESCRIPTION
I'm working on the Rust driver, and I ran into some issues with the `updateOne` and `updateMany` tests when upserts occur, namely the `matchedCount` specified in the tests differing from the `n` result obtained by our driver. I tried issuing the equivalent commands on the shell to see if the issue was just with the driver, but it doesn't seem to be the case.

For instance, when running this in the shell:

```
db.$cmd.findOne({ 
  update: "temp", updates: [ {
    q: { _id: 4 },
    u: { $inc: { x: 1 }},
    upsert: true,
    multi: false,
  } ],
  ordered: true, 
})
```

...the output is this:

```
{
        "ok" : 1,
        "nModified" : 0,
        "n" : 1,
        "upserted" : [
                {
                        "index" : 0,
                        "_id" : 4
                }
        ]
}
```

The same result is obtained when running this:

```
db.runCommand({
  update: "temp",
  updates: [ {
    q: { _id: 4 },
    u: { $inc: { x: 1 }},
    upsert: true,
    multi: false,
  } ], 
  ordered: true, 
})
```

That being said, when running the update the normal way:

```
db.temp.update({ _id: 4 }, { $inc: { x: 1 }}, true, false)
```

The output is the same as the tests specify:

```
WriteResult({ "nMatched" : 0, "nUpserted" : 1, "nModified" : 0, "_id" : 4 })
```

I'm not actually sure that the test specifications here are wrong; according to the manual (http://docs.mongodb.org/manual/reference/command/update/#update.n), the value `n` should be "the number of documents selected for update". It seems to me that in this case, this should be "0". However, it's a little strange to me that running the update directly on the collection rather than as a command gives the right result.

What was the specific rationale for having the expected `matchedCount` value be "0" rather than "1"? Should we be having the driver manually modify the result in the same way that the shell does to ensure that the result specifies that no documents were matched in this case, or is there some issue in either the shell or the server that's causing an incorrect disparity in the results?