### PR TITLE
Application-configurable server selector

### DIFF
--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -262,5 +262,5 @@ Application-Provided Server Selector
 
 The Server Selection spec allows drivers to configure registration of a server selector
 function that filters the list of suitable servers.  Drivers implementing this part
-of the spec MUST test that the applicaton-provided server selector is executed
+of the spec MUST test that the application-provided server selector is executed
 as part of the server selection process.

--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -264,3 +264,8 @@ The Server Selection spec allows drivers to configure registration of a server s
 function that filters the list of suitable servers.  Drivers implementing this part
 of the spec MUST test that the application-provided server selector is executed
 as part of the server selection process.
+
+For example, execute a test against a replica set: Register a server selector that selects
+the suitable server with the highest port number. Execute 10 queries with nearest read
+preference and, using command monitoring, assert that all the operations execute on the
+member with the highest port number.

--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -8,7 +8,7 @@ Server Selection -- Test Plan
 :Advisors: David Golden
 :Status: Draft
 :Type: Standards
-:Last Modified: February 2, 2015
+:Last Modified: November 10, 2017
 
 See also the YAML test files and their accompanying README in the "tests"
 directory.
@@ -256,3 +256,11 @@ return a set of three suitable servers within the latency window::
 
 Drivers SHOULD check that their implementation selects one of ``primary``, ``secondary_1``,
 and ``secondary_2`` at random.
+
+Application-Provided Server Selector
+====================================
+
+The Server Selection spec allows drivers to configure registration of a server selector
+function that filters the list of suitable servers.  Drivers implementing this part
+of the spec MUST test that the applicaton-provided server selector is executed
+as part of the server selection process.

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -344,10 +344,10 @@ in the Max Staleness Spec.
 serverSelector
 ~~~~~~~~~~~~~~
 
-An optional, application-provided function that augments the server selection
-rules.  The functions takes as a parameter a list of server descriptions representing
-the suitable servers for the read or write operation, and returns a list of server
-descriptions that should still be considered suitable.
+Implementations MAY allow configuration of an optional, application-provided function
+that augments the server selection rules.  The functions takes as a parameter a list
+of server descriptions representingthe suitable servers for the read or write operation,
+and returns a list of server descriptions that should still be considered suitable.
 
 Read Preference
 ---------------

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -345,7 +345,7 @@ serverSelector
 ~~~~~~~~~~~~~~
 
 Implementations MAY allow configuration of an optional, application-provided function
-that augments the server selection rules.  The functions takes as a parameter a list
+that augments the server selection rules.  The function takes as a parameter a list
 of server descriptions representingthe suitable servers for the read or write operation,
 and returns a list of server descriptions that should still be considered suitable.
 


### PR DESCRIPTION
SPEC-897

Here's how I resolved the open questions on the spec ticket:

Q. Precisely what information should be passed to the application's server selector? Note that driver's can re-use types that have been defined for SDAM Monitoring, e.g. ServerDescription

A. The server selector takes as a parameter a list of server descriptions and returns a list of server descriptions.

Q. Should the application's server selector replace RTT or just be inserted right before, and allow RTT to be applied to the list of selected server's in the case where the application's select selects more than one? My preference is to always apply RTT to the list of servers returned by the application's selector, since an application can turn that into a no-op by returning a single server.

A. The server selector is inserted in the middle, after the list of suitable server is determined, and before RTT.  This requires the least change to the specification, and has the following benefits:

- It starts with the list of suitable servers, so for example read preference is always applied first b the driver and can't be subverted by the application-provided selector
- RTT can still be used as a tie-breaker if the application-provided selector finds more than one suitable server.  If the application wants to skip RTT entirely it's very easy: just ensure that it's selector returns at most a single server

