### PR TITLE
Add tests with collation option to CRUD spec tests

### DIFF
--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -68,7 +68,7 @@ Each YAML file has the following keys:
 Tests including a collation argument
 ====================================
 Tests including a collation argument should be expected to succeed against server versions >= 3.4
-and fail in server versions < 3.4. The error should be throw by the driver and its message should
+and fail in server versions < 3.4. The error should be thrown by the driver and its message should
 explain that collation is not a supported feature in the server selected for the operation.
 
 Use as integration tests

--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -65,6 +65,11 @@ Each YAML file has the following keys:
           - data: The data that should exist in the collection after the 
                   operation has been run.
 
+Tests including a collation argument
+====================================
+Tests including a collation argument should be expected to succeed against server versions >= 3.4
+and fail in server versions < 3.4. The error should be throw by the driver and its message should
+explain that collation is not a supported feature in the server selected for the operation.
 
 Use as integration tests
 ========================

--- a/source/crud/tests/read/aggregate.yml
+++ b/source/crud/tests/read/aggregate.yml
@@ -43,6 +43,7 @@ tests:
                     - {_id: 3, x: 33}
     -
         description: "Aggregate with collation"
+        maxWireVersion: 5
         operation:
             name: aggregate
             arguments:

--- a/source/crud/tests/read/aggregate.yml
+++ b/source/crud/tests/read/aggregate.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'ping'}
 
 tests:
     -
@@ -11,8 +12,8 @@ tests:
             arguments:
                 pipeline:
                     - $sort: {x: 1}
-                    - $match: 
-                        _id: {$gt: 1}
+                    - $match:
+                        _id: {$gt: 1, $lt: 4}
                 batchSize: 2
 
         outcome:
@@ -24,10 +25,10 @@ tests:
         operation:
             name: aggregate
             arguments:
-                pipeline: 
+                pipeline:
                     - $sort: {x: 1}
                     - $match:
-                        _id: {$gt: 1}
+                        _id: {$gt: 1, $lt: 4}
                     - $out: "other_test_collection"
                 batchSize: 2
 
@@ -40,3 +41,15 @@ tests:
                 data:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+    -
+        description: "Aggregate with collation"
+        operation:
+            name: aggregate
+            arguments:
+                pipeline:
+                    - $match:
+                        x: 'PING'
+                collation: { locale: 'en_US', strength: 2 }
+        outcome:
+            result:
+                - {_id: 4, x: 'ping'}

--- a/source/crud/tests/read/count.yml
+++ b/source/crud/tests/read/count.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'PING'}
 
 tests:
     -
@@ -12,14 +13,14 @@ tests:
                 filter: { }
 
         outcome:
-            result: 3
+            result: 4
     -
         description: "Count with a filter"
         operation:
             name: count
             arguments:
-                filter: 
-                    _id: {$gt: 1}
+                filter:
+                    _id: {$gt: 1, $lt: 4}
 
         outcome:
             result: 2
@@ -33,4 +34,14 @@ tests:
                 limit: 3
 
         outcome:
-            result: 2
+            result: 3
+    -
+        description: "Count with collation"
+        operation:
+            name: count
+            arguments:
+                filter: { x: 'ping' }
+                collation: { locale: 'en_US', strength: 2 }
+
+        outcome:
+            result: 1

--- a/source/crud/tests/read/distinct.yml
+++ b/source/crud/tests/read/distinct.yml
@@ -2,6 +2,8 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, string: 'PING'}
+    - {_id: 5, string: 'ping'}
 
 tests:
     -
@@ -13,7 +15,7 @@ tests:
                 filter: {}
 
         outcome:
-            result: 
+            result:
                 - 11
                 - 22
                 - 33
@@ -23,10 +25,21 @@ tests:
             name: distinct
             arguments:
                 fieldName: "x"
-                filter: 
+                filter:
                     _id: {$gt: 1}
 
         outcome:
-            result: 
+            result:
                 - 22
                 - 33
