### PR TITLE
SPEC-971 and SPEC-972: Revise error reporting for retryable and bulk writes

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -12,7 +12,7 @@ Driver CRUD API
 :Status: Approved
 :Type: Standards
 :Minimum Server Version: 2.6
-:Last Modified: October 17, 2017
+:Last Modified: October 23, 2017
 
 .. contents::
 
@@ -1253,6 +1253,14 @@ Below are defined the exceptions that should be thrown from the various write me
     unprocessedRequests: Optional<Iterable<WriteModel>>;
 
     /**
+     * The intermediary write result for any operations that succeeded before
+     * the bulk write was interrupted.
+     *
+     * NOT REQUIRED: Drivers may choose to not provide this property.
+     */
+    writeResult: Optional<BulkWriteResult>;
+
+    /**
      * The error that occured on account of write concern failure. If the error was a Write Concern related, this field must be present.
      */
     writeConcernError: Optional<WriteConcernError>;
@@ -1616,6 +1624,7 @@ Q: Where is ``singleBatch`` in FindOptions?
 Changes
 =======
 
+* 2017-10-23: Allow BulkWriteException to provide an intermediary write result.
 * 2017-10-17: Document negative limit for FindOptions.
 * 2017-10-09: Bumped minimum server version to 2.6 and removed references to older versions in spec and tests.
 * 2017-10-09: Prohibit empty insertMany() and bulkWrite() operations.

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -278,7 +278,9 @@ In the case of a multi-statement write operation split across multiple write
 commands, a failed retry attempt will also interrupt execution of any additional
 write operations in the batch (regardless of the ordered option). This is no
 different than if a retryable error had been encountered without retryable
-behavior enabled or supported by the driver.
+behavior enabled or supported by the driver. Drivers are encouraged to provide
+access to an intermediary write result (e.g. BulkWriteResult, InsertManyResult)
+through the BulkWriteException, in accordance with the `CRUD`_ specification.
 
 Supported Write Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -610,7 +612,8 @@ Changes
 =======
 
 2017-10-23: Raise the original retryable error if server selection or wire
-protocol checks fail during the retry attempt.
+protocol checks fail during the retry attempt. Encourage drivers to provide
+intermediary write results after an unrecoverable failure during a bulk write.
 
 2017-10-18: Standalone servers do not support retryable writes.
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-971
https://jira.mongodb.org/browse/SPEC-972

Note: I've lumped both tickets into the same PR as they're somewhat related. The retryable writes revisions for SPEC-972 are also relevant to improving access to intermediary write results during a failed bulk write (SPEC-971).