### PR TITLE
don't wipe json files if the yaml is invalid

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -4,7 +4,13 @@ JSON_FILES=$(patsubst %.yml,%.json,$(YAML_FILES))
 all: $(JSON_FILES) HAS_JSYAML
 
 %.json: %.yml
-	js-yaml $< > $@
+	tmpfile=$$(mktemp);               \
+	if js-yaml $< > "$$tmpfile"; then \
+	    mv "$$tmpfile" $@;            \
+	else                              \
+	    rm "$$tmpfile";               \
+	    exit 1;                       \
+	fi
 
 HAS_JSYAML:
 	@if ! command -v js-yaml > /dev/null; then            \


### PR DESCRIPTION
This fixes the issue where running `make` would wipe any JSON files if the corresponding yaml file had an error