### PR TITLE
Remove prohibition of raising errors when DNS issues occur during parsing

### DIFF
--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -10,8 +10,8 @@ Initial DNS Seedlist Discovery
 :Authors: Derick Rethans
 :Status: Draft
 :Type: Standards
-:Last Modified: 2017-10-04
-:Version: 1.1.1
+:Last Modified: 2017-10-18
+:Version: 1.1.2
 :Spec Lead: Matt Broadstone
 :Advisory Group: \A. Jesse Jiryu Davis
 :Approver(s): Bernie Hackett, David Golden, Jeff Yemin, Matt Broadstone, A. Jesse Jiryu Davis
@@ -77,9 +77,7 @@ returned its results.
 If the DNS result returns no SRV records, or no records at all, or a DNS error
 happens, an error MUST be raised indicating that the URI could not be used to
 find hostnames. The error SHALL include the reason why they could not be
-found. This error MUST be raised only when the application attempts any
-operation which requires a server, in the same way as other server selection
-errors.
+found.
 
 Clients SHOULD respect the default domain and current domain when looking up
 the SRV record. For example, when using the non-FQDN ``servername`` and the
@@ -235,6 +233,9 @@ SRV records.
 
 ChangeLog
 =========
+
+2017-10-18 — 1.1.2
+    Removed prohibition of raising DNS related errors when parsing the URI.
 
 2017-10-04 — 1.1.1
     Removed from `Future Work`_ the line about multiple MongoS discovery. The

--- a/source/initial-dns-seedlist-discovery/tests/one-result-default-port.json
+++ b/source/initial-dns-seedlist-discovery/tests/one-result-default-port.json
@@ -1,7 +1,7 @@
 {
   "uri": "mongodb+srv://test3.test.build.10gen.cc/?replicaSet=repl0",
   "seeds": [
-    "localhost:27017"
+    "localhost.build.10gen.cc:27017"
   ],
   "hosts": [
     "localhost:27017",

--- a/source/initial-dns-seedlist-discovery/tests/one-result-default-port.yml
+++ b/source/initial-dns-seedlist-discovery/tests/one-result-default-port.yml
@@ -1,6 +1,6 @@
 uri: "mongodb+srv://test3.test.build.10gen.cc/?replicaSet=repl0"
 seeds:
-    - localhost:27017
+    - localhost.build.10gen.cc:27017
 hosts:
     - localhost:27017
     - localhost:27018

--- a/source/initial-dns-seedlist-discovery/tests/one-txt-record.json
+++ b/source/initial-dns-seedlist-discovery/tests/one-txt-record.json
@@ -1,7 +1,7 @@
 {
   "uri": "mongodb+srv://test5.test.build.10gen.cc/?replicaSet=repl0",
   "seeds": [
-    "localhost:27017"
+    "localhost.build.10gen.cc:27017"
   ],
   "hosts": [
     "localhost:27017",

--- a/source/initial-dns-seedlist-discovery/tests/one-txt-record.yml
+++ b/source/initial-dns-seedlist-discovery/tests/one-txt-record.yml
@@ -1,6 +1,6 @@
 uri: "mongodb+srv://test5.test.build.10gen.cc/?replicaSet=repl0"
 seeds:
-    - localhost:27017
+    - localhost.build.10gen.cc:27017
 hosts:
     - localhost:27017
     - localhost:27018

--- a/source/initial-dns-seedlist-discovery/tests/two-results-default-port.json
+++ b/source/initial-dns-seedlist-discovery/tests/two-results-default-port.json
@@ -1,8 +1,8 @@
 {
   "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0",
   "seeds": [
-    "localhost:27017",
-    "localhost:27018"
+    "localhost.build.10gen.cc:27017",
+    "localhost.build.10gen.cc:27018"
   ],
   "hosts": [
     "localhost:27017",

--- a/source/initial-dns-seedlist-discovery/tests/two-results-default-port.yml
+++ b/source/initial-dns-seedlist-discovery/tests/two-results-default-port.yml
@@ -1,7 +1,7 @@
 uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0"
 seeds:
-    - localhost:27017
-    - localhost:27018
+    - localhost.build.10gen.cc:27017
+    - localhost.build.10gen.cc:27018
 hosts:
     - localhost:27017
     - localhost:27018

--- a/source/initial-dns-seedlist-discovery/tests/two-results-nonstandard-port.json
+++ b/source/initial-dns-seedlist-discovery/tests/two-results-nonstandard-port.json
@@ -1,8 +1,8 @@
 {
   "uri": "mongodb+srv://test2.test.build.10gen.cc/?replicaSet=repl0",
   "seeds": [
-    "localhost:27018",
-    "localhost:27019"
+    "localhost.build.10gen.cc:27018",
+    "localhost.build.10gen.cc:27019"
   ],
   "hosts": [
     "localhost:27017",

--- a/source/initial-dns-seedlist-discovery/tests/two-results-nonstandard-port.yml
+++ b/source/initial-dns-seedlist-discovery/tests/two-results-nonstandard-port.yml
@@ -1,7 +1,7 @@
 uri: "mongodb+srv://test2.test.build.10gen.cc/?replicaSet=repl0"
 seeds:
-    - localhost:27018
-    - localhost:27019
+    - localhost.build.10gen.cc:27018
+    - localhost.build.10gen.cc:27019
 hosts:
     - localhost:27017
     - localhost:27018

--- a/source/initial-dns-seedlist-discovery/tests/two-txt-records-with-override.json
+++ b/source/initial-dns-seedlist-discovery/tests/two-txt-records-with-override.json
@@ -1,7 +1,7 @@
 {
   "uri": "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0&connectTimeoutMS=250000",
   "seeds": [
-    "localhost:27017"
+    "localhost.build.10gen.cc:27017"
   ],
   "hosts": [
     "localhost:27017",

--- a/source/initial-dns-seedlist-discovery/tests/two-txt-records-with-override.yml
+++ b/source/initial-dns-seedlist-discovery/tests/two-txt-records-with-override.yml
@@ -1,6 +1,6 @@
 uri: "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0&connectTimeoutMS=250000"
 seeds:
-    - localhost:27017
+    - localhost.build.10gen.cc:27017
 hosts:
     - localhost:27017
     - localhost:27018

--- a/source/initial-dns-seedlist-discovery/tests/two-txt-records.json
+++ b/source/initial-dns-seedlist-discovery/tests/two-txt-records.json
@@ -1,7 +1,7 @@
 {
   "uri": "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0",
   "seeds": [
-    "localhost:27017"
+    "localhost.build.10gen.cc:27017"
   ],
   "hosts": [
     "localhost:27017",

--- a/source/initial-dns-seedlist-discovery/tests/two-txt-records.yml
+++ b/source/initial-dns-seedlist-discovery/tests/two-txt-records.yml
@@ -1,6 +1,6 @@
 uri: "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0"
 seeds:
-    - localhost:27017
+    - localhost.build.10gen.cc:27017
 hosts:
     - localhost:27017
     - localhost:27018


### PR DESCRIPTION
And update the tests to use localhost.build.10gen.cc instead of localhost.