+    -
+        description: "Distinct with a collation"
+        operation:
+            name: distinct
+            arguments:
+                fieldName: "string"
+                collation: { locale: 'en_US', strength: 2 }
+
+        outcome:
+            result:
+                - 'PING'

--- a/source/crud/tests/read/find.yml
+++ b/source/crud/tests/read/find.yml
@@ -4,6 +4,7 @@ data:
     - {_id: 3, x: 33}
     - {_id: 4, x: 44}
     - {_id: 5, x: 55}
+    - {_id: 6, x: 'ping'}
 
 tests:
     -
@@ -17,13 +18,13 @@ tests:
             result:
                 - {_id: 1, x: 11}
 
-    - 
+    -
         description: "Find with filter, sort, skip, and limit"
-        operation: 
+        operation:
             name: "find"
             arguments:
-                filter: 
-                    _id: {$gt: 2}
+                filter:
+                    _id: {$gt: 2, $lt: 6}
                 sort: {_id: 1}
                 skip: 2
                 limit: 2
@@ -33,7 +34,7 @@ tests:
                 - {_id: 5, x: 55}
     -
         description: "Find with limit, sort, and batchsize"
-        operation: 
+        operation:
             name: "find"
             arguments:
                 filter: {}
@@ -47,3 +48,13 @@ tests:
                 - {_id: 2, x: 22}
                 - {_id: 3, x: 33}
                 - {_id: 4, x: 44}
+    -
+        description: "Find with a collation"
+        operation:
+            name: "find"
+            arguments:
+                filter: {x: 'PING'}
+                collation: { locale: 'en_US', strength: 2 }
+        outcome:
+            result:
+                - {_id: 6, x: 'ping'}

--- a/source/crud/tests/write/deleteMany.yml
+++ b/source/crud/tests/write/deleteMany.yml
@@ -2,6 +2,8 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'ping'}
+    - {_id: 5, x: 'pINg'}
 
 tests:
     -
@@ -9,8 +11,23 @@ tests:
         operation:
             name: "deleteMany"
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
+
+        outcome:
+            result:
+                deletedCount: 4
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+    -
+        description: "DeleteMany when many documents match with collation"
+        operation:
+            name: "deleteMany"
+            arguments:
+                filter:
+                    x: 'PING'
+                collation: { locale: 'en_US', strength: 2 }
 
         outcome:
             result:
@@ -18,12 +35,14 @@ tests:
             collection:
                 data:
                     - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
     -
         description: "DeleteMany when no document matches"
         operation:
             name: "deleteMany"
             arguments:
-                filter: {_id: 4}
+                filter: {_id: 6}
 
         outcome:
             result:
@@ -33,3 +52,5 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}

--- a/source/crud/tests/write/deleteOne.yml
+++ b/source/crud/tests/write/deleteOne.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'ping'}
 
 tests:
     -
@@ -9,7 +10,7 @@ tests:
         operation:
             name: "deleteOne"
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
 
         outcome:
@@ -31,12 +32,29 @@ tests:
                 data:
                     - {_id: 1, x: 11}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+    -
+        description: "DeleteOne when one document matches with collation"
+        operation:
+            name: "deleteOne"
+            arguments:
+                filter: {x: 'PING'}
+                collation: { locale: 'en_US', strength: 2 }
+
+        outcome:
+            result:
+                deletedCount: 1
+            collection:
+                data:
+                   - {_id: 1, x: 11}
+                   - {_id: 2, x: 22}
+                   - {_id: 3, x: 33}
     -
         description: "DeleteOne when no documents match"
         operation:
             name: "deleteOne"
             arguments:
-                filter: {_id: 4}
+                filter: {_id: 5}
 
         outcome:
             result:
@@ -46,3 +64,4 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}

--- a/source/crud/tests/write/findOneAndDelete.yml
+++ b/source/crud/tests/write/findOneAndDelete.yml
@@ -2,6 +2,8 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'ping'}
+    - {_id: 5, x: 'pINg'}
 
 tests:
     -
