### PR TITLE
Deprecate snapshot and maxScan

### DIFF
--- a/source/command-monitoring/tests/find.json
+++ b/source/command-monitoring/tests/find.json
@@ -97,14 +97,12 @@
             "$max": {
               "_id": 6
             },
-            "$maxScan": 5000,
             "$maxTimeMS": 6000,
             "$min": {
               "_id": 0
             },
             "$returnKey": false,
-            "$showDiskLoc": false,
-            "$snapshot": false
+            "$showDiskLoc": false
           }
         }
       },
@@ -131,14 +129,12 @@
               "max": {
                 "_id": 6
               },
-              "maxScan": 5000,
               "maxTimeMS": 6000,
               "min": {
                 "_id": 0
               },
               "returnKey": false,
-              "showRecordId": false,
-              "snapshot": false
+              "showRecordId": false
             },
             "command_name": "find",
             "database_name": "command-monitoring-tests"

--- a/source/command-monitoring/tests/find.yml
+++ b/source/command-monitoring/tests/find.yml
@@ -47,12 +47,10 @@ tests:
           $comment: "test"
           $hint: { _id: 1 }
           $max: { _id: 6 }
-          $maxScan: 5000
           $maxTimeMS: 6000
           $min: { _id: 0 }
           $returnKey: false
           $showDiskLoc: false
-          $snapshot: false
     expectations:
       -
         command_started_event:
@@ -64,12 +62,10 @@ tests:
             comment: "test"
             hint: { _id: 1 }
             max: { _id: 6 }
-            maxScan: 5000
             maxTimeMS: 6000
             min: { _id: 0 }
             returnKey: false
             showRecordId: false
-            snapshot: false
           command_name: "find"
           database_name: *database_name
       -


### PR DESCRIPTION
The server has begun rejecting queries with "snapshot" and I assume it will eventually reject queries with "maxScan". To avoid test failures, remove them from the Command Monitoring tests.