### PR TITLE
fix unchanged command monitoring options to follow previous changes

### DIFF
--- a/source/command-monitoring/tests/insertMany.json
+++ b/source/command-monitoring/tests/insertMany.json
@@ -32,7 +32,9 @@
                   "x": 22
                 }
               ],
-              "ordered": true
+              "options": {
+                "ordered": true
+              }
             },
             "command_name": "insert",
             "database_name": "command-monitoring-tests"
@@ -73,7 +75,9 @@
                   "x": 11
                 }
               ],
-              "ordered": true
+              "options": {
+                "ordered": true
+              }
             },
             "command_name": "insert",
             "database_name": "command-monitoring-tests"
@@ -124,7 +128,9 @@
                   "x": 22
                 }
               ],
-              "ordered": false
+              "options": {
+                "ordered": false
+              }
             },
             "command_name": "insert",
             "database_name": "command-monitoring-tests"

--- a/source/command-monitoring/tests/insertMany.yml
+++ b/source/command-monitoring/tests/insertMany.yml
@@ -19,7 +19,7 @@ tests:
             insert: *collection_name
             documents:
               - { _id: 2, x: 22 }
-            ordered: true
+            options: { ordered: true }
           command_name: "insert"
           database_name: *database_name
       -
@@ -40,7 +40,7 @@ tests:
             insert: *collection_name
             documents:
               - { _id: 1, x: 11 }
-            ordered: true
+            options: { ordered: true }
           command_name: "insert"
           database_name: *database_name
       -
@@ -66,7 +66,7 @@ tests:
             insert: *collection_name
             documents:
               - { _id: 2, x: 22 }
-            ordered: false
+            options: { ordered: false }
           command_name: "insert"
           database_name: *database_name
       -


### PR DESCRIPTION
The command monitoring bulk tests were updated to use a different syntax for options, but a few places in the insertMany file were missed.