@@ -9,7 +11,7 @@ tests:
         operation:
             name: findOneAndDelete
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -20,6 +22,8 @@ tests:
                 data:
                     - {_id: 1, x: 11}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
     -
         description: "FindOneAndDelete when one document matches"
         operation:
@@ -35,12 +39,32 @@ tests:
                 data:
                     - {_id: 1, x: 11}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
+    -
+        description: "FindOneAndDelete when one document matches with collation"
+        operation:
+            name: findOneAndDelete
+            arguments:
+                filter: {_id: 4, x: 'PING'}
+                projection: {x: 1, _id: 0}
+                sort: {x: 1}
+                collation: { locale: 'en_US', strength: 2 }
+
+        outcome:
+            result: {x: 'ping'}
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+                    - {_id: 5, x: 'pINg'}
     -
         description: "FindOneAndDelete when no documents match"
         operation:
             name: findOneAndDelete
             arguments:
-                filter: {_id: 4}
+                filter: {_id: 6}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
 
@@ -51,3 +75,5 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}

--- a/source/crud/tests/write/findOneAndReplace.yml
+++ b/source/crud/tests/write/findOneAndReplace.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'ping'}
 
 tests:
     -
@@ -9,7 +10,7 @@ tests:
         operation:
             name: findOneAndReplace
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 replacement: {x: 32}
                 projection: {x: 1, _id: 0}
@@ -22,12 +23,13 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 32}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
     -
         description: "FindOneAndReplace when many documents match returning the document after modification"
         operation:
             name: findOneAndReplace
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 replacement: {x: 32}
                 projection: {x: 1, _id: 0}
@@ -41,6 +43,7 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 32}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
     -
         description: "FindOneAndReplace when one document matches returning the document before modification"
         operation:
@@ -58,6 +61,7 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 32}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
     -
         description: "FindOneAndReplace when one document matches returning the document after modification"
         operation:
@@ -76,13 +80,35 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 32}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+
+    -
+        description: "FindOneAndReplace when one document matches with collation returning the document after modification"
+        operation:
+            name: findOneAndReplace
+            arguments:
+                filter: {x: 'PING'}
+                replacement: {x: 32}
+                projection: {x: 1, _id: 0}
+                returnDocument: After
+                sort: {x: 1}
+                collation: { locale: 'en_US', strength: 2 }
+
+        outcome:
+            result: {x: 32}
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+                    - {_id: 4, x: 32}
     -
         description: "FindOneAndReplace when no documents match returning the document before modification"
         operation:
             name: findOneAndReplace
             arguments:
-                filter: {_id: 4}
-                replacement: {x: 44}
+                filter: {_id: 5}
+                replacement: {x: 55}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
 
@@ -93,13 +119,14 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
     -
         description: "FindOneAndReplace when no documents match with upsert returning the document before modification"
         operation:
             name: findOneAndReplace
             arguments:
-                filter: {_id: 4}
-                replacement: {x: 44}
+                filter: {_id: 5}
+                replacement: {x: 55}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
                 upsert: true
@@ -111,14 +138,15 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
-                    - {_id: 4, x: 44}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 55}
     -
         description: "FindOneAndReplace when no documents match returning the document after modification"
         operation:
             name: findOneAndReplace
             arguments:
-                filter: {_id: 4}
-                replacement: {x: 44}
+                filter: {_id: 5}
+                replacement: {x: 55}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
                 sort: {x: 1}
@@ -130,23 +158,25 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
     -
         description: "FindOneAndReplace when no documents match with upsert returning the document after modification"
         operation:
             name: findOneAndReplace
             arguments:
-                filter: {_id: 4}
-                replacement: {x: 44}
+                filter: {_id: 5}
+                replacement: {x: 55}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
                 sort: {x: 1}
                 upsert: true
 
         outcome:
-            result: {x: 44}
+            result: {x: 55}
             collection:
                 data:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
-                    - {_id: 4, x: 44}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 55}

