### PR TITLE
Extended JSON test case for NaN with payload is lossy.

### DIFF
--- a/source/bson-corpus/tests/dbref.json
+++ b/source/bson-corpus/tests/dbref.json
@@ -1,0 +1,31 @@
+{
+    "description": "DBRef",
+    "bson_type": "0x03",
+    "valid": [
+        {
+            "description": "DBRef",
+            "bson": "37000000036462726566002b0000000224726566000b000000636f6c6c656374696f6e00072469640058921b3e6e32ab156a22b59e0000",
+            "extjson": "{\"dbref\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}}}"
+        },
+        {
+            "description": "DBRef with database",
+            "bson": "4300000003646272656600370000000224726566000b000000636f6c6c656374696f6e00072469640058921b3e6e32ab156a22b59e0224646200030000006462000000",
+            "extjson": "{\"dbref\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}, \"$db\": \"db\"}}"
+        },
+        {
+            "description": "DBRef with database and additional fields",
+            "bson": "48000000036462726566003c0000000224726566000b000000636f6c6c656374696f6e0010246964002a00000002246462000300000064620002666f6f0004000000626172000000",
+            "extjson": "{\"dbref\": {\"$ref\": \"collection\", \"$id\": {\"$numberInt\": \"42\"}, \"$db\": \"db\", \"foo\": \"bar\"}}"
+        },
+        {
+            "description": "DBRef with additional fields",
+            "bson": "4400000003646272656600380000000224726566000b000000636f6c6c656374696f6e00072469640058921b3e6e32ab156a22b59e02666f6f0004000000626172000000",
+            "extjson": "{\"dbref\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}, \"foo\": \"bar\"}}"
+        },
+        {
+            "description": "Document with key names similar to those of a DBRef",
+            "bson": "3e0000000224726566000c0000006e6f742d612d646272656600072469640058921b3e6e32ab156a22b59e022462616e616e6100050000007065656c0000",
+            "extjson": "{\"$ref\": \"not-a-dbref\", \"$id\": {\"$oid\": \"58921b3e6e32ab156a22b59e\"}, \"$banana\": \"peel\"}"
+        }
+    ]
+}

--- a/source/bson-corpus/tests/double.json
+++ b/source/bson-corpus/tests/double.json
@@ -51,7 +51,8 @@
         {
             "description": "NaN with payload",
             "bson": "10000000016400120000000000F87F00",
-            "extjson": "{\"d\": {\"$numberDouble\": \"NaN\"}}"
+            "extjson": "{\"d\": {\"$numberDouble\": \"NaN\"}}",
+            "lossy": true
         },
         {
             "description": "Inf",


### PR DESCRIPTION
Add test cases for DBRef in ~document.json~ (now dbref.json).
