### PR TITLE
test(max-staleness): make sure we are testing the correct value

### DIFF
--- a/source/max-staleness/tests/Unknown/SmallMaxStaleness.json
+++ b/source/max-staleness/tests/Unknown/SmallMaxStaleness.json
@@ -5,7 +5,8 @@
     "servers": [
       {
         "address": "a:27017",
-        "type": "Unknown"
+        "type": "Unknown",
+        "maxWireVersion": 5
       }
     ]
   },

--- a/source/max-staleness/tests/Unknown/SmallMaxStaleness.yml
+++ b/source/max-staleness/tests/Unknown/SmallMaxStaleness.yml
@@ -7,6 +7,7 @@ topology_description:
   - &1
     address: a:27017
     type: Unknown
+    maxWireVersion: 5
 read_preference:
   mode: Nearest
   maxStalenessSeconds: 1


### PR DESCRIPTION
The lack of a `maxWireProtocol` field in the ismaster on this test
forces an immediate incompatibility error in creation of a read
preference due to lack of a server greater than protocol 5. This
change ensures we are directly testing the invalid value of `1`
for the `maxStalesnessSeconds` value, rather than the aforementioned
incompatibility.