### PR TITLE
fixed issue with bypass doc change being specified at the wrong level.

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -562,6 +562,16 @@ Basic
      */
     ordered: Boolean;
 
+    /**
+     * If true, allows the write to opt-out of document level validation. 
+     * 
+     * On servers >= 3.2, the default is to not send a value. No 
+     * "bypassDocumentValidation" option is sent with the write commands.
+     *
+     * On servers < 3.2, this option is ignored.
+     */
+    bypassDocumentValidation: Optional<Boolean>;
+
   }
 
   class InsertOneOptions {
@@ -638,16 +648,6 @@ Bulk Write Models
      * @see http://docs.mongodb.org/manual/reference/command/insert/
      */
     document: Document;
-
-    /**
-     * If true, allows the write to opt-out of document level validation. 
-     * 
-     * On servers >= 3.2, the default is to not send a value. No 
-     * "bypassDocumentValidation" option is sent with the "insert" command.
-     *
-     * On servers < 3.2, this option is ignored.
-     */
-    bypassDocumentValidation: Optional<Boolean>;
   }
 
   class DeleteOneModel implements WriteModel {
@@ -689,16 +689,6 @@ Bulk Write Models
     replacement: Document;
 
     /**
-     * If true, allows the write to opt-out of document level validation. 
-     * 
-     * On servers >= 3.2, the default is to not send a value. No 
-     * "bypassDocumentValidation" option is sent with the "update" command.
-     *
-     * On servers < 3.2, this option is ignored.
-     */
-    bypassDocumentValidation: Optional<Boolean>;
-
-    /**
      * When true, creates a new document if no document matches the query. The default is false.
      *
      * @see http://docs.mongodb.org/manual/reference/command/update/
@@ -724,16 +714,6 @@ Bulk Write Models
     update: Update;
 
     /**
-     * If true, allows the write to opt-out of document level validation. 
-     * 
-     * On servers >= 3.2, the default is to not send a value. No 
-     * "bypassDocumentValidation" option is sent with the "update" command.
-     *
-     * On servers < 3.2, this option is ignored.
-     */
-    bypassDocumentValidation: Optional<Boolean>;
-
-    /**
      * When true, creates a new document if no document matches the query. The default is false.
      *
      * @see http://docs.mongodb.org/manual/reference/command/update/
@@ -757,16 +737,6 @@ Bulk Write Models
      * @see http://docs.mongodb.org/manual/reference/command/update/
      */
     update: Update;
-
-    /**
-     * If true, allows the write to opt-out of document level validation. 
-     * 
-     * On servers >= 3.2, the default is to not send a value. No 
-     * "bypassDocumentValidation" option is sent with the "update" command.
-     *
-     * On servers < 3.2, this option is ignored.
-     */
-    bypassDocumentValidation: Optional<Boolean>;
 
     /**
      * When true, creates a new document if no document matches the query. The default is false.
@@ -1318,5 +1288,6 @@ Q: What about explain?
 Changes
 -------
 
+2015-10-01: Moved bypassDocumentValidation into BulkWriteOptions and removed it from the individual write models.
 2015-09-16: Added bypassDocumentValidation.
 2015-09-16: Added readConcern notes.


### PR DESCRIPTION
Moves bypassDocumentValidation out of the individual bulk write models and into the BulkWriteOptions. This negates the need to batch writes differently based on the bypassDocumentValidation setting.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb/specifications/64)
<!-- Reviewable:end -->
