### PR TITLE
Inconsistent write concern in document test is invalid

### DIFF
--- a/source/read-write-concern/tests/README.rst
+++ b/source/read-write-concern/tests/README.rst
@@ -51,7 +51,7 @@ array of test case objects, each of which have the following keys:
 
 - ``description``: A string describing the test.
 - ``uri``: A string containing the URI to be parsed.
-- ``valid:``: a boolean indicating if parsing the uri should result in an error.
+- ``valid:``: a boolean indicating if the write concern created from the document is valid.
 - ``writeConcern:`` A document indicating the write concern to use.
 - ``writeConcernDocument:`` A document indicating the write concern to be sent to the server.
 - ``readConcern:`` A document indicating the read concern to use.

--- a/source/read-write-concern/tests/document/write-concern.json
+++ b/source/read-write-concern/tests/document/write-concern.json
@@ -142,7 +142,7 @@
     },
     {
       "description": "W is 0 with journal true",
-      "valid": true,
+      "valid": false,
       "writeConcern": {
         "w": 0,
         "journal": true

--- a/source/read-write-concern/tests/document/write-concern.yml
+++ b/source/read-write-concern/tests/document/write-concern.yml
@@ -85,7 +85,7 @@ tests:
         isAcknowledged: false
     -
         description: "W is 0 with journal true"
-        valid: true
+        valid: false
         writeConcern: { w: 0, journal: true }
         writeConcernDocument: { w: 0, j: true }
         isServerDefault: false


### PR DESCRIPTION
(Apologies for not noticing this before the last PR)

Similar to #267, one of the "document" tests in the read-write-concern spec also describes `w=0,j=true` as being valid. I think_that this should be invalid, although the phrasing of what "valid" means for this test in the README is copy-pasted from the above test and therefore doesn't really make sense. I proposed a wording change to README which clarifies that this should be invalid, but it's possible that we want this test to be interpreted differently since it's just creating write concern from a document, so theoretically we might want users to still be able to construct this write concern even if it causes an error when actually used.