--- a/source/crud/tests/write/findOneAndUpdate.yml
+++ b/source/crud/tests/write/findOneAndUpdate.yml
@@ -2,6 +2,8 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'ping'}
+    - {_id: 5, x: 'pINg'}
 
 tests:
     -
@@ -9,9 +11,9 @@ tests:
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -23,14 +25,40 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 23}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
+
+    -
+        description: "FindOneAndUpdate when many documents match with collation returning the document before modification"
+        operation:
+            name: findOneAndUpdate
+            arguments:
+                filter:
+                    x: 'PING'
+                update:
+                    $set: {x: 'pong'}
+                projection: {x: 1, _id: 0}
+                sort: {_id: 1}
+                collation: { locale: 'en_US', strength: 2 }
+
+        outcome:
+            result: {x: 'ping'}
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+                    - {_id: 4, x: 'pong'}
+                    - {_id: 5, x: 'pINg'}
+
     -
         description: "FindOneAndUpdate when many documents match returning the document after modification"
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -43,13 +71,15 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 23}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
     -
         description: "FindOneAndUpdate when one document matches returning the document before modification"
         operation:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 2}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -61,13 +91,15 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 23}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
     -
         description: "FindOneAndUpdate when one document matches returning the document after modification"
         operation:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 2}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -80,13 +112,15 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 23}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
     -
         description: "FindOneAndUpdate when no documents match returning the document before modification"
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: {_id: 4}
-                update: 
+                filter: {_id: 6}
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -98,13 +132,15 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
     -
         description: "FindOneAndUpdate when no documents match with upsert returning the document before modification"
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: {_id: 4}
-                update: 
+                filter: {_id: 6}
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -117,14 +153,16 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
-                    - {_id: 4, x: 1}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
+                    - {_id: 6, x: 1}
     -
         description: "FindOneAndUpdate when no documents match returning the document after modification"
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: {_id: 4}
-                update: 
+                filter: {_id: 6}
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -137,13 +175,15 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
     -
         description: "FindOneAndUpdate when no documents match with upsert returning the document after modification"
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: {_id: 4}
-                update: 
+                filter: {_id: 6}
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -157,4 +197,6 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
-                    - {_id: 4, x: 1}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
+                    - {_id: 6, x: 1}

--- a/source/crud/tests/write/replaceOne.yml
+++ b/source/crud/tests/write/replaceOne.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'ping'}
 
 tests:
     -
@@ -9,7 +10,7 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 replacement: {x: 111}
 
@@ -36,13 +37,33 @@ tests:
                     - {_id: 1, x: 111}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+    -
+        description: "ReplaceOne when one document matches with collation"
+        operation:
+            name: "replaceOne"
+            arguments:
+                filter: {x: 'PING'}
+                replacement: {_id: 4, x: 'pong'}
+                collation: {locale: 'en_US', strength: 2}
+
+        outcome:
+            result:
+                matchedCount: 1
+                modifiedCount: 1
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+                    - {_id: 4, x: 'pong'}
     -
         description: "ReplaceOne when no documents match"
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {_id: 4, x: 1}
+                filter: {_id: 5}
+                replacement: {_id: 5, x: 1}
 
         outcome:
             result:
@@ -53,12 +74,13 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
     -
         description: "ReplaceOne with upsert when no documents match without an id specified"
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
+                filter: {_id: 5}
                 replacement: {x: 1}
                 upsert: true
 
@@ -66,30 +88,32 @@ tests:
             result:
                 matchedCount: 0
                 modifiedCount: 0
-                upsertedId: 4
+                upsertedId: 5
             collection:
                 data:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
-                    - {_id: 4, x: 1}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 1}
     -
         description: "ReplaceOne with upsert when no documents match with an id specified"
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {_id: 4, x: 1}
+                filter: {_id: 5}
+                replacement: {_id: 5, x: 1}
                 upsert: true
 
         outcome:
             result:
                 matchedCount: 0
                 modifiedCount: 0
-                upsertedId: 4
+                upsertedId: 5
             collection:
                 data:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
-                    - {_id: 4, x: 1}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 1}

