### PR TITLE
SPEC-1082: test transactional runCommand

### DIFF
--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -98,7 +98,14 @@ For each YAML file, for each element in ``tests``:
    - Enter a "try" block or your programming language's closest equivalent.
    - If ``name`` is "startTransaction", "commitTransaction", or
      "abortTransaction", call the named method on ``session0`` or
-     ``session1``, depending on the "session" argument.
+     ``session1``, depending on the "session" argument. 
+   - If ``name`` is "runCommand", call the runCommand method on the database
+     specified in the test. Pass the argument named "command" to the runCommand 
+     method. Pass ``session0`` or ``session1`` to the runCommand method, depending 
+     on which session's name is in the arguments list. If ``arguments`` 
+     contains no "session", pass no explicit session to the method. If ``arguments`` 
+     includes "readPreference", also pass the read preference to the runCommand 
+     method.    
    - Otherwise, ``name`` refers to a CRUD method, such as ``insertOne``.
      Execute the named method on the "transactions-tests" database on the "test"
      collection, passing the arguments listed. Pass ``session0`` or ``session1``

--- a/source/transactions/tests/run-command.json
+++ b/source/transactions/tests/run-command.json
@@ -68,6 +68,78 @@
       ]
     },
     {
+      "description": "run command with secondary read preference in client option and primary read preference in transaction options",
+      "clientOptions": {
+        "readPreference": "secondary"
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "Primary"
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "count": "test"
+            },
+            "session": "session0"
+          },
+          "result": {
+            "n": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "count": "test",
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "count",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
       "description": "run command with explicit primary read preference",
       "operations": [
         {
@@ -135,7 +207,7 @@
       ]
     },
     {
-      "description": "run command with explicit secondary read preference",
+      "description": "run command fails with explicit secondary read preference",
       "operations": [
         {
           "name": "startTransaction",
@@ -155,48 +227,7 @@
             }
           },
           "result": {
-            "n": 0
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "count": "test",
-              "readConcern": null,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": true,
-              "autocommit": false,
-              "writeConcern": null
-            },
-            "command_name": "count",
-            "database_name": "transaction-tests"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "commitTransaction": 1,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": null,
-              "autocommit": false,
-              "writeConcern": null
-            },
-            "command_name": "commitTransaction",
-            "database_name": "admin"
+            "errorContains": "read preference in a transaction must be primary"
           }
         }
       ]

--- a/source/transactions/tests/run-command.json
+++ b/source/transactions/tests/run-command.json
@@ -261,6 +261,34 @@
           }
         }
       ]
+    },
+    {
+      "description": "run command fails with secondary read preference from transaction options",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "Secondary"
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "count": "test"
+            },
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        }
+      ]
     }
   ]
 }

