### PR TITLE
Inconsistent write concern should cause error in connection string

### DIFF
--- a/source/read-write-concern/tests/connection-string/write-concern.json
+++ b/source/read-write-concern/tests/connection-string/write-concern.json
@@ -107,8 +107,8 @@
     {
       "description": "Acknowledged with w as 0 and journal true",
       "uri": "mongodb://localhost/?w=0&journal=true",
-      "valid": true,
-      "warning": true,
+      "valid": false,
+      "warning": false,
       "writeConcern": {
         "w": 0,
         "journal": true

--- a/source/read-write-concern/tests/connection-string/write-concern.yml
+++ b/source/read-write-concern/tests/connection-string/write-concern.yml
@@ -72,6 +72,6 @@ tests:
     -
         description: "Acknowledged with w as 0 and journal true"
         uri: "mongodb://localhost/?w=0&journal=true"
-        valid: true
-        warning: true
+        valid: false
+        warning: false
         writeConcern: { w: 0, journal: true }


### PR DESCRIPTION
Given that the spec says that this option should error [when specified](https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#inconsistent-writeconcern), I think this should be an error instead of a warning.