### PR TITLE
SPEC-337: Deprecate modifiers and clean up existing wording for default values

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -137,21 +137,21 @@ Read
      * MAY setup a cursor to be executed upon iteration against the $out collection such
      * that if a user were to iterate a pipeline including $out, results would be returned.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.com/manual/reference/command/aggregate/
      */
     aggregate(pipeline: Document[], options: Optional<AggregateOptions>): Iterable<Document>;
 
     /**
      * Gets the number of documents matching the filter.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.com/manual/reference/command/count/
      */
     count(filter: Document, options: Optional<CountOptions>): Int64;
 
     /**
      * Finds the distinct values for a specified field across a single collection. 
      *
-     * @see https://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.com/manual/reference/command/distinct/
      */
     distinct(fieldName: string, filter: Document, options: Optional<DistinctOptions>): Iterable<any>;
 
@@ -166,7 +166,7 @@ Read
      * Note: If $explain is specified in the modifiers, the return value is a single 
      * document. This could cause problems for static languages using strongly typed entities.
      *
-     * @see https://docs.mongodb.org/manual/core/read-operations-introduction/
+     * @see https://docs.mongodb.com/manual/core/read-operations-introduction/
      */
     find(filter: Document, options: Optional<FindOptions>): Iterable<Document>;
 
@@ -181,7 +181,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default 
      * is to not send a value.
      * 
-     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.com/manual/reference/command/aggregate/
      */ 
     allowDiskUse: Optional<Boolean>;
 
@@ -191,7 +191,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 2.6, this option is ignored and should not be sent as aggregation cursors are not available.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.com/manual/reference/command/aggregate/
      */ 
     batchSize: Optional<Int32>;
 
@@ -202,7 +202,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.com/manual/reference/command/aggregate/
      */
     bypassDocumentValidation: Optional<Boolean>;
 
@@ -212,7 +212,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.com/manual/reference/command/aggregate/
      */
     collation: Optional<Document>;
     
@@ -221,7 +221,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.com/manual/reference/command/aggregate/
      */ 
     maxTimeMS: Optional<Int64>;
 
@@ -231,7 +231,7 @@ Read
      * If true, this option is sent with a value of "cursor: {}". The default value is true. 
      * For servers < 2.6, this option is ignored and not sent as aggregation cursors are not available.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.com/manual/reference/command/aggregate/
      */
     useCursor: Optional<Boolean>;
   }
@@ -244,7 +244,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.com/manual/reference/command/count/
      */
     collation: Optional<Document>;
 
@@ -253,7 +253,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.com/manual/reference/command/count/
      */
     hint: Optional<(String | Document)>;
 
@@ -262,7 +262,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.com/manual/reference/command/count/
      */
     limit: Optional<Int64>;
 
@@ -271,7 +271,7 @@ Read
 
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.com/manual/reference/command/count/
      */
     maxTimeMS: Optional<Int64>;
 
@@ -280,7 +280,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.com/manual/reference/command/count/
      */
     skip: Optional<Int64>;
   }
@@ -293,7 +293,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.com/manual/reference/command/distinct/
      */
     collation: Optional<Document>;
 
@@ -302,7 +302,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.com/manual/reference/command/distinct/
      */
     maxTimeMS: Optional<Int64>;
   }
@@ -320,7 +320,7 @@ Read
      * some point (CursorNotFound) – for example if the final object it 
      * references were deleted.
      *
-     * @see https://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
+     * @see https://docs.mongodb.com/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
      */
     TAILABLE,
     /**
@@ -330,7 +330,7 @@ Read
      * while rather than returning no data. After a timeout period, we do return
      * as normal. The default is true.
      *
-     * @see https://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
+     * @see https://docs.mongodb.com/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
      */
     TAILABLE_AWAIT
   }
@@ -363,7 +363,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/find/
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     collation: Optional<Document>;
 
@@ -586,9 +586,9 @@ Basic
      * and no documents sent.
      *
      * NOTE: see the FAQ about the previous bulk API and how it relates to this.
-     * @see https://docs.mongodb.org/manual/reference/command/delete/
-     * @see https://docs.mongodb.org/manual/reference/command/insert/
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/delete/
+     * @see https://docs.mongodb.com/manual/reference/command/insert/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      * @throws BulkWriteException
      */
     bulkWrite(requests: WriteModel[], options: Optional<BulkWriteOptions>): BulkWriteResult;
@@ -597,7 +597,7 @@ Basic
      * Inserts the provided document. If the document is missing an identifier,
      * the driver should generate one.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/insert/
+     * @see https://docs.mongodb.com/manual/reference/command/insert/
      * @throws WriteException
      */
     insertOne(document: Document, options: Optional<InsertOneOptions>): InsertOneResult;
@@ -610,7 +610,7 @@ Basic
      * use OP_INSERT. This will be slow on < 2.6 servers, so document
      * your driver appropriately.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/insert/
+     * @see https://docs.mongodb.com/manual/reference/command/insert/
      * @throws BulkWriteException
      */
     insertMany(Iterable<Document> documents, options: Optional<InsertManyOptions>): InsertManyResult;
@@ -618,7 +618,7 @@ Basic
     /**
      * Deletes one document.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.com/manual/reference/command/delete/
      * @throws WriteException
      */
     deleteOne(filter: Document, options: Optional<DeleteOptions>): DeleteResult;
@@ -626,7 +626,7 @@ Basic
     /**
      * Deletes multiple documents.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.com/manual/reference/command/delete/
      * @throws WriteException
      */
     deleteMany(filter: Document, options: Optional<DeleteOptions>): DeleteResult;
@@ -634,7 +634,7 @@ Basic
     /**
      * Replaces a single document.
      * 
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      * @throws WriteException
      */
     replaceOne(filter: Document, replacement: Document, options: Optional<UpdateOptions>): UpdateResult;
@@ -642,7 +642,7 @@ Basic
     /**
      * Updates one document.
      * 
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      * @throws WriteException
      */
     updateOne(filter: Document, update: Document, options: Optional<UpdateOptions>): UpdateResult;
@@ -650,7 +650,7 @@ Basic
     /**
      * Updates multiple documents.
      * 
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      * @throws WriteException
      */
     updateMany(filter: Document, update: Document, options: Optional<UpdateOptions>): UpdateResult;
@@ -724,7 +724,7 @@ Basic
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     collation: Optional<Document>;
 
@@ -733,7 +733,7 @@ Basic
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
   }
@@ -747,7 +747,7 @@ Basic
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.com/manual/reference/command/delete/
      */
     collation: Optional<Document>;
   }
@@ -767,7 +767,7 @@ Bulk Write Models
     /**
      * The document to insert.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/insert/
+     * @see https://docs.mongodb.com/manual/reference/command/insert/
      */
     document: Document;
   }
@@ -777,7 +777,7 @@ Bulk Write Models
     /**
      * The filter to limit the deleted documents.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.com/manual/reference/command/delete/
      */
     filter: Document;
 
@@ -788,7 +788,7 @@ Bulk Write Models
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.com/manual/reference/command/delete/
      */
     collation: Optional<Document>;
   }
@@ -798,7 +798,7 @@ Bulk Write Models
     /**
      * The filter to limit the deleted documents.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.com/manual/reference/command/delete/
      */
     filter: Document;
 
@@ -809,7 +809,7 @@ Bulk Write Models
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.com/manual/reference/command/delete/
      */
     collation: Optional<Document>;
   }
@@ -819,14 +819,14 @@ Bulk Write Models
     /**
      * The filter to limit the replaced document.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     filter: Document;
 
     /**
      * The document with which to replace the matched document.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     replacement: Document;
 
@@ -837,7 +837,7 @@ Bulk Write Models
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     collation: Optional<Document>;
 
@@ -846,7 +846,7 @@ Bulk Write Models
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
 
@@ -863,14 +863,14 @@ Bulk Write Models
     /**
      * The filter to limit the updated documents.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     filter: Document;
 
     /**
      * A document containing update operators.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     update: Update;
 
@@ -881,7 +881,7 @@ Bulk Write Models
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     collation: Optional<Document>;
 
@@ -890,7 +890,7 @@ Bulk Write Models
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
 
@@ -907,14 +907,14 @@ Bulk Write Models
     /**
      * The filter to limit the updated documents.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     filter: Document;
 
     /**
      * A document containing update operators.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     update: Update;
 
@@ -925,7 +925,7 @@ Bulk Write Models
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     collation: Optional<Document>;
 
@@ -934,7 +934,7 @@ Bulk Write Models
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
 
@@ -1107,21 +1107,21 @@ Below are defined the exceptions that should be thrown from the various write me
     /**
      * An integer value identifying the write concern error.
      *
-     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.com/manual/reference/method/WriteResult/
      */
     code: Int32;
 
     /**
      * A document identifying the write concern setting related to the error.
      *
-     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.com/manual/reference/method/WriteResult/
      */
     details: Document;
 
     /**
      * A description of the error.
      *
-     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.com/manual/reference/method/WriteResult/
      */
     message: String;
 
@@ -1132,14 +1132,14 @@ Below are defined the exceptions that should be thrown from the various write me
     /**
      * An integer value identifying the error.
      *
-     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.com/manual/reference/method/WriteResult/
      */
     code: Int32;
 
     /**
      * A description of the error.
      *
-     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.com/manual/reference/method/WriteResult/
      */
     message: String;
 
