### PR TITLE
SPEC-342

### DIFF
--- a/source/command-monitoring/tests/bulkWrite.json
+++ b/source/command-monitoring/tests/bulkWrite.json
@@ -116,7 +116,7 @@
             {
               "insertOne": {
                 "document": {
-                  "_id": 4,
+                  "_id": -4,
                   "x": 44
                 }
               }
@@ -135,7 +135,7 @@
               "insert": "test",
               "documents": [
                 {
-                  "_id": 4,
+                  "_id": -4,
                   "x": 44
                 }
               ],

--- a/source/command-monitoring/tests/bulkWrite.json
+++ b/source/command-monitoring/tests/bulkWrite.json
@@ -116,7 +116,7 @@
             {
               "insertOne": {
                 "document": {
-                  "_id": -4,
+                  "_id": "unorderedBulkWriteInsertW0",
                   "x": 44
                 }
               }
@@ -135,7 +135,7 @@
               "insert": "test",
               "documents": [
                 {
-                  "_id": -4,
+                  "_id": "unorderedBulkWriteInsertW0",
                   "x": 44
                 }
               ],

--- a/source/command-monitoring/tests/bulkWrite.json
+++ b/source/command-monitoring/tests/bulkWrite.json
@@ -105,58 +105,6 @@
           }
         }
       ]
-    },
-    {
-      "description": "A successful unordered bulk write with an unacknowledged write concern",
-      "comment": "On a 2.4 server, no GLE is sent and requires a client-side manufactured reply",
-      "operation": {
-        "name": "bulkWrite",
-        "arguments": {
-          "requests": [
-            {
-              "insertOne": {
-                "document": {
-                  "_id": "unorderedBulkWriteInsertW0",
-                  "x": 44
-                }
-              }
-            }
-          ],
-          "ordered": false,
-          "writeConcern": {
-            "w": 0
-          }
-        }
-      },
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "test",
-              "documents": [
-                {
-                  "_id": "unorderedBulkWriteInsertW0",
-                  "x": 44
-                }
-              ],
-              "ordered": false,
-              "writeConcern": {
-                "w": 0
-              }
-            },
-            "command_name": "insert",
-            "database_name": "command-monitoring-tests"
-          }
-        },
-        {
-          "command_succeeded_event": {
-            "reply": {
-              "ok": 1
-            },
-            "command_name": "insert"
-          }
-        }
-      ]
     }
   ]
 }

--- a/source/command-monitoring/tests/bulkWrite.yml
+++ b/source/command-monitoring/tests/bulkWrite.yml
@@ -53,7 +53,7 @@ tests:
       arguments:
         requests:
           - insertOne: 
-              document: { _id: 4, x: 44 }
+              document: { _id: -4, x: 44 }
         ordered: false
         writeConcern: { w: 0 }
     expectations:
@@ -62,7 +62,7 @@ tests:
           command:
             insert: *collection_name
             documents:
-              - { _id: 4, x: 44 }
+              - { _id: -4, x: 44 }
             ordered: false
             writeConcern: { w: 0 }
           command_name: "insert"

--- a/source/command-monitoring/tests/bulkWrite.yml
+++ b/source/command-monitoring/tests/bulkWrite.yml
@@ -53,7 +53,7 @@ tests:
       arguments:
         requests:
           - insertOne: 
-              document: { _id: -4, x: 44 }
+              document: { _id: "unorderedBulkWriteInsertW0", x: 44 }
         ordered: false
         writeConcern: { w: 0 }
     expectations:
@@ -62,7 +62,7 @@ tests:
           command:
             insert: *collection_name
             documents:
-              - { _id: -4, x: 44 }
+              - { _id: "unorderedBulkWriteInsertW0", x: 44 }
             ordered: false
             writeConcern: { w: 0 }
           command_name: "insert"

--- a/source/command-monitoring/tests/bulkWrite.yml
+++ b/source/command-monitoring/tests/bulkWrite.yml
@@ -45,29 +45,3 @@ tests:
         command_succeeded_event:
           reply: { ok: 1.0, n: 1 }
           command_name: "update"
-  -
-    description: "A successful unordered bulk write with an unacknowledged write concern"
-    comment: "On a 2.4 server, no GLE is sent and requires a client-side manufactured reply"
-    operation:
-      name: "bulkWrite"
-      arguments:
-        requests:
-          - insertOne: 
-              document: { _id: "unorderedBulkWriteInsertW0", x: 44 }
-        ordered: false
-        writeConcern: { w: 0 }
-    expectations:
-      -
-        command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - { _id: "unorderedBulkWriteInsertW0", x: 44 }
-            ordered: false
-            writeConcern: { w: 0 }
-          command_name: "insert"
-          database_name: *database_name
-      -
-        command_succeeded_event:
-          reply: { ok: 1.0 }
-          command_name: "insert"

--- a/source/command-monitoring/tests/unacknowledgedBulkWrite.json
+++ b/source/command-monitoring/tests/unacknowledgedBulkWrite.json
@@ -1,0 +1,64 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    }
+  ],
+  "collection_name": "test-unacknowledged-bulk-write",
+  "database_name": "command-monitoring-tests",
+  "tests": [
+    {
+      "description": "A successful unordered bulk write with an unacknowledged write concern",
+      "comment": "On a 2.4 server, no GLE is sent and requires a client-side manufactured reply",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "insertOne": {
+                "document": {
+                  "_id": "unorderedBulkWriteInsertW0",
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "ordered": false,
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      },
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test-unacknowledged-bulk-write",
+              "documents": [
+                {
+                  "_id": "unorderedBulkWriteInsertW0",
+                  "x": 44
+                }
+              ],
+              "ordered": false,
+              "writeConcern": {
+                "w": 0
+              }
+            },
+            "command_name": "insert",
+            "database_name": "command-monitoring-tests"
+          }
+        },
+        {
+          "command_succeeded_event": {
+            "reply": {
+              "ok": 1
+            },
+            "command_name": "insert"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/command-monitoring/tests/unacknowledgedBulkWrite.yml
+++ b/source/command-monitoring/tests/unacknowledgedBulkWrite.yml
@@ -1,0 +1,33 @@
+data:
+  - { _id: 1, x: 11 }
+
+collection_name: &collection_name "test-unacknowledged-bulk-write"
+database_name: &database_name "command-monitoring-tests"
+
+tests:
+  -
+    description: "A successful unordered bulk write with an unacknowledged write concern"
+    comment: "On a 2.4 server, no GLE is sent and requires a client-side manufactured reply"
+    operation:
+      name: "bulkWrite"
+      arguments:
+        requests:
+          - insertOne: 
+              document: { _id: "unorderedBulkWriteInsertW0", x: 44 }
+        ordered: false
+        writeConcern: { w: 0 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: "unorderedBulkWriteInsertW0", x: 44 }
+            ordered: false
+            writeConcern: { w: 0 }
+          command_name: "insert"
+          database_name: *database_name
+      -
+        command_succeeded_event:
+          reply: { ok: 1.0 }
+          command_name: "insert"


### PR DESCRIPTION
Use different _id in w : 0 write test to avoid race condition between the write and the collection drop

See https://jira.mongodb.org/browse/SPEC-342 for details.