### PR TITLE
SPEC-826 Add test of aggregate with $out with a batch size of 0

### DIFF
--- a/source/crud/tests/read/aggregate-out.json
+++ b/source/crud/tests/read/aggregate-out.json
@@ -65,6 +65,57 @@
           ]
         }
       }
+    },
+    {
+      "description": "Aggregate with $out and batch size of 0",
+      "operation": {
+        "name": "aggregate",
+        "arguments": {
+          "pipeline": [
+            {
+              "$sort": {
+                "x": 1
+              }
+            },
+            {
+              "$match": {
+                "_id": {
+                  "$gt": 1
+                }
+              }
+            },
+            {
+              "$out": "other_test_collection"
+            }
+          ],
+          "batchSize": 0
+        }
+      },
+      "outcome": {
+        "result": [
+          {
+            "_id": 2,
+            "x": 22
+          },
+          {
+            "_id": 3,
+            "x": 33
+          }
+        ],
+        "collection": {
+          "name": "other_test_collection",
+          "data": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/crud/tests/read/aggregate-out.yml
+++ b/source/crud/tests/read/aggregate-out.yml
@@ -26,3 +26,24 @@ tests:
                 data:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+    -
+        description: "Aggregate with $out and batch size of 0"
+        operation:
+            name: aggregate
+            arguments:
+                pipeline:
+                    - $sort: {x: 1}
+                    - $match:
+                        _id: {$gt: 1}
+                    - $out: "other_test_collection"
+                batchSize: 0
+
+        outcome:
+            result:
+                - {_id: 2, x: 22}
+                - {_id: 3, x: 33}
+            collection:
+                name: "other_test_collection"
+                data:
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}


### PR DESCRIPTION
This is a pretty small change (just duplicating the existing $out test with the batch size changed to zero), so I think one LGTM should be enough.