### PR TITLE
SPEC-969: Standalone servers do not support retryable writes

### DIFF
--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -361,12 +361,18 @@ If possible, drivers should test that transaction IDs are never included in
 commands for unsupported write operations:
 
 * Write commands with unacknowledged write concerns (e.g. ``{w: 0}``)
+
 * Unsupported single-statement write operations
+
   - ``updateMany()``
   - ``deleteMany()``
+
 * Unsupported multi-statement write operations
+
   - ``bulkWrite()`` that includes ``UpdateMany`` or ``DeleteMany``
+
 * Unsupported write commands
+
   - ``aggregate`` with ``$out`` pipeline operator
 
 Drivers may also be able to verify at-most-once semantics as described above by

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -262,6 +262,12 @@ server may not support retryable writes if the
 cluster; however, that can only be reported as a server-side error (discussed
 later).
 
+Write commands executed on a standalone server do not support retryable behavior
+as standalone servers do not have an oplog. Drivers MUST NOT consider the server
+type when deciding to include a transaction ID in a supported write command and
+instead rely on the server to raise an error in this case. Such an error will
+inform users that the driver has been misconfigured.
+
 Write commands specifying an unacknowledged write concern (e.g. ``{w: 0})``) do
 not support retryable behavior. Drivers MUST NOT add a transaction ID to any
 write command with an unacknowledged write concern executed within a MongoClient
@@ -294,8 +300,9 @@ commands and MUST NOT retry these commands if they fail to return a response.
 
 Retryable write commands may not be supported at all in MongoDB 3.6 if the
 ``{setFeatureCompatibilityVersion: 3.6}`` admin command has not been run on the
-cluster. Drivers cannot anticipate this scenario and MUST rely on the server to
-raise an error if 3.6 feature compatibility is not enabled.
+cluster. Additionally, retryable write commands may not be supported on a shard
+cluster where one or more shards is a standalone server. Drivers cannot
+anticipate these scenarios and MUST rely on the server to raise an error.
 
 Logging Retry Attempts
 ======================
@@ -548,6 +555,8 @@ may report the same ``requestId``.
 
 Changes
 =======
+
+2017-10-18: Standalone servers do not support retryable writes.
 
 2017-10-18: Also retry writes after a "not master" error.
 

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -52,14 +52,16 @@ Transaction ID
    running. In a write command where the client has requested retryable
    behavior, it is expressed by the top-level ``lsid`` and ``txnNumber`` fields.
    The ``lsid`` component is the corresponding server session ID. which is a
-   BSON value defined in the Driver Session specification. The ``txnNumber``
+   BSON value defined in the `Driver Session`_ specification. The ``txnNumber``
    component is a monotonically increasing (per server session), positive 64-bit
    integer.
 
+   .. _Driver Session: ../sessions/driver-sessions.rst
+
 ClientSession
-   Driver object representing a client session, which is defined in the Driver
-   Session specification. This object is always associated with a server
-   session; however, drivers will pool server sessions so that creating a
+   Driver object representing a client session, which is defined in the
+   `Driver Session`_ specification. This object is always associated with a
+   server session; however, drivers will pool server sessions so that creating a
    ClientSession will not always entail creation of a new server session. The
    name of this object MAY vary across drivers.
 
@@ -71,7 +73,7 @@ Retryable Error
 
    .. _Error Handling: ../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#error-handling
 
-Additional terms may be defined in the Driver Session specification.
+Additional terms may be defined in the `Driver Session`_ specification.
 
 Naming Deviations
 -----------------
@@ -150,9 +152,9 @@ When constructing a supported write command that will be executed within a
 MongoClient where retryable writes have been enabled, drivers MUST increment the
 transaction number for the corresponding server session and include the server
 session ID and transaction number in top-level ``lsid`` and ``txnNumber``
-fields, respectively. ``lsid`` is a BSON value (discussed in the Driver Session
-specification). ``txnNumber`` MUST be a positive 64-bit integer (BSON type
-0x12).
+fields, respectively. ``lsid`` is a BSON value (discussed in the
+`Driver Session`_ specification). ``txnNumber`` MUST be a positive 64-bit
+integer (BSON type 0x12).
 
 The following example illustrates a possible write command for an
 ``updateOne()`` operation:
@@ -381,7 +383,7 @@ support this behavior.
 Design Rationale
 ================
 
-The design of this specification piggy-backs that of the Driver Session
+The design of this specification piggy-backs that of the `Driver Session`_
 specification in that it modifies the driver API as little as possible to
 introduce the concept of at-most-once semantics and retryable behavior for write
 operations. A transaction ID will be included in all supported write commands

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -127,14 +127,19 @@ Each YAML file has the following keys:
 Use as Integration Tests
 ========================
 
