### PR TITLE
docs(sessions): adding prose test for find+getmore

### DIFF
--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -638,6 +638,40 @@ any circumstances:
 Drivers MUST document the behavior of unacknowledged writes for both explicit
 and implicit sessions.
 
+When wrapping commands in a ``$query`` field
+--------------------------------------------
+
+If the driver is wrapping the command in a ``$query`` field in order to pass a readPreference to a mongos (see `ReadPreference and Mongos <./find_getmore_killcursors_commands.rst#readpreference-and-mongos>`_), the driver SHOULD NOT add the ``lsid`` as a top-level field, and MUST add the ``lsid`` as a field of the ``$query``
+
+.. code:: typescript
+
+    // Wrapped command:
+    {
+      $query: {
+        find: { foo: 1 }
+      },
+      $readPreference: {}
+    }
+
+    // Correct application of lsid
+    {
+      $query: {
+        find: { foo: 1 },
+        lsid: <...>
+      },
+      $readPreference: {}
+    }
+
+    // Incorrect application of lsid.
+    {
+      $query: {
+        find: { foo: 1 }
+      },
+      $readPreference: {},
+      lsid: <...>
+    }
+
+
 Server Commands
 ===============
 
@@ -1008,6 +1042,12 @@ ensure that they close any explicit client sessions and any unexhausted cursors.
     * Assert that the server receives a non-zero lsid
     * Iterate through enough documents (3) to force a ``getMore``
     * Assert that the server receives a non-zero lsid equal to the lsid that ``find`` sent.
+
+
+Tests that only apply to drivers that have not implemented OP_MSG and are still using OP_QUERY
+----------------------------------------------------------------------------------------------
+
+1. For a command to a mongos that includes a readPreference, verify that the ``lsid`` on query commands is added inside the ``$query`` field, and NOT as a top-level field
 
 
 Tests that only apply to drivers that allow authentication to be changed on the fly


### PR DESCRIPTION
In response to NODE-1420, adding a test that ensures that find
and getmore both send an lsid, and that it is the same id. Test
must be run against all topoligies and readPreferences, as we
have some strage query behavior in mongos + not primary.