### PR TITLE
SPEC-958: Use standard bulkWrite format for retryable write tests

### DIFF
--- a/source/retryable-writes/tests/supported-multi-statement-failure.json
+++ b/source/retryable-writes/tests/supported-multi-statement-failure.json
@@ -17,8 +17,7 @@
         "arguments": {
           "requests": [
             {
-              "name": "updateOne",
-              "arguments": {
+              "updateOne": {
                 "filter": {
                   "_id": 1
                 },
@@ -30,8 +29,7 @@
               }
             },
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 2,
                   "x": 22

--- a/source/retryable-writes/tests/supported-multi-statement-failure.yml
+++ b/source/retryable-writes/tests/supported-multi-statement-failure.yml
@@ -17,15 +17,11 @@ tests:
             name: "bulkWrite"
             arguments:
                 requests:
-                    -
-                        name: "updateOne"
-                        arguments:
-                            filter: { _id: 1 }
-                            update: { $inc: { x : 1 }}
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 2, x: 22 }
+                    - updateOne:
+                        filter: { _id: 1 }
+                        update: { $inc: { x : 1 }}
+                    - insertOne:
+                        document: { _id: 2, x: 22 }
                 options: { ordered: true }
         outcome:
             error: true

--- a/source/retryable-writes/tests/supported-multi-statement.json
+++ b/source/retryable-writes/tests/supported-multi-statement.json
@@ -17,16 +17,14 @@
         "arguments": {
           "requests": [
             {
-              "name": "deleteOne",
-              "arguments": {
+              "deleteOne": {
                 "filter": {
                   "_id": 1
                 }
               }
             },
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 2,
                   "x": 22
@@ -34,8 +32,7 @@
               }
             },
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 3,
                   "x": 33
@@ -43,8 +40,7 @@
               }
             },
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 4,
                   "x": 44
@@ -52,8 +48,7 @@
               }
             },
             {
-              "name": "replaceOne",
-              "arguments": {
+              "replaceOne": {
                 "filter": {
                   "_id": 3
                 },
@@ -64,8 +59,7 @@
               }
             },
             {
-              "name": "updateOne",
-              "arguments": {
+              "updateOne": {
                 "filter": {
                   "_id": 4
                 },
@@ -77,8 +71,7 @@
               }
             },
             {
-              "name": "updateOne",
-              "arguments": {
+              "updateOne": {
                 "filter": {
                   "_id": 5,
                   "x": 55
@@ -144,16 +137,14 @@
         "arguments": {
           "requests": [
             {
-              "name": "deleteOne",
-              "arguments": {
+              "deleteOne": {
                 "filter": {
                   "_id": 1
                 }
               }
             },
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 2,
                   "x": 22
@@ -161,8 +152,7 @@
               }
             },
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 3,
                   "x": 33
@@ -170,8 +160,7 @@
               }
             },
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 4,
                   "x": 44
@@ -179,8 +168,7 @@
               }
             },
             {
-              "name": "replaceOne",
-              "arguments": {
+              "replaceOne": {
                 "filter": {
                   "_id": 3
                 },
@@ -191,8 +179,7 @@
               }
             },
             {
-              "name": "updateOne",
-              "arguments": {
+              "updateOne": {
                 "filter": {
                   "_id": 4
                 },
@@ -204,8 +191,7 @@
               }
             },
             {
-              "name": "updateOne",
-              "arguments": {
+              "updateOne": {
                 "filter": {
                   "_id": 5,
                   "x": 55
@@ -268,8 +254,7 @@
         "arguments": {
           "requests": [
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 1,
                   "x": 11
@@ -277,8 +262,7 @@
               }
             },
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 2,
                   "x": 22

--- a/source/retryable-writes/tests/supported-multi-statement.yml
+++ b/source/retryable-writes/tests/supported-multi-statement.yml
@@ -15,38 +15,24 @@ tests:
             name: "bulkWrite"
             arguments:
                 requests:
-                    -
-                        name: "deleteOne"
-                        arguments:
-                            filter: { _id: 1 }
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 2, x: 22 }
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 3, x: 33 }
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 4, x: 44 }
-                    -
-                        name: "replaceOne"
-                        arguments:
-                            filter: { _id: 3 }
-                            replacement: { _id: 3, x: 333 }
-                    -
-                        name: "updateOne"
-                        arguments:
-                            filter: { _id: 4 }
-                            update: { $inc: { x : 1 }}
-                    -
-                        name: "updateOne"
-                        arguments:
-                            filter: { _id: 5, x: 55 }
-                            update: { $inc: { x : 1 }}
-                            upsert: true
+                    - deleteOne:
+                        filter: { _id: 1 }
+                    - insertOne:
+                        document: { _id: 2, x: 22 }
+                    - insertOne:
+                        document: { _id: 3, x: 33 }
+                    - insertOne:
+                        document: { _id: 4, x: 44 }
+                    - replaceOne:
+                        filter: { _id: 3 }
+                        replacement: { _id: 3, x: 333 }
+                    - updateOne:
+                        filter: { _id: 4 }
+                        update: { $inc: { x : 1 }}
+                    - updateOne:
+                        filter: { _id: 5, x: 55 }
+                        update: { $inc: { x : 1 }}
+                        upsert: true
                 options: { ordered: true }
         outcome:
             result:
@@ -82,38 +68,24 @@ tests:
             name: "bulkWrite"
             arguments:
                 requests:
-                    -
-                        name: "deleteOne"
-                        arguments:
-                            filter: { _id: 1 }
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 2, x: 22 }
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 3, x: 33 }
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 4, x: 44 }
-                    -
-                        name: "replaceOne"
-                        arguments:
-                            filter: { _id: 3 }
-                            replacement: { _id: 3, x: 333 }
-                    -
-                        name: "updateOne"
-                        arguments:
-                            filter: { _id: 4 }
-                            update: { $inc: { x : 1 }}
-                    -
-                        name: "updateOne"
-                        arguments:
-                            filter: { _id: 5, x: 55 }
-                            update: { $inc: { x : 1 }}
-                            upsert: true
+                    - deleteOne:
+                        filter: { _id: 1 }
+                    - insertOne:
+                        document: { _id: 2, x: 22 }
+                    - insertOne:
+                        document: { _id: 3, x: 33 }
+                    - insertOne:
+                        document: { _id: 4, x: 44 }
+                    - replaceOne:
+                        filter: { _id: 3 }
+                        replacement: { _id: 3, x: 333 }
+                    - updateOne:
+                        filter: { _id: 4 }
+                        update: { $inc: { x : 1 }}
+                    - updateOne:
+                        filter: { _id: 5, x: 55 }
+                        update: { $inc: { x : 1 }}
+                        upsert: true
                 options: { ordered: true }
         outcome:
             result:
@@ -135,14 +107,10 @@ tests:
             name: "bulkWrite"
             arguments:
                 requests:
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 1, x: 11 }
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 2, x: 22 }
+                    - insertOne:
+                        document: { _id: 1, x: 11 }
+                    - insertOne:
+                        document: { _id: 2, x: 22 }
                 options: { ordered: false }
         outcome:
             result:

--- a/source/retryable-writes/tests/supported-single-statement.yml
+++ b/source/retryable-writes/tests/supported-single-statement.yml
@@ -24,7 +24,7 @@ tests:
         failPoint:
             times: 1
         operation:
-            name: "FindOneAndDelete"
+            name: "findOneAndDelete"
             arguments:
                 filter: { _id: 1 }
         outcome:
@@ -36,7 +36,7 @@ tests:
         failPoint:
             times: 1
         operation:
-            name: "FindOneAndReplace"
+            name: "findOneAndReplace"
             arguments:
                 filter: { _id: 1 }
                 replacement: { _id: 1, x: 111 }
@@ -51,7 +51,7 @@ tests:
         failPoint:
             times: 1
         operation:
-            name: "FindOneAndUpdate"
+            name: "findOneAndUpdate"
             arguments:
                 filter: { _id: 1 }
                 update: { $inc: { x : 1 }}

--- a/source/retryable-writes/tests/unsupported-multi-statement.json
+++ b/source/retryable-writes/tests/unsupported-multi-statement.json
@@ -18,8 +18,7 @@
         "arguments": {
           "requests": [
             {
-              "name": "insertOne",
-              "arguments": {
+              "insertOne": {
                 "document": {
                   "_id": 3,
                   "x": 33
@@ -27,8 +26,7 @@
               }
             },
             {
-              "name": "deleteMany",
-              "arguments": {
+              "deleteMany": {
                 "filter": {
                   "x": {
                     "$gt": 10
@@ -69,8 +67,7 @@
         "arguments": {
           "requests": [
             {
-              "name": "updateOne",
-              "arguments": {
+              "updateOne": {
                 "filter": {
                   "_id": 1
                 },
@@ -82,8 +79,7 @@
               }
             },
             {
-              "name": "updateMany",
-              "arguments": {
+              "updateMany": {
                 "filter": {
                   "x": {
                     "$gt": 10

--- a/source/retryable-writes/tests/unsupported-multi-statement.yml
+++ b/source/retryable-writes/tests/unsupported-multi-statement.yml
@@ -17,14 +17,10 @@ tests:
             name: "bulkWrite"
             arguments:
                 requests:
-                    -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 3, x: 33 }
-                    -
-                        name: "deleteMany"
-                        arguments:
-                            filter: { x: { $gt: 10 }}
+                    - insertOne:
+                        document: { _id: 3, x: 33 }
+                    - deleteMany:
+                        filter: { x: { $gt: 10 }}
                 options: { ordered: true }
         outcome:
             error: true
@@ -39,16 +35,12 @@ tests:
             name: "bulkWrite"
             arguments:
                 requests:
-                    -
-                        name: "updateOne"
-                        arguments:
-                            filter: { _id: 1 }
-                            update: { $inc: { x : 1 }}
-                    -
-                        name: "updateMany"
-                        arguments:
-                            filter: { x: { $gt: 10 }}
-                            update: { $inc: { x : 1 }}
+                    - updateOne:
+                        filter: { _id: 1 }
+                        update: { $inc: { x : 1 }}
+                    - updateMany:
+                        filter: { x: { $gt: 10 }}
+                        update: { $inc: { x : 1 }}
                 options: { ordered: true }
         outcome:
             error: true

--- a/source/retryable-writes/tests/unsupported-write-commands.yml
+++ b/source/retryable-writes/tests/unsupported-write-commands.yml
@@ -10,7 +10,7 @@ tests:
     -
         description: "Aggregate with $out is not supported"
         operation:
-            name: aggregate
+            name: "aggregate"
             arguments:
                 pipeline:
                     - $match: { _id: { $gt: 1 }}


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-958

This updates the bulkWrite test format to be consistent with that used in the APM tests. Related to @ShaneHarvey's earlier work in https://github.com/mongodb/specifications/pull/206.