### PR TITLE
Client.sessionId is null or error after endSession()

### DIFF
--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -315,6 +315,9 @@ This property returns the session ID of this session. Note that if server
 sessions are pooled, different ``ClientSession`` instances will have the same session ID,
 but never at the same time.
 
+After a ``ClientSession`` has ended, accessing ``sessionId`` MUST either return
+a null value or raise an exception.
+
 advanceClusterTime
 ------------------
 


### PR DESCRIPTION
No driver changes needed, just clarifying.