### PR TITLE
% is valid character in user information

### DIFF
--- a/source/connection-string/connection-string-spec.rst
+++ b/source/connection-string/connection-string-spec.rst
@@ -71,7 +71,7 @@ A password may be supplied as part of the user information and is anything after
 
 If the username section contains a percent sign ("%"), an at-sign ("@") or a colon (":") it MUST be URL encoded.
 
-If the user information contains a percent sign ("%"), an at-sign ("@") or more than one colon (":") then an exception MUST be thrown informing the user that the username and password must be URL encoded.
+If the user information contains an at-sign ("@") or more than one colon (":") then an exception MUST be thrown informing the user that the username and password must be URL encoded.
 
 ----------------
 Host Information


### PR DESCRIPTION
The spec requires usernames that contain % @ and : to be URL encoded.
It then goes on to say % @ and more-than-one : is prohibited in user information.

URL encoded % still contains % (%25) so % is acceptable character