@@ -1217,7 +1217,7 @@ Find And Modify
     /**
      * Finds a single document and deletes it, returning the original. The document to return may be null.
      * 
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      * @throws WriteException
      */
     findOneAndDelete(filter: Document, options: Optional<FindOneAndDeleteOptions>): Document;
@@ -1226,7 +1226,7 @@ Find And Modify
      * Finds a single document and replaces it, returning either the original or the replaced
      * document. The document to return may be null.
      * 
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      * @throws WriteException
      */
     findOneAndReplace(filter: Document, replacement: Document, options: Optional<FindOneAndReplaceOptions>): Document;
@@ -1235,7 +1235,7 @@ Find And Modify
      * Finds a single document and updates it, returning either the original or the updated
      * document. The document to return may be null.
      * 
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      * @throws WriteException
      */
     findOneAndUpdate(filter: Document, update: Document, options: Optional<FindOneAndUpdateOptions>): Document;
@@ -1261,7 +1261,7 @@ Find And Modify
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     collation: Optional<Document>;
 
@@ -1270,7 +1270,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */ 
     maxTimeMS: Optional<Int64>;
 
@@ -1281,7 +1281,7 @@ Find And Modify
      *
      * Note: this option is mapped to the "fields" findAndModify field.
      *     
-     * @see https://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
+     * @see https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results
      */
     projection: Optional<Document>;
 
@@ -1290,7 +1290,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
   }
@@ -1311,7 +1311,7 @@ Find And Modify
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     collation: Optional<Document>;
 
@@ -1320,7 +1320,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */ 
     maxTimeMS: Optional<Int64>;
 
@@ -1331,7 +1331,7 @@ Find And Modify
      *
      * Note: this option is mapped to the "fields" findAndModify field.
      *
-     * @see https://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
+     * @see https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results
      */
     projection: Optional<Document>;
 
@@ -1343,7 +1343,7 @@ Find And Modify
      * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before represents false, 
      * and ReturnDocument.After represents true.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     returnDocument: Optional<ReturnDocument>;
 
@@ -1352,7 +1352,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
 
@@ -1361,7 +1361,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     upsert: Optional<Boolean>;
   }
@@ -1382,14 +1382,14 @@ Find And Modify
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     collation: Optional<Document>;
 
     /**
      * The maximum amount of time to allow the query to run.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */ 
     maxTimeMS: Optional<Int64>;
     
@@ -1400,7 +1400,7 @@ Find And Modify
      *
      * Note: this option is mapped to the "fields" findAndModify field.
      *
-     * @see https://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
+     * @see https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results
      */
     projection: Optional<Document>;
 
@@ -1412,7 +1412,7 @@ Find And Modify
      * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before is represents false, 
      * and ReturnDocument.After represents true.
      *     
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     returnDocument: Optional<ReturnDocument>;
 
@@ -1421,7 +1421,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
 
@@ -1430,7 +1430,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     upsert: Optional<Boolean>;
   }
@@ -1489,7 +1489,7 @@ If a driver needs to refer to items in the following list, the below are the acc
 Q & A
 =====
 
-Q: Why do the names of the fields differ from those defined on docs.mongodb.org?
+Q: Why do the names of the fields differ from those defined on docs.mongodb.com?
   documentation and commands often refer to same-purposed fields with different names making it difficult to have a cohesive API. In addition, occasionally the name was correct at one point and its purpose has expanded to a point where the initial name doesn't accurately describe its current function.
 
   In addition, responses from the servers are sometimes cryptic and used for the purposes of compactness. In these cases, we felt the more verbose form was desirable for self-documentation purposes.

--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -12,7 +12,7 @@ Driver CRUD API
 :Status: Approved
 :Type: Standards
 :Minimum Server Version: 2.4
-:Last Modified: Aug. 5, 2016
+:Last Modified: Aug. 17, 2016
 
 .. contents::
 
@@ -123,7 +123,7 @@ Read
 
 .. note::
     
-    The term Iterable<T> is used below to indicate many of T. This spec is flexible on what that means as different drivers will have different requirements, types, and idioms.
+    The term Iterable<T> is used below to indicate many of T. This spec is flexible on what that means as different drivers will have different requirements, types, and idioms. 
 
 .. code:: typescript
   
@@ -177,9 +177,10 @@ Read
     /**
      * Enables writing to temporary files. When set to true, aggregation stages 
      * can write data to the _tmp subdirectory in the dbPath directory.
-     * The default is no value: the driver sends no "allowDiskUse" option to the
-     * server with the "aggregate" command.
      *
+     * This option is sent only if the caller explicitly provides a value. The default 
+     * is to not send a value.
+     * 
      * @see http://docs.mongodb.org/manual/reference/command/aggregate/
      */ 
     allowDiskUse: Optional<Boolean>;
@@ -187,9 +188,8 @@ Read
     /**
      * The number of documents to return per batch. 
      *
-     * For servers < 2.6, this option is ignored as aggregation cursors are not available.
-     * The default is no value: the driver sends no "batchSize" option to the server with
-     * the "aggregate" command, thus accepting the server default batch size.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 2.6, this option is ignored and should not be sent as aggregation cursors are not available.
      *
      * @see http://docs.mongodb.org/manual/reference/command/aggregate/
      */ 
@@ -199,17 +199,25 @@ Read
      * If true, allows the write to opt-out of document level validation. This only applies
      * when the $out stage is specified.
      * 
-     * On servers >= 3.2, the default is no value: no 
-     * "bypassDocumentValidation" option is sent with the "aggregate" command.
-     *
-     * On servers < 3.2, this option is ignored.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
 
     /**
+     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see http://docs.mongodb.org/manual/reference/command/aggregate/
+     */
+    collation: Optional<Document>;
+    
+    /**
      * The maximum amount of time to allow the query to run.
-     * The default is no value: the driver sends no "maxTimeMS" option to the
-     * server with the "aggregate" command.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see http://docs.mongodb.org/manual/reference/command/aggregate/
      */ 
@@ -218,38 +226,39 @@ Read
     /**
      * Indicates whether the command will request that the server provide results using a cursor.
      *
-     * For servers < 2.6, this option is ignored as aggregation cursors are not available.
-     * For servers >= 2.6, this option allows users to turn off cursors if necessary to aid in mongod/mongos upgrades.
-     * The default value is true: the driver sends "cursor: {}" to the server with the "aggregate" command
-     * by default.
+     * If true, this option is sent with a value of "cursor: {}". The default value is true. 
+     * For servers < 2.6, this option is ignored and not sent as aggregation cursors are not available.
      *
      * @see http://docs.mongodb.org/manual/reference/command/aggregate/
      */
     useCursor: Optional<Boolean>;