--- a/source/crud/tests/write/updateMany.yml
+++ b/source/crud/tests/write/updateMany.yml
@@ -2,6 +2,8 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'ping'}
+    - {_id: 5, x: 'pINg'}
 
 tests:
     -
@@ -9,9 +11,9 @@ tests:
         operation:
             name: "updateMany"
             arguments:
-                filter: 
-                    _id: {$gt: 1}
-                update: 
+                filter:
+                    _id: {$gt: 1, $lt: 4}
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -23,13 +25,37 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 23}
                     - {_id: 3, x: 34}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
+    -
+        description: "UpdateMany when many documents match with collation"
+        operation:
+            name: "updateMany"
+            arguments:
+                filter:
+                    x: 'ping'
+                update:
+                    $set: {x: 'pong'}
+                collation: { locale: 'en_US', strength: 2 }
+
+        outcome:
+            result:
+                matchedCount: 2
+                modifiedCount: 2
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+                    - {_id: 4, x: 'pong'}
+                    - {_id: 5, x: 'pong'}
     -
         description: "UpdateMany when one document matches"
         operation:
             name: "updateMany"
             arguments:
                 filter: {_id: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -41,13 +67,15 @@ tests:
                     - {_id: 1, x: 12}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
     -
         description: "UpdateMany when no documents match"
         operation:
             name: "updateMany"
             arguments:
-                filter: {_id: 4}
-                update: 
+                filter: {_id: 6}
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -59,13 +87,15 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
     -
         description: "UpdateMany with upsert when no documents match"
         operation:
             name: "updateMany"
             arguments:
-                filter: {_id: 4}
-                update: 
+                filter: {_id: 6}
+                update:
                     $inc: {x: 1}
                 upsert: true
 
@@ -73,10 +103,12 @@ tests:
             result:
                 matchedCount: 0
                 modifiedCount: 0
-                upsertedId: 4
+                upsertedId: 6
             collection:
                 data:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
-                    - {_id: 4, x: 1}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 'pINg'}
+                    - {_id: 6, x: 1}

--- a/source/crud/tests/write/updateOne.yml
+++ b/source/crud/tests/write/updateOne.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
+    - {_id: 4, x: 'ping'}
 
 tests:
     -
@@ -9,9 +10,9 @@ tests:
         operation:
             name: "updateOne"
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -26,7 +27,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -38,13 +39,35 @@ tests:
                     - {_id: 1, x: 12}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
+    -
+        description: "UpdateOne when one document matches with collation"
+        operation:
+            name: "updateOne"
+            arguments:
+                filter: {x: 'PING'}
+                update:
+                    $set: {x: 'pong'}
+                collation: { locale: 'en_US', strength: 2}
+
+        outcome:
+            result:
+                matchedCount: 1
+                modifiedCount: 1
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+                    - {_id: 4, x: 'pong'}
+
     -
         description: "UpdateOne when no documents match"
         operation:
             name: "updateOne"
             arguments:
-                filter: {_id: 4}
-                update: 
+                filter: {_id: 5}
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -56,13 +79,14 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+                    - {_id: 4, x: 'ping'}
     -
         description: "UpdateOne with upsert when no documents match"
         operation:
             name: "updateOne"
             arguments:
-                filter: {_id: 4}
-                update: 
+                filter: {_id: 5}
+                update:
                     $inc: {x: 1}
                 upsert: true
 
@@ -70,10 +94,11 @@ tests:
             result:
                 matchedCount: 0
                 modifiedCount: 0
-                upsertedId: 4
+                upsertedId: 5
             collection:
                 data:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
-                    - {_id: 4, x: 1}
+                    - {_id: 4, x: 'ping'}
+                    - {_id: 5, x: 1}


### PR DESCRIPTION
I've already included them in the Ruby driver Collation implementation: https://github.com/mongodb/mongo-ruby-driver/pull/788

Note that these additional tests should only pass when testing against server >= 3.4
The tests should be otherwise expected to throw an error.