### PR TITLE
test(auto-start): correct assumptions about committing empty txns

### DIFF
--- a/source/transactions/tests/auto-start.json
+++ b/source/transactions/tests/auto-start.json
@@ -457,9 +457,6 @@
           "name": "commitTransaction",
           "arguments": {
             "session": "session0"
-          },
-          "result": {
-            "errorContains": "no transaction started"
           }
         }
       ],

--- a/source/transactions/tests/auto-start.yml
+++ b/source/transactions/tests/auto-start.yml
@@ -298,8 +298,6 @@ tests:
       - name: commitTransaction
         arguments:
           session: session0
-        result:
-          errorContains: no transaction started
 
     expectations:
       - command_started_event:


### PR DESCRIPTION
The way this test is currently written is broken: if an empty commit succeeds (first operation), then an empty commit (last operation) after a non-empty commit (third operation) should also succeed. So the expectation of an error is incorrect, but is it worth keeping the test around anyway? I'm not sure. There aren't any expectations in the test anymore, other than the fact that no error is thrown.