-
-    /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
-     *
-     * The default is no value: the driver sends no "collation" document to the
-     * server with the "aggregate" command.
-     *
-     * @see http://docs.mongodb.org/manual/reference/command/aggregate/
-     */
-    collation: Optional<Document>;
-
   }
 
   class CountOptions {
 
     /**
-     * The index to use. The default is no hint.
+     * Specifies a collation.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see http://docs.mongodb.org/manual/reference/command/count/
+     */
+    collation: Optional<Document>;
+
+    /**
+     * The index to use.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see http://docs.mongodb.org/manual/reference/command/count/
      */
     hint: Optional<(String | Document)>;
 
     /**
-     * The maximum number of documents to count. The default is no limit.
+     * The maximum number of documents to count.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see http://docs.mongodb.org/manual/reference/command/count/
      */
@@ -257,50 +266,43 @@ Read
 
     /**
      * The maximum amount of time to allow the query to run.
-     * The default is no maxTimeMS.
+
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see http://docs.mongodb.org/manual/reference/command/count/
      */
     maxTimeMS: Optional<Int64>;
 
     /**
-     * The number of documents to skip before counting. The default is no skip.
+     * The number of documents to skip before counting.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see http://docs.mongodb.org/manual/reference/command/count/
      */
     skip: Optional<Int64>;
-
-    /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
-     *
-     * The default is no value: the driver sends no "collation" document to the
-     * server with the "count" command.
-     *
-     * @see http://docs.mongodb.org/manual/reference/command/count/
-     */
-    collation: Optional<Document>;
-
   }
 
   class DistinctOptions {
 
     /**
-     * The maximum amount of time to allow the query to run.
-     * The default is no maxTimeMS.
+     * Specifies a collation.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
-     */
-    maxTimeMS: Optional<Int64>;
-
-    /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
-     *
-     * The default is no value: the driver sends no "collation" document to the
-     * server with the "distinct" command.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
      * @see http://docs.mongodb.org/manual/reference/command/distinct/
      */
     collation: Optional<Document>;
+
+    /**
+     * The maximum amount of time to allow the query to run.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     */
+    maxTimeMS: Optional<Int64>;
   }
 
   enum CursorType {
@@ -336,32 +338,39 @@ Read
     /**
      * Get partial results from a mongos if some shards are down (instead of throwing an error).
      *
-     * The default in servers >= 3.2 is no value: no "allowPartialResults" option is sent with
-     * the "find" command.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, the Partial wire protocol flag defaults to false.
      *
-     * In servers < 3.2, the Partial OP_QUERY flag defaults to false.
-     *
-     * @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     allowPartialResults: Optional<Boolean>;
     
     /**
      * The number of documents to return per batch.
      *
-     * In servers < 3.2, this is combined with limit to create the OP_QUERY numberToReturn value.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this is combined with limit to create the wire protocol numberToReturn value.
      *
-     * The default is no value: the driver accepts the server default batch size.
-     *
-     * @see http://docs.mongodb.org/manual/reference/method/cursor.batchSize/
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */ 
     batchSize: Optional<Int32>;
 
     /**
-     * Attaches a comment to the query. If $comment also exists
-     * in the modifiers document, the comment field overwrites $comment.
-     * The default is no comment.
+     * Specifies a collation.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/meta/comment/
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     */
+    collation: Optional<Document>;
+
+    /**
+     * Attaches a comment to the query.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */ 
     comment: Optional<String>;
 
@@ -369,132 +378,169 @@ Read
      * Indicates the type of cursor to use. This value includes both
      * the tailable and awaitData options.
      *
-     * The default in servers >= 3.2 is no value: no "awaitData" or "tailable"
-     * option is sent with the "find" command.
-     *
-     * In servers < 3.2, the AwaitData OP_QUERY flag and the Tailable OP_QUERY
-     * flag default to false.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, the AwaitData wire protocol flag and the Tailable wire protocol flag default to false.
      *
      * @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
      */
     cursorType: Optional<CursorType>;
 
     /**
+     * The index to use.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/find/
+     */
+    hint: Optional<(String | Document)>;
+
+    /**
      * The maximum number of documents to return.
      *
-     * In servers < 3.2, this is combined with batchSize to create the OP_QUERY numberToReturn value.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this is combined with batchSize to create the wire protocol numberToReturn value.
      *
-     * The default is no limit.
-     *
-     * @see http://docs.mongodb.org/manual/reference/method/cursor.limit/
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
-    limit: Optional<Int32>;
+    limit: Optional<Int64>;
+
+    /**
+     * The exclusive upper bound for a specific index.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/method/cursor.max/#cursor.max
+     */
+    max: Optional<Document>;
 
     /**
      * The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor 
      * query. This only applies to a TAILABLE_AWAIT cursor. When the cursor is not a TAILABLE_AWAIT cursor,
      * this option is ignored.
      *
-     * On servers >= 3.2, this option will be specified on the getMore command as "maxTimeMS". The default
-     * is no value: no "maxTimeMS" is sent to the server with the getMore command.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as maxTimeMS does not exist in the get more wire protocol.
      *
-     * On servers < 3.2, this option is ignored.
+     * Note: This option is specified as "maxTimeMS" in the getMore command and not provided as part of the 
+     * initial find command.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     maxAwaitTimeMS: Optional<Int64>;
 
     /**
-     * The maximum amount of time to allow the query to run. If $maxTimeMS also exists
-     * in the modifiers document, the maxTimeMS field overwrites $maxTimeMS.
+     * Maximum number of documents or index keys to scan when executing the query.
      *
-     * The default is no maxTimeMS.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS/
+     * @see https://docs.mongodb.com/manual/reference/method/cursor.max/#cursor.max
+     */
+    maxScan: Optional<Int64>;
+
+    /**
+     * The maximum amount of time to allow the query to run.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     maxTimeMS: Optional<Int64>;
 
     /**
-     * Meta-operators modifying the output or behavior of a query.
-     * The default is no modifers.
+     * The inclusive lower bound for a specific index.
      *
-     * @see http://docs.mongodb.org/manual/reference/operator/query-modifier/
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/method/cursor.min/#cursor.min
      */
-    modifiers: Optional<Document>;
+    min: Optional<Document>;
 
     /**
      * The server normally times out idle cursors after an inactivity period (10 minutes) 
      * to prevent excess memory use. Set this option to prevent that.
      *
-     * The default in servers >= 3.2 is no value: no "noCursorTimeout" option is sent with
-     * the "find" command.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, the NoCursorTimeout wire protocol flag defaults to false.
      *
-     * In servers < 3.2, the NoCursorTimeout OP_QUERY flag defaults to false.
-     *
-     * @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     noCursorTimeout: Optional<Boolean>;
 
     /**
      * Internal replication use only - driver should not set
      *
-     * The default in servers >= 3.2 is no value: no "oplogReplay" option is sent with
-     * the "find" command.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, the OplogReplay wire protocol flag defaults to false.
      *
-     * In servers < 3.2, the OplogReplay OP_QUERY flag defaults to false.
-     *
-     * @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     oplogReplay: Optional<Boolean>;
 
     /** 
      * Limits the fields to return for all matching documents.
-     * The default is no projection.
      *
-     * @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results/
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     projection: Optional<Document>;
+
+    /** 
+     * If true, returns only the index keys in the resulting documents.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/find/
+     */
+    returnKey: Optional<Document>;
+
+    /** 
+     * Determines whether to return the record identifier for each document. If true, adds a field $recordId to the returned documents.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/find/
+     */
+    showRecordId: Optional<Document>;
 
     /**
      * The number of documents to skip before returning.
      *
-     * In servers < 3.2, this is a wire protocol parameter that defaults to 0.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this is a wire protocol parameter that defaults to 0.
      *
-     * The default in servers >= 3.2 is no skip: no "skip" option is sent with
-     * the "find" command.
-     *
-     * @see http://docs.mongodb.org/manual/reference/method/cursor.skip/
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
-    skip: Optional<Int32>;
+    skip: Optional<Int64>;
+
+    /** 
+     * Determines whether to return the record identifier for each document. If true, adds a field $recordId to the returned documents.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/find/
+     */
+    snapshot: Optional<Document>;
 
     /**
-     * The order in which to return matching documents. If $orderby also exists
-     * in the modifiers document, the sort field overwrites $orderby.
-     * The default is no sort.
+     * The order in which to return matching documents.
      *
-     * @see http://docs.mongodb.org/manual/reference/method/cursor.sort/
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */ 
     sort: Optional<Document>;
-
-    /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
-     *
-     * The default is no value: the driver sends no "collation" document to the
-     * server with the "find" command.
-     *
-     * @see http://docs.mongodb.org/manual/reference/command/find/
-     */
-    collation: Optional<Document>;
-
   }
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Combining Limit and Batch Size for the Wire Protocol
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The OP_QUERY wire protocol only contains a numberToReturn value which drivers must calculate to get expected limit and batch size behavior. Subsequent calls to OP_GET_MORE should use the user-specified batchSize or default to 0. Below is pseudo-code for calculating numberToReturn for OP_QUERY.
+The OP_QUERY wire protocol only contains a numberToReturn value which drivers must calculate to get expected limit and batch size behavior. Subsequent calls to OP_GET_MORE should use the user-specified batchSize or default to 0. If the result is larger than the max Int32 value, an error MUST be raised as the computed value is impossible to send to the server. Below is pseudo-code for calculating numberToReturn for OP_QUERY.
 
 .. code:: typescript
 
-  function calculateFirstNumberToReturn(FindOptions options) {
+  function calculateFirstNumberToReturn(FindOptions options) Int32 {
     Int32 numberToReturn;
     Int32 limit = options.limit || 0;
     Int32 batchSize = options.batchSize || 0;
@@ -603,7 +649,6 @@ Basic
      * @throws WriteException
      */
     updateMany(filter: Document, update: Document, options: Optional<UpdateOptions>): UpdateResult;
-
   }
 
   class BulkWriteOptions {
@@ -618,13 +663,10 @@ Basic
     /**
      * If true, allows the write to opt-out of document level validation. 
      * 
-     * On servers >= 3.2, the default is no value: no 
-     * "bypassDocumentValidation" option is sent with the write command.
-     *
-     * On servers < 3.2, this option is ignored.
+     * For servers >= 3.2, this option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
-
   }
 
   class InsertOneOptions {
@@ -632,13 +674,10 @@ Basic
     /**
      * If true, allows the write to opt-out of document level validation. 
      * 
-     * On servers >= 3.2, the default is no value: no 
-     * "bypassDocumentValidation" option is sent with the "insert" command.
-     *
-     * On servers < 3.2, this option is ignored.
+     * For servers >= 3.2, this option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
-
   }
 
   class InsertManyOptions {
@@ -646,10 +685,8 @@ Basic
     /**
      * If true, allows the write to opt-out of document level validation. 
      * 
-     * On servers >= 3.2, the default is no value: no 
-     * "bypassDocumentValidation" option is sent with the "insert" command.
-     *
-     * On servers < 3.2, this option is ignored.
+     * For servers >= 3.2, this option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
 
@@ -659,7 +696,6 @@ Basic
      * Defaults to true.
      */
     ordered: Boolean;
-
   }
 
   class UpdateOptions
@@ -667,39 +703,42 @@ Basic
     /**
      * If true, allows the write to opt-out of document level validation. 
      * 
-     * On servers >= 3.2, the default is no value: no 
-     * "bypassDocumentValidation" option is sent with the "update" command.
-     *
-     * On servers < 3.2, this option is ignored.
+     * For servers >= 3.2, this option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
 
     /**
-     * When true, creates a new document if no document matches the query. The default is false.
+     * Specifies a collation.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     */
+    collation: Optional<Document>;
+
+    /**
+     * When true, creates a new document if no document matches the query.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
-
-    /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
-     *
-     * The default is no value: the driver sends no "collation" document to the
-     * server with the "update" command.
-     */
-    collation: Optional<Document>;
   }
 
   class DeleteOptions
 
     /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
