### PR TITLE
reorder transactions bulk test to avoid specifying how mixed operatio…

### DIFF
--- a/source/transactions/tests/bulk.json
+++ b/source/transactions/tests/bulk.json
@@ -154,16 +154,6 @@
                 }
               },
               {
-                "name": "deleteMany",
-                "arguments": {
-                  "filter": {
-                    "_id": {
-                      "$gte": 6
-                    }
-                  }
-                }
-              },
-              {
                 "name": "updateMany",
                 "arguments": {
                   "filter": {
@@ -174,6 +164,16 @@
                   "update": {
                     "$set": {
                       "z": 1
+                    }
+                  }
+                }
+              },
+              {
+                "name": "deleteMany",
+                "arguments": {
+                  "filter": {
+                    "_id": {
+                      "$gte": 6
                     }
                   }
                 }
@@ -191,8 +191,8 @@
               "6": 6,
               "7": 7
             },
-            "matchedCount": 5,
-            "modifiedCount": 5,
+            "matchedCount": 7,
+            "modifiedCount": 7,
             "upsertedCount": 1,
             "upsertedIds": {
               "2": 2
@@ -409,14 +409,6 @@
                     "_id": 4
                   },
                   "limit": 1
-                },
-                {
-                  "q": {
-                    "_id": {
-                      "$gte": 6
-                    }
-                  },
-                  "limit": 0
                 }
               ],
               "ordered": true,
@@ -462,6 +454,33 @@
               "writeConcern": null
             },
             "command_name": "update",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "test",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": {
+                      "$gte": 6
+                    }
+                  },
+                  "limit": 0
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "delete",
             "database_name": "transaction-tests"
           }
         },

--- a/source/transactions/tests/bulk.yml
+++ b/source/transactions/tests/bulk.yml
@@ -70,19 +70,21 @@ tests:
             - name: deleteOne
               arguments:
                 filter: {_id: 4}
-            - name: deleteMany
-              arguments:
-                filter: {_id: {$gte: 6}}
             - name: updateMany
               arguments:
                 filter: {_id: {$gte: 2}}
                 update: {$set: {z: 1}}
+            # Keep deleteMany segregated from deleteOne, so that drivers that aren't able to coalesce
+            # adjacent mixed deletes into a single delete command will still pass this test
+            - name: deleteMany
+              arguments:
+                filter: {_id: {$gte: 6}}
           session: session0
         result:
           deletedCount: 4
           insertedIds: {0: 1, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7}
-          matchedCount: 5
-          modifiedCount: 5
+          matchedCount: 7
+          modifiedCount: 7
           upsertedCount: 1
           upsertedIds: {2: 2}
       - name: commitTransaction
@@ -203,8 +205,6 @@ tests:
                 limit: 1
               - q: {_id: 4}
                 limit: 1
-              - q: {_id: {$gte: 6}}
-                limit: 0
             ordered: true
             lsid: session0
             txnNumber:
@@ -230,6 +230,21 @@ tests:
             autocommit: false
             writeConcern:
           command_name: update
+          database_name: *database_name
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              - q: {_id: {$gte: 6}}
+                limit: 0
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: delete
           database_name: *database_name
       - command_started_event:
           command:


### PR DESCRIPTION
…ns should combine

The Ruby driver unfortunately does not currently combine `deleteOne` and `deleteMany` operations in a bulk write to execute as a single command. While this needs to be fixed, I think it would make sense for the transactions tests to be agnostic to this given that the CRUD spec currently doesn't define the behavior of bulk operations.