### PR TITLE
Additional test for adding new hosts to ReplicaSetWithPrimary

### DIFF
--- a/source/server-discovery-and-monitoring/tests/rs/primary_reports_new_member.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_reports_new_member.json
@@ -1,0 +1,139 @@
+{
+    "description": "Primary reports a new member",
+    "phases": [
+        {
+            "outcome": {
+                "servers": {
+                    "a:27017": {
+                        "setName": "rs",
+                        "type": "RSSecondary"
+                    },
+                    "b:27017": {
+                        "setName": null,
+                        "type": "Unknown"
+                    }
+                },
+                "setName": "rs",
+                "topologyType": "ReplicaSetNoPrimary"
+            },
+            "responses": [
+                [
+                    "a:27017",
+                    {
+                        "hosts": [
+                            "a:27017",
+                            "b:27017"
+                        ],
+                        "ismaster": false,
+                        "ok": 1,
+                        "secondary": true,
+                        "setName": "rs"
+                    }
+                ]
+            ]
+        },
+        {
+            "outcome": {
+                "servers": {
+                    "a:27017": {
+                        "setName": "rs",
+                        "type": "RSSecondary"
+                    },
+                    "b:27017": {
+                        "setName": "rs",
+                        "type": "RSPrimary"
+                    }
+                },
+                "setName": "rs",
+                "topologyType": "ReplicaSetWithPrimary"
+            },
+            "responses": [
+                [
+                    "b:27017",
+                    {
+                        "hosts": [
+                            "a:27017",
+                            "b:27017"
+                        ],
+                        "ismaster": true,
+                        "ok": 1,
+                        "setName": "rs"
+                    }
+                ]
+            ]
+        },
+        {
+            "outcome": {
+                "servers": {
+                    "a:27017": {
+                        "setName": "rs",
+                        "type": "RSSecondary"
+                    },
+                    "b:27017": {
+                        "setName": "rs",
+                        "type": "RSPrimary"
+                    },
+                    "c:27017": {
+                        "setName": null,
+                        "type": "Unknown"
+                    }
+                },
+                "setName": "rs",
+                "topologyType": "ReplicaSetWithPrimary"
+            },
+            "responses": [
+                [
+                    "b:27017",
+                    {
+                        "hosts": [
+                            "a:27017",
+                            "b:27017",
+                            "c:27017"
+                        ],
+                        "ismaster": true,
+                        "ok": 1,
+                        "setName": "rs"
+                    }
+                ]
+            ]
+        },
+        {
+            "outcome": {
+                "servers": {
+                    "a:27017": {
+                        "setName": "rs",
+                        "type": "RSSecondary"
+                    },
+                    "b:27017": {
+                        "setName": "rs",
+                        "type": "RSPrimary"
+                    },
+                    "c:27017": {
+                        "setName": "rs",
+                        "type": "RSSecondary"
+                    }
+                },
+                "setName": "rs",
+                "topologyType": "ReplicaSetWithPrimary"
+            },
+            "responses": [
+                [
+                    "c:27017",
+                    {
+                        "hosts": [
+                            "a:27017",
+                            "b:27017",
+                            "c:27017"
+                        ],
+                        "ismaster": false,
+                        "ok": 1,
+                        "primary": "b:27017",
+                        "secondary": true,
+                        "setName": "rs"
+                    }
+                ]
+            ]
+        }
+    ],
+    "uri": "mongodb://a/?replicaSet=rs"
+}

--- a/source/server-discovery-and-monitoring/tests/rs/primary_reports_new_member.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_reports_new_member.yml
@@ -1,0 +1,163 @@
+description: "Primary reports a new member"
+
+uri: "mongodb://a/?replicaSet=rs"
+
+phases: [
+
+    # At first, a is a secondary.
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"]
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+            },
+
+            topologyType: "ReplicaSetNoPrimary",
+            setName: "rs"
+        }
+    },
+
+    # b is the primary.
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"]
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                }
+            },
+
+            topologyType: "ReplicaSetWithPrimary",
+            setName: "rs"
+        }
+    },
+
+    # Admin adds a secondary member c.
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017", "c:27017"]
+                }]
+        ],
+
+        outcome: {
+
+            # c is new.
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "c:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+            },
+
+            topologyType: "ReplicaSetWithPrimary",
+            setName: "rs"
+        }
+    },
+
+    # c becomes secondary.
+    {
+        responses: [
+
+                ["c:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    primary: "b:27017",
+                    hosts: ["a:27017", "b:27017", "c:27017"]
+                }]
+        ],
+
+        outcome: {
+
+            # c is a secondary.
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "c:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                }
+            },
+
+            topologyType: "ReplicaSetWithPrimary",
+            setName: "rs"
+        }
+    }
+]


### PR DESCRIPTION
The Ruby driver had a bug where a primary in a ReplicaSetWithPrimary topology would report an additional member in its list of hosts but not add it to the cluster. We don't have an SDAM test for this simple, vanilla case. This PR adds one.
See [RUBY-1087](https://jira.mongodb.org/browse/RUBY-1087) for details.