### PR TITLE
SPEC-849 - Fix BSON/JSON spec tests for keys that start with '$'.

### DIFF
--- a/source/bson-corpus/tests/top.json
+++ b/source/bson-corpus/tests/top.json
@@ -1,6 +1,23 @@
 {
     "description": "Top-level document validity",
     "bson_type": "0x00",
+    "valid": [
+        {
+            "description": "Document with keys that start with $",
+            "bson": "0f00000010246b6579002a00000000",
+            "extjson": "{\"$key\": {\"$numberInt\": \"42\"}}"
+        },
+        {
+            "description": "Document that resembles extended JSON, but with extra keys",
+            "bson": "3f00000002247265676578000c0000006e6f742d612d72656765780002246f7074696f6e7300020000006900022462616e616e6100050000007065656c0000",
+            "extjson": "{\"$regex\": \"not-a-regex\", \"$options\": \"i\", \"$banana\": \"peel\"}"
+        },
+        {
+            "description": "Document that resembles extended JSON, but with missing keys",
+            "bson": "1a000000022462696e6172790008000000616263646566670000",
+            "extjson": "{\"$binary\": \"abcdefg\"}"
+        }
+    ],
     "decodeErrors": [
         {
             "description": "An object size that's too small to even include the object size, but is a well-formed, empty object",
@@ -57,21 +74,6 @@
         {
             "description": "Document truncated mid-key",
             "bson": "1200000002666F"
-        },
-        {
-            "description": "Document with keys that start with $",
-            "bson": "0f00000010246b6579002a00000000",
-            "extjson": "{\"$key\": 42}"
-        },
-        {
-            "description": "Document that resembles extended JSON, but with extra keys",
-            "bson": "3f000000022462616e616e6100050000007065656c0002246f7074696f6e730002000000690002247265676578000c0000006e6f742d612d72656765780000",
-            "extjson": "{\"$regex\": \"not-a-regex\", \"$options\": \"i\", \"$banana\": \"peel\"}"
-        },
-        {
-            "description": "Document that resembles extended JSON, but with missing keys",
-            "bson": "1a000000022462696e6172790008000000616263646566670000",
-            "extjson": "{\"$binary\": \"abcdefg\"}"
         }
     ]
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-849

These tests were incorrectly added under the "decodeErrors" cases; all these documents can be converted between bson/json.