--- a/source/transactions/tests/run-command.json
+++ b/source/transactions/tests/run-command.json
@@ -16,12 +16,17 @@
           "name": "runCommand",
           "arguments": {
             "command": {
-              "count": "test"
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ]
             },
             "session": "session0"
           },
           "result": {
-            "n": 0
+            "n": 1
           }
         },
         {
@@ -35,7 +40,12 @@
         {
           "command_started_event": {
             "command": {
-              "count": "test",
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
               "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
@@ -45,7 +55,7 @@
               "autocommit": false,
               "writeConcern": null
             },
-            "command_name": "count",
+            "command_name": "insert",
             "database_name": "transaction-tests"
           }
         },
@@ -88,12 +98,17 @@
           "name": "runCommand",
           "arguments": {
             "command": {
-              "count": "test"
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ]
             },
             "session": "session0"
           },
           "result": {
-            "n": 0
+            "n": 1
           }
         },
         {
@@ -107,7 +122,12 @@
         {
           "command_started_event": {
             "command": {
-              "count": "test",
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
               "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
@@ -117,7 +137,7 @@
               "autocommit": false,
               "writeConcern": null
             },
-            "command_name": "count",
+            "command_name": "insert",
             "database_name": "transaction-tests"
           }
         },
@@ -152,7 +172,12 @@
           "name": "runCommand",
           "arguments": {
             "command": {
-              "count": "test"
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ]
             },
             "session": "session0",
             "readPreference": {
@@ -160,7 +185,7 @@
             }
           },
           "result": {
-            "n": 0
+            "n": 1
           }
         },
         {
@@ -174,7 +199,12 @@
         {
           "command_started_event": {
             "command": {
-              "count": "test",
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
               "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
@@ -184,7 +214,7 @@
               "autocommit": false,
               "writeConcern": null
             },
-            "command_name": "count",
+            "command_name": "insert",
             "database_name": "transaction-tests"
           }
         },

--- a/source/transactions/tests/run-command.json
+++ b/source/transactions/tests/run-command.json
@@ -1,0 +1,205 @@
+{
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "run command with default read preference",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "count": "test"
+            },
+            "session": "session0"
+          },
+          "result": {
+            "n": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "count": "test",
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "count",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
+      "description": "run command with explicit primary read preference",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "count": "test"
+            },
+            "session": "session0",
+            "readPreference": {
+              "mode": "Primary"
+            }
+          },
+          "result": {
+            "n": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "count": "test",
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "count",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
+      "description": "run command with explicit secondary read preference",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "count": "test"
+            },
+            "session": "session0",
+            "readPreference": {
+              "mode": "Secondary"
+            }
+          },
+          "result": {
+            "n": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "count": "test",
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "count",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/transactions/tests/run-command.yml
+++ b/source/transactions/tests/run-command.yml
@@ -165,3 +165,21 @@ tests:
             mode: Secondary
         result:
           errorContains: read preference in a transaction must be primary
+
+  - description: run command fails with secondary read preference from transaction options
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+          options:
+            readPreference:
+              mode: secondary
+      - name: runCommand
+        arguments:
+          command: 
+            count: *collection_name
+          session: session0
+        result:
+          errorContains: read preference in a transaction must be primary
+

--- a/source/transactions/tests/run-command.yml
+++ b/source/transactions/tests/run-command.yml
@@ -1,0 +1,133 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  - description: run command with default read preference
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+      - name: runCommand
+        arguments:
+          command: 
+            count: *collection_name
+          session: session0
+        result:
+          n: 0 
+      - name: commitTransaction
+        arguments:
+          session: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            count: *collection_name
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: count
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+  - description: run command with explicit primary read preference
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+      - name: runCommand
+        arguments:
+          command: 
+            count: *collection_name
+          session: session0
+          readPreference:
+            mode: Primary
+        result:
+          n: 0 
+      - name: commitTransaction
+        arguments:
+          session: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            count: *collection_name
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: count
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+  - description: run command with explicit secondary read preference
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+      - name: runCommand
+        arguments:
+          command: 
+            count: *collection_name
+          session: session0
+          readPreference:
+            mode: Secondary
+        result:
+          n: 0 
+      - name: commitTransaction
+        arguments:
+          session: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            count: *collection_name
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: count
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin

--- a/source/transactions/tests/run-command.yml
+++ b/source/transactions/tests/run-command.yml
@@ -45,6 +45,55 @@ tests:
             writeConcern:
           command_name: commitTransaction
           database_name: admin
+
+  - description: run command with secondary read preference in client option and primary read preference in transaction options
+
+    clientOptions:
+      readPreference: secondary
+
+    operations:
+      - name: startTransaction
+        arguments:
+          session: session0
+          options:
+            readPreference:
+              mode: Primary
+      - name: runCommand
+        arguments:
+          command: 
+            count: *collection_name
+          session: session0
+        result:
+          n: 0 
+      - name: commitTransaction
+        arguments:
+          session: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            count: *collection_name
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: count
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin 
+
   - description: run command with explicit primary read preference
 
     operations:
@@ -88,7 +137,7 @@ tests:
             writeConcern:
           command_name: commitTransaction
           database_name: admin
-  - description: run command with explicit secondary read preference
+  - description: run command fails with explicit secondary read preference
 
     operations:
       - name: startTransaction
@@ -102,32 +151,4 @@ tests:
           readPreference:
             mode: Secondary
         result:
-          n: 0 
-      - name: commitTransaction
-        arguments:
-          session: session0
-
-    expectations:
-      - command_started_event:
-          command:
-            count: *collection_name
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
-          command_name: count
-          database_name: *database_name
-      - command_started_event:
-          command:
-            commitTransaction: 1
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction:
-            autocommit: false
-            writeConcern:
-          command_name: commitTransaction
-          database_name: admin
+          errorContains: read preference in a transaction must be primary

--- a/source/transactions/tests/run-command.yml
+++ b/source/transactions/tests/run-command.yml
@@ -13,10 +13,12 @@ tests:
       - name: runCommand
         arguments:
           command: 
-            count: *collection_name
+            insert: *collection_name
+            documents:
+              - _id : 1
           session: session0
         result:
-          n: 0 
+          n: 1
       - name: commitTransaction
         arguments:
           session: session0
@@ -24,7 +26,9 @@ tests:
     expectations:
       - command_started_event:
           command:
-            count: *collection_name
+            insert: *collection_name
+            documents: 
+              - _id : 1
             readConcern:
             lsid: session0
             txnNumber:
@@ -32,7 +36,7 @@ tests:
             startTransaction: true
             autocommit: false
             writeConcern:
-          command_name: count
+          command_name: insert
           database_name: *database_name
       - command_started_event:
           command:
@@ -61,10 +65,12 @@ tests:
       - name: runCommand
         arguments:
           command: 
-            count: *collection_name
+            insert: *collection_name
+            documents:
+              - _id : 1
           session: session0
         result:
-          n: 0 
+          n: 1
       - name: commitTransaction
         arguments:
           session: session0
@@ -72,7 +78,9 @@ tests:
     expectations:
       - command_started_event:
           command:
-            count: *collection_name
+            insert: *collection_name
+            documents:
+              - _id : 1
             readConcern:
             lsid: session0
             txnNumber:
@@ -80,7 +88,7 @@ tests:
             startTransaction: true
             autocommit: false
             writeConcern:
-          command_name: count
+          command_name: insert
           database_name: *database_name
       - command_started_event:
           command:
@@ -103,12 +111,14 @@ tests:
       - name: runCommand
         arguments:
           command: 
-            count: *collection_name
+            insert: *collection_name
+            documents:
+              - _id : 1
           session: session0
           readPreference:
             mode: Primary
         result:
-          n: 0 
+          n: 1
       - name: commitTransaction
         arguments:
           session: session0
@@ -116,7 +126,9 @@ tests:
     expectations:
       - command_started_event:
           command:
-            count: *collection_name
+            insert: *collection_name
+            documents:
+              - _id : 1
             readConcern:
             lsid: session0
             txnNumber:
@@ -124,7 +136,7 @@ tests:
             startTransaction: true
             autocommit: false
             writeConcern:
-          command_name: count
+          command_name: insert
           database_name: *database_name
       - command_started_event:
           command:
@@ -137,6 +149,7 @@ tests:
             writeConcern:
           command_name: commitTransaction
           database_name: admin
+
   - description: run command fails with explicit secondary read preference
 
     operations:


### PR DESCRIPTION
Test that runCommand works as specified.  Two aspects of the assertions

* That all the transaction-related fields are added to the command
* That the transaction's read preference is obeyed, regardless of the runCommand read preference.  This assertion is implicit for the secondary read preference test, in that the command would fail if it was actually executed against a secondary (I think it would at any rate).