+     * Specifies a collation.
      *
-     * The default is no value: the driver sends no "collation" document to the
-     * server with the "delete" command.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see http://docs.mongodb.org/manual/reference/command/distinct/
      */
     collation: Optional<Document>;
-
   }
 
 
@@ -773,8 +812,10 @@ Bulk Write Models
     replacement: Document;
 
     /**
-     * When true, creates a new document if no document matches the query. The default is false.
+     * When true, creates a new document if no document matches the query.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
@@ -804,8 +845,10 @@ Bulk Write Models
     update: Update;
 
     /**
-     * When true, creates a new document if no document matches the query. The default is false.
+     * When true, creates a new document if no document matches the query.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
@@ -835,7 +878,9 @@ Bulk Write Models
     update: Update;
 
     /**
-     * When true, creates a new document if no document matches the query. The default is false.
+     * When true, creates a new document if no document matches the query.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see http://docs.mongodb.org/manual/reference/command/update/
      */
@@ -1159,8 +1204,20 @@ Find And Modify
   class FindOneAndDeleteOptions {
     
     /**
+     * Specifies a collation.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     */
+    collation: Optional<Document>;
+
+    /**
      * The maximum amount of time to allow the query to run.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
      */ 
     maxTimeMS: Optional<Int64>;
@@ -1168,6 +1225,10 @@ Find And Modify
     /** 
      * Limits the fields to return for all matching documents.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * Note: this option is mapped to the "fields" findAndModify field.
+     *     
      * @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
      */
     projection: Optional<Document>;
@@ -1175,17 +1236,11 @@ Find And Modify
     /**
      * Determines which document the operation modifies if the query selects multiple documents.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
-
-    /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
-     *
-     * The default is no value: the driver sends no "collation" document to the
-     * server with the "findAndModify" command.
-     */
-    collation: Optional<Document>;
   }
 
   class FindOneAndReplaceOptions {
@@ -1193,22 +1248,36 @@ Find And Modify
     /**
      * If true, allows the write to opt-out of document level validation. 
      * 
-     * On servers >= 3.2, the default is to not send a value. no 
-     * "bypassDocumentValidation" option is sent with the "findAndModify" command.
-     *
-     * On servers < 3.2, this option is ignored.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
 
     /**
+     * Specifies a collation.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     */
+    collation: Optional<Document>;
+
+    /**
      * The maximum amount of time to allow the query to run.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
      */ 
     maxTimeMS: Optional<Int64>;
 
     /** 
      * Limits the fields to return for all matching documents.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * Note: this option is mapped to the "fields" findAndModify field.
      *
      * @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
      */
@@ -1216,8 +1285,12 @@ Find And Modify
 
     /**
      * When ReturnDocument.After, returns the replaced or inserted document rather than the original.
-     * Defaults to ReturnDocument.Before.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before is represents false, 
+     * and ReturnDocument.After represents true.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     returnDocument: Optional<ReturnDocument>;
@@ -1225,25 +1298,20 @@ Find And Modify
     /**
      * Determines which document the operation modifies if the query selects multiple documents.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
 
     /**
-     * When true, findAndModify creates a new document if no document matches the query. The
-     * default is false.
+     * When true, findAndModify creates a new document if no document matches the query.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     upsert: Optional<Boolean>;
-
-    /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
-     *
-     * The default is no value: the driver sends no "collation" document to the
-     * server with the "findAndModify" command.
-     */
-    collation: Optional<Document>;
   }
 
   class FindOneAndUpdateOptions {
@@ -1251,13 +1319,21 @@ Find And Modify
     /**
      * If true, allows the write to opt-out of document level validation. 
      * 
-     * On servers >= 3.2, the default is to not send a value. no 
-     * "bypassDocumentValidation" option is sent with the "findAndModify" command.
-     *
-     * On servers < 3.2, this option is ignored.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
     
+    /**
+     * Specifies a collation.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     */
+    collation: Optional<Document>;
+
     /**
      * The maximum amount of time to allow the query to run.
      *
@@ -1268,14 +1344,22 @@ Find And Modify
     /** 
      * Limits the fields to return for all matching documents.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * Note: this option is mapped to the "fields" findAndModify field.
+     *
      * @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
      */
     projection: Optional<Document>;
 
     /**
-     * When ReturnDocument.After, returns the updated or inserted document rather than the original.
-     * Defaults to ReturnDocument.Before.
+     * When ReturnDocument.After, returns the replaced or inserted document rather than the original.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
+     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before is represents false, 
+     * and ReturnDocument.After represents true.
+     *     
      * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     returnDocument: Optional<ReturnDocument>;
@@ -1283,24 +1367,20 @@ Find And Modify
     /**
      * Determines which document the operation modifies if the query selects multiple documents.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     *
      * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
 
     /**
-     * When true, creates a new document if no document matches the query. The default is false.
+     * When true, creates a new document if no document matches the query.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     upsert: Optional<Boolean>;
-
-    /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
-     *
-     * The default is no value: the driver sends no "collation" document to the
-     * server with the "findAndModify" command.
-     */
-    collation: Optional<Document>;
   }
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1362,7 +1442,6 @@ Q: Why do the names of the fields differ from those defined on docs.mongodb.org?
 
   In addition, responses from the servers are sometimes cryptic and used for the purposes of compactness. In these cases, we felt the more verbose form was desirable for self-documentation purposes.
 
-
 Q: Where is read preference?
   Read preference is about selecting a server with which to perform a read operation, such as a query, a count, or an aggregate. Since all operations defined in this specification are performed on a collection, it's uncommon that two different read operations on the same collection would use a different read preference, potentially getting out-of-sync results. As such, the most natural place to indicate read preference is on the client, the database, or the collection itself and not the operations within it.
 
@@ -1373,44 +1452,41 @@ Q: Where is read concern?
 
   However, it might be that a driver needs to expose read concern to a user per operation for various reasons. As noted before, it is permitted to specify this, along with other driver-specific options, in some alternative way.
 
-
 Q: Where is write concern?
   Write concern is about indicating how writes are acknowledged. Since all operations defined in this specification are performed on a collection, it's uncommon that two different write operations on the same collection would use a different write concern, potentially causing mismatched and out-of-sync data. As such, the most natural place to indicate write concern is on the client, the database, or the collection itself and not the operations within it.
 
   However, it might be that a driver needs to expose write concern to a user per operation for various reasons. As noted before, it is permitted to specify this, along with other driver-specific options, in some alternative way.
 
-
 Q: How do I throttle unacknowledged writes now that write concern is longer defined on a per operation basis?
   Some users used to throttle unacknowledged writes by using a write concern every X number of operations. The proper way to handle this on >= 2.6 servers is to use the bulk write API. Users working with servers < 2.6 should manually send a ``getLastError`` command every X number of operations if the driver does not support write concerns per operation.
-
 
 Q: What is the logic for adding "One" or "Many" into the method and model names?
   If the maximum number of documents affected can only be one, we added "One" into the name. This makes it explicit that the maximum number of documents that could be affected is one vs. infinite.
 
   In addition, the current API exposed by all our drivers has the default value for "one" or "many" set differently for update and delete. This generally causes some issues for new developers and is a minor annoyance for existing developers. The safest way to combat this without introducing discrepencies between drivers/driver versions or breaking backwards compatibility was to use multiple methods, each signifying the number of documents that could be affected.
 
-
 Q: Speaking of "One", where is ``findOne``?
   If your driver wishes to offer a ``findOne`` method, that is perfectly fine. If you choose to implement ``findOne``, please keep to the naming conventions followed by the ``FindOptions`` and keep in mind that certain things don't make sense like limit (which should be -1), tailable, awaitData, etc...
-
 
 Q: What considerations have been taken for the eventual merging of query and the aggregation framework?
   In the future, it is probable that a new query engine (QE) will look very much like the aggregation framework. Given this assumption, we know that both ``find`` and ``aggregate`` will be renderable in QE, each maintaining their ordering guarantees for full backwards compatibility.
 
   Hence, the only real concern is how to initiate a query using QE. While ``find`` is preferable, it would be a backwards breaking change. It might be decided that ``find`` is what should be used, and all drivers will release major revisions with this backwards breaking change. Alternatively, it might be decided that another initiator would be used.
 
-
 Q: Didn't we just build a bulk API?
   Yes, most drivers did just build out a bulk API (fluent-bulk-api). While unfortunate, we felt it better to have the bulk api be consistent with the rest of the methods in the CRUD family of operations. However, the fluent-bulk-api is still able to be used as this change is non-backwards breaking. Any driver which implemented the fluent bulk API should deprecate it and drivers that have not built it should not do so.
-
 
 Q: What about explain?
   Explain has been determined to be not a normal use-case for a driver. We'd like users to use the shell for this purpose. However, explain is still possible from a driver. For find, it can be passed as a modifier. Aggregate can be run using a runCommand method passing the explain option. In addition, server 3.0 offers an explain command that can be run using a runCommand method.
 
