### PR TITLE
Added first draft for TXT record parsing and tests

### DIFF
--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -103,15 +103,17 @@ Although options in a connection string are separated by a ``&``, this
 character MUST NOT be present to separate options between TXT record strings
 as a separation is implied by using multiple TXT records.
 
-TXT records MAY be queried before SRV records because for example they could
-include the ``replicaSet`` option to define the replica set name.
+TXT records MAY be queried either before, in parallel, or after SRV records.
+Clients MUST query both the SRV and the TXT records before attempting any
+connection to MongoDB.
 
-A Client MUST use options specified in the Connection String to override
-options provided through TXT records.
+A Client MUST use options specified in the Connection String, and options
+passed in as parameters in code to the MongoClient constructor (or equivalent
+API for each driver), to override options provided through TXT records.
 
 .. _`Connection String spec`: ../connection-string/connection-string-spec.rst#defining-connection-options
 
-If any connection string options in a TXT record is incorrectly formatted, a
+If any connection string option in a TXT record is incorrectly formatted, a
 Client must throw a parse exception.
 
 This specification does not change the behaviour of handling unknown keys or

--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -192,6 +192,28 @@ Design Rationale
 The design specifically calls for a pre-processing stage of the processing of
 connection URLs to minimize the impact on existing functionality.
 
+Justifications
+==============
+
+Why Are Multiple Key-Value Pairs Allowed in One TXT Record?
+-----------------------------------------------------------
+
+One could imagine an alternative design in which each TXT record would allow
+only one URI option. No ``&`` character would be allowed as a delimiter within
+TXT records.
+
+In this spec we allow multiple key-value pairs within one TXT record,
+delimited by ``&``, because it will be common for all options to fit in a
+single 255-character TXT record, and it is much more convenient to configure
+one record in this case than to configure several.
+
+Secondly, in some cases the order in which options occur is important. For
+example, readPreferenceTags can appear both multiple times, and the order in
+which they appear is significant. Because DNS servers may return TXT records
+in any order, it is only possible to guarantee the order in which
+readPreferenceTags keys appear by having them in the same TXT record.
+
+
 Reference Implementation
 ========================
 

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -11,52 +11,27 @@ Test Setup
 Start a three-node replica set on localhost, on ports 27017, 27018, and 27019,
 with replica set name "repl0".
 
-There are two methods to provide the SRV records required for testing: either
-mock them with the resolv_wrapper library and test only on Linux, or configure
-the SRV records with a real name server.
+To run the tests that accompany this spec, you need to configure the SRV and
+TXT records with a real name server. The following records are required for
+these tests::
 
-If you choose the first method, build the `CWRAP resolv_wrapper library
-<https://cwrap.org/resolv_wrapper.html>`_ and initialize its hosts file, for
-example with this shell script:
+  Record                                    TTL    Class   Port   Target
+  _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27017  localhost
+  _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27018  localhost
+  _mongodb._tcp.test2.test.build.10gen.cc.  86400  IN SRV  27018  localhost
+  _mongodb._tcp.test2.test.build.10gen.cc.  86400  IN SRV  27019  localhost
+  _mongodb._tcp.test3.test.build.10gen.cc.  86400  IN SRV  27017  localhost
+  _mongodb._tcp.test5.test.build.10gen.cc.  86400  IN SRV  27017  localhost
+  _mongodb._tcp.test6.test.build.10gen.cc.  86400  IN SRV  27017  localhost
 
-.. code-block:: sh
+  Record                                    TTL    Class   Text
+  test5.test.build.10gen.cc.                86400  IN TXT  "connectTimeoutMS=300000&socketTimeoutMS=300000"
+  test6.test.build.10gen.cc.                86400  IN TXT  "connectTimeoutMS=200000"
+  test6.test.build.10gen.cc.                86400  IN TXT  "socketTimeoutMS=200000"
 
-  if [ ! -f resolv_wrapper_build/src/libresolv_wrapper.so ]; then
-    curl -LO https://ftp.samba.org/pub/cwrap/resolv_wrapper-1.1.5.tar.gz
-    tar xvf resolv_wrapper-1.1.5.tar.gz
-    mkdir resolv_wrapper_build
-    cd resolv_wrapper_build
-    cmake ../resolv_wrapper-1.1.5
-    make
-    cd ..
-  fi
-
-  cat << EOF > hosts.txt
-  SRV _mongodb._tcp.test1.test.build.10gen.cc localhost 27017
-  SRV _mongodb._tcp.test1.test.build.10gen.cc localhost 27018
-  SRV _mongodb._tcp.test2.test.build.10gen.cc localhost 27018
-  SRV _mongodb._tcp.test2.test.build.10gen.cc localhost 27019
-  SRV _mongodb._tcp.test3.test.build.10gen.cc localhost 27017
-  SRV _mongodb._tcp.test5.test.build.10gen.cc localhost 27017
-  SRV _mongodb._tcp.test6.test.build.10gen.cc localhost 27017
-  TXT test5.test.build.10gen.cc "connectTimeoutMS=300000&socketTimeoutMS=300000"
-  TXT test6.test.build.10gen.cc "connectTimeoutMS=200000"
-  TXT test6.test.build.10gen.cc "socketTimeoutMS=200000"
-  EOF
-
-  export LD_PRELOAD=`pwd`/resolv_wrapper_build/src/libresolv_wrapper.so
-  export RESOLV_WRAPPER_HOSTS=hosts.txt
-
-You can debug the library by exporting ``RESOLV_WRAPPER_DEBUGLEVEL=3``.
-
-Please note that CWRAP does not return more than one record per type/host
-combination. It also does not understand TXT records, so your mileage may
-vary.
-
-If you choose instead to configure a real name server with SRV and TXT
-records, adapt the records shown above to your domain name, and update the
-"uri" field in the YAML or JSON files in this directory with the actual
-domain.
+You need to adapt the records shown above to replace ``build.10gen.cc`` with
+your own domain name, and update the "uri" field in the YAML or JSON files in
+this directory with the actual domain.
 
 Test Format and Use
 -------------------

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -37,6 +37,11 @@ example with this shell script:
   SRV _mongodb._tcp.test2.test.build.10gen.cc localhost 27018
   SRV _mongodb._tcp.test2.test.build.10gen.cc localhost 27019
   SRV _mongodb._tcp.test3.test.build.10gen.cc localhost 27017
