### PR TITLE
added new command-monitoring tests.

### DIFF
--- a/source/command-monitoring/tests/bulkWrite.json
+++ b/source/command-monitoring/tests/bulkWrite.json
@@ -1,0 +1,161 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    },
+    {
+      "_id": 3,
+      "x": 33
+    }
+  ],
+  "collection_name": "test",
+  "database_name": "command-monitoring-tests",
+  "tests": [
+    {
+      "description": "A successful mixed bulk write",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "insertOne": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            },
+            {
+              "updateOne": {
+                "filter": {
+                  "_id": 3
+                },
+                "update": {
+                  "$set": {
+                    "x": 333
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 4,
+                  "x": 44
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert",
+            "database_name": "command-monitoring-tests"
+          }
+        },
+        {
+          "command_succeeded_event": {
+            "reply": {
+              "ok": 1.0,
+              "n": 1
+            },
+            "command_name": "insert"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 3
+                  },
+                  "u": {
+                    "$set": {
+                      "x": 333
+                    }
+                  },
+                  "upsert": false,
+                  "multi": false
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "update",
+            "database_name": "command-monitoring-tests"
+          }
+        },
+        {
+          "command_succeeded_event": {
+            "reply": {
+              "ok": 1.0,
+              "n": 1
+            },
+            "command_name": "update"
+          }
+        }
+      ]
+    },
+    {
+      "description": "A successful unordered bulk write with an unacknowledged write concern",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "insertOne": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "ordered": false,
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 4,
+                  "x": 44
+                }
+              ],
+              "ordered": false,
+              "writeConcern": {
+                "w": 0
+              }
+            },
+            "command_name": "insert",
+            "database_name": "command-monitoring-tests"
+          }
+        },
+        {
+          "command_succeeded_event": {
+            "reply": {
+              "ok": 1.0
+            },
+            "command_name": "insert"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/command-monitoring/tests/bulkWrite.yml
+++ b/source/command-monitoring/tests/bulkWrite.yml
@@ -1,0 +1,73 @@
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+  - { _id: 3, x: 33 }
+
+collection_name: &collection_name "test"
+database_name: &database_name "command-monitoring-tests"
+
+tests:
+  -
+    description: "A successful mixed bulk write"
+    operation:
+      name: "bulkWrite"
+      arguments:
+        requests:
+          - insertOne: 
+              document: { _id: 4, x: 44 }
+          - updateOne:
+              filter: { _id: 3 }
+              update: { $set: { x: 333 } }
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 4, x: 44 }
+            ordered: true
+          command_name: "insert"
+          database_name: *database_name
+      -
+        command_succeeded_event:
+          reply: { ok: 1.0, n: 1 }
+          command_name: "insert"
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - { q: {_id: 3 }, u: { $set: { x: 333 } }, upsert: false, multi: false }
+            ordered: true
+          command_name: "update"
+          database_name: *database_name
+      -
+        command_succeeded_event:
+          reply: { ok: 1.0, n: 1 }
+          command_name: "update"
+  -
+    description: "A successful unordered bulk write with an unacknowledged write concern"
+    comment: "On a 2.4 server, no GLE is sent and requires a client-side manufactored reply"
+    operation:
+      name: "bulkWrite"
+      arguments:
+        requests:
+          - insertOne: 
+              document: { _id: 4, x: 44 }
+        ordered: false
+        writeConcern: { w: 0 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 4, x: 44 }
+            ordered: false
+            writeConcern: { w: 0 }
+          command_name: "insert"
+          database_name: *database_name
+      -
+        command_succeeded_event:
+          reply: { ok: 1.0 }
+          command_name: "insert"

--- a/source/command-monitoring/tests/find.json
+++ b/source/command-monitoring/tests/find.json
@@ -51,7 +51,7 @@
         {
           "command_succeeded_event": {
             "reply": {
-              "ok": 1.0,
+              "ok": 1,
               "cursor": {
                 "id": {
                   "$numberLong": "0"
@@ -76,12 +76,35 @@
         "name": "find",
         "arguments": {
           "filter": {
-            "_id": 1
+            "_id": {
+              "$gt": 1
+            }
           },
           "sort": {
             "_id": 1
           },
-          "limit": 2
+          "limit": 2,
+          "skip": 2,
+          "modifiers": {
+            "$comment": "test",
+            "$hint": {
+              "_id": 1
+            },
+            "$max": {
+              "_id": 6
+            },
+            "$maxScan": 5000,
+            "$maxTimeMS": 6000,
+            "$min": {
+              "_id": 0
+            },
+            "$readPreference": {
+              "mode": "secondaryPreferred"
+            },
+            "$returnKey": false,
+            "$showDiskLoc": false,
+            "$snapshot": false
+          }
         }
       },
       "expectations": [
@@ -90,12 +113,33 @@
             "command": {
               "find": "test",
               "filter": {
-                "_id": 1
+                "_id": {
+                  "$gt": 1
+                }
               },
               "sort": {
                 "_id": 1
               },
-              "limit": 2
+              "limit": 2,
+              "skip": 2,
+              "comment": "test",
+              "hint": {
+                "_id": 1
+              },
+              "max": {
+                "_id": 6
+              },
+              "maxScan": 5000,
+              "maxTimeMS": 6000,
+              "min": {
+                "_id": 0
+              },
+              "readPreference": {
+                "mode": "secondaryPreferred"
+              },
+              "returnKey": false,
+              "showRecordId": false,
+              "snapshot": false
             },
             "command_name": "find",
             "database_name": "command-monitoring-tests"
@@ -104,7 +148,7 @@
         {
           "command_succeeded_event": {
             "reply": {
-              "ok": 1.0,
+              "ok": 1,
               "cursor": {
                 "id": {
                   "$numberLong": "0"
@@ -112,8 +156,12 @@
                 "ns": "command-monitoring-tests.test",
                 "firstBatch": [
                   {
-                    "_id": 1,
-                    "x": 11
+                    "_id": 4,
+                    "x": 44
+                  },
+                  {
+                    "_id": 5,
+                    "x": 55
                   }
                 ]
               }
@@ -161,7 +209,7 @@
         {
           "command_succeeded_event": {
             "reply": {
-              "ok": 1.0,
+              "ok": 1,
               "cursor": {
                 "id": {
                   "$numberLong": "42"
@@ -202,7 +250,7 @@
         {
           "command_succeeded_event": {
             "reply": {
-              "ok": 1.0,
+              "ok": 1,
               "cursor": {
                 "id": {
                   "$numberLong": "0"
@@ -265,7 +313,7 @@
         {
           "command_succeeded_event": {
             "reply": {
-              "ok": 1.0,
+              "ok": 1,
               "cursor": {
                 "id": {
                   "$numberLong": "42"
@@ -306,7 +354,7 @@
         {
           "command_succeeded_event": {
             "reply": {
-              "ok": 1.0,
+              "ok": 1,
               "cursor": {
                 "id": {
                   "$numberLong": "42"
@@ -340,7 +388,7 @@
         {
           "command_succeeded_event": {
             "reply": {
-              "ok": 1.0,
+              "ok": 1,
               "cursorsUnknown": [
                 {
                   "$numberLong": "42"

--- a/source/command-monitoring/tests/find.yml
+++ b/source/command-monitoring/tests/find.yml
@@ -39,17 +39,40 @@ tests:
     operation:
       name: "find"
       arguments:
-        filter: { _id: 1 }
+        filter: { _id: { $gt: 1 } }
         sort: { _id: 1 }
         limit: 2
+        skip: 2
+        modifiers:
+          $comment: "test"
+          $hint: { _id: 1 }
+          $max: { _id: 6 }
+          $maxScan: 5000
+          $maxTimeMS: 6000 
+          $min: { _id: 0 }
+          $readPreference: { mode: "secondaryPreferred" }
+          $returnKey: false
+          $showDiskLoc: false
+          $snapshot: false
     expectations:
       -
         command_started_event:
           command:
             find: *collection_name
-            filter: { _id: 1 }
+            filter: { _id:  { $gt: 1 } }
             sort: { _id: 1 }
             limit: 2
+            skip: 2
+            comment: "test"
+            hint: { _id: 1 }
+            max: { _id: 6 }
+            maxScan: 5000
+            maxTimeMS: 6000
+            min: { _id: 0 }
+            readPreference: { mode: "secondaryPreferred" }
+            returnKey: false
+            showRecordId: false
+            snapshot: false
           command_name: "find"
           database_name: *database_name
       -
@@ -60,7 +83,8 @@ tests:
               id: { $numberLong: "0" }
               ns: *namespace
               firstBatch:
-                - { _id: 1, x: 11 }
+                - { _id: 4, x: 44 }
+                - { _id: 5, x: 55 }
           command_name: "find"
   -
     description: "A successful find event with a getmore"

--- a/source/command-monitoring/tests/updateOne.json
+++ b/source/command-monitoring/tests/updateOne.json
@@ -72,6 +72,64 @@
       ]
     },
     {
+      "description": "A successful update one with upsert when the upserted id is not an object id",
+      "operation": {
+        "name": "updateOne",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          },
+          "upsert": true
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "ordered": true,
+              "updates": [
+                {
+                  "q": {
+                    "_id": 4
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": false,
+                  "upsert": true
+                }
+              ]
+            },
+            "command_name": "update",
+            "database_name": "command-monitoring-tests"
+          }
+        },
+        {
+          "command_succeeded_event": {
+            "reply": {
+              "ok": 1.0,
+              "n": 1,
+              "upserted": [
+                {
+                  "index": 0,
+                  "_id": 4
+                }
+              ]
+            },
+            "command_name": "update"
+          }
+        }
+      ]
+    },
+    {
       "description": "A successful update one command with write errors",
       "operation": {
         "name": "updateOne",

--- a/source/command-monitoring/tests/updateOne.yml
+++ b/source/command-monitoring/tests/updateOne.yml
@@ -35,6 +35,34 @@ tests:
           reply: { ok: 1.0, n: 1 }
           command_name: "update"
   -
+    description: "A successful update one with upsert when the upserted id is not an object id"
+    operation:
+      name: "updateOne"
+      arguments:
+        filter:
+          _id: 4
+        update:
+          $inc: { x: 1 }
+        upsert: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            ordered: true
+            updates:
+              -
+                q: { _id: 4 }
+                u: { $inc: { x: 1 } }
+                multi: false
+                upsert: true
+          command_name: "update"
+          database_name: *database_name
+      -
+        command_succeeded_event:
+          reply: { ok: 1.0, n: 1, upserted: [{ index: 0, _id: 4 }] }
+          command_name: "update"
+  -
     description: "A successful update one command with write errors"
     operation:
       name: "updateOne"


### PR DESCRIPTION
This handles:

1. mixed bulk write
2. faked reply when no GLE is sent
3. find with all renamed options present (not all options, just the ones that need special massaging)
4. upsert where the identifier does not come back from the server due to it's non-objectid-ness.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb/specifications/45)
<!-- Reviewable:end -->
