### PR TITLE
Fix insertMany failpoint

### DIFF
--- a/source/retryable-writes/tests/insertMany.json
+++ b/source/retryable-writes/tests/insertMany.json
@@ -110,9 +110,7 @@
     {
       "description": "InsertMany fails after multiple network errors",
       "failPoint": {
-        "mode": {
-          "times": 2
-        },
+        "mode": "alwaysOn",
         "data": {
           "failBeforeCommitExceptionCode": 1
         }

--- a/source/retryable-writes/tests/insertMany.yml
+++ b/source/retryable-writes/tests/insertMany.yml
@@ -45,12 +45,12 @@ tests:
     -
         description: "InsertMany fails after multiple network errors"
         failPoint:
-            mode: { times: 2 }
+            mode: "alwaysOn"
             data: { failBeforeCommitExceptionCode: 1 }
         operation:
             name: "insertMany"
             arguments:
-                documents: 
+                documents:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
                     - { _id: 4, x: 44 }

--- a/source/retryable-writes/tests/insertMany.yml
+++ b/source/retryable-writes/tests/insertMany.yml
@@ -45,6 +45,12 @@ tests:
     -
         description: "InsertMany fails after multiple network errors"
         failPoint:
+            # Normally, a mongod will insert the documents as a batch with a
+            # single commit. If this fails, mongod may try to insert each
+            # document one at a time depending on the failure. Therefore our
+            # single insert command may trigger the failpoint twice on each
+            # driver attempt. This test permanently enables the fail point to
+            # ensure the retry attempt always fails.
             mode: "alwaysOn"
             data: { failBeforeCommitExceptionCode: 1 }
         operation:


### PR DESCRIPTION
With `times: 2` the retry attempt for this insert still succeeds:
```
> db.adminCommand( { "configureFailPoint" : "onPrimaryTransactionalWrite", "mode" : { "times" : 2 }, "data" : { "failBeforeCommitExceptionCode" : 1 } })
{ "ok" : 1, "operationTime" : Timestamp(1509648432, 5) }
> var txnCmd = {"insert":"test","documents":[{_id:1},{_id:2},{_id:3}], "lsid": {"id": BinData(4, "nGmSpxKoTcWrYclQh5xF0A==")}, txnNumber: NumberLong(12), ordered: true}
> db.runCommand(txnCmd);
2017-11-02T14:47:25.664-0400 E QUERY    [thread1] Error: error doing query: failed: network error while attempting to run command 'insert' on host '127.0.0.1:27017'  :
DB.prototype.runCommand@src/mongo/shell/db.js:132:1
@(shell):1:1
2017-11-02T14:47:25.666-0400 I NETWORK  [thread1] trying reconnect to 127.0.0.1:27017 (127.0.0.1) failed
2017-11-02T14:47:25.667-0400 I NETWORK  [thread1] reconnect 127.0.0.1:27017 (127.0.0.1) ok
> db.runCommand(txnCmd);
{
	"n" : 3,
	"opTime" : {
		"ts" : Timestamp(1509648446, 3),
		"t" : NumberLong(1)
	},
	"electionId" : ObjectId("7fffffff0000000000000001"),
	"ok" : 1,
	"operationTime" : Timestamp(1509648446, 3)
}
```
With "alwaysOn" the retry fails like we want:
```
> db.adminCommand( { "configureFailPoint" : "onPrimaryTransactionalWrite", "mode" : "alwaysOn", "data" : { "failBeforeCommitExceptionCode" : 1 } })
{ "ok" : 1, "operationTime" : Timestamp(1509648549, 5) }
> var txnCmd = {"insert":"test","documents":[{_id:1},{_id:2},{_id:3}], "lsid": {"id": BinData(4, "nGmSpxKoTcWrYclQh5xF0A==")}, txnNumber: NumberLong(12), ordered: true}
> db.runCommand(txnCmd);
2017-11-02T14:49:29.482-0400 E QUERY    [thread1] Error: error doing query: failed: network error while attempting to run command 'insert' on host '127.0.0.1:27017'  :
DB.prototype.runCommand@src/mongo/shell/db.js:132:1
@(shell):1:1
2017-11-02T14:49:29.483-0400 I NETWORK  [thread1] trying reconnect to 127.0.0.1:27017 (127.0.0.1) failed
2017-11-02T14:49:29.485-0400 I NETWORK  [thread1] reconnect 127.0.0.1:27017 (127.0.0.1) ok
> db.runCommand(txnCmd);
2017-11-02T14:49:30.529-0400 E QUERY    [thread1] Error: error doing query: failed: network error while attempting to run command 'insert' on host '127.0.0.1:27017'  :
DB.prototype.runCommand@src/mongo/shell/db.js:132:1
@(shell):1:1
2017-11-02T14:49:30.532-0400 I NETWORK  [thread1] trying reconnect to 127.0.0.1:27017 (127.0.0.1) failed
2017-11-02T14:49:30.533-0400 I NETWORK  [thread1] reconnect 127.0.0.1:27017 (127.0.0.1) ok
```