+  SRV _mongodb._tcp.test5.test.build.10gen.cc localhost 27017
+  SRV _mongodb._tcp.test6.test.build.10gen.cc localhost 27017
+  TXT test5.test.build.10gen.cc "connectTimeoutMS=300000&socketTimeoutMS=300000"
+  TXT test6.test.build.10gen.cc "connectTimeoutMS=200000"
+  TXT test6.test.build.10gen.cc "socketTimeoutMS=200000"
   EOF
 
   export LD_PRELOAD=`pwd`/resolv_wrapper_build/src/libresolv_wrapper.so
@@ -44,9 +49,14 @@ example with this shell script:
 
 You can debug the library by exporting ``RESOLV_WRAPPER_DEBUGLEVEL=3``.
 
-If you choose instead to configure a real name server with SRV records, adapt
-the records shown above to your domain name, and update the "uri" field in the
-YAML or JSON files in this directory with the actual domain.
+Please note that CWRAP does not return more than one record per type/host
+combination. It also does not understand TXT records, so your mileage may
+vary.
+
+If you choose instead to configure a real name server with SRV and TXT
+records, adapt the records shown above to your domain name, and update the
+"uri" field in the YAML or JSON files in this directory with the actual
+domain.
 
 Test Format and Use
 -------------------
@@ -56,8 +66,11 @@ These YAML and JSON files contain the following fields:
 - ``uri``: a mongodb+srv connection string
 - ``seeds``: the expected set of initial seeds discovered from the SRV record
 - ``hosts``: the discovered topology's list of hosts once SDAM completes a scan
+- ``options``: the parsed connection string options as discovered from URI and
+  TXT records
 
 For each file, create MongoClient initialized with the mongodb+srv connection
-string. You SHOULD verify the client's initial seed list matches the list of
-seeds. You MUST verify the set of ServerDescriptions in the client's
-TopologyDescription eventually matches the list of hosts.
+string. You SHOULD verify that the client's initial seed list matches the list of
+seeds. You MUST verify that the set of ServerDescriptions in the client's
+TopologyDescription eventually matches the list of hosts. You MUST verify that
+the set of Connection String Options matches the client's parsed set.

--- a/source/initial-dns-seedlist-discovery/tests/one-txt-record.json
+++ b/source/initial-dns-seedlist-discovery/tests/one-txt-record.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "connectTimeoutMS": 300000,
+    "replicaSet": "repl0",
+    "socketTimeoutMS": 300000
+  }
+}

--- a/source/initial-dns-seedlist-discovery/tests/one-txt-record.yml
+++ b/source/initial-dns-seedlist-discovery/tests/one-txt-record.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test5.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    connectTimeoutMS: 300000
+    replicaSet: repl0
+    socketTimeoutMS: 300000

--- a/source/initial-dns-seedlist-discovery/tests/two-txt-records-with-override.json
+++ b/source/initial-dns-seedlist-discovery/tests/two-txt-records-with-override.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0&connectTimeoutMS=250000",
+  "seeds": [
+    "localhost:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "connectTimeoutMS": 250000,
+    "replicaSet": "repl0",
+    "socketTimeoutMS": 200000
+  }
+}

--- a/source/initial-dns-seedlist-discovery/tests/two-txt-records-with-override.yml
+++ b/source/initial-dns-seedlist-discovery/tests/two-txt-records-with-override.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0&connectTimeoutMS=250000"
+seeds:
+    - localhost:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    connectTimeoutMS: 250000
+    replicaSet: repl0
+    socketTimeoutMS: 200000

--- a/source/initial-dns-seedlist-discovery/tests/two-txt-records.json
+++ b/source/initial-dns-seedlist-discovery/tests/two-txt-records.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "connectTimeoutMS": 200000,
+    "replicaSet": "repl0",
+    "socketTimeoutMS": 200000
+  }
+}

--- a/source/initial-dns-seedlist-discovery/tests/two-txt-records.yml
+++ b/source/initial-dns-seedlist-discovery/tests/two-txt-records.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    connectTimeoutMS: 200000
+    replicaSet: repl0
+    socketTimeoutMS: 200000


### PR DESCRIPTION
A first draft. I do also believe we should rename this spec, for example to "Initial Seedlist and Options DNS discovery".