### PR TITLE
Add tests for auth in DNS Seedlist specs

### DIFF
--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -85,8 +85,8 @@ seeds. You MUST verify that the set of ServerDescriptions in the client's
 TopologyDescription eventually matches the list of hosts. You MUST verify that
 each of the values of the Connection String Options under ``options`` match the
 Client's parsed value for that option. There may be other options parsed by
-the Client as well, which a test does not verify. In ``uri-with-auth`` the uri
+the Client as well, which a test does not verify. In ``uri-with-auth`` the URI
 contains a user/password set and additional options are provided in
 ``parsed_options`` so that tests can verify authentication is maintained when
-evaluating uris. You MUST verify that an error has been thrown if ``error`` is
+evaluating URIs. You MUST verify that an error has been thrown if ``error`` is
 present.

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -73,6 +73,8 @@ These YAML and JSON files contain the following fields:
 - ``hosts``: the discovered topology's list of hosts once SDAM completes a scan
 - ``options``: the parsed connection string options as discovered from URI and
   TXT records
+- ``parsed_options``: additional options present in the URI such as user/password
+credentials
 - ``error``: indicates that the parsing of the URI, or the resolving or
   contents of the SRV or TXT records included errors.
 - ``comment``: a comment to indicate why a test would fail.
@@ -83,5 +85,8 @@ seeds. You MUST verify that the set of ServerDescriptions in the client's
 TopologyDescription eventually matches the list of hosts. You MUST verify that
 each of the values of the Connection String Options under ``options`` match the
 Client's parsed value for that option. There may be other options parsed by
-the Client as well, which a test does not verify. You MUST verify that an
-error has been thrown if ``error`` is present.
+the Client as well, which a test does not verify. In ``uri-with-auth`` the uri
+contains a user/password set and additional options are provided in
+``parsed_options`` so that tests can verify authentication is maintained when
+evaluating uris. You MUST verify that an error has been thrown if ``error`` is
+present.

--- a/source/initial-dns-seedlist-discovery/tests/uri-with-auth.json
+++ b/source/initial-dns-seedlist-discovery/tests/uri-with-auth.json
@@ -9,11 +9,9 @@
     "localhost:27018",
     "localhost:27019"
   ],
-  "options": {
-    "auth": {
-      "user": "auser",
-      "password": "apass"
-    }
+  "parsed_options": {
+    "user": "auser",
+    "password": "apass"
   },
   "comment": "Should preserve auth credentials"
 }

--- a/source/initial-dns-seedlist-discovery/tests/uri-with-auth.json
+++ b/source/initial-dns-seedlist-discovery/tests/uri-with-auth.json
@@ -1,0 +1,19 @@
+{
+  "uri": "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "auth": {
+      "user": "auser",
+      "password": "apass"
+    }
+  },
+  "comment": "Should preserve auth credentials"
+}

--- a/source/initial-dns-seedlist-discovery/tests/uri-with-auth.yml
+++ b/source/initial-dns-seedlist-discovery/tests/uri-with-auth.yml
@@ -6,8 +6,7 @@ hosts:
     - localhost:27017
     - localhost:27018
     - localhost:27019
-options:
-    auth:
-      user: auser
-      password: apass
+parsed_options:
+    user: auser
+    password: apass
 comment: Should preserve auth credentials

--- a/source/initial-dns-seedlist-discovery/tests/uri-with-auth.yml
+++ b/source/initial-dns-seedlist-discovery/tests/uri-with-auth.yml
@@ -1,6 +1,7 @@
 uri: "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0"
 seeds:
     - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
 hosts:
     - localhost:27017
     - localhost:27018

--- a/source/initial-dns-seedlist-discovery/tests/uri-with-auth.yml
+++ b/source/initial-dns-seedlist-discovery/tests/uri-with-auth.yml
@@ -1,0 +1,12 @@
+uri: "mongodb+srv://auser:apass@test1.test.build.10gen.cc/?replicaSet=repl0"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    auth:
+      user: auser
+      password: apass
+comment: Should preserve auth credentials


### PR DESCRIPTION
There was a bug in our driver's implementation of the DNS Seedlist discovery where auth that came in with a `+srv` uri was not preserved in the final connection string.

This PR adds a spec for that case by duplicating the `one-result-default-port` spec and adding dummy `user` and `password` credentials that can be checked by driver tests. No new test servers need to be set up for this.

🔗 https://github.com/mongodb/node-mongodb-native/pull/1640.

cc @mbroadst @daprahamian 