### PR TITLE
Clarify when implicit sessions must be returned to the server session pool

### DIFF
--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -955,7 +955,7 @@ topologies.  It MUST NOT be run against a standalone server.
     * Assert that the command sent to the server does not have an ``lsid`` field
 
 6. Client-side cursor that exhausts the results on the initial query immediately returns the implicit session
-to pool.
+to the pool.
     * Insert two documents into a collection
     * Execute a find operation on the collection and iterate past the first document
     * Assert that the implicit session is returned to the pool. This can be done in several ways:
@@ -964,7 +964,7 @@ to pool.
         assert that the same lsid is used as for the find operation.
 
 7. Client-side cursor that exhausts the results after a ``getMore`` immediately returns the implicit session
-to pool.
+to the pool.
     * Insert four documents into a collection
     * Execute a find operation on the collection with batch size of 2
     * Iterate past the first three documents, forcing the final ``getMore`` operation

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -954,7 +954,7 @@ topologies.  It MUST NOT be run against a standalone server.
     * Capture the command sent to the server
     * Assert that the command sent to the server does not have an ``lsid`` field
 
-6. Client-side cursor that exhausts the results on the initial query immediately returns implicit session
+6. Client-side cursor that exhausts the results on the initial query immediately returns the implicit session
 to pool.
     * Insert two documents into a collection
     * Execute a find operation on the collection and iterate past the first document
@@ -963,7 +963,7 @@ to pool.
       * Track the lsid used for the find operation (e.g. with APM) and then do another operation and
         assert that the same lsid is used as for the find operation.
 
-7. Client-side cursor that exhausts the results after a ``getMore`` immediately returns implicit session
+7. Client-side cursor that exhausts the results after a ``getMore`` immediately returns the implicit session
 to pool.
     * Insert four documents into a collection
     * Execute a find operation on the collection with batch size of 2

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -954,9 +954,23 @@ topologies.  It MUST NOT be run against a standalone server.
     * Capture the command sent to the server
     * Assert that the command sent to the server does not have an ``lsid`` field
 
-6. At the end of every individual functional test of the driver, there SHOULD be an assertion that
+6. Client-side cursor that exhausts the results on the initial query immediately returns implicit session
+to pool.
+    * Insert one document into a collection
+    * Execute a find operation on the collection
+    * Assert that the implicit session is returned to the pool prior to iterating the cursor
+
+7. Client-side cursor that exhausts the results after a ``getMore`` immediately returns implicit session
+to pool.
+    * Insert four documents into a collection
+    * Execute a find operation on the collection with batch size of 2
+    * Iterate past the first three documents, forcing the final ``getMore`` operation
+    * Assert that the implicit session is returned to the pool prior to iterating past the last document
+
+8. At the end of every individual functional test of the driver, there SHOULD be an assertion that
 there are no remaining sessions checked out from the pool.  This may require changes to existing tests to
 ensure that they close any explicit client sessions and any unexhausted cursors.
+
 
 Tests that only apply to drivers that allow authentication to be changed on the fly
 -----------------------------------------------------------------------------------

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -956,9 +956,12 @@ topologies.  It MUST NOT be run against a standalone server.
 
 6. Client-side cursor that exhausts the results on the initial query immediately returns implicit session
 to pool.
-    * Insert one document into a collection
-    * Execute a find operation on the collection
-    * Assert that the implicit session is returned to the pool prior to iterating the cursor
+    * Insert two documents into a collection
+    * Execute a find operation on the collection and iterate past the first document
+    * Assert that the implicit session is returned to the pool. This can be done in several ways:
+      * Track in-use count in the server session pool and assert that the count has dropped to zero
+      * Track the lsid used for the find operation (e.g. with APM) and then do another operation and
+        assert that the same lsid is used as for the find operation.
 
 7. Client-side cursor that exhausts the results after a ``getMore`` immediately returns implicit session
 to pool.


### PR DESCRIPTION
SPEC-1030

