### PR TITLE
Take out irrelevant OP_MSG test

### DIFF
--- a/source/message/OP_MSG.rst
+++ b/source/message/OP_MSG.rst
@@ -467,8 +467,6 @@ Test Plan
 - Repeat the previous 5 tests as updates, and then deletes.
 - Create one small document, and one large 16mb document. Ensure they are
   inserted, updated and deleted in one roundtrip.
-- Create 10 16mb documents. Ensure they are inserted, updated, and deleted in 4
-  roundtrips, 3 documents each followed by one alone in the 4th trip.
 
 
 


### PR DESCRIPTION
I suggest we take out this test, as it's not relevant to OP_MSG and the math isn't accurate given the current maxMessageSizeBytes.