-Running these as integration tests will require a running mongod server. Each of
-these tests is valid against a standalone mongod, a replica set, and a sharded
-system for server version 3.6.0 or later.
+Running these as integration tests will require a running MongoDB cluster with
+server versions 3.6.0 or later. The ``{setFeatureCompatibilityVersion: 3.6}``
+admin command will also need to have been executed to enable support for
+retryable writes on the cluster.
 
 Network Error Tests
 ===================
 
-The YAML tests exercise the following test scenarios:
+The YAML tests may be used to test a replica set. The tests cannot be run
+against a shard cluster because mongos does not support the necessary fail
+point.
+
+The tests exercise the following scenarios:
 
 - Single-statement write operations
 

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -246,18 +246,25 @@ Drivers should test that transaction IDs are never included in commands for
 unsupported write operations:
 
 * Write commands with unacknowledged write concerns (e.g. ``{w: 0}``)
+
 * Unsupported single-statement write operations
+
   - ``updateMany()``
   - ``deleteMany()``
+
 * Unsupported multi-statement write operations
+
   - ``bulkWrite()`` that includes ``UpdateMany`` or ``DeleteMany``
+
 * Unsupported write commands
+
   - ``aggregate`` with ``$out`` pipeline operator
 
 Drivers should test that transactions IDs are always included in commands for
 supported write operations:
 
 * Supported single-statement write operations
+
   - ``insertOne()``
   - ``updateOne()``
   - ``replaceOne()``
@@ -265,7 +272,9 @@ supported write operations:
   - ``findOneAndDelete()``
   - ``findOneAndReplace()``
   - ``findOneAndUpdate()``
+
 * Supported multi-statement write operations
+
   - ``insertMany()`` with ``ordered=true``
   - ``insertMany()`` with ``ordered=false``
   - ``bulkWrite()`` with ``ordered=true`` (no ``UpdateMany`` or ``DeleteMany``)

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -224,3 +224,46 @@ The test proceeds as follows:
   means to observe both attempts.
 - Using the fail point client, deactivate the fail point by setting ``mode``
   to ``"off"``.
+
+Command Construction Tests
+==========================
+
+Drivers should also assert that command documents are properly constructed with
+or without a transaction ID, depending on whether the write operation is
+supported. `Command Monitoring`_ may be used to check for the presence of a
+``txnNumber`` field in the command document. Note that command documents may
+always include an ``lsid`` field per the `Driver Session`_ specification.
+
+.. _Command Monitoring: ../../command-monitoring/command-monitoring.rst
+.. _Driver Session: ../../sessions/driver-sessions.rst
+
+These tests may be run against both a replica set and shard cluster.
+
+Drivers should test that transaction IDs are never included in commands for
+unsupported write operations:
+
+* Write commands with unacknowledged write concerns (e.g. ``{w: 0}``)
+* Unsupported single-statement write operations
+  - ``updateMany()``
+  - ``deleteMany()``
+* Unsupported multi-statement write operations
+  - ``bulkWrite()`` that includes ``UpdateMany`` or ``DeleteMany``
+* Unsupported write commands
+  - ``aggregate`` with ``$out`` pipeline operator
+
+Drivers should test that transactions IDs are always included in commands for
+supported write operations:
+
+* Supported single-statement write operations
+  - ``insertOne()``
+  - ``updateOne()``
+  - ``replaceOne()``
+  - ``deleteOne()``
+  - ``findOneAndDelete()``
+  - ``findOneAndReplace()``
+  - ``findOneAndUpdate()``
+* Supported multi-statement write operations
+  - ``insertMany()`` with ``ordered=true``
+  - ``insertMany()`` with ``ordered=false``
+  - ``bulkWrite()`` with ``ordered=true`` (no ``UpdateMany`` or ``DeleteMany``)
+  - ``bulkWrite()`` with ``ordered=false`` (no ``UpdateMany`` or ``DeleteMany``)

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -50,10 +50,10 @@ may be combined if desired:
   If set, the specified exception code will be thrown and the write will not be
   committed. If unset, the write will be allowed to commit.
 
-Disabling Fail Point after Test Failure
----------------------------------------
+Disabling Fail Point after Test Execution
+-----------------------------------------
 
-In the event of a test failure, drivers should disable the
+After each test that configures a fail point, drivers should disable the
 ``onPrimaryTransactionalWrite`` fail point to avoid spurious failures in
 subsequent tests. The fail point may be disabled like so::
 

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -85,9 +85,9 @@ Each YAML file has the following keys:
   - ``description``: The name of the test.
 
   - ``failPoint``: Document describing options for configuring the
-    ``onPrimaryTransactionalWrite`` fail point. This document should be merged
-    with the ``{ configureFailPoint: "onPrimaryTransactionalWrite" }`` command
-    document.
+    ``onPrimaryTransactionalWrite`` fail point on the primary server. This
+    document should be merged with the
+    ``{ configureFailPoint: "onPrimaryTransactionalWrite" }`` command document.
 
   - ``operation``: Document describing the operation to be executed. The
     operation should be executed through a collection object derived from a


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-969