### PR TITLE
Fix Max Key type id

### DIFF
--- a/source/bson-corpus/tests/maxkey.json
+++ b/source/bson-corpus/tests/maxkey.json
@@ -1,6 +1,6 @@
 {
     "description": "Maxkey type",
-    "bson_type": "0xFF",
+    "bson_type": "0x7F",
     "test_key": "a",
     "valid": [
         {


### PR DESCRIPTION
http://bsonspec.org/spec.html

 	| 	"\xFF" e_name 	Min key
	| 	"\x7F" e_name 	Max key