### PR TITLE
Auth tests - set warning to false

### DIFF
--- a/source/auth/tests/connection-string.json
+++ b/source/auth/tests/connection-string.json
@@ -150,7 +150,7 @@
       "uri": "mongodb://localhost/?authMechanism=GSSAPI",
       "hosts": null,
       "valid": false,
-      "warning": true,
+      "warning": false,
       "auth": null,
       "options": null
     },
@@ -204,7 +204,7 @@
       "uri": "mongodb://localhost/?authMechanism=MONGODB-CR",
       "hosts": null,
       "valid": false,
-      "warning": true,
+      "warning": false,
       "auth": null,
       "options": null
     },
@@ -282,7 +282,7 @@
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/foo?authMechanism=MONGODB-X509&authSource=bar",
       "hosts": null,
       "valid": false,
-      "warning": true,
+      "warning": false,
       "auth": null,
       "options": null
     },

--- a/source/auth/tests/connection-string.yml
+++ b/source/auth/tests/connection-string.yml
@@ -122,7 +122,7 @@ tests:
         uri: "mongodb://localhost/?authMechanism=GSSAPI"
         hosts: ~
         valid: false
-        warning: true
+        warning: false
         auth: ~
         options: ~
     -
@@ -166,7 +166,7 @@ tests:
         uri: "mongodb://localhost/?authMechanism=MONGODB-CR"
         hosts: ~
         valid: false
-        warning: true
+        warning: false
         auth: ~
         options: ~
     -
@@ -230,7 +230,7 @@ tests:
         uri: "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/foo?authMechanism=MONGODB-X509&authSource=bar"
         hosts: ~
         valid: false
-        warning: true
+        warning: false
         auth: ~
         options: ~
     -


### PR DESCRIPTION
Test cases that are not valid should throw an exception
rather than log a warning.