### PR TITLE
SPEC-971: Allow assertions of write results on BulkWriteException

### DIFF
--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -108,7 +108,13 @@ Each YAML file has the following keys:
       write result object.
 
     - ``result``: The return value from the operation. This will correspond to
-      an operation's result object as defined in the CRUD specification.
+      an operation's result object as defined in the CRUD specification. This
+      field may be omitted if ``error`` is ``true``. If this field is present
+      and ``error`` is ``true`` (generally for multi-statement tests), the
+      result reports information about operations that succeeded before an
+      unrecoverable failure. In that case, drivers may choose to check the
+      result object if their BulkWriteException (or equivalent) provides access
+      to a write result object.
 
     - ``collection``:
 

--- a/source/retryable-writes/tests/bulkWrite.json
+++ b/source/retryable-writes/tests/bulkWrite.json
@@ -58,7 +58,7 @@
         "result": {
           "deletedCount": 1,
           "insertedIds": {
-            "1": 2
+            "0": 2
           },
           "matchedCount": 1,
           "modifiedCount": 1,
@@ -260,7 +260,7 @@
         "result": {
           "deletedCount": 0,
           "insertedIds": {
-            "1": 2
+            "0": 2
           },
           "matchedCount": 2,
           "modifiedCount": 2,
@@ -337,7 +337,7 @@
         "result": {
           "deletedCount": 0,
           "insertedIds": {
-            "1": 2
+            "0": 2
           },
           "matchedCount": 2,
           "modifiedCount": 2,
@@ -475,6 +475,14 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
         "collection": {
           "data": [
             {
@@ -537,6 +545,16 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedIds": {
+            "0": 2
+          },
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
         "collection": {
           "data": [
             {
@@ -608,6 +626,16 @@
       },
       "outcome": {
         "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedIds": {
+            "0": 2
+          },
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
         "collection": {
           "data": [
             {

--- a/source/retryable-writes/tests/bulkWrite.yml
+++ b/source/retryable-writes/tests/bulkWrite.yml
@@ -220,6 +220,13 @@ tests:
                 options: { ordered: true }
         outcome:
             error: true
+            result:
+                deletedCount: 0
+                insertedIds: { }
+                matchedCount: 0
+                modifiedCount: 0
+                upsertedCount: 0
+                upsertedIds: { }
             collection:
                 data:
                     - { _id: 1, x: 11 }
@@ -248,6 +255,13 @@ tests:
                 options: { ordered: true }
         outcome:
             error: true
+            result:
+                deletedCount: 0
+                insertedIds: { 0: 2 }
+                matchedCount: 0
+                modifiedCount: 0
+                upsertedCount: 0
+                upsertedIds: { }
             collection:
                 data:
                     - { _id: 1, x: 11 }
@@ -278,6 +292,13 @@ tests:
                 options: { ordered: true }
         outcome:
             error: true
+            result:
+                deletedCount: 0
+                insertedIds: { 0: 2 }
+                matchedCount: 1
+                modifiedCount: 1
+                upsertedCount: 0
+                upsertedIds: { }
             collection:
                 data:
                     - { _id: 1, x: 12 }

--- a/source/retryable-writes/tests/bulkWrite.yml
+++ b/source/retryable-writes/tests/bulkWrite.yml
@@ -29,7 +29,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
-                insertedIds: { 1: 2 }
+                insertedIds: { 0: 2 }
                 matchedCount: 1
                 modifiedCount: 1
                 upsertedCount: 0
@@ -121,7 +121,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
-                insertedIds: { 1: 2 }
+                insertedIds: { 0: 2 }
                 matchedCount: 2
                 modifiedCount: 2
                 upsertedCount: 0
@@ -156,7 +156,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
-                insertedIds: { 1: 2 }
+                insertedIds: { 0: 2 }
                 matchedCount: 2
                 modifiedCount: 2
                 upsertedCount: 0


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-971

Note that the first commit in this PR also fixes an off-by-one error for indexes of `insertedIds` objects in the write result. @rozza: If you didn't notice that error while reviewing https://github.com/mongodb/specifications/pull/219, it's possible that you might not be asserting `insertedIds` correctly.