+Q: Where did modifiers go in FindOptions?
+  MongoDB 3.2 introduced the find command. As opposed to using the general "modifiers" field any longer, each relevant option is listed explicitly. Some options, such as "tailable" or "singleBatch" are not listed as they are derived from other fields. Upgrading a driver should be a simple procedure of deprecating the "modifiers" field and introducing the new fields. When a collision occurs, the explicitly specified field should override the value in "modifiers". 
 
 Changes
 =======
 
+* 2016-08-17: Removed modifiers from FindOptions and added in all options.
+* 2016-08-17: Reworded description of how default values are handled and when to send certain options.
 * 2016-08-05: Added in collation option.
 * 2015-11-05: Typos in comments about bypassDocumentValidation
 * 2015-10-16: Added maxAwaitTimeMS to FindOptions.

--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -381,7 +381,7 @@ Read
      * the tailable and awaitData options.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, the AwaitData and Tailable wire protocol flag are used and default to false.
+     * For servers < 3.2, the AwaitData and Tailable wire protocol flags are used and default to false.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
      */
@@ -1279,7 +1279,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * Note: this option is mapped to the "fields" findAndModify field.
+     * Note: this option is mapped to the "fields" findAndModify command option.
      *
      * @see https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results
      */
@@ -1329,7 +1329,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * Note: this option is mapped to the "fields" findAndModify field.
+     * Note: this option is mapped to the "fields" findAndModify command option.
      *
      * @see https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results
      */
@@ -1398,7 +1398,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * Note: this option is mapped to the "fields" findAndModify field.
+     * Note: this option is mapped to the "fields" findAndModify command option.
      *
      * @see https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results
      */
@@ -1409,7 +1409,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before is represents false,
+     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before represents false,
      * and ReturnDocument.After represents true.
      *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
@@ -1489,8 +1489,8 @@ If a driver needs to refer to items in the following list, the below are the acc
 Q & A
 =====
 
-Q: Why do the names of the fields differ from those defined on docs.mongodb.com?
-  documentation and commands often refer to same-purposed fields with different names making it difficult to have a cohesive API. In addition, occasionally the name was correct at one point and its purpose has expanded to a point where the initial name doesn't accurately describe its current function.
+Q: Why do the names of the fields differ from those defined in the MongoDB manual?
+  Documentation and commands often refer to same-purposed fields with different names making it difficult to have a cohesive API. In addition, occasionally the name was correct at one point and its purpose has expanded to a point where the initial name doesn't accurately describe its current function.
 
   In addition, responses from the servers are sometimes cryptic and used for the purposes of compactness. In these cases, we felt the more verbose form was desirable for self-documentation purposes.
 

--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -95,7 +95,7 @@ A non-exhaustive list of acceptable deviations are as follows:
 Naming
 ------
 
-All drivers MUST name operations, objects, and parameters as defined in the following sections. 
+All drivers MUST name operations, objects, and parameters as defined in the following sections.
 
 Deviations are permitted as outlined below.
 
@@ -122,11 +122,11 @@ Read
 ----
 
 .. note::
-    
-    The term Iterable<T> is used below to indicate many of T. This spec is flexible on what that means as different drivers will have different requirements, types, and idioms. 
+
+    The term Iterable<T> is used below to indicate many of T. This spec is flexible on what that means as different drivers will have different requirements, types, and idioms.
 
 .. code:: typescript
