### PR TITLE
Fix invalid-uris connection string YAML test format

### DIFF
--- a/source/connection-string/tests/invalid-uris.yml
+++ b/source/connection-string/tests/invalid-uris.yml
@@ -231,7 +231,7 @@ tests:
         hosts: ~
         auth: ~
         options: ~
- -
+    -
         description: "Username with password containing an unescaped percent sign"
         uri: "mongodb://alice%foo:bar@127.0.0.1"
         valid: false


### PR DESCRIPTION
This was causing the Ruby YAML parser to error.