### PR TITLE
SPEC-996 re-order bulk write ops to avoid mid-batch error

### DIFF
--- a/source/retryable-writes/tests/bulkWrite.json
+++ b/source/retryable-writes/tests/bulkWrite.json
@@ -584,15 +584,6 @@
         "arguments": {
           "requests": [
             {
-              "name": "insertOne",
-              "arguments": {
-                "document": {
-                  "_id": 2,
-                  "x": 22
-                }
-              }
-            },
-            {
               "name": "updateOne",
               "arguments": {
                 "filter": {
@@ -602,6 +593,15 @@
                   "$inc": {
                     "x": 1
                   }
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 2,
+                  "x": 22
                 }
               }
             },

--- a/source/retryable-writes/tests/bulkWrite.yml
+++ b/source/retryable-writes/tests/bulkWrite.yml
@@ -276,14 +276,14 @@ tests:
             arguments:
                 requests:
                     -
-                        name: "insertOne"
-                        arguments:
-                            document: { _id: 2, x: 22 }
-                    -
                         name: "updateOne"
                         arguments:
                             filter: { _id: 1 }
                             update: { $inc: { x : 1 }}
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 2, x: 22 }
                     -
                         name: "updateOne"
                         arguments:


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-996

See: https://github.com/jmikola/mongo-c-driver/pull/3/commits/e74ff806d59fba37c4af64ac69519aed25348735#r151318363 for additional context.