-  
+
   interface Collection {
 
     /**
@@ -149,7 +149,7 @@ Read
     count(filter: Document, options: Optional<CountOptions>): Int64;
 
     /**
-     * Finds the distinct values for a specified field across a single collection. 
+     * Finds the distinct values for a specified field across a single collection.
      *
      * @see https://docs.mongodb.com/manual/reference/command/distinct/
      */
@@ -159,11 +159,11 @@ Read
      * Finds the documents matching the model.
      *
      * Note: The filter parameter below equates to the $query meta operator. It cannot
-     * contain other meta operators like $maxScan. However, do not validate this document 
+     * contain other meta operators like $maxScan. However, do not validate this document
      * as it would be impossible to be forwards and backwards compatible. Let the server
      * handle the validation.
      *
-     * Note: If $explain is specified in the modifiers, the return value is a single 
+     * Note: If $explain is specified in the modifiers, the return value is a single
      * document. This could cause problems for static languages using strongly typed entities.
      *
      * @see https://docs.mongodb.com/manual/core/read-operations-introduction/
@@ -175,30 +175,30 @@ Read
   class AggregateOptions {
 
     /**
-     * Enables writing to temporary files. When set to true, aggregation stages 
+     * Enables writing to temporary files. When set to true, aggregation stages
      * can write data to the _tmp subdirectory in the dbPath directory.
      *
-     * This option is sent only if the caller explicitly provides a value. The default 
+     * This option is sent only if the caller explicitly provides a value. The default
      * is to not send a value.
-     * 
+     *
      * @see https://docs.mongodb.com/manual/reference/command/aggregate/
-     */ 
+     */
     allowDiskUse: Optional<Boolean>;
 
     /**
-     * The number of documents to return per batch. 
+     * The number of documents to return per batch.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 2.6, this option is ignored and should not be sent as aggregation cursors are not available.
      *
      * @see https://docs.mongodb.com/manual/reference/command/aggregate/
-     */ 
+     */
     batchSize: Optional<Int32>;
 
     /**
      * If true, allows the write to opt-out of document level validation. This only applies
      * when the $out stage is specified.
-     * 
+     *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      *
@@ -215,20 +215,20 @@ Read
      * @see https://docs.mongodb.com/manual/reference/command/aggregate/
      */
     collation: Optional<Document>;
-    
+
     /**
      * The maximum amount of time to allow the query to run.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see https://docs.mongodb.com/manual/reference/command/aggregate/
-     */ 
+     */
     maxTimeMS: Optional<Int64>;
 
     /**
      * Indicates whether the command will request that the server provide results using a cursor.
      *
-     * If true, this option is sent with a value of "cursor: {}". The default value is true. 
+     * If true, this option is sent with a value of "cursor: {}". The default value is true.
      * For servers < 2.6, this option is ignored and not sent as aggregation cursors are not available.
      *
      * @see https://docs.mongodb.com/manual/reference/command/aggregate/
@@ -313,11 +313,11 @@ Read
      */
     NON_TAILABLE,
     /**
-     * Tailable means the cursor is not closed when the last data is retrieved. 
-     * Rather, the cursor marks the final object’s position. You can resume 
-     * using the cursor later, from where it was located, if more data were 
-     * received. Like any “latent cursor”, the cursor may become invalid at 
-     * some point (CursorNotFound) – for example if the final object it 
+     * Tailable means the cursor is not closed when the last data is retrieved.
+     * Rather, the cursor marks the final object’s position. You can resume
+     * using the cursor later, from where it was located, if more data were
+     * received. Like any “latent cursor”, the cursor may become invalid at
+     * some point (CursorNotFound) – for example if the final object it
      * references were deleted.
      *
      * @see https://docs.mongodb.com/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
@@ -346,7 +346,7 @@ Read
      * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     allowPartialResults: Optional<Boolean>;
-    
+
     /**
      * The number of documents to return per batch.
      *
@@ -354,7 +354,7 @@ Read
      * For servers < 3.2, this is combined with limit to create the wire protocol numberToReturn value.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
-     */ 
+     */
     batchSize: Optional<Int32>;
 
     /**
@@ -373,7 +373,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
-     */ 
+     */
     comment: Optional<String>;
 
     /**
@@ -416,14 +416,14 @@ Read
     max: Optional<Document>;
 
     /**
-     * The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor 
+     * The maximum amount of time for the server to wait on new documents to satisfy a tailable cursor
      * query. This only applies to a TAILABLE_AWAIT cursor. When the cursor is not a TAILABLE_AWAIT cursor,
      * this option is ignored.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.2, this option is ignored and not sent as maxTimeMS does not exist in the get more wire protocol.
      *
-     * Note: This option is specified as "maxTimeMS" in the getMore command and not provided as part of the 
+     * Note: This option is specified as "maxTimeMS" in the getMore command and not provided as part of the
      * initial find command.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
@@ -458,7 +458,7 @@ Read
     min: Optional<Document>;
 
     /**
-     * The server normally times out idle cursors after an inactivity period (10 minutes) 
+     * The server normally times out idle cursors after an inactivity period (10 minutes)
      * to prevent excess memory use. Set this option to prevent that.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
@@ -478,7 +478,7 @@ Read
      */
     oplogReplay: Optional<Boolean>;
 
-    /** 
+    /**
      * Limits the fields to return for all matching documents.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
@@ -487,7 +487,7 @@ Read
      */
     projection: Optional<Document>;
 
-    /** 
+    /**
      * If true, returns only the index keys in the resulting documents.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
@@ -496,7 +496,7 @@ Read
      */
     returnKey: Optional<Document>;
 
-    /** 
+    /**
      * Determines whether to return the record identifier for each document. If true, adds a field $recordId to the returned documents.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
@@ -515,7 +515,7 @@ Read
      */
     skip: Optional<Int64>;
 
-    /** 
+    /**
      * Determines whether to return the record identifier for each document. If true, adds a field $recordId to the returned documents.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
@@ -530,7 +530,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
-     */ 
+     */
     sort: Optional<Document>;
   }
 
@@ -582,7 +582,7 @@ Basic
     /**
      * Sends a batch of writes to the server at the same time.
      *
-     * For servers < 3.4, if a collation was explicitly set for any request, an error MUST be raised 
+     * For servers < 3.4, if a collation was explicitly set for any request, an error MUST be raised
      * and no documents sent.
      *
      * NOTE: see the FAQ about the previous bulk API and how it relates to this.
@@ -633,7 +633,7 @@ Basic
 
     /**
      * Replaces a single document.
-     * 
+     *
      * @see https://docs.mongodb.com/manual/reference/command/update/
      * @throws WriteException
      */
@@ -641,7 +641,7 @@ Basic
 
     /**
      * Updates one document.
-     * 
+     *
      * @see https://docs.mongodb.com/manual/reference/command/update/
      * @throws WriteException
      */
@@ -649,7 +649,7 @@ Basic
 
     /**
      * Updates multiple documents.
-     * 
+     *
      * @see https://docs.mongodb.com/manual/reference/command/update/
      * @throws WriteException
      */
@@ -659,15 +659,15 @@ Basic
   class BulkWriteOptions {
 
     /**
-     * If true, when a write fails, return without performing the remaining 
-     * writes. If false, when a write fails, continue with the remaining writes, if any. 
+     * If true, when a write fails, return without performing the remaining
+     * writes. If false, when a write fails, continue with the remaining writes, if any.
      * Defaults to true.
      */
     ordered: Boolean;
 
     /**
      * If true, allows the write to opt-out of document level validation.
-     * 
+     *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
@@ -679,7 +679,7 @@ Basic
 
     /**
      * If true, allows the write to opt-out of document level validation.
-     * 
+     *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
@@ -691,7 +691,7 @@ Basic
 
     /**
      * If true, allows the write to opt-out of document level validation.
-     * 
+     *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
@@ -699,8 +699,8 @@ Basic
     bypassDocumentValidation: Optional<Boolean>;
 
     /**
-     * If true, when an insert fails, return without performing the remaining 
-     * writes. If false, when a write fails, continue with the remaining writes, if any. 
+     * If true, when an insert fails, return without performing the remaining
+     * writes. If false, when a write fails, continue with the remaining writes, if any.
      * Defaults to true.
      */
     ordered: Boolean;
@@ -710,7 +710,7 @@ Basic
 
     /**
      * If true, allows the write to opt-out of document level validation.
-     * 
+     *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
@@ -732,7 +732,7 @@ Basic
      * When true, creates a new document if no document matches the query.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
@@ -763,7 +763,7 @@ Bulk Write Models
   }
 
   class InsertOneModel implements WriteModel {
-    
+
     /**
      * The document to insert.
      *
@@ -845,7 +845,7 @@ Bulk Write Models
      * When true, creates a new document if no document matches the query.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
@@ -859,7 +859,7 @@ Bulk Write Models
   }
 
   class UpdateOneModel implements WriteModel {
-    
+
     /**
      * The filter to limit the updated documents.
      *
@@ -889,7 +889,7 @@ Bulk Write Models
      * When true, creates a new document if no document matches the query.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
@@ -903,7 +903,7 @@ Bulk Write Models
   }
 
   class UpdateManyModel implements WriteModel {
-    
+
     /**
      * The filter to limit the updated documents.
      *
@@ -950,7 +950,7 @@ Bulk Write Models
 Results
 ~~~~~~~
 
-The acknowledged property is defined for languages/frameworks without a sufficient optional type. Hence, a driver may choose to return an Optional<BulkWriteResult> such that unacknowledged writes don't have a value and acknowledged writes do have a value. 
+The acknowledged property is defined for languages/frameworks without a sufficient optional type. Hence, a driver may choose to return an Optional<BulkWriteResult> such that unacknowledged writes don't have a value and acknowledged writes do have a value.
 
 .. note::
     If you have a choice, consider providing the acknowledged member and raising an error if the other fields are accessed in an unacknowledged write. Instead of users receiving a null reference exception, you have the opportunity to provide an informative error message indicating the correct way to handle the situation. For instance, "The insertedCount member is not available when the write was unacknowledged. Check the acknowledged member to avoid this error."
@@ -958,7 +958,7 @@ The acknowledged property is defined for languages/frameworks without a sufficie
 Any result class with all parameters marked NOT REQUIRED is ultimately NOT REQUIRED as well. For instance, the ``InsertOneResult`` has all NOT REQUIRED parameters and is therefore also NOT REQUIRED allowing a driver to use "void" as the return value for the ``insertOne`` method.
 
 .. code:: typescript
-  
+
   class BulkWriteResult {
 
     /**
@@ -1167,7 +1167,7 @@ Below are defined the exceptions that should be thrown from the various write me
 
     /**
      * The error that occurred on account of write concern failure.
-     */ 
+     */
     writeConcernError: Optional<WriteConcernError>;
 
     /**
@@ -1195,7 +1195,7 @@ Below are defined the exceptions that should be thrown from the various write me
 
     /**
      * The error that occured on account of write concern failure. If the error was a Write Concern related, this field must be present.
-     */ 
+     */
     writeConcernError: Optional<WriteConcernError>;
 
     /**
@@ -1211,12 +1211,12 @@ Find And Modify
 ~~~~~~~~~~~~~~~
 
 .. code:: typescript
-  
+
   interface Collection {
 
     /**
      * Finds a single document and deletes it, returning the original. The document to return may be null.
-     * 
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      * @throws WriteException
      */
@@ -1225,7 +1225,7 @@ Find And Modify
     /**
      * Finds a single document and replaces it, returning either the original or the replaced
      * document. The document to return may be null.
-     * 
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      * @throws WriteException
      */
@@ -1234,7 +1234,7 @@ Find And Modify
     /**
      * Finds a single document and updates it, returning either the original or the updated
      * document. The document to return may be null.
-     * 
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      * @throws WriteException
      */
@@ -1254,7 +1254,7 @@ Find And Modify
   }
 
   class FindOneAndDeleteOptions {
-    
+
     /**
      * Specifies a collation.
      *
@@ -1269,18 +1269,18 @@ Find And Modify
      * The maximum amount of time to allow the query to run.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
-     */ 
+     */
     maxTimeMS: Optional<Int64>;
 
-    /** 
+    /**
      * Limits the fields to return for all matching documents.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
      * Note: this option is mapped to the "fields" findAndModify field.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/tutorial/project-fields-from-query-results
      */
     projection: Optional<Document>;
@@ -1289,17 +1289,17 @@ Find And Modify
      * Determines which document the operation modifies if the query selects multiple documents.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
   }
 
   class FindOneAndReplaceOptions {
-    
+
     /**
-     * If true, allows the write to opt-out of document level validation. 
-     * 
+     * If true, allows the write to opt-out of document level validation.
+     *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      */
@@ -1319,12 +1319,12 @@ Find And Modify
      * The maximum amount of time to allow the query to run.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
-     */ 
+     */
     maxTimeMS: Optional<Int64>;
 
-    /** 
+    /**
      * Limits the fields to return for all matching documents.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
@@ -1340,9 +1340,9 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before represents false, 
+     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before represents false,
      * and ReturnDocument.After represents true.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     returnDocument: Optional<ReturnDocument>;
@@ -1351,7 +1351,7 @@ Find And Modify
      * Determines which document the operation modifies if the query selects multiple documents.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
@@ -1360,22 +1360,22 @@ Find And Modify
      * When true, findAndModify creates a new document if no document matches the query.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     upsert: Optional<Boolean>;
   }
 
   class FindOneAndUpdateOptions {
-    
+
     /**
-     * If true, allows the write to opt-out of document level validation. 
-     * 
+     * If true, allows the write to opt-out of document level validation.
+     *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
-    
+
     /**
      * Specifies a collation.
      *
@@ -1390,10 +1390,10 @@ Find And Modify
      * The maximum amount of time to allow the query to run.
      *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
-     */ 
+     */
     maxTimeMS: Optional<Int64>;
-    
-    /** 
+
+    /**
      * Limits the fields to return for all matching documents.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
@@ -1409,9 +1409,9 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before is represents false, 
+     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before is represents false,
      * and ReturnDocument.After represents true.
-     *     
+     *
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     returnDocument: Optional<ReturnDocument>;
@@ -1532,7 +1532,7 @@ Q: What about explain?
   Explain has been determined to be not a normal use-case for a driver. We'd like users to use the shell for this purpose. However, explain is still possible from a driver. For find, it can be passed as a modifier. Aggregate can be run using a runCommand method passing the explain option. In addition, server 3.0 offers an explain command that can be run using a runCommand method.
 
 Q: Where did modifiers go in FindOptions?
-  MongoDB 3.2 introduced the find command. As opposed to using the general "modifiers" field any longer, each relevant option is listed explicitly. Some options, such as "tailable" or "singleBatch" are not listed as they are derived from other fields. Upgrading a driver should be a simple procedure of deprecating the "modifiers" field and introducing the new fields. When a collision occurs, the explicitly specified field should override the value in "modifiers". 
+  MongoDB 3.2 introduced the find command. As opposed to using the general "modifiers" field any longer, each relevant option is listed explicitly. Some options, such as "tailable" or "singleBatch" are not listed as they are derived from other fields. Upgrading a driver should be a simple procedure of deprecating the "modifiers" field and introducing the new fields. When a collision occurs, the explicitly specified field should override the value in "modifiers".
 
 Changes
 =======

--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -137,21 +137,21 @@ Read
      * MAY setup a cursor to be executed upon iteration against the $out collection such
      * that if a user were to iterate a pipeline including $out, results would be returned.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
      */
     aggregate(pipeline: Document[], options: Optional<AggregateOptions>): Iterable<Document>;
 
     /**
      * Gets the number of documents matching the filter.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.org/manual/reference/command/count/
      */
     count(filter: Document, options: Optional<CountOptions>): Int64;
 
     /**
      * Finds the distinct values for a specified field across a single collection. 
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.org/manual/reference/command/distinct/
      */
     distinct(fieldName: string, filter: Document, options: Optional<DistinctOptions>): Iterable<any>;
 
@@ -166,7 +166,7 @@ Read
      * Note: If $explain is specified in the modifiers, the return value is a single 
      * document. This could cause problems for static languages using strongly typed entities.
      *
-     * @see http://docs.mongodb.org/manual/core/read-operations-introduction/
+     * @see https://docs.mongodb.org/manual/core/read-operations-introduction/
      */
     find(filter: Document, options: Optional<FindOptions>): Iterable<Document>;
 
@@ -181,7 +181,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default 
      * is to not send a value.
      * 
-     * @see http://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
      */ 
     allowDiskUse: Optional<Boolean>;
 
@@ -191,7 +191,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 2.6, this option is ignored and should not be sent as aggregation cursors are not available.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
      */ 
     batchSize: Optional<Int32>;
 
@@ -200,17 +200,19 @@ Read
      * when the $out stage is specified.
      * 
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
+     * For servers < 3.2, this option is ignored and not sent as document validation is not available.
+     *
+     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
      */
     bypassDocumentValidation: Optional<Boolean>;
 
     /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
+     * Specifies a collation.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
      */
     collation: Optional<Document>;
     
@@ -219,7 +221,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
      */ 
     maxTimeMS: Optional<Int64>;
 
@@ -229,7 +231,7 @@ Read
      * If true, this option is sent with a value of "cursor: {}". The default value is true. 
      * For servers < 2.6, this option is ignored and not sent as aggregation cursors are not available.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/aggregate/
+     * @see https://docs.mongodb.org/manual/reference/command/aggregate/
      */
     useCursor: Optional<Boolean>;
   }
@@ -242,7 +244,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.org/manual/reference/command/count/
      */
     collation: Optional<Document>;
 
@@ -251,7 +253,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.org/manual/reference/command/count/
      */
     hint: Optional<(String | Document)>;
 
@@ -260,7 +262,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.org/manual/reference/command/count/
      */
     limit: Optional<Int64>;
 
@@ -269,7 +271,7 @@ Read
 
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.org/manual/reference/command/count/
      */
     maxTimeMS: Optional<Int64>;
 
@@ -278,7 +280,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/count/
+     * @see https://docs.mongodb.org/manual/reference/command/count/
      */
     skip: Optional<Int64>;
   }
