### PR TITLE
Add test for single mongos connection

### DIFF
--- a/source/server-discovery-and-monitoring/tests/sharded/single_mongos.json
+++ b/source/server-discovery-and-monitoring/tests/sharded/single_mongos.json
@@ -1,0 +1,28 @@
+{
+    "description": "Single mongos", 
+    "phases": [
+        {
+            "outcome": {
+                "servers": {
+                    "a:27017": {
+                        "setName": null, 
+                        "type": "Mongos"
+                    }
+                }, 
+                "setName": null, 
+                "topologyType": "Sharded"
+            }, 
+            "responses": [
+                [
+                    "a:27017", 
+                    {
+                        "ismaster": true, 
+                        "msg": "isdbgrid", 
+                        "ok": 1
+                    }
+                ]
+            ]
+        }
+    ], 
+    "uri": "mongodb://a"
+}

--- a/source/server-discovery-and-monitoring/tests/sharded/single_mongos.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/single_mongos.yml
@@ -1,0 +1,33 @@
+description: "Single mongos"
+
+uri: "mongodb://a"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    msg: "isdbgrid"
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "Mongos",
+                    setName:
+                }
+            },
+
+            topologyType: "Sharded",
+            setName:
+        }
+    }
+]

--- a/source/server-discovery-and-monitoring/tests/sharded/single_mongos.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/single_mongos.yml
@@ -2,6 +2,8 @@ description: "Single mongos"
 
 uri: "mongodb://a"
 
+# Note that drivers may implement this differently.
+# Some may expect that the topology is Single instead of Sharded.
 phases: [
 
     {


### PR DESCRIPTION
In the Ruby driver, if the connect type was not explicitly specified by the user and a single host was provided, we were assuming Single topology. We've changed our code to discover the Sharded topology in the case that the single host is a mongos.
This test ensures that a single mongos provided results in a Sharded topology.