### PR TITLE
Exclude servers of type RSGhost and RSArbiter when considering logicalSessionTimeoutMinutes

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -1264,10 +1264,9 @@ Logical Session Timeout
 
 Whenever a client updates the TopologyDescription from an ismaster response,
 it MUST set TopologyDescription.logicalSessionTimeoutMinutes to the smallest
-logicalSessionTimeoutMinutes value among all ServerDescriptions of
-known ServerType. If any ServerDescription of known ServerType has a null
-logicalSessionTimeoutMinutes, then
-TopologyDescription.logicalSessionTimeoutMinutes MUST be set to null.
+logicalSessionTimeoutMinutes value among ServerDescriptions of all ServerTypes
+except RSArbiter or RSGhost . If any have a null logicalSessionTimeoutMinutes,
+then TopologyDescription.logicalSessionTimeoutMinutes MUST be set to null.
 
 See the Driver Sessions Spec for the purpose of this value.
 

--- a/source/server-discovery-and-monitoring/tests/rs/ls_timeout.json
+++ b/source/server-discovery-and-monitoring/tests/rs/ls_timeout.json
@@ -11,14 +11,127 @@
             "ismaster": true,
             "hosts": [
               "a:27017",
-              "b:27017"
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
             ],
             "setName": "rs",
-            "logicalSessionTimeoutMinutes": 1,
+            "logicalSessionTimeoutMinutes": 3,
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ],
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "Unknown"
+          },
+          "e:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 3,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "d:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "isreplicaset": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 3,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "e:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
+            ],
+            "setName": "rs",
+            "arbiterOnly": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 3,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
         [
           "b:27017",
           {
@@ -27,7 +140,10 @@
             "secondary": true,
             "hosts": [
               "a:27017",
-              "b:27017"
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
             ],
             "setName": "rs",
             "logicalSessionTimeoutMinutes": 2,
@@ -45,6 +161,58 @@
           "b:27017": {
             "type": "RSSecondary",
             "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 2,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "c:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "setName": "rs",
+            "hidden": true,
+            "logicalSessionTimeoutMinutes": 1,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
@@ -55,21 +223,6 @@
     {
       "responses": [
         [
-          "a:27017",
-          {
-            "ok": 1,
-            "ismaster": true,
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
-            "setName": "rs",
-            "logicalSessionTimeoutMinutes": 1,
-            "minWireVersion": 0,
-            "maxWireVersion": 6
-          }
-        ],
-        [
           "b:27017",
           {
             "ok": 1,
@@ -77,7 +230,10 @@
             "secondary": true,
             "hosts": [
               "a:27017",
-              "b:27017"
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
             ],
             "setName": "rs",
             "logicalSessionTimeoutMinutes": null,
@@ -94,6 +250,17 @@
           },
           "b:27017": {
             "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
             "setName": "rs"
           }
         },

--- a/source/server-discovery-and-monitoring/tests/rs/ls_timeout.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/ls_timeout.yml
@@ -3,31 +3,134 @@ description: "Parse logicalSessionTimeoutMinutes from replica set"
 uri: "mongodb://a/?replicaSet=rs"
 
 phases: [
-
+    # RSPrimary responds with a non-null logicalSessionTimeoutMinutes
     {
         responses: [
-            ["a:27017", {
+             ["a:27017", {
                 ok: 1,
                 ismaster: true,
-                hosts: ["a:27017", "b:27017"],
+                hosts: ["a:27017", "b:27017", "c:27017", "d:27017", "e:27017"],
                 setName: "rs",
-                logicalSessionTimeoutMinutes: 1,
+                logicalSessionTimeoutMinutes: 3,
                 minWireVersion: 0,
                 maxWireVersion: 6
             }],
-            ["b:27017", {
+        ],
+        # RSGhost is ignored
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "Unknown",
+                },
+                "c:27017": {
+                    type: "Unknown",
+                },
+                "d:27017": {
+                    type: "Unknown",
+                },
+                "e:27017": {
+                    type: "Unknown",
+                }
+
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: 3,
+            setName: "rs",
+        }
+    },
+    # An RSGhost responds without a logicalSessionTimeoutMinutes
+    {
+        responses: [
+            ["d:27017", {
                 ok: 1,
                 ismaster: false,
-                secondary: true,
-                hosts: ["a:27017", "b:27017"],
+                isreplicaset: true,
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }],
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "Unknown",
+                },
+                "c:27017": {
+                    type: "Unknown",
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "Unknown",
+                }
+
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: 3,
+            setName: "rs",
+        }
+    },
+    # An RSArbiter responds without a logicalSessionTimeoutMinutes
+    {
+        responses: [
+           ["e:27017", {
+                ok: 1,
+                ismaster: false,
+                hosts: ["a:27017", "b:27017", "c:27017", "d:27017", "e:27017"],
                 setName: "rs",
-                logicalSessionTimeoutMinutes: 2,
+                arbiterOnly: true,
                 minWireVersion: 0,
                 maxWireVersion: 6
             }]
         ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "Unknown",
+                },
+                "c:27017": {
+                    type: "Unknown",
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "RSArbiter",
+                    setName: "rs"
+                }
 
-        # logicalSessionTimeoutMinutes is the minimum of the two
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: 3,
+            setName: "rs",
+        }
+    },
+    # An RSSecondary responds with a lower logicalSessionTimeoutMinutes
+    {
+        responses: [
+            ["b:27017", {
+                ok: 1,
+                ismaster: false,
+                secondary: true,
+                hosts: ["a:27017", "b:27017", "c:27017", "d:27017", "e:27017"],
+                setName: "rs",
+                logicalSessionTimeoutMinutes: 2,
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }],
+        ],
         outcome: {
             servers: {
                 "a:27017": {
@@ -37,30 +140,72 @@ phases: [
                 "b:27017": {
                     type: "RSSecondary",
                     setName: "rs"
+                },
+                "c:27017": {
+                    type: "Unknown",
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "RSArbiter",
+                    setName: "rs"
                 }
+
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: 2,
+            setName: "rs",
+        }
+    },
+    # An RSOther responds with an even lower logicalSessionTimeoutMinutes
+    {
+        responses: [
+            ["c:27017", {
+                ok: 1,
+                ismaster: false,
+                setName: "rs",
+                hidden: true,
+                logicalSessionTimeoutMinutes: 1,
+                minWireVersion: 0,
+                maxWireVersion: 6
+            }],
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+                "c:27017": {
+                    type: "RSOther",
+                    setName: "rs"
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "RSArbiter",
+                    setName: "rs"
+              }
             },
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: 1,
             setName: "rs",
         }
     },
-    # Now an isMaster response with no logicalSessionTimeoutMinutes
+    # Now the RSSecondary responds with no logicalSessionTimeoutMinutes
     {
         responses: [
-            ["a:27017", {
-                ok: 1,
-                ismaster: true,
-                hosts: ["a:27017", "b:27017"],
-                setName: "rs",
-                logicalSessionTimeoutMinutes: 1,
-                minWireVersion: 0,
-                maxWireVersion: 6
-            }],
             ["b:27017", {
                 ok: 1,
                 ismaster: false,
                 secondary: true,
-                hosts: ["a:27017", "b:27017"],
+                hosts: ["a:27017", "b:27017", "c:27017", "d:27017", "e:27017"],
                 setName: "rs",
                 logicalSessionTimeoutMinutes: null,
                 minWireVersion: 0,
@@ -77,6 +222,17 @@ phases: [
                 },
                 "b:27017": {
                     type: "RSSecondary",
+                    setName: "rs"
+                },
+                "c:27017": {
+                    type: "RSOther",
+                    setName: "rs"
+                },
+                "d:27017": {
+                    type: "RSGhost",
+                },
+                "e:27017": {
+                    type: "RSArbiter",
                     setName: "rs"
                 }
             },

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -489,13 +489,15 @@ A driver can determine whether a deployment supports sessions by checking
 whether the ``logicalSessionTimeoutMinutes`` property of the ``TopologyDescription``
 has a value or not. If it has a value the deployment supports sessions.
 However, in order for this determination to be valid, the driver MUST be
-connected to at least one server. Therefore, the detailed steps to determine
+connected to at least one server of a type that is able to report a value for
+``logicalSessionTimeoutMinutes``. Therefore, the detailed steps to determine
 whether sessions are supported are: 
 
 1. If the ``TopologyDescription`` indicates that the driver is not connected to
-any servers, a driver must do a server selection for any server. Server
-selection will either time out or result in a ``TopologyDescription`` that
-includes at least one connected server
+any servers, or only connected to servers of type RSArbiter or RSGhost, a driver must do
+a server selection for any server whose type is neither RSArbiter nor RSGhost. Server
+selection will either time out or result in a ``TopologyDescription`` that includes
+at least one connected server
 
 2. Having verified in step 1 that the ``TopologyDescription`` includes at least
 one connected server a driver can now determine whether sessions are supported


### PR DESCRIPTION
Neither ghosts not arbiters can be trusted for logicalSessionTimeoutMinutes because neither are participating in replication and therefore do not know about changes to FCV.