@@ -291,7 +293,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.org/manual/reference/command/distinct/
      */
     collation: Optional<Document>;
 
@@ -300,7 +302,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.org/manual/reference/command/distinct/
      */
     maxTimeMS: Optional<Int64>;
   }
@@ -318,7 +320,7 @@ Read
      * some point (CursorNotFound) – for example if the final object it 
      * references were deleted.
      *
-     * @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
+     * @see https://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
      */
     TAILABLE,
     /**
@@ -328,7 +330,7 @@ Read
      * while rather than returning no data. After a timeout period, we do return
      * as normal. The default is true.
      *
-     * @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
+     * @see https://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
      */
     TAILABLE_AWAIT
   }
@@ -339,7 +341,7 @@ Read
      * Get partial results from a mongos if some shards are down (instead of throwing an error).
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, the Partial wire protocol flag defaults to false.
+     * For servers < 3.2, the Partial wire protocol flag is used and defaults to false.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
      */
@@ -361,7 +363,7 @@ Read
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.org/manual/reference/command/find/
      */
     collation: Optional<Document>;
 
@@ -379,9 +381,9 @@ Read
      * the tailable and awaitData options.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, the AwaitData wire protocol flag and the Tailable wire protocol flag default to false.
+     * For servers < 3.2, the AwaitData and Tailable wire protocol flag are used and default to false.
      *
-     * @see http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/#op-query
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     cursorType: Optional<CursorType>;
 
@@ -409,7 +411,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.com/manual/reference/method/cursor.max/#cursor.max
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     max: Optional<Document>;
 
@@ -433,7 +435,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.com/manual/reference/method/cursor.max/#cursor.max
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     maxScan: Optional<Int64>;
 
@@ -451,7 +453,7 @@ Read
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see https://docs.mongodb.com/manual/reference/method/cursor.min/#cursor.min
+     * @see https://docs.mongodb.com/manual/reference/command/find/
      */
     min: Optional<Document>;
 
@@ -460,7 +462,7 @@ Read
      * to prevent excess memory use. Set this option to prevent that.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, the NoCursorTimeout wire protocol flag defaults to false.
+     * For servers < 3.2, the NoCursorTimeout wire protocol flag is used and defaults to false.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
      */
@@ -470,7 +472,7 @@ Read
      * Internal replication use only - driver should not set
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, the OplogReplay wire protocol flag defaults to false.
+     * For servers < 3.2, the OplogReplay wire protocol flag is used and defaults to false.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
      */
@@ -540,7 +542,7 @@ The OP_QUERY wire protocol only contains a numberToReturn value which drivers mu
 
 .. code:: typescript
 
-  function calculateFirstNumberToReturn(FindOptions options) Int32 {
+  function calculateFirstNumberToReturn(options: FindOptions): Int32 {
     Int32 numberToReturn;
     Int32 limit = options.limit || 0;
     Int32 batchSize = options.batchSize || 0;
@@ -580,10 +582,13 @@ Basic
     /**
      * Sends a batch of writes to the server at the same time.
      *
+     * For servers < 3.4, if a collation was explicitly set for any request, an error MUST be raised 
+     * and no documents sent.
+     *
      * NOTE: see the FAQ about the previous bulk API and how it relates to this.
-     * @see http://docs.mongodb.org/manual/reference/command/delete/
-     * @see http://docs.mongodb.org/manual/reference/command/insert/
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.org/manual/reference/command/insert/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      * @throws BulkWriteException
      */
     bulkWrite(requests: WriteModel[], options: Optional<BulkWriteOptions>): BulkWriteResult;
@@ -592,7 +597,7 @@ Basic
      * Inserts the provided document. If the document is missing an identifier,
      * the driver should generate one.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/insert/
+     * @see https://docs.mongodb.org/manual/reference/command/insert/
      * @throws WriteException
      */
     insertOne(document: Document, options: Optional<InsertOneOptions>): InsertOneResult;
@@ -605,7 +610,7 @@ Basic
      * use OP_INSERT. This will be slow on < 2.6 servers, so document
      * your driver appropriately.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/insert/
+     * @see https://docs.mongodb.org/manual/reference/command/insert/
      * @throws BulkWriteException
      */
     insertMany(Iterable<Document> documents, options: Optional<InsertManyOptions>): InsertManyResult;
@@ -613,7 +618,7 @@ Basic
     /**
      * Deletes one document.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.org/manual/reference/command/delete/
      * @throws WriteException
      */
     deleteOne(filter: Document, options: Optional<DeleteOptions>): DeleteResult;
@@ -621,7 +626,7 @@ Basic
     /**
      * Deletes multiple documents.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.org/manual/reference/command/delete/
      * @throws WriteException
      */
     deleteMany(filter: Document, options: Optional<DeleteOptions>): DeleteResult;
@@ -629,7 +634,7 @@ Basic
     /**
      * Replaces a single document.
      * 
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      * @throws WriteException
      */
     replaceOne(filter: Document, replacement: Document, options: Optional<UpdateOptions>): UpdateResult;
@@ -637,7 +642,7 @@ Basic
     /**
      * Updates one document.
      * 
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      * @throws WriteException
      */
     updateOne(filter: Document, update: Document, options: Optional<UpdateOptions>): UpdateResult;
@@ -645,7 +650,7 @@ Basic
     /**
      * Updates multiple documents.
      * 
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      * @throws WriteException
      */
     updateMany(filter: Document, update: Document, options: Optional<UpdateOptions>): UpdateResult;
@@ -661,10 +666,11 @@ Basic
     ordered: Boolean;
 
     /**
-     * If true, allows the write to opt-out of document level validation. 
+     * If true, allows the write to opt-out of document level validation.
      * 
-     * For servers >= 3.2, this option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as document validation is not available.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      */
     bypassDocumentValidation: Optional<Boolean>;
   }
@@ -672,10 +678,11 @@ Basic
   class InsertOneOptions {
 
     /**
-     * If true, allows the write to opt-out of document level validation. 
+     * If true, allows the write to opt-out of document level validation.
      * 
-     * For servers >= 3.2, this option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as document validation is not available.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      */
     bypassDocumentValidation: Optional<Boolean>;
   }
@@ -683,10 +690,11 @@ Basic
   class InsertManyOptions {
 
     /**
-     * If true, allows the write to opt-out of document level validation. 
+     * If true, allows the write to opt-out of document level validation.
      * 
-     * For servers >= 3.2, this option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as document validation is not available.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      */
     bypassDocumentValidation: Optional<Boolean>;
 
@@ -701,10 +709,11 @@ Basic
   class UpdateOptions
 
     /**
-     * If true, allows the write to opt-out of document level validation. 
+     * If true, allows the write to opt-out of document level validation.
      * 
-     * For servers >= 3.2, this option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.2, this option is ignored and not sent as document validation is not available.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      */
     bypassDocumentValidation: Optional<Boolean>;
 
@@ -713,8 +722,9 @@ Basic
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     collation: Optional<Document>;
 
@@ -723,7 +733,7 @@ Basic
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
   }
@@ -735,8 +745,9 @@ Basic
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.org/manual/reference/command/delete/
      */
     collation: Optional<Document>;
   }
