### PR TITLE
A percent sign ("%") MUST be URL encoded

### DIFF
--- a/source/connection-string/connection-string-spec.rst
+++ b/source/connection-string/connection-string-spec.rst
@@ -69,9 +69,9 @@ The user information if present, is followed by a commercial at-sign ("@") that 
 
 A password may be supplied as part of the user information and is anything after the first colon (":") up until the end of the user information.
 
-If the username section contains either an at-sign ("@") or a colon (":") it MUST be URL encoded.
+If the username section contains a percent sign ("%"), an at-sign ("@") or a colon (":") it MUST be URL encoded.
 
-If the user information contains an at-sign ("@") or more than one colon (":") then an exception MUST be thrown informing the user that the username and password must be URL encoded.
+If the user information contains a percent sign ("%"), an at-sign ("@") or more than one colon (":") then an exception MUST be thrown informing the user that the username and password must be URL encoded.
 
 ----------------
 Host Information


### PR DESCRIPTION
For a password that doesn't contain `@` or `:` but does contain `%40` there appears to be no way to determine if the password contains an `@` or the following 3 characters in sequence `%40`, unless we specify that `%` must be encoded.

/cc @rozza
