### PR TITLE
SPEC-888 Add arrayFilters to bulk write update models.

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -879,6 +879,17 @@ Bulk Write Models
     update: Update;
 
     /**
+     * A set of filters specifying to which array elements an update should apply.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.6, the driver MUST raise an error if the caller explicitly provides a value.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/update/
+     */
+    arrayFilters: Optional<Array<Document>>;
+
+    /**
      * Specifies a collation.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
@@ -914,6 +925,17 @@ Bulk Write Models
      * @see https://docs.mongodb.com/manual/reference/command/update/
      */
     update: Update;
+
+    /**
+     * A set of filters specifying to which array elements an update should apply.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * For servers < 3.6, the driver MUST raise an error if the caller explicitly provides a value.
+     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/update/
+     */
+    arrayFilters: Optional<Array<Document>>;
 
     /**
      * Specifies a collation.
@@ -1541,6 +1563,7 @@ Q: Where is ``save``?
 Changes
 =======
 
+* 2017-08-31: Added arrayFilters to bulk write update models.
 * 2017-06-29: Remove requirement of using OP_KILL_CURSOR to kill cursors.
 * 2017-06-27: Added arrayFilters to UpdateOptions and FindOneAndUpdateOptions.
 * 2017-06-26: Added FAQ entry for omission of save method.

--- a/source/crud/tests/write/bulkWrite-arrayFilters.json
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.json
@@ -1,0 +1,114 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "y": [
+        {
+          "b": 3
+        },
+        {
+          "b": 1
+        }
+      ]
+    },
+    {
+      "_id": 2,
+      "y": [
+        {
+          "b": 0
+        },
+        {
+          "b": 1
+        }
+      ]
+    }
+  ],
+  "minServerVersion": "3.6",
+  "tests": [
+    {
+      "description": "BulkWrite with arrayFilters",
+      "operation": {
+        "arguments": {
+          "options": {
+            "ordered": true
+          },
+          "requests": [
+            {
+              "arguments": {
+                "arrayFilters": [
+                  {
+                    "i.b": {
+                      "$eq": 3
+                    }
+                  }
+                ],
+                "filter": {},
+                "update": {
+                  "$set": {
+                    "y.$[i].b": 2
+                  }
+                }
+              },
+              "name": "updateOne"
+            },
+            {
+              "arguments": {
+                "arrayFilters": [
+                  {
+                    "i.b": {
+                      "$eq": 1
+                    }
+                  }
+                ],
+                "filter": {},
+                "update": {
+                  "$set": {
+                    "y.$[i].b": 5
+                  }
+                }
+              },
+              "name": "updateMany"
+            }
+          ]
+        },
+        "name": "bulkWrite"
+      },
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "y": [
+                {
+                  "b": 2
+                },
+                {
+                  "b": 5
+                }
+              ]
+            },
+            {
+              "_id": 2,
+              "y": [
+                {
+                  "b": 0
+                },
+                {
+                  "b": 5
+                }
+              ]
+            }
+          ]
+        },
+        "result": {
+          "deletedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 3,
+          "modifiedCount": 3,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        }
+      }
+    }
+  ]
+}

--- a/source/crud/tests/write/bulkWrite-arrayFilters.json
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.json
@@ -23,7 +23,7 @@
       ]
     }
   ],
-  "minServerVersion": "3.6",
+  "minServerVersion": "3.5.6",
   "tests": [
     {
       "description": "BulkWrite with arrayFilters",

--- a/source/crud/tests/write/bulkWrite-arrayFilters.json
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.json
@@ -47,7 +47,6 @@
                   }
                 }
               },
-              "description": "UpdateOne when one document matches arrayFilters",
               "name": "updateOne"
             },
             {
@@ -64,7 +63,6 @@
                   }
                 }
               },
-              "description": "UpdateMany when multiple documents match arrayFilters",
               "name": "updateMany"
             }
           ]

--- a/source/crud/tests/write/bulkWrite-arrayFilters.json
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.json
@@ -37,9 +37,7 @@
               "arguments": {
                 "arrayFilters": [
                   {
-                    "i.b": {
-                      "$eq": 3
-                    }
+                    "i.b": 3
                   }
                 ],
                 "filter": {},
@@ -49,24 +47,24 @@
                   }
                 }
               },
+              "description": "UpdateOne when one document matches arrayFilters",
               "name": "updateOne"
             },
             {
               "arguments": {
                 "arrayFilters": [
                   {
-                    "i.b": {
-                      "$eq": 1
-                    }
+                    "i.b": 1
                   }
                 ],
                 "filter": {},
                 "update": {
                   "$set": {
-                    "y.$[i].b": 5
+                    "y.$[i].b": 2
                   }
                 }
               },
+              "description": "UpdateMany when multiple documents match arrayFilters",
               "name": "updateMany"
             }
           ]
@@ -83,7 +81,7 @@
                   "b": 2
                 },
                 {
-                  "b": 5
+                  "b": 2
                 }
               ]
             },
@@ -94,7 +92,7 @@
                   "b": 0
                 },
                 {
-                  "b": 5
+                  "b": 2
                 }
               ]
             }

--- a/source/crud/tests/write/bulkWrite-arrayFilters.yml
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.yml
@@ -12,7 +12,7 @@ tests:
             arguments:
                 requests:
                     -
-                        description: "UpdateOne when one document matches arrayFilters"
+                        # UpdateOne when one document matches arrayFilters
                         name: "updateOne"
                         arguments:
                             filter: {}
@@ -21,7 +21,7 @@ tests:
                             arrayFilters:
                               - {i.b: 3}
                     -
-                        description: "UpdateMany when multiple documents match arrayFilters"
+                        # UpdateMany when multiple documents match arrayFilters
                         name: "updateMany"
                         arguments:
                             filter: {}

--- a/source/crud/tests/write/bulkWrite-arrayFilters.yml
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.yml
@@ -1,0 +1,42 @@
+data:
+    - {_id: 1, y: [{b: 3}, {b: 1}]}
+    - {_id: 2, y: [{b: 0}, {b: 1}]}
+
+minServerVersion: '3.6'
+
+tests:
+    -
+        description: "BulkWrite with arrayFilters"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                requests:
+                    -
+                        name: "updateOne"
+                        arguments:
+                            filter: {}
+                            update:
+                                $set: {"y.$[i].b": 2}
+                            arrayFilters:
+                              - {i.b: {"$eq": 3}}
+                    -
+                        name: "updateMany"
+                        arguments:
+                            filter: {}
+                            update:
+                                $set: {"y.$[i].b": 5}
+                            arrayFilters:
+                              - {i.b: {"$eq": 1}}
+                options: { ordered: true }
+        outcome:
+            result:
+                deletedCount: 0
+                insertedIds: {}
+                matchedCount: 3
+                modifiedCount: 3
+                upsertedCount: 0
+                upsertedIds: {}
+            collection:
+                data:
+                    - {_id: 1, y: [{b: 2}, {b: 5}]}
+                    - {_id: 2, y: [{b: 0}, {b: 5}]}

--- a/source/crud/tests/write/bulkWrite-arrayFilters.yml
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.yml
@@ -12,21 +12,23 @@ tests:
             arguments:
                 requests:
                     -
+                        description: "UpdateOne when one document matches arrayFilters"
                         name: "updateOne"
                         arguments:
                             filter: {}
                             update:
                                 $set: {"y.$[i].b": 2}
                             arrayFilters:
-                              - {i.b: {"$eq": 3}}
+                              - {i.b: 3}
                     -
+                        description: "UpdateMany when multiple documents match arrayFilters"
                         name: "updateMany"
                         arguments:
                             filter: {}
                             update:
-                                $set: {"y.$[i].b": 5}
+                                $set: {"y.$[i].b": 2}
                             arrayFilters:
-                              - {i.b: {"$eq": 1}}
+                              - {i.b: 1}
                 options: { ordered: true }
         outcome:
             result:
@@ -38,5 +40,5 @@ tests:
                 upsertedIds: {}
             collection:
                 data:
-                    - {_id: 1, y: [{b: 2}, {b: 5}]}
-                    - {_id: 2, y: [{b: 0}, {b: 5}]}
+                    - {_id: 1, y: [{b: 2}, {b: 2}]}
+                    - {_id: 2, y: [{b: 0}, {b: 2}]}

--- a/source/crud/tests/write/bulkWrite-arrayFilters.yml
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.yml
@@ -2,7 +2,7 @@ data:
     - {_id: 1, y: [{b: 3}, {b: 1}]}
     - {_id: 2, y: [{b: 0}, {b: 1}]}
 
-minServerVersion: '3.6'
+minServerVersion: '3.5.6'
 
 tests:
     -

--- a/source/crud/tests/write/findOneAndUpdate-arrayFilters.json
+++ b/source/crud/tests/write/findOneAndUpdate-arrayFilters.json
@@ -23,7 +23,7 @@
       ]
     }
   ],
-  "minServerVersion": "3.6",
+  "minServerVersion": "3.5.6",
   "tests": [
     {
       "description": "FindOneAndUpdate when no document matches arrayFilters",

--- a/source/crud/tests/write/findOneAndUpdate-arrayFilters.yml
+++ b/source/crud/tests/write/findOneAndUpdate-arrayFilters.yml
@@ -1,7 +1,7 @@
 data:
     - {_id: 1, y: [{b: 3}, {b: 1}]}
     - {_id: 2, y: [{b: 0}, {b: 1}]}
-minServerVersion: '3.6'
+minServerVersion: '3.5.6'
 
 tests:
     -

--- a/source/crud/tests/write/updateMany-arrayFilters.json
+++ b/source/crud/tests/write/updateMany-arrayFilters.json
@@ -23,7 +23,7 @@
       ]
     }
   ],
-  "minServerVersion": "3.6",
+  "minServerVersion": "3.5.6",
   "tests": [
     {
       "description": "UpdateMany when no documents match arrayFilters",

--- a/source/crud/tests/write/updateMany-arrayFilters.yml
+++ b/source/crud/tests/write/updateMany-arrayFilters.yml
@@ -1,7 +1,7 @@
 data:
     - {_id: 1, y: [{b: 3}, {b: 1}]}
     - {_id: 2, y: [{b: 0}, {b: 1}]}
-minServerVersion: '3.6'
+minServerVersion: '3.5.6'
 
 tests:
     -

--- a/source/crud/tests/write/updateOne-arrayFilters.json
+++ b/source/crud/tests/write/updateOne-arrayFilters.json
@@ -39,7 +39,7 @@
       ]
     }
   ],
-  "minServerVersion": "3.6",
+  "minServerVersion": "3.5.6",
   "tests": [
     {
       "description": "UpdateOne when no document matches arrayFilters",

--- a/source/crud/tests/write/updateOne-arrayFilters.yml
+++ b/source/crud/tests/write/updateOne-arrayFilters.yml
@@ -2,7 +2,7 @@ data:
     - {_id: 1, y: [{b: 3}, {b: 1}]}
     - {_id: 2, y: [{b: 0}, {b: 1}]}
     - {_id: 3, y: [{b: 5, c: [{d: 2}, {d: 1}] }]}
-minServerVersion: '3.6'
+minServerVersion: '3.5.6'
 
 tests:
     -


### PR DESCRIPTION
In the original PR https://github.com/mongodb/specifications/pull/159 we forgot to add `arrayFilters` to UpdateOneModel and UpdateManyModel.