### PR TITLE
SPEC-1092 Test reset session state to "no transaction"

### DIFF
--- a/source/transactions/tests/commit.json
+++ b/source/transactions/tests/commit.json
@@ -704,6 +704,138 @@
           "data": []
         }
       }
+    },
+    {
+      "description": "reset session state",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "no transaction started"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "no transaction started"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": null,
+              "startTransaction": null,
+              "autocommit": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/transactions/tests/commit.json
+++ b/source/transactions/tests/commit.json
@@ -706,7 +706,7 @@
       }
     },
     {
-      "description": "reset session state",
+      "description": "reset session state commit",
       "operations": [
         {
           "name": "startTransaction",
@@ -746,15 +746,6 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          },
-          "result": {
-            "errorContains": "no transaction started"
-          }
-        },
-        {
-          "name": "abortTransaction",
           "arguments": {
             "session": "session0"
           },
@@ -830,6 +821,126 @@
             {
               "_id": 1
             },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "reset session state abort",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "no transaction started"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": null,
+              "startTransaction": null,
+              "autocommit": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
             {
               "_id": 2
             }

--- a/source/transactions/tests/commit.yml
+++ b/source/transactions/tests/commit.yml
@@ -456,7 +456,7 @@ tests:
       collection:
         data: []
 
-  - description: reset session state
+  - description: reset session state commit
 
     operations:
       - name: startTransaction
@@ -483,12 +483,6 @@ tests:
           insertedId: 2
       # Calling commit again should error instead of re-running the commit.
       - name: commitTransaction
-        arguments:
-          session: session0
-        result:
-          errorContains: no transaction started
-      # Calling abort should also error with "no transaction started".
-      - name: abortTransaction
         arguments:
           session: session0
         result:
@@ -539,4 +533,83 @@ tests:
       collection:
         data:
           - _id: 1
+          - _id: 2
+
+  - description: reset session state abort
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+      - name: insertOne
+        arguments:
+          document:
+            _id: 1
+          session: session0
+        result:
+          insertedId: 1
+      - name: abortTransaction
+        arguments:
+          session: session0
+      # Running any operation after an ended transaction resets the session
+      # state to "no transaction".
+      - name: insertOne
+        arguments:
+          document:
+            _id: 2
+          session: session0
+        result:
+          insertedId: 2
+      # Calling abort should error with "no transaction started" instead of
+      # "cannot call abortTransaction twice".
+      - name: abortTransaction
+        arguments:
+          session: session0
+        result:
+          errorContains: no transaction started
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 2
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+            startTransaction:
+            autocommit:
+          command_name: insert
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
           - _id: 2

--- a/source/transactions/tests/commit.yml
+++ b/source/transactions/tests/commit.yml
@@ -455,3 +455,88 @@ tests:
     outcome:
       collection:
         data: []
+
+  - description: reset session state
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+      - name: insertOne
+        arguments:
+          document:
+            _id: 1
+          session: session0
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        arguments:
+          session: session0
+      # Running any operation after an ended transaction resets the session
+      # state to "no transaction".
+      - name: insertOne
+        arguments:
+          document:
+            _id: 2
+          session: session0
+        result:
+          insertedId: 2
+      # Calling commit again should error instead of re-running the commit.
+      - name: commitTransaction
+        arguments:
+          session: session0
+        result:
+          errorContains: no transaction started
+      # Calling abort should also error with "no transaction started".
+      - name: abortTransaction
+        arguments:
+          session: session0
+        result:
+          errorContains: no transaction started
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 2
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+            startTransaction:
+            autocommit:
+          command_name: insert
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+          - _id: 2


### PR DESCRIPTION
Should I expand this and test every operation that can be performed (delete, update, find, agg, etc..) or do you think a single case is enough? My assumption is that there is a single place the driver should reset the sate and that a single test is enough. I want to avoid creating a combinatorial explosion of tests.   