### PR TITLE
SPEC-861: showRecordId in FindOptions is a boolean

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -510,7 +510,7 @@ Read
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
      */
-    showRecordId: Optional<Document>;
+    showRecordId: Optional<Boolean>;
 
     /**
      * The number of documents to skip before returning.


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-861

Related issues discussed in the spec ticket were previously fixed by @saghm in https://github.com/mongodb/specifications/commit/72190ee6ee132c9e79d392a6a62d29b39bcf56c3
https://github.com/mongodb/specifications/commit/587c9654f5f1ee47287c57855ce8058e44b5a0d6 in #150 and #151, respectively.