@@ -756,7 +767,7 @@ Bulk Write Models
     /**
      * The document to insert.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/insert/
+     * @see https://docs.mongodb.org/manual/reference/command/insert/
      */
     document: Document;
   }
@@ -766,16 +777,20 @@ Bulk Write Models
     /**
      * The filter to limit the deleted documents.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.org/manual/reference/command/delete/
      */
     filter: Document;
 
     /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
+     * Specifies a collation.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see https://docs.mongodb.org/manual/reference/command/delete/
      */
     collation: Optional<Document>;
-
   }
 
   class DeleteManyModel implements WriteModel {
@@ -783,16 +798,20 @@ Bulk Write Models
     /**
      * The filter to limit the deleted documents.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/delete/
+     * @see https://docs.mongodb.org/manual/reference/command/delete/
      */
     filter: Document;
 
     /**
-     * Optionally specifies a collation to use in MongoDB 3.4 and higher.
+     * Specifies a collation.
      *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see https://docs.mongodb.org/manual/reference/command/delete/
      */
     collation: Optional<Document>;
-
   }
 
   class ReplaceOneModel implements WriteModel {
@@ -800,23 +819,34 @@ Bulk Write Models
     /**
      * The filter to limit the replaced document.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     filter: Document;
 
     /**
      * The document with which to replace the matched document.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     replacement: Document;
+
+    /**
+     * Specifies a collation.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see https://docs.mongodb.org/manual/reference/command/update/
+     */
+    collation: Optional<Document>;
 
     /**
      * When true, creates a new document if no document matches the query.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
 
@@ -833,23 +863,34 @@ Bulk Write Models
     /**
      * The filter to limit the updated documents.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     filter: Document;
 
     /**
      * A document containing update operators.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     update: Update;
+
+    /**
+     * Specifies a collation.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see https://docs.mongodb.org/manual/reference/command/update/
+     */
+    collation: Optional<Document>;
 
     /**
      * When true, creates a new document if no document matches the query.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
 
@@ -866,23 +907,34 @@ Bulk Write Models
     /**
      * The filter to limit the updated documents.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     filter: Document;
 
     /**
      * A document containing update operators.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     update: Update;
+
+    /**
+     * Specifies a collation.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see https://docs.mongodb.org/manual/reference/command/update/
+     */
+    collation: Optional<Document>;
 
     /**
      * When true, creates a new document if no document matches the query.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/update/
+     * @see https://docs.mongodb.org/manual/reference/command/update/
      */
     upsert: Optional<Boolean>;
 
@@ -1055,21 +1107,21 @@ Below are defined the exceptions that should be thrown from the various write me
     /**
      * An integer value identifying the write concern error.
      *
-     * @see http://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
      */
     code: Int32;
 
     /**
      * A document identifying the write concern setting related to the error.
      *
-     * @see http://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
      */
     details: Document;
 
     /**
      * A description of the error.
      *
-     * @see http://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
      */
     message: String;
 
@@ -1080,14 +1132,14 @@ Below are defined the exceptions that should be thrown from the various write me
     /**
      * An integer value identifying the error.
      *
-     * @see http://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
      */
     code: Int32;
 
     /**
      * A description of the error.
      *
-     * @see http://docs.mongodb.org/manual/reference/method/WriteResult/
+     * @see https://docs.mongodb.org/manual/reference/method/WriteResult/
      */
     message: String;
 
@@ -1165,7 +1217,7 @@ Find And Modify
     /**
      * Finds a single document and deletes it, returning the original. The document to return may be null.
      * 
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      * @throws WriteException
      */
     findOneAndDelete(filter: Document, options: Optional<FindOneAndDeleteOptions>): Document;
@@ -1174,7 +1226,7 @@ Find And Modify
      * Finds a single document and replaces it, returning either the original or the replaced
      * document. The document to return may be null.
      * 
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      * @throws WriteException
      */
     findOneAndReplace(filter: Document, replacement: Document, options: Optional<FindOneAndReplaceOptions>): Document;
@@ -1183,7 +1235,7 @@ Find And Modify
      * Finds a single document and updates it, returning either the original or the updated
      * document. The document to return may be null.
      * 
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      * @throws WriteException
      */
     findOneAndUpdate(filter: Document, update: Document, options: Optional<FindOneAndUpdateOptions>): Document;
@@ -1209,7 +1261,7 @@ Find And Modify
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     collation: Optional<Document>;
 
@@ -1218,7 +1270,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */ 
     maxTimeMS: Optional<Int64>;
 
@@ -1229,7 +1281,7 @@ Find And Modify
      *
      * Note: this option is mapped to the "fields" findAndModify field.
      *     
-     * @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
+     * @see https://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
      */
     projection: Optional<Document>;
 
@@ -1238,7 +1290,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
   }
@@ -1249,7 +1301,7 @@ Find And Modify
      * If true, allows the write to opt-out of document level validation. 
      * 
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
+     * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
 
@@ -1259,7 +1311,7 @@ Find And Modify
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     collation: Optional<Document>;
 
@@ -1268,7 +1320,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */ 
     maxTimeMS: Optional<Int64>;
 
@@ -1279,7 +1331,7 @@ Find And Modify
      *
      * Note: this option is mapped to the "fields" findAndModify field.
      *
-     * @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
+     * @see https://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
      */
     projection: Optional<Document>;
 
@@ -1288,10 +1340,10 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before is represents false, 
+     * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before represents false, 
      * and ReturnDocument.After represents true.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     returnDocument: Optional<ReturnDocument>;
 
@@ -1300,7 +1352,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
 
@@ -1309,7 +1361,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     upsert: Optional<Boolean>;
   }
@@ -1320,7 +1372,7 @@ Find And Modify
      * If true, allows the write to opt-out of document level validation. 
      * 
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
-     * For servers < 3.2, this option is ignored and not sent as documentation validation is not available.
+     * For servers < 3.2, this option is ignored and not sent as document validation is not available.
      */
     bypassDocumentValidation: Optional<Boolean>;
     
@@ -1330,14 +1382,14 @@ Find And Modify
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.4, the driver MUST raise an error if the caller explicitly provides a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/distinct/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     collation: Optional<Document>;
 
     /**
      * The maximum amount of time to allow the query to run.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */ 
     maxTimeMS: Optional<Int64>;
     
@@ -1348,7 +1400,7 @@ Find And Modify
      *
      * Note: this option is mapped to the "fields" findAndModify field.
      *
-     * @see http://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
+     * @see https://docs.mongodb.org/manual/tutorial/project-fields-from-query-results
      */
     projection: Optional<Document>;
 
@@ -1360,7 +1412,7 @@ Find And Modify
      * Note: this option is mapped to the "new" findAndModify boolean field. ReturnDocument.Before is represents false, 
      * and ReturnDocument.After represents true.
      *     
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     returnDocument: Optional<ReturnDocument>;
 
@@ -1369,7 +1421,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     sort: Optional<Document>;
 
@@ -1378,7 +1430,7 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      *
-     * @see http://docs.mongodb.org/manual/reference/command/findAndModify/
+     * @see https://docs.mongodb.org/manual/reference/command/findAndModify/
      */
     upsert: Optional<Boolean>;
   }
@@ -1438,7 +1490,7 @@ Q & A
 =====
 
 Q: Why do the names of the fields differ from those defined on docs.mongodb.org?
-  Documentation and commands often refer to same-purposed fields with different names making it difficult to have a cohesive API. In addition, occasionally the name was correct at one point and its purpose has expanded to a point where the initial name doesn't accurately describe its current function.
+  documentation and commands often refer to same-purposed fields with different names making it difficult to have a cohesive API. In addition, occasionally the name was correct at one point and its purpose has expanded to a point where the initial name doesn't accurately describe its current function.
 
   In addition, responses from the servers are sometimes cryptic and used for the purposes of compactness. In these cases, we felt the more verbose form was desirable for self-documentation purposes.
 
@@ -1486,7 +1538,9 @@ Changes
 =======
 
 * 2016-08-17: Removed modifiers from FindOptions and added in all options.
+* 2016-08-17: Changed the value type of FindOptions.skip and FindOptions.limit to Int64 with a note related to calculating batchSize for opcode writes.
 * 2016-08-17: Reworded description of how default values are handled and when to send certain options.
+* 2016-08-17: Included collation option in the bulk write models and removed it from bulk write.
 * 2016-08-05: Added in collation option.
 * 2015-11-05: Typos in comments about bypassDocumentValidation
 * 2015-10-16: Added maxAwaitTimeMS to FindOptions.


### PR DESCRIPTION
Supersedes https://github.com/mongodb/specifications/pull/102.