### PR TITLE
SPEC-1020: Add "find" command to "may-use-secondary" list

### DIFF
--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -692,14 +692,17 @@ the command and how it is invoked:
 
       The current list of "may-use-secondary" commands includes:
 
-        - group
-        - mapreduce (with out: {inline: 1})
         - aggregate (without $out specified)
-        - collStats, dbStats
-        - count, distinct
-        - geoNear, geoSearch, geoWalk
+        - collStats
+        - count
+        - dbStats
+        - distinct
+        - find
+        - geoNear
+        - geoSearch
+        - group
+        - mapReduce, mapreduce (with out: {inline: 1})
         - parallelCollectionScan
-        - text (but see caveats under `The 'text' command and mongos`_)
 
       Associated command-specific helpers SHOULD take a read preference
       argument and otherwise MUST use the default read preference from client,


### PR DESCRIPTION
I also went ahead and alphabetized the list so that it more closely resembles [the `set_read_preference_secondary.js` override in the mongodb/mongo repository](https://github.com/mongodb/mongo/blob/r3.7.1/jstests/libs/override_methods/set_read_preference_secondary.js#L25-L38).