### PR TITLE
Add clientOptions to retryable writes tests

### DIFF
--- a/source/command-monitoring/tests/bulkWrite.json
+++ b/source/command-monitoring/tests/bulkWrite.json
@@ -23,7 +23,8 @@
         "arguments": {
           "requests": [
             {
-              "insertOne": {
+              "name": "insertOne",
+              "arguments": {
                 "document": {
                   "_id": 4,
                   "x": 44
@@ -31,7 +32,8 @@
               }
             },
             {
-              "updateOne": {
+              "name": "updateOne",
+              "arguments": {
                 "filter": {
                   "_id": 3
                 },

--- a/source/command-monitoring/tests/bulkWrite.yml
+++ b/source/command-monitoring/tests/bulkWrite.yml
@@ -13,9 +13,11 @@ tests:
       name: "bulkWrite"
       arguments:
         requests:
-          - insertOne: 
+          - name: "insertOne"
+            arguments:
               document: { _id: 4, x: 44 }
-          - updateOne:
+          - name: "updateOne"
+            arguments:
               filter: { _id: 3 }
               update: { $set: { x: 333 } }
     expectations:

--- a/source/command-monitoring/tests/insertMany.json
+++ b/source/command-monitoring/tests/insertMany.json
@@ -108,7 +108,9 @@
               "x": 22
             }
           ],
-          "ordered": false
+          "options": {
+            "ordered": false
+          }
         }
       },
       "expectations": [

--- a/source/command-monitoring/tests/insertMany.yml
+++ b/source/command-monitoring/tests/insertMany.yml
@@ -58,7 +58,7 @@ tests:
       arguments:
         documents:
           - { _id: 2, x: 22 }
-        ordered: false
+        options: { ordered: false }
     expectations:
       -
         command_started_event:

--- a/source/command-monitoring/tests/unacknowledgedBulkWrite.json
+++ b/source/command-monitoring/tests/unacknowledgedBulkWrite.json
@@ -16,7 +16,8 @@
         "arguments": {
           "requests": [
             {
-              "insertOne": {
+              "name": "insertOne",
+              "arguments": {
                 "document": {
                   "_id": "unorderedBulkWriteInsertW0",
                   "x": 44
@@ -24,7 +25,9 @@
               }
             }
           ],
-          "ordered": false,
+          "options": {
+            "ordered": false
+          },
           "writeConcern": {
             "w": 0
           }

--- a/source/command-monitoring/tests/unacknowledgedBulkWrite.yml
+++ b/source/command-monitoring/tests/unacknowledgedBulkWrite.yml
@@ -12,9 +12,10 @@ tests:
       name: "bulkWrite"
       arguments:
         requests:
-          - insertOne: 
+          - name: "insertOne"
+            arguments:
               document: { _id: "unorderedBulkWriteInsertW0", x: 44 }
-        ordered: false
+        options: { ordered: false }
         writeConcern: { w: 0 }
     expectations:
       -

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -15,10 +15,11 @@ that drivers can use to prove their conformance to the Retryable Writes spec.
 Several prose tests, which are not easily expressed in YAML, are also presented
 in this file. Those tests will need to be manually implemented by each driver.
 
-Tests will require a MongoClient with ``retryWrites`` enabled. Integration tests
-will require a running MongoDB cluster with server versions 3.6.0 or later. The
-``{setFeatureCompatibilityVersion: 3.6}`` admin command will also need to have
-been executed to enable support for retryable writes on the cluster.
+Tests will require a MongoClient created with options defined in the tests.
+Integration tests will require a running MongoDB cluster with server versions
+3.6.0 or later. The ``{setFeatureCompatibilityVersion: 3.6}`` admin command
+will also need to have been executed to enable support for retryable writes on
+the cluster.
 
 Server Fail Point
 =================
@@ -137,6 +138,8 @@ Each YAML file has the following keys:
 
   - ``description``: The name of the test.
 
+  - ``clientOptions``: Parameters to pass to MongoClient().
+
   - ``failPoint``: Document describing options for configuring the
     ``onPrimaryTransactionalWrite`` fail point on the primary server. This
     document should be merged with the
@@ -144,8 +147,8 @@ Each YAML file has the following keys:
 
   - ``operation``: Document describing the operation to be executed. The
     operation should be executed through a collection object derived from a
-    client that has been created with the ``retryWrites=true`` option.
-    This will have some or all of the following fields:
+    client that has been created with ``clientOptions``. The operation will have
+    some or all of the following fields:
 
     - ``name``: The name of the operation as defined in the CRUD specification.
 

--- a/source/retryable-writes/tests/bulkWrite.json
+++ b/source/retryable-writes/tests/bulkWrite.json
@@ -9,6 +9,9 @@
   "tests": [
     {
       "description": "First command is retried",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -77,6 +80,9 @@
     },
     {
       "description": "All commands are retried",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 7
@@ -206,6 +212,9 @@
     },
     {
       "description": "Both commands are retried after their first statement fails",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2
@@ -283,6 +292,9 @@
     },
     {
       "description": "Second command is retried after its second statement fails",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "skip": 2
@@ -360,6 +372,9 @@
     },
     {
       "description": "BulkWrite with unordered execution",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -425,6 +440,9 @@
     },
     {
       "description": "First insertOne is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2
@@ -495,6 +513,9 @@
     },
     {
       "description": "Second updateOne is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "skip": 1
@@ -571,6 +592,9 @@
     },
     {
       "description": "Third updateOne is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "skip": 2
@@ -652,6 +676,9 @@
     },
     {
       "description": "Single-document write following deleteMany is retried",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -710,6 +737,9 @@
     },
     {
       "description": "Single-document write following updateMany is retried",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1

--- a/source/retryable-writes/tests/bulkWrite.yml
+++ b/source/retryable-writes/tests/bulkWrite.yml
@@ -6,6 +6,8 @@ minServerVersion: '3.6'
 tests:
     -
         description: "First command is retried"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -42,6 +44,8 @@ tests:
         # that each write command consists of a single statement, which will
         # fail on the first attempt and succeed on the second, retry attempt.
         description: "All commands are retried"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 7 }
         operation:
@@ -97,6 +101,8 @@ tests:
                     - { _id: 5, x: 55 }
     -
         description: "Both commands are retried after their first statement fails"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
         operation:
@@ -132,6 +138,8 @@ tests:
                     - { _id: 2, x: 23 }
     -
         description: "Second command is retried after its second statement fails"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { skip: 2 }
         operation:
@@ -167,6 +175,8 @@ tests:
                     - { _id: 2, x: 23 }
     -
         description: "BulkWrite with unordered execution"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -197,6 +207,8 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "First insertOne is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -232,6 +244,8 @@ tests:
                     - { _id: 1, x: 11 }
     -
         description: "Second updateOne is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { skip: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -268,6 +282,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "Third updateOne is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { skip: 2 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -309,6 +325,8 @@ tests:
         # affect the initial deleteMany and will trigger once (and only once)
         # for the first insertOne attempt.
         description: "Single-document write following deleteMany is retried"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -342,6 +360,8 @@ tests:
         # affect the initial updateMany and will trigger once (and only once)
         # for the first insertOne attempt.
         description: "Single-document write following updateMany is retried"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }

--- a/source/retryable-writes/tests/deleteOne.json
+++ b/source/retryable-writes/tests/deleteOne.json
@@ -13,6 +13,9 @@
   "tests": [
     {
       "description": "DeleteOne is committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -42,6 +45,9 @@
     },
     {
       "description": "DeleteOne is not committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -74,6 +80,9 @@
     },
     {
       "description": "DeleteOne is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2

--- a/source/retryable-writes/tests/deleteOne.yml
+++ b/source/retryable-writes/tests/deleteOne.yml
@@ -7,6 +7,8 @@ minServerVersion: '3.6'
 tests:
     -
         description: "DeleteOne is committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -21,6 +23,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "DeleteOne is not committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -36,6 +40,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "DeleteOne is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
             data: { failBeforeCommitExceptionCode: 1 }

--- a/source/retryable-writes/tests/findOneAndDelete.json
+++ b/source/retryable-writes/tests/findOneAndDelete.json
@@ -13,6 +13,9 @@
   "tests": [
     {
       "description": "FindOneAndDelete is committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -48,6 +51,9 @@
     },
     {
       "description": "FindOneAndDelete is not committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -86,6 +92,9 @@
     },
     {
       "description": "FindOneAndDelete is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2

--- a/source/retryable-writes/tests/findOneAndDelete.yml
+++ b/source/retryable-writes/tests/findOneAndDelete.yml
@@ -7,6 +7,8 @@ minServerVersion: '3.6'
 tests:
     -
         description: "FindOneAndDelete is committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -21,6 +23,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "FindOneAndDelete is not committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -36,6 +40,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "FindOneAndDelete is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
             data: { failBeforeCommitExceptionCode: 1 }

--- a/source/retryable-writes/tests/findOneAndReplace.json
+++ b/source/retryable-writes/tests/findOneAndReplace.json
@@ -13,6 +13,9 @@
   "tests": [
     {
       "description": "FindOneAndReplace is committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -52,6 +55,9 @@
     },
     {
       "description": "FindOneAndReplace is not committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -94,6 +100,9 @@
     },
     {
       "description": "FindOneAndReplace is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2

--- a/source/retryable-writes/tests/findOneAndReplace.yml
+++ b/source/retryable-writes/tests/findOneAndReplace.yml
@@ -7,6 +7,8 @@ minServerVersion: '3.6'
 tests:
     -
         description: "FindOneAndReplace is committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -23,6 +25,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "FindOneAndReplace is not committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -40,6 +44,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "FindOneAndReplace is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
             data: { failBeforeCommitExceptionCode: 1 }

--- a/source/retryable-writes/tests/findOneAndUpdate.json
+++ b/source/retryable-writes/tests/findOneAndUpdate.json
@@ -13,6 +13,9 @@
   "tests": [
     {
       "description": "FindOneAndUpdate is committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -53,6 +56,9 @@
     },
     {
       "description": "FindOneAndUpdate is not committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -96,6 +102,9 @@
     },
     {
       "description": "FindOneAndUpdate is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2

--- a/source/retryable-writes/tests/findOneAndUpdate.yml
+++ b/source/retryable-writes/tests/findOneAndUpdate.yml
@@ -7,6 +7,8 @@ minServerVersion: '3.6'
 tests:
     -
         description: "FindOneAndUpdate is committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -23,6 +25,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "FindOneAndUpdate is not committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -40,6 +44,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "FindOneAndUpdate is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
             data: { failBeforeCommitExceptionCode: 1 }

--- a/source/retryable-writes/tests/insertMany.json
+++ b/source/retryable-writes/tests/insertMany.json
@@ -9,6 +9,9 @@
   "tests": [
     {
       "description": "InsertMany succeeds after one network error",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -59,6 +62,9 @@
     },
     {
       "description": "InsertMany with unordered execution",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -109,6 +115,9 @@
     },
     {
       "description": "InsertMany fails after multiple network errors",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": "alwaysOn",
         "data": {

--- a/source/retryable-writes/tests/insertMany.yml
+++ b/source/retryable-writes/tests/insertMany.yml
@@ -6,6 +6,8 @@ minServerVersion: '3.6'
 tests:
     -
         description: "InsertMany succeeds after one network error"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -25,6 +27,8 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertMany with unordered execution"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -44,6 +48,8 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertMany fails after multiple network errors"
+        clientOptions:
+            retryWrites: true
         failPoint:
             # Normally, a mongod will insert the documents as a batch with a
             # single commit. If this fails, mongod may try to insert each

--- a/source/retryable-writes/tests/insertOne.json
+++ b/source/retryable-writes/tests/insertOne.json
@@ -13,6 +13,9 @@
   "tests": [
     {
       "description": "InsertOne is committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -51,6 +54,9 @@
     },
     {
       "description": "InsertOne is not committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -92,6 +98,9 @@
     },
     {
       "description": "InsertOne is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2

--- a/source/retryable-writes/tests/insertOne.yml
+++ b/source/retryable-writes/tests/insertOne.yml
@@ -7,6 +7,8 @@ minServerVersion: '3.6'
 tests:
     -
         description: "InsertOne is committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -23,6 +25,8 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne is not committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -40,6 +44,8 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
             data: { failBeforeCommitExceptionCode: 1 }

--- a/source/retryable-writes/tests/replaceOne.json
+++ b/source/retryable-writes/tests/replaceOne.json
@@ -13,6 +13,9 @@
   "tests": [
     {
       "description": "ReplaceOne is committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -52,6 +55,9 @@
     },
     {
       "description": "ReplaceOne is not committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -94,6 +100,9 @@
     },
     {
       "description": "ReplaceOne is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2

--- a/source/retryable-writes/tests/replaceOne.yml
+++ b/source/retryable-writes/tests/replaceOne.yml
@@ -7,6 +7,8 @@ minServerVersion: '3.6'
 tests:
     -
         description: "ReplaceOne is committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -25,6 +27,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "ReplaceOne is not committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -44,6 +48,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "ReplaceOne is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
             data: { failBeforeCommitExceptionCode: 1 }

--- a/source/retryable-writes/tests/updateOne.json
+++ b/source/retryable-writes/tests/updateOne.json
@@ -13,6 +13,9 @@
   "tests": [
     {
       "description": "UpdateOne is committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -53,6 +56,9 @@
     },
     {
       "description": "UpdateOne is not committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -96,6 +102,9 @@
     },
     {
       "description": "UpdateOne is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2
@@ -135,6 +144,9 @@
     },
     {
       "description": "UpdateOne with upsert is committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -182,6 +194,9 @@
     },
     {
       "description": "UpdateOne with upsert is not committed on first attempt",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 1
@@ -232,6 +247,9 @@
     },
     {
       "description": "UpdateOne with upsert is never committed",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "mode": {
           "times": 2

--- a/source/retryable-writes/tests/updateOne.yml
+++ b/source/retryable-writes/tests/updateOne.yml
@@ -7,6 +7,8 @@ minServerVersion: '3.6'
 tests:
     -
         description: "UpdateOne is committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -25,6 +27,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "UpdateOne is not committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -44,6 +48,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "UpdateOne is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -60,6 +66,8 @@ tests:
                     - { _id: 2, x: 22 }
     -
         description: "UpdateOne with upsert is committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
         operation:
@@ -81,6 +89,8 @@ tests:
                     - { _id: 3, x: 34 }
     -
         description: "UpdateOne with upsert is not committed on first attempt"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 1 }
             data: { failBeforeCommitExceptionCode: 1 }
@@ -103,6 +113,8 @@ tests:
                     - { _id: 3, x: 34 }
     -
         description: "UpdateOne with upsert is never committed"
+        clientOptions:
+            retryWrites: true
         failPoint:
             mode: { times: 2 }
             data: { failBeforeCommitExceptionCode: 1 }


### PR DESCRIPTION
Bring retryable writes tests closer to transactions tests: specify retryWrites in the clientOptions object instead of in the test's README. Also, update Command Monitoring bulk format to match the Retryable Writes format. A step toward a unified CRUD/APM test syntax we can use for most spec tests.