### PR TITLE
 SPEC-1097 Move collection options to collectionOptions

### DIFF
--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -41,12 +41,15 @@ Each YAML file has the following keys:
   - ``operations``: Array of documents, each describing an operation to be
     executed. Each document has the following fields:
 
-      - ``name``: The name of the operation.
+      - ``name``: The name of the operation on ``object``.
+
+      - ``object``: The name of the object to perform the operation on. Can be
+        "collection", "session0", or "session1".
 
       - ``collectionOptions``: Optional, parameters to pass to the Collection()
         used for this operation.
 
-      - ``arguments``: The names and values of arguments.
+      - ``arguments``: Optional, the names and values of arguments.
 
       - ``result``: The return value from the operation, if any. If the
         operation is expected to return an error, the ``result`` has one field,
@@ -99,19 +102,11 @@ For each YAML file, for each element in ``tests``:
 #. For each element in ``operations``:
 
    - Enter a "try" block or your programming language's closest equivalent.
-   - If ``name`` is "startTransaction", "commitTransaction", or
-     "abortTransaction", call the named method on ``session0`` or
-     ``session1``, depending on the "session" argument. 
-   - If ``name`` is "runCommand", call the runCommand method on the database
-     specified in the test. Pass the argument named "command" to the runCommand 
-     method. Pass ``session0`` or ``session1`` to the runCommand method, depending 
-     on which session's name is in the arguments list. If ``arguments`` 
-     contains no "session", pass no explicit session to the method. If ``arguments`` 
-     includes "readPreference", also pass the read preference to the runCommand 
-     method.    
-   - Otherwise, ``name`` refers to a CRUD method, such as ``insertOne``.
-     Execute the named method on the "transactions-tests" database on the "test"
-     collection (with the optional ``collectionOptions``), passing the
+   - Create a collection object from the MongoClient, using the
+     ``database_name`` and ``collection_name`` fields at the top level file.
+     If ``collectionOptions`` is present create the collection object with the
+     provided options. Otherwise create the object with the default options.
+   - Execute the named method on the provided ``object``, passing the
      arguments listed. Pass ``session0`` or ``session1`` to the method,
      depending on which session's name is in the arguments list.
      If ``arguments`` contains no "session", pass no explicit session to the

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -43,6 +43,9 @@ Each YAML file has the following keys:
 
       - ``name``: The name of the operation.
 
+      - ``collectionOptions``: Optional, parameters to pass to the Collection()
+        used for this operation.
+
       - ``arguments``: The names and values of arguments.
 
       - ``result``: The return value from the operation, if any. If the
@@ -108,11 +111,11 @@ For each YAML file, for each element in ``tests``:
      method.    
    - Otherwise, ``name`` refers to a CRUD method, such as ``insertOne``.
      Execute the named method on the "transactions-tests" database on the "test"
-     collection, passing the arguments listed. Pass ``session0`` or ``session1``
-     to the method, depending on which session's name is in the arguments list.
+     collection (with the optional ``collectionOptions``), passing the
+     arguments listed. Pass ``session0`` or ``session1`` to the method,
+     depending on which session's name is in the arguments list.
      If ``arguments`` contains no "session", pass no explicit session to the
-     method. If ``arguments`` includes "readPreference", configure the specified
-     read preference in whatever manner the driver supports.
+     method.
    - If the driver throws an exception / returns an error while executing this
      series of operations, store the error message and server error code.
    - If the result document has an "errorContains" field, verify that the

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -70,12 +70,15 @@ Each YAML file has the following keys:
 Use as integration tests
 ========================
 
-Run a MongoDB replica set with a primary, two secondaries, and an arbiter,
-server version 4.0 or later. (Including two secondaries ensures that transaction
-pinning works properly. Include an arbiter to ensure no new bugs have been
-introduced related to arbiters.)
+Run a MongoDB replica set with a primary, a secondary, and an arbiter,
+server version 4.0 or later. (Including a secondary ensures that server
+selection in a transaction works properly. Including an arbiter helps ensure
+that no new bugs have been introduced related to arbiters.)
 
-For each YAML file, for each element in ``tests``:
+Load each YAML (or JSON) file using a Canonical Extended JSON parser.
+The parser MUST preserve the order of keys in dictionaries.
+
+Then for each element in ``tests``:
 
 #. Create a MongoClient and call
    ``client.admin.runCommand({killAllSessions: []})`` to clean up any open
@@ -117,13 +120,16 @@ For each YAML file, for each element in ``tests``:
      series of operations, store the error message and server error code.
    - If the result document has an "errorContains" field, verify that the
      method threw an exception or returned an error, and that the value of the
-     "errorContains" field matches the error string. If the result document has
-     an "errorCodeName" field, verify that the method threw a command failed
-     exception or returned an error, and that the value of the "errorCodeName"
-     field matches the "codeName" in the server error response.
+     "errorContains" field matches the error string. "errorContains" is a
+     substring (case-insensitive) of the actual error message.
+     If the result document has an "errorCodeName" field, verify that the
+     method threw a command failed exception or returned an error, and that
+     the value of the "errorCodeName" field matches the "codeName" in the
+     server error response.
+     If the operation returns a raw command response, eg from ``runCommand``,
+     then compare only the fields present in the expected result document.
      Otherwise, compare the method's return value to ``result`` using the same
-     logic as the CRUD Spec Tests runner. key is a substring (case-insensitive)
-     of the actual error message.
+     logic as the CRUD Spec Tests runner.
 
 #. Call ``session0.endSession()`` and ``session1.endSession``.
 #. If the test includes a list of command-started events in ``expectations``,

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -44,7 +44,7 @@ Each YAML file has the following keys:
       - ``name``: The name of the operation on ``object``.
 
       - ``object``: The name of the object to perform the operation on. Can be
-        "collection", "session0", or "session1".
+        "database", collection", "session0", or "session1".
 
       - ``collectionOptions``: Optional, parameters to pass to the Collection()
         used for this operation.
@@ -102,9 +102,11 @@ For each YAML file, for each element in ``tests``:
 #. For each element in ``operations``:
 
    - Enter a "try" block or your programming language's closest equivalent.
-   - Create a collection object from the MongoClient, using the
-     ``database_name`` and ``collection_name`` fields at the top level file.
-     If ``collectionOptions`` is present create the collection object with the
+   - Create a Database object from the MongoClient, using the ``database_name``
+     field at the top level of the test file.
+   - Create a Collection object from the Database, using the
+     ``collection_name`` field at the top level of the test file.
+     If ``collectionOptions`` is present create the Collection object with the
      provided options. Otherwise create the object with the default options.
    - Execute the named method on the provided ``object``, passing the
      arguments listed. Pass ``session0`` or ``session1`` to the method,

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -49,6 +49,10 @@ Each YAML file has the following keys:
       - ``collectionOptions``: Optional, parameters to pass to the Collection()
         used for this operation.
 
+      - ``command_name``: Present only when ``name`` is "runCommand". The name
+        of the command to run. Required for languages that are unable preserve
+        the order keys in the "command" argument when parsing JSON/YAML.
+
       - ``arguments``: Optional, the names and values of arguments.
 
       - ``result``: The return value from the operation, if any. If the
@@ -76,7 +80,6 @@ selection in a transaction works properly. Including an arbiter helps ensure
 that no new bugs have been introduced related to arbiters.)
 
 Load each YAML (or JSON) file using a Canonical Extended JSON parser.
-The parser MUST preserve the order of keys in dictionaries.
 
 Then for each element in ``tests``:
 

--- a/source/transactions/tests/abort.json
+++ b/source/transactions/tests/abort.json
@@ -315,9 +315,7 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
           "result": {
             "errorContains": "Cannot call abortTransaction after calling commitTransaction"
           }
@@ -356,9 +354,7 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
           "result": {
             "errorContains": "Cannot call abortTransaction after calling commitTransaction"
           }

--- a/source/transactions/tests/abort.json
+++ b/source/transactions/tests/abort.json
@@ -14,6 +14,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -38,6 +39,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -154,6 +156,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -223,6 +226,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -359,6 +363,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -447,6 +452,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -459,6 +465,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -471,6 +478,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -597,6 +605,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1

--- a/source/transactions/tests/abort.json
+++ b/source/transactions/tests/abort.json
@@ -8,9 +8,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -27,15 +26,13 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -52,9 +49,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -150,9 +146,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -220,9 +215,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -239,15 +233,13 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "cannot call abortTransaction twice"
           }
@@ -305,9 +297,8 @@
       "operations": [
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "no transaction started"
           }
@@ -325,15 +316,13 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "abortTransaction",
@@ -357,9 +346,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -376,9 +364,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "abortTransaction",
@@ -446,9 +433,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -491,9 +477,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -594,8 +579,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": 10
@@ -618,9 +603,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "outcome": {

--- a/source/transactions/tests/abort.json
+++ b/source/transactions/tests/abort.json
@@ -8,8 +8,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -26,13 +25,11 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -49,8 +46,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -146,8 +142,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -215,8 +210,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -233,13 +227,11 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "abortTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "cannot call abortTransaction twice"
           }
@@ -298,7 +290,6 @@
         {
           "name": "abortTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "no transaction started"
           }
@@ -316,13 +307,11 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "abortTransaction",
@@ -346,8 +335,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -364,8 +352,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "abortTransaction",
@@ -433,8 +420,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -477,8 +463,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -603,8 +588,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "outcome": {

--- a/source/transactions/tests/abort.json
+++ b/source/transactions/tests/abort.json
@@ -14,10 +14,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -35,10 +35,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -148,10 +148,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -216,10 +216,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -339,10 +339,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -422,10 +422,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -435,10 +435,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "errorCodeName": "DuplicateKey"
@@ -448,10 +448,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "errorCodeName": "NoSuchTransaction"
@@ -573,10 +573,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1

--- a/source/transactions/tests/abort.yml
+++ b/source/transactions/tests/abort.yml
@@ -213,8 +213,7 @@ tests:
       - name: commitTransaction
         object: session0
       - name: abortTransaction  # Error calling abort after no-op commit.
-        arguments:
-          session: session0
+        object: session0
         result:
           errorContains: Cannot call abortTransaction after calling commitTransaction
 
@@ -240,8 +239,7 @@ tests:
       - name: commitTransaction
         object: session0
       - name: abortTransaction  # Error calling abort after commit.
-        arguments:
-          session: session0
+        object: session0
         result:
           errorContains: Cannot call abortTransaction after calling commitTransaction
 

--- a/source/transactions/tests/abort.yml
+++ b/source/transactions/tests/abort.yml
@@ -12,9 +12,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction
@@ -24,9 +24,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction
@@ -101,9 +101,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
 
@@ -147,9 +147,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction
@@ -231,9 +231,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -284,27 +284,27 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       # Abort the server transaction with a duplicate key error.
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           errorCodeName: DuplicateKey
       # Make sure the server aborted the transaction.
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           errorCodeName: NoSuchTransaction
       # abortTransaction must ignore the TransactionAborted and succeed.
@@ -386,9 +386,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction

--- a/source/transactions/tests/abort.yml
+++ b/source/transactions/tests/abort.yml
@@ -11,6 +11,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -24,6 +25,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -102,6 +104,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -148,6 +151,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -238,6 +242,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -293,6 +298,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -301,6 +307,7 @@ tests:
           insertedId: 1
       # Abort the server transaction with a duplicate key error.
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -309,6 +316,7 @@ tests:
           errorCodeName: DuplicateKey
       # Make sure the server aborted the transaction.
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -393,6 +401,7 @@ tests:
             writeConcern:
               w: 10
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1

--- a/source/transactions/tests/abort.yml
+++ b/source/transactions/tests/abort.yml
@@ -8,8 +8,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -19,11 +19,11 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -33,8 +33,8 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -101,8 +101,8 @@ tests:
       # Start a transaction but don't commit - the driver calls abortTransaction
       # from ClientSession.endSession().
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -148,8 +148,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -159,11 +159,11 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           errorContains: cannot call abortTransaction twice
 
@@ -203,8 +203,8 @@ tests:
 
     operations:
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           errorContains: no transaction started
 
@@ -218,11 +218,11 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: abortTransaction  # Error calling abort after no-op commit.
         arguments:
           session: session0
@@ -239,8 +239,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -250,8 +250,8 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: abortTransaction  # Error calling abort after commit.
         arguments:
           session: session0
@@ -295,8 +295,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -325,8 +325,8 @@ tests:
           errorCodeName: NoSuchTransaction
       # abortTransaction must ignore the TransactionAborted and succeed.
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -395,8 +395,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: 10
@@ -409,8 +409,8 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
         # No CannotSatisfyWriteConcern error.
 
     outcome:

--- a/source/transactions/tests/abort.yml
+++ b/source/transactions/tests/abort.yml
@@ -9,7 +9,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -20,10 +19,8 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -34,7 +31,6 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -102,7 +98,6 @@ tests:
       # from ClientSession.endSession().
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -149,7 +144,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -160,10 +154,8 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
       - name: abortTransaction
         object: session0
-        arguments:
         result:
           errorContains: cannot call abortTransaction twice
 
@@ -204,7 +196,6 @@ tests:
     operations:
       - name: abortTransaction
         object: session0
-        arguments:
         result:
           errorContains: no transaction started
 
@@ -219,10 +210,8 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: commitTransaction
         object: session0
-        arguments:
       - name: abortTransaction  # Error calling abort after no-op commit.
         arguments:
           session: session0
@@ -240,7 +229,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -251,7 +239,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
       - name: abortTransaction  # Error calling abort after commit.
         arguments:
           session: session0
@@ -296,7 +283,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -326,7 +312,6 @@ tests:
       # abortTransaction must ignore the TransactionAborted and succeed.
       - name: abortTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -410,7 +395,6 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
         # No CannotSatisfyWriteConcern error.
 
     outcome:

--- a/source/transactions/tests/bulk.json
+++ b/source/transactions/tests/bulk.json
@@ -8,8 +8,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -203,8 +202,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/bulk.json
+++ b/source/transactions/tests/bulk.json
@@ -8,9 +8,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -204,9 +203,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/bulk.json
+++ b/source/transactions/tests/bulk.json
@@ -14,10 +14,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -27,10 +27,10 @@
           "name": "deleteOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "deletedCount": 1
@@ -40,6 +40,7 @@
           "name": "bulkWrite",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "requests": [
               {
                 "name": "insertOne",
@@ -179,8 +180,7 @@
                   }
                 }
               }
-            ],
-            "session": "session0"
+            ]
           },
           "result": {
             "deletedCount": 4,

--- a/source/transactions/tests/bulk.json
+++ b/source/transactions/tests/bulk.json
@@ -14,6 +14,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -26,6 +27,7 @@
         },
         {
           "name": "deleteOne",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -38,6 +40,7 @@
         },
         {
           "name": "bulkWrite",
+          "object": "collection",
           "arguments": {
             "requests": [
               {

--- a/source/transactions/tests/bulk.yml
+++ b/source/transactions/tests/bulk.yml
@@ -11,6 +11,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -18,6 +19,7 @@ tests:
         result:
           insertedId: 1
       - name: deleteOne
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -25,6 +27,7 @@ tests:
         result:
           deletedCount: 1
       - name: bulkWrite
+        object: collection
         arguments:
           requests:
             - name: insertOne

--- a/source/transactions/tests/bulk.yml
+++ b/source/transactions/tests/bulk.yml
@@ -9,7 +9,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -92,7 +91,6 @@ tests:
           upsertedIds: {2: 2}
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/bulk.yml
+++ b/source/transactions/tests/bulk.yml
@@ -12,22 +12,23 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: deleteOne
         object: collection
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           deletedCount: 1
       - name: bulkWrite
         object: collection
         arguments:
+          session: session0
           requests:
             - name: insertOne
               arguments:
@@ -81,7 +82,6 @@ tests:
             - name: deleteMany
               arguments:
                 filter: {_id: {$gte: 6}}
-          session: session0
         result:
           deletedCount: 4
           insertedIds: {0: 1, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7}

--- a/source/transactions/tests/bulk.yml
+++ b/source/transactions/tests/bulk.yml
@@ -8,8 +8,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -91,8 +91,8 @@ tests:
           upsertedCount: 1
           upsertedIds: {2: 2}
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/causal-consistency.json
+++ b/source/transactions/tests/causal-consistency.json
@@ -33,9 +33,8 @@
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "updateOne",
@@ -59,9 +58,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -180,9 +178,8 @@
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "updateOne",
@@ -207,9 +204,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/causal-consistency.json
+++ b/source/transactions/tests/causal-consistency.json
@@ -167,6 +167,7 @@
       "operations": [
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -185,6 +186,7 @@
         },
         {
           "name": "updateOne",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1

--- a/source/transactions/tests/causal-consistency.json
+++ b/source/transactions/tests/causal-consistency.json
@@ -13,6 +13,7 @@
       "operations": [
         {
           "name": "updateOne",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -37,6 +38,7 @@
         },
         {
           "name": "updateOne",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1

--- a/source/transactions/tests/causal-consistency.json
+++ b/source/transactions/tests/causal-consistency.json
@@ -33,8 +33,7 @@
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "updateOne",
@@ -58,8 +57,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -178,8 +176,7 @@
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "updateOne",
@@ -204,8 +201,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/causal-consistency.json
+++ b/source/transactions/tests/causal-consistency.json
@@ -15,6 +15,7 @@
           "name": "updateOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
             },
@@ -23,8 +24,7 @@
                 "count": 1
               }
             },
-            "upsert": false,
-            "session": "session0"
+            "upsert": false
           },
           "result": {
             "matchedCount": 1,
@@ -40,6 +40,7 @@
           "name": "updateOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
             },
@@ -48,8 +49,7 @@
                 "count": 1
               }
             },
-            "upsert": false,
-            "session": "session0"
+            "upsert": false
           },
           "result": {
             "matchedCount": 1,
@@ -167,10 +167,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -184,6 +184,7 @@
           "name": "updateOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
             },
@@ -192,8 +193,7 @@
                 "count": 1
               }
             },
-            "upsert": false,
-            "session": "session0"
+            "upsert": false
           },
           "result": {
             "matchedCount": 1,

--- a/source/transactions/tests/causal-consistency.yml
+++ b/source/transactions/tests/causal-consistency.yml
@@ -26,12 +26,12 @@ tests:
       # Casual consistency ensures that the transaction snapshot is causally
       # after the first updateOne.
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - *updateOne
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -105,8 +105,8 @@ tests:
         result:
           insertedId: 2
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: updateOne
         object: collection
         arguments:
@@ -120,8 +120,8 @@ tests:
           modifiedCount: 1
           upsertedCount: 0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/causal-consistency.yml
+++ b/source/transactions/tests/causal-consistency.yml
@@ -97,6 +97,7 @@ tests:
     operations:
       # Insert a document without a transaction.
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 2
@@ -107,6 +108,7 @@ tests:
         arguments:
           session: session0
       - name: updateOne
+        object: collection
         arguments:
           filter: {_id: 1}
           update:

--- a/source/transactions/tests/causal-consistency.yml
+++ b/source/transactions/tests/causal-consistency.yml
@@ -12,6 +12,7 @@ tests:
       # Update a document without a transaction.
       - &updateOne
         name: updateOne
+        object: collection
         arguments:
           filter: {_id: 1}
           update:

--- a/source/transactions/tests/causal-consistency.yml
+++ b/source/transactions/tests/causal-consistency.yml
@@ -27,11 +27,9 @@ tests:
       # after the first updateOne.
       - name: startTransaction
         object: session0
-        arguments:
       - *updateOne
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -106,7 +104,6 @@ tests:
           insertedId: 2
       - name: startTransaction
         object: session0
-        arguments:
       - name: updateOne
         object: collection
         arguments:
@@ -121,7 +118,6 @@ tests:
           upsertedCount: 0
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/causal-consistency.yml
+++ b/source/transactions/tests/causal-consistency.yml
@@ -14,11 +14,11 @@ tests:
         name: updateOne
         object: collection
         arguments:
+          session: session0
           filter: {_id: 1}
           update:
             $inc: {count: 1}
           upsert: false
-          session: session0
         result:
           matchedCount: 1
           modifiedCount: 1
@@ -98,9 +98,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 2
-          session: session0
         result:
           insertedId: 2
       - name: startTransaction
@@ -108,11 +108,11 @@ tests:
       - name: updateOne
         object: collection
         arguments:
+          session: session0
           filter: {_id: 1}
           update:
             $inc: {count: 1}
           upsert: false
-          session: session0
         result:
           matchedCount: 1
           modifiedCount: 1

--- a/source/transactions/tests/commit.json
+++ b/source/transactions/tests/commit.json
@@ -14,6 +14,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -38,6 +39,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -179,6 +181,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -258,6 +261,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -386,6 +390,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -479,6 +484,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -558,6 +564,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -600,6 +607,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -716,6 +724,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -734,6 +743,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -839,6 +849,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -857,6 +868,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2

--- a/source/transactions/tests/commit.json
+++ b/source/transactions/tests/commit.json
@@ -8,8 +8,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -26,13 +25,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -49,8 +46,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -153,23 +149,19 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -186,8 +178,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -246,8 +237,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -264,18 +254,15 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -391,7 +378,6 @@
         {
           "name": "commitTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorCodeName": "CannotSatisfyWriteConcern"
           }
@@ -413,7 +399,6 @@
         {
           "name": "commitTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "no transaction started"
           }
@@ -431,18 +416,15 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "Cannot call commitTransaction after calling abortTransaction"
           }
@@ -460,8 +442,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -478,13 +459,11 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "Cannot call commitTransaction after calling abortTransaction"
           }
@@ -537,8 +516,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -555,28 +533,23 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -593,8 +566,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -690,8 +662,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -708,8 +679,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -727,7 +697,6 @@
         {
           "name": "commitTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "no transaction started"
           }
@@ -812,8 +781,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -830,8 +798,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -849,7 +816,6 @@
         {
           "name": "abortTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "no transaction started"
           }

--- a/source/transactions/tests/commit.json
+++ b/source/transactions/tests/commit.json
@@ -8,9 +8,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -27,15 +26,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -52,9 +49,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -157,27 +153,23 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -194,9 +186,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -255,9 +246,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -274,21 +264,18 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -379,8 +366,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": 10
@@ -403,9 +390,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorCodeName": "CannotSatisfyWriteConcern"
           }
@@ -426,9 +412,8 @@
       "operations": [
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "no transaction started"
           }
@@ -446,21 +431,18 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "Cannot call commitTransaction after calling abortTransaction"
           }
@@ -478,9 +460,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -497,15 +478,13 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "Cannot call commitTransaction after calling abortTransaction"
           }
@@ -558,9 +537,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -577,33 +555,28 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -620,9 +593,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -718,9 +690,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -737,9 +708,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -756,9 +726,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "no transaction started"
           }
@@ -843,9 +812,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -862,9 +830,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -881,9 +848,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "no transaction started"
           }

--- a/source/transactions/tests/commit.json
+++ b/source/transactions/tests/commit.json
@@ -14,10 +14,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -35,10 +35,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -167,10 +167,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -243,10 +243,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -366,10 +366,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -448,10 +448,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -522,10 +522,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -555,10 +555,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -668,10 +668,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -685,10 +685,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -787,10 +787,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -804,10 +804,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2

--- a/source/transactions/tests/commit.yml
+++ b/source/transactions/tests/commit.yml
@@ -11,9 +11,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -24,9 +24,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 2
-          session: session0
         result:
           insertedId: 2
       - name: commitTransaction
@@ -108,9 +108,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -157,9 +157,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -236,9 +236,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -299,9 +299,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction
@@ -347,9 +347,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction
@@ -368,9 +368,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction
@@ -444,9 +444,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -456,9 +456,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 2
-          session: session0
         result:
           insertedId: 2
       # Calling commit again should error instead of re-running the commit.
@@ -522,9 +522,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction
@@ -534,9 +534,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 2
-          session: session0
         result:
           insertedId: 2
       # Calling abort should error with "no transaction started" instead of

--- a/source/transactions/tests/commit.yml
+++ b/source/transactions/tests/commit.yml
@@ -7,8 +7,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -18,12 +18,12 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Again, to verify that txnNumber is incremented.
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -33,8 +33,8 @@ tests:
         result:
           insertedId: 2
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -101,18 +101,18 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Rerun the commit (which does not increment the txnNumber).
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -122,8 +122,8 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -162,8 +162,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -173,14 +173,14 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -241,8 +241,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: 10
@@ -255,8 +255,8 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           # {
           #   'ok': 1.0,
@@ -277,8 +277,8 @@ tests:
 
     operations:
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           errorContains: no transaction started
 
@@ -292,14 +292,14 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           errorContains: Cannot call commitTransaction after calling abortTransaction
 
@@ -313,8 +313,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -324,11 +324,11 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           errorContains: Cannot call commitTransaction after calling abortTransaction
 
@@ -364,8 +364,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -375,23 +375,23 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
       # Increments txnNumber.
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       # These commits aren't sent to server, transaction is empty.
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Verify that previous, empty transaction incremented txnNumber.
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -401,8 +401,8 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -468,8 +468,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -479,8 +479,8 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Running any operation after an ended transaction resets the session
       # state to "no transaction".
       - name: insertOne
@@ -493,8 +493,8 @@ tests:
           insertedId: 2
       # Calling commit again should error instead of re-running the commit.
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           errorContains: no transaction started
 
@@ -549,8 +549,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -560,8 +560,8 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
       # Running any operation after an ended transaction resets the session
       # state to "no transaction".
       - name: insertOne
@@ -575,8 +575,8 @@ tests:
       # Calling abort should error with "no transaction started" instead of
       # "cannot call abortTransaction twice".
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           errorContains: no transaction started
 

--- a/source/transactions/tests/commit.yml
+++ b/source/transactions/tests/commit.yml
@@ -8,7 +8,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -19,11 +18,9 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
       # Again, to verify that txnNumber is incremented.
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -34,7 +31,6 @@ tests:
           insertedId: 2
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -102,17 +98,13 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: commitTransaction
         object: session0
-        arguments:
       # Rerun the commit (which does not increment the txnNumber).
       - name: commitTransaction
         object: session0
-        arguments:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -123,7 +115,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -163,7 +154,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -174,13 +164,10 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
       - name: commitTransaction
         object: session0
-        arguments:
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -256,7 +243,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
         result:
           # {
           #   'ok': 1.0,
@@ -278,7 +264,6 @@ tests:
     operations:
       - name: commitTransaction
         object: session0
-        arguments:
         result:
           errorContains: no transaction started
 
@@ -293,13 +278,10 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: abortTransaction
         object: session0
-        arguments:
       - name: commitTransaction
         object: session0
-        arguments:
         result:
           errorContains: Cannot call commitTransaction after calling abortTransaction
 
@@ -314,7 +296,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -325,10 +306,8 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
       - name: commitTransaction
         object: session0
-        arguments:
         result:
           errorContains: Cannot call commitTransaction after calling abortTransaction
 
@@ -365,7 +344,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -376,22 +354,17 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
       # Increments txnNumber.
       - name: startTransaction
         object: session0
-        arguments:
       # These commits aren't sent to server, transaction is empty.
       - name: commitTransaction
         object: session0
-        arguments:
       - name: commitTransaction
         object: session0
-        arguments:
       # Verify that previous, empty transaction incremented txnNumber.
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -402,7 +375,6 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -469,7 +441,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -480,7 +451,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
       # Running any operation after an ended transaction resets the session
       # state to "no transaction".
       - name: insertOne
@@ -494,7 +464,6 @@ tests:
       # Calling commit again should error instead of re-running the commit.
       - name: commitTransaction
         object: session0
-        arguments:
         result:
           errorContains: no transaction started
 
@@ -550,7 +519,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -561,7 +529,6 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
       # Running any operation after an ended transaction resets the session
       # state to "no transaction".
       - name: insertOne
@@ -576,7 +543,6 @@ tests:
       # "cannot call abortTransaction twice".
       - name: abortTransaction
         object: session0
-        arguments:
         result:
           errorContains: no transaction started
 

--- a/source/transactions/tests/commit.yml
+++ b/source/transactions/tests/commit.yml
@@ -10,6 +10,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -24,6 +25,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 2
@@ -112,6 +114,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -162,6 +165,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -243,6 +247,7 @@ tests:
             writeConcern:
               w: 10
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -311,6 +316,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -361,6 +367,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -386,6 +393,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -463,6 +471,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -475,6 +484,7 @@ tests:
       # Running any operation after an ended transaction resets the session
       # state to "no transaction".
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 2
@@ -542,6 +552,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -554,6 +565,7 @@ tests:
       # Running any operation after an ended transaction resets the session
       # state to "no transaction".
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 2

--- a/source/transactions/tests/delete.json
+++ b/source/transactions/tests/delete.json
@@ -24,9 +24,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "deleteOne",
@@ -71,9 +70,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -187,8 +185,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": "majority"
@@ -236,9 +234,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/delete.json
+++ b/source/transactions/tests/delete.json
@@ -180,7 +180,7 @@
       }
     },
     {
-      "description": "operation writeConcern ignored for delete",
+      "description": "collection writeConcern ignored for delete",
       "operations": [
         {
           "name": "startTransaction",
@@ -195,12 +195,14 @@
         },
         {
           "name": "deleteOne",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "filter": {
               "_id": 1
-            },
-            "writeConcern": {
-              "w": "majority"
             },
             "session": "session0"
           },
@@ -210,14 +212,16 @@
         },
         {
           "name": "deleteMany",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "filter": {
               "_id": {
                 "$lte": 3
               }
-            },
-            "writeConcern": {
-              "w": "majority"
             },
             "session": "session0"
           },

--- a/source/transactions/tests/delete.json
+++ b/source/transactions/tests/delete.json
@@ -30,6 +30,7 @@
         },
         {
           "name": "deleteOne",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -42,6 +43,7 @@
         },
         {
           "name": "deleteMany",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": {
@@ -56,6 +58,7 @@
         },
         {
           "name": "deleteOne",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 4
@@ -195,6 +198,7 @@
         },
         {
           "name": "deleteOne",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"
@@ -212,6 +216,7 @@
         },
         {
           "name": "deleteMany",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"

--- a/source/transactions/tests/delete.json
+++ b/source/transactions/tests/delete.json
@@ -30,10 +30,10 @@
           "name": "deleteOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "deletedCount": 1
@@ -43,12 +43,12 @@
           "name": "deleteMany",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": {
                 "$lte": 3
               }
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "deletedCount": 2
@@ -58,10 +58,10 @@
           "name": "deleteOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 4
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "deletedCount": 1
@@ -201,10 +201,10 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "deletedCount": 1
@@ -219,12 +219,12 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": {
                 "$lte": 3
               }
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "deletedCount": 2

--- a/source/transactions/tests/delete.json
+++ b/source/transactions/tests/delete.json
@@ -24,8 +24,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "deleteOne",
@@ -70,8 +69,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -234,8 +232,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/delete.yml
+++ b/source/transactions/tests/delete.yml
@@ -14,7 +14,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: deleteOne
         object: collection
         arguments:
@@ -41,7 +40,6 @@ tests:
           deletedCount: 1
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -139,7 +137,6 @@ tests:
           deletedCount: 2
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/delete.yml
+++ b/source/transactions/tests/delete.yml
@@ -13,8 +13,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: deleteOne
         object: collection
         arguments:
@@ -40,8 +40,8 @@ tests:
         result:
           deletedCount: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -110,8 +110,8 @@ tests:
   - description: collection writeConcern ignored for delete
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: majority
@@ -138,8 +138,8 @@ tests:
         result:
           deletedCount: 2
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/delete.yml
+++ b/source/transactions/tests/delete.yml
@@ -16,6 +16,7 @@ tests:
         arguments:
           session: session0
       - name: deleteOne
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -23,6 +24,7 @@ tests:
         result:
           deletedCount: 1
       - name: deleteMany
+        object: collection
         arguments:
           filter:
             _id: {$lte: 3}
@@ -30,6 +32,7 @@ tests:
         result:
           deletedCount: 2
       - name: deleteOne
+        object: collection
         arguments:
           filter:
             _id: 4
@@ -113,6 +116,7 @@ tests:
             writeConcern:
               w: majority
       - name: deleteOne
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority
@@ -123,6 +127,7 @@ tests:
         result:
           deletedCount: 1
       - name: deleteMany
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority

--- a/source/transactions/tests/delete.yml
+++ b/source/transactions/tests/delete.yml
@@ -104,7 +104,7 @@ tests:
         data:
           - _id: 5
 
-  - description: operation writeConcern ignored for delete
+  - description: collection writeConcern ignored for delete
     operations:
       - name: startTransaction
         arguments:
@@ -113,20 +113,22 @@ tests:
             writeConcern:
               w: majority
       - name: deleteOne
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           filter:
             _id: 1
-          writeConcern:
-            w: majority
           session: session0
         result:
           deletedCount: 1
       - name: deleteMany
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           filter:
             _id: {$lte: 3}
-          writeConcern:
-            w: majority
           session: session0
         result:
           deletedCount: 2

--- a/source/transactions/tests/delete.yml
+++ b/source/transactions/tests/delete.yml
@@ -17,25 +17,25 @@ tests:
       - name: deleteOne
         object: collection
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           deletedCount: 1
       - name: deleteMany
         object: collection
         arguments:
+          session: session0
           filter:
             _id: {$lte: 3}
-          session: session0
         result:
           deletedCount: 2
       - name: deleteOne
         object: collection
         arguments:
+          session: session0
           filter:
             _id: 4
-          session: session0
         result:
           deletedCount: 1
       - name: commitTransaction
@@ -119,9 +119,9 @@ tests:
           writeConcern:
             w: majority
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           deletedCount: 1
       - name: deleteMany
@@ -130,9 +130,9 @@ tests:
           writeConcern:
             w: majority
         arguments:
+          session: session0
           filter:
             _id: {$lte: 3}
-          session: session0
         result:
           deletedCount: 2
       - name: commitTransaction

--- a/source/transactions/tests/errors.json
+++ b/source/transactions/tests/errors.json
@@ -14,6 +14,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -72,6 +73,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -116,6 +118,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -134,6 +137,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -172,6 +176,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -190,6 +195,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1

--- a/source/transactions/tests/errors.json
+++ b/source/transactions/tests/errors.json
@@ -8,8 +8,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -27,15 +26,13 @@
         {
           "name": "startTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "transaction already in progress"
           }
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ]
     },
@@ -44,13 +41,11 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
           "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "transaction already in progress"
           }
@@ -62,8 +57,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -80,18 +74,15 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
         },
         {
           "name": "startTransaction",
           "object": "session0",
-          "arguments": null
-        },
-        {
-          "name": "startTransaction",
-          "object": "session0",
-          "arguments": null,
           "result": {
             "errorContains": "transaction already in progress"
           }
@@ -103,8 +94,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -121,8 +111,7 @@
         },
         {
           "name": "startTransaction",
-          "object": "session1",
-          "arguments": null
+          "object": "session1"
         },
         {
           "name": "insertOne",
@@ -139,13 +128,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "commitTransaction",
           "object": "session1",
-          "arguments": null,
           "result": {
             "errorCodeName": "NoSuchTransaction"
           }
@@ -157,8 +144,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -175,8 +161,7 @@
         },
         {
           "name": "startTransaction",
-          "object": "session1",
-          "arguments": null
+          "object": "session1"
         },
         {
           "name": "insertOne",
@@ -193,13 +178,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "abortTransaction",
-          "object": "session1",
-          "arguments": null
+          "object": "session1"
         }
       ]
     }

--- a/source/transactions/tests/errors.json
+++ b/source/transactions/tests/errors.json
@@ -8,9 +8,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -27,18 +26,16 @@
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "transaction already in progress"
           }
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ]
     },
@@ -47,15 +44,13 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "transaction already in progress"
           }
@@ -67,9 +62,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -86,21 +80,18 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          },
+          "object": "session0",
+          "arguments": null,
           "result": {
             "errorContains": "transaction already in progress"
           }
@@ -112,9 +103,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -131,9 +121,8 @@
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session1"
-          }
+          "object": "session1",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -150,15 +139,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session1"
-          },
+          "object": "session1",
+          "arguments": null,
           "result": {
             "errorCodeName": "NoSuchTransaction"
           }
@@ -170,9 +157,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -189,9 +175,8 @@
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session1"
-          }
+          "object": "session1",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -208,15 +193,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session1"
-          }
+          "object": "session1",
+          "arguments": null
         }
       ]
     }

--- a/source/transactions/tests/errors.json
+++ b/source/transactions/tests/errors.json
@@ -14,10 +14,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -63,10 +63,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -100,10 +100,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -117,10 +117,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session1",
             "document": {
               "_id": 1
-            },
-            "session": "session1"
+            }
           },
           "result": {
             "errorCodeName": "WriteConflict"
@@ -150,10 +150,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -167,10 +167,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session1",
             "document": {
               "_id": 1
-            },
-            "session": "session1"
+            }
           },
           "result": {
             "errorCodeName": "WriteConflict"

--- a/source/transactions/tests/errors.yml
+++ b/source/transactions/tests/errors.yml
@@ -11,9 +11,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: startTransaction
@@ -44,9 +44,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -67,9 +67,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: startTransaction
@@ -77,9 +77,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session1
           document:
             _id: 1
-          session: session1
         result:
           errorCodeName: WriteConflict
       - name: commitTransaction
@@ -97,9 +97,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: startTransaction
@@ -107,9 +107,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session1
           document:
             _id: 1
-          session: session1
         result:
           errorCodeName: WriteConflict
       - name: commitTransaction

--- a/source/transactions/tests/errors.yml
+++ b/source/transactions/tests/errors.yml
@@ -10,6 +10,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -47,6 +48,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -73,6 +75,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -83,6 +86,7 @@ tests:
         arguments:
           session: session1
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -105,6 +109,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -115,6 +120,7 @@ tests:
         arguments:
           session: session1
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1

--- a/source/transactions/tests/errors.yml
+++ b/source/transactions/tests/errors.yml
@@ -8,7 +8,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -19,24 +18,20 @@ tests:
           insertedId: 1
       - name: startTransaction
         object: session0
-        arguments:
         result:
           # Client-side error.
           errorContains: transaction already in progress
       # Just to clean up.
       - name: commitTransaction
         object: session0
-        arguments:
 
   - description: start twice
 
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: startTransaction
         object: session0
-        arguments:
         result:
           # Client-side error.
           errorContains: transaction already in progress
@@ -46,7 +41,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -57,13 +51,10 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
       - name: startTransaction
         object: session0
-        arguments:
       - name: startTransaction
         object: session0
-        arguments:
         result:
           # Client-side error.
           errorContains: transaction already in progress
@@ -73,7 +64,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -84,7 +74,6 @@ tests:
           insertedId: 1
       - name: startTransaction
         object: session1
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -95,10 +84,8 @@ tests:
           errorCodeName: WriteConflict
       - name: commitTransaction
         object: session0
-        arguments:
       - name: commitTransaction
         object: session1
-        arguments:
         result:
           errorCodeName: NoSuchTransaction
 
@@ -107,7 +94,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -118,7 +104,6 @@ tests:
           insertedId: 1
       - name: startTransaction
         object: session1
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -129,8 +114,6 @@ tests:
           errorCodeName: WriteConflict
       - name: commitTransaction
         object: session0
-        arguments:
       # Driver ignores "NoSuchTransaction" error.
       - name: abortTransaction
         object: session1
-        arguments:

--- a/source/transactions/tests/errors.yml
+++ b/source/transactions/tests/errors.yml
@@ -7,8 +7,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -18,25 +18,25 @@ tests:
         result:
           insertedId: 1
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           # Client-side error.
           errorContains: transaction already in progress
       # Just to clean up.
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
   - description: start twice
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           # Client-side error.
           errorContains: transaction already in progress
@@ -45,8 +45,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -56,14 +56,14 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
         result:
           # Client-side error.
           errorContains: transaction already in progress
@@ -72,8 +72,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -83,8 +83,8 @@ tests:
         result:
           insertedId: 1
       - name: startTransaction
+        object: session1
         arguments:
-          session: session1
       - name: insertOne
         object: collection
         arguments:
@@ -94,11 +94,11 @@ tests:
         result:
           errorCodeName: WriteConflict
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: commitTransaction
+        object: session1
         arguments:
-          session: session1
         result:
           errorCodeName: NoSuchTransaction
 
@@ -106,8 +106,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -117,8 +117,8 @@ tests:
         result:
           insertedId: 1
       - name: startTransaction
+        object: session1
         arguments:
-          session: session1
       - name: insertOne
         object: collection
         arguments:
@@ -128,9 +128,9 @@ tests:
         result:
           errorCodeName: WriteConflict
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Driver ignores "NoSuchTransaction" error.
       - name: abortTransaction
+        object: session1
         arguments:
-          session: session1

--- a/source/transactions/tests/findOneAndDelete.json
+++ b/source/transactions/tests/findOneAndDelete.json
@@ -18,8 +18,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "findOneAndDelete",
@@ -47,8 +46,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -159,8 +157,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/findOneAndDelete.json
+++ b/source/transactions/tests/findOneAndDelete.json
@@ -24,10 +24,10 @@
           "name": "findOneAndDelete",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 3
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "_id": 3
@@ -37,10 +37,10 @@
           "name": "findOneAndDelete",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 4
-            },
-            "session": "session0"
+            }
           },
           "result": null
         },
@@ -146,10 +146,10 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 3
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "_id": 3

--- a/source/transactions/tests/findOneAndDelete.json
+++ b/source/transactions/tests/findOneAndDelete.json
@@ -126,7 +126,7 @@
       }
     },
     {
-      "description": "operation writeConcern ignored for findOneAndDelete",
+      "description": "collection writeConcern ignored for findOneAndDelete",
       "operations": [
         {
           "name": "startTransaction",
@@ -141,14 +141,16 @@
         },
         {
           "name": "findOneAndDelete",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "filter": {
               "_id": 3
             },
-            "session": "session0",
-            "writeConcern": {
-              "w": "majority"
-            }
+            "session": "session0"
           },
           "result": {
             "_id": 3

--- a/source/transactions/tests/findOneAndDelete.json
+++ b/source/transactions/tests/findOneAndDelete.json
@@ -24,6 +24,7 @@
         },
         {
           "name": "findOneAndDelete",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 3
@@ -36,6 +37,7 @@
         },
         {
           "name": "findOneAndDelete",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 4
@@ -141,6 +143,7 @@
         },
         {
           "name": "findOneAndDelete",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"

--- a/source/transactions/tests/findOneAndDelete.json
+++ b/source/transactions/tests/findOneAndDelete.json
@@ -18,9 +18,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "findOneAndDelete",
@@ -48,9 +47,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -132,8 +130,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": "majority"
@@ -161,9 +159,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/findOneAndDelete.yml
+++ b/source/transactions/tests/findOneAndDelete.yml
@@ -12,7 +12,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: findOneAndDelete
         object: collection
         arguments:
@@ -27,7 +26,6 @@ tests:
         result:
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -97,7 +95,6 @@ tests:
         result: {_id: 3}
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/findOneAndDelete.yml
+++ b/source/transactions/tests/findOneAndDelete.yml
@@ -75,7 +75,7 @@ tests:
           - {_id: 1}
           - {_id: 2}
 
-  - description: operation writeConcern ignored for findOneAndDelete
+  - description: collection writeConcern ignored for findOneAndDelete
 
     operations:
       - name: startTransaction
@@ -85,11 +85,12 @@ tests:
             writeConcern:
               w: majority
       - name: findOneAndDelete
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           filter: {_id: 3}
           session: session0
-          writeConcern:
-            w: majority
         result: {_id: 3}
       - name: commitTransaction
         arguments:

--- a/source/transactions/tests/findOneAndDelete.yml
+++ b/source/transactions/tests/findOneAndDelete.yml
@@ -15,14 +15,14 @@ tests:
       - name: findOneAndDelete
         object: collection
         arguments:
-          filter: {_id: 3}
           session: session0
+          filter: {_id: 3}
         result: {_id: 3}
       - name: findOneAndDelete
         object: collection
         arguments:
-          filter: {_id: 4}
           session: session0
+          filter: {_id: 4}
         result:
       - name: commitTransaction
         object: session0
@@ -90,8 +90,8 @@ tests:
           writeConcern:
             w: majority
         arguments:
-          filter: {_id: 3}
           session: session0
+          filter: {_id: 3}
         result: {_id: 3}
       - name: commitTransaction
         object: session0

--- a/source/transactions/tests/findOneAndDelete.yml
+++ b/source/transactions/tests/findOneAndDelete.yml
@@ -14,11 +14,13 @@ tests:
         arguments:
           session: session0
       - name: findOneAndDelete
+        object: collection
         arguments:
           filter: {_id: 3}
           session: session0
         result: {_id: 3}
       - name: findOneAndDelete
+        object: collection
         arguments:
           filter: {_id: 4}
           session: session0
@@ -85,6 +87,7 @@ tests:
             writeConcern:
               w: majority
       - name: findOneAndDelete
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority

--- a/source/transactions/tests/findOneAndDelete.yml
+++ b/source/transactions/tests/findOneAndDelete.yml
@@ -11,8 +11,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: findOneAndDelete
         object: collection
         arguments:
@@ -26,8 +26,8 @@ tests:
           session: session0
         result:
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -81,8 +81,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: majority
@@ -96,8 +96,8 @@ tests:
           session: session0
         result: {_id: 3}
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/findOneAndReplace.json
+++ b/source/transactions/tests/findOneAndReplace.json
@@ -24,14 +24,14 @@
           "name": "findOneAndReplace",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 3
             },
             "replacement": {
               "x": 1
             },
-            "returnDocument": "Before",
-            "session": "session0"
+            "returnDocument": "Before"
           },
           "result": {
             "_id": 3
@@ -41,6 +41,7 @@
           "name": "findOneAndReplace",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 4
             },
@@ -48,8 +49,7 @@
               "x": 1
             },
             "upsert": true,
-            "returnDocument": "After",
-            "session": "session0"
+            "returnDocument": "After"
           },
           "result": {
             "_id": 4,
@@ -173,14 +173,14 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 3
             },
             "replacement": {
               "x": 1
             },
-            "returnDocument": "Before",
-            "session": "session0"
+            "returnDocument": "Before"
           },
           "result": {
             "_id": 3

--- a/source/transactions/tests/findOneAndReplace.json
+++ b/source/transactions/tests/findOneAndReplace.json
@@ -153,7 +153,7 @@
       }
     },
     {
-      "description": "operation writeConcern ignored for findOneAndReplace",
+      "description": "collection writeConcern ignored for findOneAndReplace",
       "operations": [
         {
           "name": "startTransaction",
@@ -168,6 +168,11 @@
         },
         {
           "name": "findOneAndReplace",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "filter": {
               "_id": 3
@@ -176,10 +181,7 @@
               "x": 1
             },
             "returnDocument": "Before",
-            "session": "session0",
-            "writeConcern": {
-              "w": "majority"
-            }
+            "session": "session0"
           },
           "result": {
             "_id": 3

--- a/source/transactions/tests/findOneAndReplace.json
+++ b/source/transactions/tests/findOneAndReplace.json
@@ -18,9 +18,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "findOneAndReplace",
@@ -60,9 +59,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -159,8 +157,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": "majority"
@@ -192,9 +190,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/findOneAndReplace.json
+++ b/source/transactions/tests/findOneAndReplace.json
@@ -18,8 +18,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "findOneAndReplace",
@@ -59,8 +58,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -190,8 +188,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/findOneAndReplace.json
+++ b/source/transactions/tests/findOneAndReplace.json
@@ -24,6 +24,7 @@
         },
         {
           "name": "findOneAndReplace",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 3
@@ -40,6 +41,7 @@
         },
         {
           "name": "findOneAndReplace",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 4
@@ -168,6 +170,7 @@
         },
         {
           "name": "findOneAndReplace",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"

--- a/source/transactions/tests/findOneAndReplace.yml
+++ b/source/transactions/tests/findOneAndReplace.yml
@@ -11,8 +11,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: findOneAndReplace
         object: collection
         arguments:
@@ -31,8 +31,8 @@ tests:
           session: session0
         result: {_id: 4, x: 1}
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -91,8 +91,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: majority
@@ -108,8 +108,8 @@ tests:
           session: session0
         result: {_id: 3}
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/findOneAndReplace.yml
+++ b/source/transactions/tests/findOneAndReplace.yml
@@ -15,19 +15,19 @@ tests:
       - name: findOneAndReplace
         object: collection
         arguments:
+          session: session0
           filter: {_id: 3}
           replacement: {x: 1}
           returnDocument: Before
-          session: session0
         result: {_id: 3}
       - name: findOneAndReplace
         object: collection
         arguments:
+          session: session0
           filter: {_id: 4}
           replacement: {x: 1}
           upsert: true
           returnDocument: After
-          session: session0
         result: {_id: 4, x: 1}
       - name: commitTransaction
         object: session0
@@ -100,10 +100,10 @@ tests:
           writeConcern:
             w: majority
         arguments:
+          session: session0
           filter: {_id: 3}
           replacement: {x: 1}
           returnDocument: Before
-          session: session0
         result: {_id: 3}
       - name: commitTransaction
         object: session0

--- a/source/transactions/tests/findOneAndReplace.yml
+++ b/source/transactions/tests/findOneAndReplace.yml
@@ -85,7 +85,7 @@ tests:
           - {_id: 3, x: 1}
           - {_id: 4, x: 1}
 
-  - description: operation writeConcern ignored for findOneAndReplace
+  - description: collection writeConcern ignored for findOneAndReplace
 
     operations:
       - name: startTransaction
@@ -95,13 +95,14 @@ tests:
             writeConcern:
               w: majority
       - name: findOneAndReplace
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           filter: {_id: 3}
           replacement: {x: 1}
           returnDocument: Before
           session: session0
-          writeConcern:
-            w: majority
         result: {_id: 3}
       - name: commitTransaction
         arguments:

--- a/source/transactions/tests/findOneAndReplace.yml
+++ b/source/transactions/tests/findOneAndReplace.yml
@@ -12,7 +12,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: findOneAndReplace
         object: collection
         arguments:
@@ -32,7 +31,6 @@ tests:
         result: {_id: 4, x: 1}
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -109,7 +107,6 @@ tests:
         result: {_id: 3}
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/findOneAndReplace.yml
+++ b/source/transactions/tests/findOneAndReplace.yml
@@ -14,6 +14,7 @@ tests:
         arguments:
           session: session0
       - name: findOneAndReplace
+        object: collection
         arguments:
           filter: {_id: 3}
           replacement: {x: 1}
@@ -21,6 +22,7 @@ tests:
           session: session0
         result: {_id: 3}
       - name: findOneAndReplace
+        object: collection
         arguments:
           filter: {_id: 4}
           replacement: {x: 1}
@@ -95,6 +97,7 @@ tests:
             writeConcern:
               w: majority
       - name: findOneAndReplace
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority

--- a/source/transactions/tests/findOneAndUpdate.json
+++ b/source/transactions/tests/findOneAndUpdate.json
@@ -24,6 +24,7 @@
           "name": "findOneAndUpdate",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 3
             },
@@ -32,8 +33,7 @@
                 "x": 1
               }
             },
-            "returnDocument": "Before",
-            "session": "session0"
+            "returnDocument": "Before"
           },
           "result": {
             "_id": 3
@@ -43,6 +43,7 @@
           "name": "findOneAndUpdate",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 4
             },
@@ -52,8 +53,7 @@
               }
             },
             "upsert": true,
-            "returnDocument": "After",
-            "session": "session0"
+            "returnDocument": "After"
           },
           "result": {
             "_id": 4,
@@ -72,6 +72,7 @@
           "name": "findOneAndUpdate",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 3
             },
@@ -80,8 +81,7 @@
                 "x": 1
               }
             },
-            "returnDocument": "Before",
-            "session": "session0"
+            "returnDocument": "Before"
           },
           "result": {
             "_id": 3,
@@ -100,6 +100,7 @@
           "name": "findOneAndUpdate",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 3
             },
@@ -108,8 +109,7 @@
                 "x": 1
               }
             },
-            "returnDocument": "Before",
-            "session": "session0"
+            "returnDocument": "Before"
           },
           "result": {
             "_id": 3,
@@ -327,6 +327,7 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 3
             },
@@ -335,8 +336,7 @@
                 "x": 1
               }
             },
-            "returnDocument": "Before",
-            "session": "session0"
+            "returnDocument": "Before"
           },
           "result": {
             "_id": 3

--- a/source/transactions/tests/findOneAndUpdate.json
+++ b/source/transactions/tests/findOneAndUpdate.json
@@ -313,7 +313,7 @@
       }
     },
     {
-      "description": "operation writeConcern ignored for findOneAndUpdate",
+      "description": "collection writeConcern ignored for findOneAndUpdate",
       "operations": [
         {
           "name": "startTransaction",
@@ -328,6 +328,11 @@
         },
         {
           "name": "findOneAndUpdate",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "filter": {
               "_id": 3
@@ -338,10 +343,7 @@
               }
             },
             "returnDocument": "Before",
-            "session": "session0",
-            "writeConcern": {
-              "w": "majority"
-            }
+            "session": "session0"
           },
           "result": {
             "_id": 3

--- a/source/transactions/tests/findOneAndUpdate.json
+++ b/source/transactions/tests/findOneAndUpdate.json
@@ -18,9 +18,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "findOneAndUpdate",
@@ -64,15 +63,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "findOneAndUpdate",
@@ -96,15 +93,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "findOneAndUpdate",
@@ -128,9 +123,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -321,8 +315,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": "majority"
@@ -356,9 +350,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/findOneAndUpdate.json
+++ b/source/transactions/tests/findOneAndUpdate.json
@@ -18,8 +18,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "findOneAndUpdate",
@@ -63,13 +62,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "findOneAndUpdate",
@@ -93,13 +90,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "findOneAndUpdate",
@@ -123,8 +118,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -350,8 +344,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/findOneAndUpdate.json
+++ b/source/transactions/tests/findOneAndUpdate.json
@@ -24,6 +24,7 @@
         },
         {
           "name": "findOneAndUpdate",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 3
@@ -42,6 +43,7 @@
         },
         {
           "name": "findOneAndUpdate",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 4
@@ -74,6 +76,7 @@
         },
         {
           "name": "findOneAndUpdate",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 3
@@ -105,6 +108,7 @@
         },
         {
           "name": "findOneAndUpdate",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 3
@@ -328,6 +332,7 @@
         },
         {
           "name": "findOneAndUpdate",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"

--- a/source/transactions/tests/findOneAndUpdate.yml
+++ b/source/transactions/tests/findOneAndUpdate.yml
@@ -15,21 +15,21 @@ tests:
       - name: findOneAndUpdate
         object: collection
         arguments:
+          session: session0
           filter: {_id: 3}
           update:
             $inc: {x: 1}
           returnDocument: Before
-          session: session0
         result: {_id: 3}
       - name: findOneAndUpdate
         object: collection
         arguments:
+          session: session0
           filter: {_id: 4}
           update:
             $inc: {x: 1}
           upsert: true
           returnDocument: After
-          session: session0
         result: {_id: 4, x: 1}
       - name: commitTransaction
         object: session0
@@ -39,11 +39,11 @@ tests:
       - name: findOneAndUpdate
         object: collection
         arguments:
+          session: session0
           filter: {_id: 3}
           update:
             $inc: {x: 1}
           returnDocument: Before
-          session: session0
         result: {_id: 3, x: 1}
       - name: commitTransaction
         object: session0
@@ -53,11 +53,11 @@ tests:
       - name: findOneAndUpdate
         object: collection
         arguments:
+          session: session0
           filter: {_id: 3}
           update:
             $inc: {x: 1}
           returnDocument: Before
-          session: session0
         result: {_id: 3, x: 2}
       - name: abortTransaction
         object: session0
@@ -186,11 +186,11 @@ tests:
           writeConcern:
             w: majority
         arguments:
+          session: session0
           filter: {_id: 3}
           update:
             $inc: {x: 1}
           returnDocument: Before
-          session: session0
         result: {_id: 3}
       - name: commitTransaction
         object: session0

--- a/source/transactions/tests/findOneAndUpdate.yml
+++ b/source/transactions/tests/findOneAndUpdate.yml
@@ -14,6 +14,7 @@ tests:
         arguments:
           session: session0
       - name: findOneAndUpdate
+        object: collection
         arguments:
           filter: {_id: 3}
           update:
@@ -22,6 +23,7 @@ tests:
           session: session0
         result: {_id: 3}
       - name: findOneAndUpdate
+        object: collection
         arguments:
           filter: {_id: 4}
           update:
@@ -38,6 +40,7 @@ tests:
           session: session0
       # Test a second time to ensure txnNumber is incremented.
       - name: findOneAndUpdate
+        object: collection
         arguments:
           filter: {_id: 3}
           update:
@@ -53,6 +56,7 @@ tests:
         arguments:
           session: session0
       - name: findOneAndUpdate
+        object: collection
         arguments:
           filter: {_id: 3}
           update:
@@ -183,6 +187,7 @@ tests:
             writeConcern:
               w: majority
       - name: findOneAndUpdate
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority

--- a/source/transactions/tests/findOneAndUpdate.yml
+++ b/source/transactions/tests/findOneAndUpdate.yml
@@ -11,8 +11,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: findOneAndUpdate
         object: collection
         arguments:
@@ -33,11 +33,11 @@ tests:
           session: session0
         result: {_id: 4, x: 1}
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       # Test a second time to ensure txnNumber is incremented.
       - name: findOneAndUpdate
         object: collection
@@ -49,12 +49,12 @@ tests:
           session: session0
         result: {_id: 3, x: 1}
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Test a third time to ensure abort works.
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: findOneAndUpdate
         object: collection
         arguments:
@@ -65,8 +65,8 @@ tests:
           session: session0
         result: {_id: 3, x: 2}
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -181,8 +181,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: majority
@@ -199,8 +199,8 @@ tests:
           session: session0
         result: {_id: 3}
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/findOneAndUpdate.yml
+++ b/source/transactions/tests/findOneAndUpdate.yml
@@ -173,7 +173,7 @@ tests:
           - {_id: 3, x: 2}
           - {_id: 4, x: 1}
 
-  - description: operation writeConcern ignored for findOneAndUpdate
+  - description: collection writeConcern ignored for findOneAndUpdate
 
     operations:
       - name: startTransaction
@@ -183,14 +183,15 @@ tests:
             writeConcern:
               w: majority
       - name: findOneAndUpdate
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           filter: {_id: 3}
           update:
             $inc: {x: 1}
           returnDocument: Before
           session: session0
-          writeConcern:
-            w: majority
         result: {_id: 3}
       - name: commitTransaction
         arguments:

--- a/source/transactions/tests/findOneAndUpdate.yml
+++ b/source/transactions/tests/findOneAndUpdate.yml
@@ -12,7 +12,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: findOneAndUpdate
         object: collection
         arguments:
@@ -34,10 +33,8 @@ tests:
         result: {_id: 4, x: 1}
       - name: commitTransaction
         object: session0
-        arguments:
       - name: startTransaction
         object: session0
-        arguments:
       # Test a second time to ensure txnNumber is incremented.
       - name: findOneAndUpdate
         object: collection
@@ -50,11 +47,9 @@ tests:
         result: {_id: 3, x: 1}
       - name: commitTransaction
         object: session0
-        arguments:
       # Test a third time to ensure abort works.
       - name: startTransaction
         object: session0
-        arguments:
       - name: findOneAndUpdate
         object: collection
         arguments:
@@ -66,7 +61,6 @@ tests:
         result: {_id: 3, x: 2}
       - name: abortTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -200,7 +194,6 @@ tests:
         result: {_id: 3}
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/insert.json
+++ b/source/transactions/tests/insert.json
@@ -238,7 +238,63 @@
       }
     },
     {
-      "description": "operation writeConcern ignored for insert",
+      "description": "collection writeConcern without transaction",
+      "operations": [
+        {
+          "name": "insertOne",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": null,
+              "startTransaction": null,
+              "autocommit": null,
+              "writeConcern": {
+                "w": "majority"
+              }
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "collection writeConcern ignored for insert",
       "operations": [
         {
           "name": "startTransaction",
@@ -253,14 +309,16 @@
         },
         {
           "name": "insertOne",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "document": {
               "_id": 1
             },
-            "session": "session0",
-            "writeConcern": {
-              "w": "majority"
-            }
+            "session": "session0"
           },
           "result": {
             "insertedId": 1
@@ -268,6 +326,11 @@
         },
         {
           "name": "insertMany",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "documents": [
               {
@@ -277,10 +340,7 @@
                 "_id": 3
               }
             ],
-            "session": "session0",
-            "writeConcern": {
-              "w": "majority"
-            }
+            "session": "session0"
           },
           "result": {
             "insertedIds": {
@@ -363,7 +423,22 @@
             "database_name": "admin"
           }
         }
-      ]
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/transactions/tests/insert.json
+++ b/source/transactions/tests/insert.json
@@ -14,10 +14,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -48,10 +48,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 4
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 4
@@ -69,10 +69,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 5
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 5
@@ -245,10 +245,10 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -313,10 +313,10 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1

--- a/source/transactions/tests/insert.json
+++ b/source/transactions/tests/insert.json
@@ -14,6 +14,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -26,6 +27,7 @@
         },
         {
           "name": "insertMany",
+          "object": "collection",
           "arguments": {
             "documents": [
               {
@@ -46,6 +48,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 4
@@ -70,6 +73,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 5
@@ -242,6 +246,7 @@
       "operations": [
         {
           "name": "insertOne",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"
@@ -309,6 +314,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"
@@ -326,6 +332,7 @@
         },
         {
           "name": "insertMany",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"

--- a/source/transactions/tests/insert.json
+++ b/source/transactions/tests/insert.json
@@ -8,9 +8,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -61,15 +60,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -86,9 +83,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -303,8 +299,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": "majority"
@@ -358,9 +354,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/insert.json
+++ b/source/transactions/tests/insert.json
@@ -8,8 +8,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -60,13 +59,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -83,8 +80,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -354,8 +350,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/insert.yml
+++ b/source/transactions/tests/insert.yml
@@ -141,7 +141,43 @@ tests:
           - _id: 4
           - _id: 5
 
-  - description: operation writeConcern ignored for insert
+  # This test proves that the driver parses the collectionOptions writeConcern.
+  - description: collection writeConcern without transaction
+    operations:
+      - name: insertOne
+        collectionOptions:
+          writeConcern:
+            w: majority
+        arguments:
+          document:
+            _id: 1
+          session: session0
+        result:
+          insertedId: 1
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+            startTransaction:
+            autocommit:
+            writeConcern:
+              w: majority
+          command_name: insert
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+
+  - description: collection writeConcern ignored for insert
     operations:
       - name: startTransaction
         arguments:
@@ -150,22 +186,24 @@ tests:
             writeConcern:
               w: majority
       - name: insertOne
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           document:
             _id: 1
           session: session0
-          writeConcern:
-            w: majority
         result:
           insertedId: 1
       - name: insertMany
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           documents:
             - _id: 2
             - _id: 3
           session: session0
-          writeConcern:
-            w: majority
         result:
           insertedIds: {0: 2, 1: 3}
       - name: commitTransaction
@@ -215,3 +253,10 @@ tests:
               w: majority
           command_name: commitTransaction
           database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+          - _id: 2
+          - _id: 3

--- a/source/transactions/tests/insert.yml
+++ b/source/transactions/tests/insert.yml
@@ -8,8 +8,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -36,11 +36,11 @@ tests:
         result:
           insertedId: 4
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -50,8 +50,8 @@ tests:
         result:
           insertedId: 5
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -185,8 +185,8 @@ tests:
   - description: collection writeConcern ignored for insert
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: majority
@@ -214,8 +214,8 @@ tests:
         result:
           insertedIds: {0: 2, 1: 3}
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/insert.yml
+++ b/source/transactions/tests/insert.yml
@@ -9,7 +9,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -37,10 +36,8 @@ tests:
           insertedId: 4
       - name: commitTransaction
         object: session0
-        arguments:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -51,7 +48,6 @@ tests:
           insertedId: 5
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -215,7 +211,6 @@ tests:
           insertedIds: {0: 2, 1: 3}
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/insert.yml
+++ b/source/transactions/tests/insert.yml
@@ -12,9 +12,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: insertMany
@@ -29,9 +29,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 4
-          session: session0
         result:
           insertedId: 4
       - name: commitTransaction
@@ -41,9 +41,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 5
-          session: session0
         result:
           insertedId: 5
       - name: commitTransaction
@@ -150,9 +150,9 @@ tests:
           writeConcern:
             w: majority
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
 
@@ -192,9 +192,9 @@ tests:
           writeConcern:
             w: majority
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: insertMany

--- a/source/transactions/tests/insert.yml
+++ b/source/transactions/tests/insert.yml
@@ -11,6 +11,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -18,6 +19,7 @@ tests:
         result:
           insertedId: 1
       - name: insertMany
+        object: collection
         arguments:
           documents:
             - _id: 2
@@ -26,6 +28,7 @@ tests:
         result:
           insertedIds: {0: 2, 1: 3}
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 4
@@ -39,6 +42,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 5
@@ -145,6 +149,7 @@ tests:
   - description: collection writeConcern without transaction
     operations:
       - name: insertOne
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority
@@ -186,6 +191,7 @@ tests:
             writeConcern:
               w: majority
       - name: insertOne
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority
@@ -196,6 +202,7 @@ tests:
         result:
           insertedId: 1
       - name: insertMany
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority

--- a/source/transactions/tests/isolation.json
+++ b/source/transactions/tests/isolation.json
@@ -8,9 +8,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -63,9 +62,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "find",
@@ -112,15 +110,13 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session1"
-          }
+          "object": "session1",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -173,9 +169,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "find",
@@ -204,9 +199,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session1"
-          }
+          "object": "session1",
+          "arguments": null
         }
       ],
       "outcome": {

--- a/source/transactions/tests/isolation.json
+++ b/source/transactions/tests/isolation.json
@@ -14,6 +14,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -26,6 +27,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -40,6 +42,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -50,6 +53,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -65,6 +69,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -79,6 +84,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -118,6 +124,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -130,6 +137,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -144,6 +152,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -154,6 +163,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -169,6 +179,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -179,6 +190,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1

--- a/source/transactions/tests/isolation.json
+++ b/source/transactions/tests/isolation.json
@@ -14,10 +14,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -27,10 +27,10 @@
           "name": "find",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": [
             {
@@ -42,10 +42,10 @@
           "name": "find",
           "object": "collection",
           "arguments": {
+            "session": "session1",
             "filter": {
               "_id": 1
-            },
-            "session": "session1"
+            }
           },
           "result": []
         },
@@ -67,10 +67,10 @@
           "name": "find",
           "object": "collection",
           "arguments": {
+            "session": "session1",
             "filter": {
               "_id": 1
-            },
-            "session": "session1"
+            }
           },
           "result": [
             {
@@ -118,10 +118,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -131,10 +131,10 @@
           "name": "find",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": [
             {
@@ -146,10 +146,10 @@
           "name": "find",
           "object": "collection",
           "arguments": {
+            "session": "session1",
             "filter": {
               "_id": 1
-            },
-            "session": "session1"
+            }
           },
           "result": []
         },
@@ -171,10 +171,10 @@
           "name": "find",
           "object": "collection",
           "arguments": {
+            "session": "session1",
             "filter": {
               "_id": 1
-            },
-            "session": "session1"
+            }
           },
           "result": []
         },

--- a/source/transactions/tests/isolation.json
+++ b/source/transactions/tests/isolation.json
@@ -8,8 +8,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -62,8 +61,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "find",
@@ -110,13 +108,11 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session1",
-          "arguments": null
+          "object": "session1"
         },
         {
           "name": "insertOne",
@@ -169,8 +165,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "find",
@@ -199,8 +194,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session1",
-          "arguments": null
+          "object": "session1"
         }
       ],
       "outcome": {

--- a/source/transactions/tests/isolation.yml
+++ b/source/transactions/tests/isolation.yml
@@ -13,6 +13,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -20,6 +21,7 @@ tests:
         result:
           insertedId: 1
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -27,12 +29,14 @@ tests:
         result:
           - {_id: 1}
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1
           session: session1
         result: []
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -41,6 +45,7 @@ tests:
         arguments:
           session: session0
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -48,6 +53,7 @@ tests:
         result:
           - {_id: 1}
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -69,6 +75,7 @@ tests:
         arguments:
           session: session1
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -76,6 +83,7 @@ tests:
         result:
           insertedId: 1
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -83,12 +91,14 @@ tests:
         result:
           - {_id: 1}
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1
           session: session1
         result: []
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -98,12 +108,14 @@ tests:
           session: session0
       # Snapshot isolation in session1, not read-committed.
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1
           session: session1
         result: []
       - name: find
+        object: collection
         arguments:
           filter:
             _id: 1

--- a/source/transactions/tests/isolation.yml
+++ b/source/transactions/tests/isolation.yml
@@ -14,25 +14,25 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: find
         object: collection
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           - {_id: 1}
       - name: find
         object: collection
         arguments:
+          session: session1
           filter:
             _id: 1
-          session: session1
         result: []
       - name: find
         object: collection
@@ -45,9 +45,9 @@ tests:
       - name: find
         object: collection
         arguments:
+          session: session1
           filter:
             _id: 1
-          session: session1
         result:
           - {_id: 1}
       - name: find
@@ -73,25 +73,25 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: find
         object: collection
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           - {_id: 1}
       - name: find
         object: collection
         arguments:
+          session: session1
           filter:
             _id: 1
-          session: session1
         result: []
       - name: find
         object: collection
@@ -105,9 +105,9 @@ tests:
       - name: find
         object: collection
         arguments:
+          session: session1
           filter:
             _id: 1
-          session: session1
         result: []
       - name: find
         object: collection

--- a/source/transactions/tests/isolation.yml
+++ b/source/transactions/tests/isolation.yml
@@ -10,8 +10,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -42,8 +42,8 @@ tests:
             _id: 1
         result: []
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: find
         object: collection
         arguments:
@@ -69,11 +69,11 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: startTransaction
+        object: session1
         arguments:
-          session: session1
       - name: insertOne
         object: collection
         arguments:
@@ -104,8 +104,8 @@ tests:
             _id: 1
         result: []
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Snapshot isolation in session1, not read-committed.
       - name: find
         object: collection
@@ -122,8 +122,8 @@ tests:
         result:
           - {_id: 1}
       - name: commitTransaction
+        object: session1
         arguments:
-          session: session1
 
     outcome:
       collection:

--- a/source/transactions/tests/isolation.yml
+++ b/source/transactions/tests/isolation.yml
@@ -11,7 +11,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -43,7 +42,6 @@ tests:
         result: []
       - name: commitTransaction
         object: session0
-        arguments:
       - name: find
         object: collection
         arguments:
@@ -70,10 +68,8 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: startTransaction
         object: session1
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -105,7 +101,6 @@ tests:
         result: []
       - name: commitTransaction
         object: session0
-        arguments:
       # Snapshot isolation in session1, not read-committed.
       - name: find
         object: collection
@@ -123,7 +118,6 @@ tests:
           - {_id: 1}
       - name: commitTransaction
         object: session1
-        arguments:
 
     outcome:
       collection:

--- a/source/transactions/tests/read-pref.json
+++ b/source/transactions/tests/read-pref.json
@@ -48,10 +48,10 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": 1
         },
@@ -64,8 +64,8 @@
             }
           },
           "arguments": {
-            "batchSize": 3,
-            "session": "session0"
+            "session": "session0",
+            "batchSize": 3
           },
           "result": [
             {
@@ -192,10 +192,10 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": 1
         },
@@ -208,8 +208,8 @@
             }
           },
           "arguments": {
-            "batchSize": 3,
-            "session": "session0"
+            "session": "session0",
+            "batchSize": 3
           },
           "result": [
             {
@@ -336,10 +336,10 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"
@@ -354,8 +354,8 @@
             }
           },
           "arguments": {
-            "batchSize": 3,
-            "session": "session0"
+            "session": "session0",
+            "batchSize": 3
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"
@@ -447,10 +447,10 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"
@@ -465,8 +465,8 @@
             }
           },
           "arguments": {
-            "batchSize": 3,
-            "session": "session0"
+            "session": "session0",
+            "batchSize": 3
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"
@@ -558,10 +558,10 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"
@@ -576,8 +576,8 @@
             }
           },
           "arguments": {
-            "batchSize": 3,
-            "session": "session0"
+            "session": "session0",
+            "batchSize": 3
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"
@@ -635,10 +635,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1

--- a/source/transactions/tests/read-pref.json
+++ b/source/transactions/tests/read-pref.json
@@ -8,9 +8,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertMany",
@@ -120,9 +119,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "outcome": {
@@ -149,8 +147,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readPreference": {
                 "mode": "Primary"
@@ -266,9 +264,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "outcome": {
@@ -295,8 +292,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readPreference": {
                 "mode": "Secondary"
@@ -392,9 +389,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "outcome": {
@@ -408,8 +404,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readPreference": {
                 "mode": "PrimaryPreferred"
@@ -505,9 +501,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "outcome": {
@@ -521,8 +516,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readPreference": {
                 "mode": "Nearest"
@@ -618,9 +613,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "outcome": {
@@ -634,8 +628,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readPreference": {
                 "mode": "Secondary"
@@ -658,9 +652,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "outcome": {

--- a/source/transactions/tests/read-pref.json
+++ b/source/transactions/tests/read-pref.json
@@ -8,8 +8,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertMany",
@@ -119,8 +118,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "outcome": {
@@ -264,8 +262,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "outcome": {
@@ -389,8 +386,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "outcome": {
@@ -501,8 +497,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "outcome": {
@@ -613,8 +608,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "outcome": {
@@ -652,8 +646,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "outcome": {

--- a/source/transactions/tests/read-pref.json
+++ b/source/transactions/tests/read-pref.json
@@ -42,10 +42,12 @@
         },
         {
           "name": "count",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
-            },
+            }
+          },
+          "arguments": {
             "filter": {
               "_id": 1
             },
@@ -55,10 +57,12 @@
         },
         {
           "name": "find",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
-            },
+            }
+          },
+          "arguments": {
             "batchSize": 3,
             "session": "session0"
           },
@@ -79,10 +83,12 @@
         },
         {
           "name": "aggregate",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
-            },
+            }
+          },
+          "arguments": {
             "pipeline": [
               {
                 "$project": {
@@ -178,10 +184,12 @@
         },
         {
           "name": "count",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
-            },
+            }
+          },
+          "arguments": {
             "filter": {
               "_id": 1
             },
@@ -191,10 +199,12 @@
         },
         {
           "name": "find",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
-            },
+            }
+          },
+          "arguments": {
             "batchSize": 3,
             "session": "session0"
           },
@@ -215,10 +225,12 @@
         },
         {
           "name": "aggregate",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
-            },
+            }
+          },
+          "arguments": {
             "pipeline": [
               {
                 "$project": {
@@ -314,10 +326,12 @@
         },
         {
           "name": "count",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
-            },
+            }
+          },
+          "arguments": {
             "filter": {
               "_id": 1
             },
@@ -329,10 +343,12 @@
         },
         {
           "name": "find",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
-            },
+            }
+          },
+          "arguments": {
             "batchSize": 3,
             "session": "session0"
           },
@@ -342,10 +358,12 @@
         },
         {
           "name": "aggregate",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
-            },
+            }
+          },
+          "arguments": {
             "pipeline": [
               {
                 "$project": {
@@ -417,10 +435,12 @@
         },
         {
           "name": "count",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
-            },
+            }
+          },
+          "arguments": {
             "filter": {
               "_id": 1
             },
@@ -432,10 +452,12 @@
         },
         {
           "name": "find",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
-            },
+            }
+          },
+          "arguments": {
             "batchSize": 3,
             "session": "session0"
           },
@@ -445,10 +467,12 @@
         },
         {
           "name": "aggregate",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
-            },
+            }
+          },
+          "arguments": {
             "pipeline": [
               {
                 "$project": {
@@ -520,10 +544,12 @@
         },
         {
           "name": "count",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
-            },
+            }
+          },
+          "arguments": {
             "filter": {
               "_id": 1
             },
@@ -535,10 +561,12 @@
         },
         {
           "name": "find",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
-            },
+            }
+          },
+          "arguments": {
             "batchSize": 3,
             "session": "session0"
           },
@@ -548,10 +576,12 @@
         },
         {
           "name": "aggregate",
-          "arguments": {
+          "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
-            },
+            }
+          },
+          "arguments": {
             "pipeline": [
               {
                 "$project": {

--- a/source/transactions/tests/read-pref.json
+++ b/source/transactions/tests/read-pref.json
@@ -14,6 +14,7 @@
         },
         {
           "name": "insertMany",
+          "object": "collection",
           "arguments": {
             "documents": [
               {
@@ -42,6 +43,7 @@
         },
         {
           "name": "count",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
@@ -57,6 +59,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
@@ -83,6 +86,7 @@
         },
         {
           "name": "aggregate",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
@@ -156,6 +160,7 @@
         },
         {
           "name": "insertMany",
+          "object": "collection",
           "arguments": {
             "documents": [
               {
@@ -184,6 +189,7 @@
         },
         {
           "name": "count",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
@@ -199,6 +205,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
@@ -225,6 +232,7 @@
         },
         {
           "name": "aggregate",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Secondary"
@@ -298,6 +306,7 @@
         },
         {
           "name": "insertMany",
+          "object": "collection",
           "arguments": {
             "documents": [
               {
@@ -326,6 +335,7 @@
         },
         {
           "name": "count",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
@@ -343,6 +353,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
@@ -358,6 +369,7 @@
         },
         {
           "name": "aggregate",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
@@ -407,6 +419,7 @@
         },
         {
           "name": "insertMany",
+          "object": "collection",
           "arguments": {
             "documents": [
               {
@@ -435,6 +448,7 @@
         },
         {
           "name": "count",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
@@ -452,6 +466,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
@@ -467,6 +482,7 @@
         },
         {
           "name": "aggregate",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
@@ -516,6 +532,7 @@
         },
         {
           "name": "insertMany",
+          "object": "collection",
           "arguments": {
             "documents": [
               {
@@ -544,6 +561,7 @@
         },
         {
           "name": "count",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
@@ -561,6 +579,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
@@ -576,6 +595,7 @@
         },
         {
           "name": "aggregate",
+          "object": "collection",
           "collectionOptions": {
             "readPreference": {
               "mode": "Primary"
@@ -625,6 +645,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1

--- a/source/transactions/tests/read-pref.yml
+++ b/source/transactions/tests/read-pref.yml
@@ -10,7 +10,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertMany
         object: collection
         arguments:
@@ -57,7 +56,6 @@ tests:
         result: *insertedDocs
       - name: commitTransaction
         object: session0
-        arguments:
 
     outcome:
       collection:
@@ -116,7 +114,6 @@ tests:
         result: *insertedDocs
       - name: commitTransaction
         object: session0
-        arguments:
 
     outcome:
       collection:
@@ -178,7 +175,6 @@ tests:
           errorContains: read preference in a transaction must be primary
       - name: abortTransaction
         object: session0
-        arguments:
 
     outcome:
       collection:
@@ -240,7 +236,6 @@ tests:
           errorContains: read preference in a transaction must be primary
       - name: abortTransaction
         object: session0
-        arguments:
 
     outcome:
       collection:
@@ -302,7 +297,6 @@ tests:
           errorContains: read preference in a transaction must be primary
       - name: abortTransaction
         object: session0
-        arguments:
 
     outcome:
       collection:
@@ -327,7 +321,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
 
     outcome:
       collection:

--- a/source/transactions/tests/read-pref.yml
+++ b/source/transactions/tests/read-pref.yml
@@ -29,9 +29,9 @@ tests:
           readPreference:
             mode: Secondary
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result: 1
       - name: find
         object: collection
@@ -39,8 +39,8 @@ tests:
           readPreference:
             mode: Secondary
         arguments:
-          batchSize: 3
           session: session0
+          batchSize: 3
         result: *insertedDocs
       - name: aggregate
         object: collection
@@ -87,9 +87,9 @@ tests:
           readPreference:
             mode: Secondary
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result: 1
       - name: find
         object: collection
@@ -97,8 +97,8 @@ tests:
           readPreference:
             mode: Secondary
         arguments:
-          batchSize: 3
           session: session0
+          batchSize: 3
         result: *insertedDocs
       - name: aggregate
         object: collection
@@ -145,9 +145,9 @@ tests:
           readPreference:
             mode: Primary
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: find
@@ -156,8 +156,8 @@ tests:
           readPreference:
             mode: Primary
         arguments:
-          batchSize: 3
           session: session0
+          batchSize: 3
         result:
           errorContains: read preference in a transaction must be primary
       - name: aggregate
@@ -206,9 +206,9 @@ tests:
           readPreference:
             mode: Primary
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: find
@@ -217,8 +217,8 @@ tests:
           readPreference:
             mode: Primary
         arguments:
-          batchSize: 3
           session: session0
+          batchSize: 3
         result:
           errorContains: read preference in a transaction must be primary
       - name: aggregate
@@ -267,9 +267,9 @@ tests:
           readPreference:
             mode: Primary
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: find
@@ -278,8 +278,8 @@ tests:
           readPreference:
             mode: Primary
         arguments:
-          batchSize: 3
           session: session0
+          batchSize: 3
         result:
           errorContains: read preference in a transaction must be primary
       - name: aggregate
@@ -314,9 +314,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction

--- a/source/transactions/tests/read-pref.yml
+++ b/source/transactions/tests/read-pref.yml
@@ -9,8 +9,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertMany
         object: collection
         arguments:
@@ -56,8 +56,8 @@ tests:
           session: session0
         result: *insertedDocs
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     outcome:
       collection:
@@ -67,8 +67,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readPreference:
               mode: Primary
@@ -115,8 +115,8 @@ tests:
           session: session0
         result: *insertedDocs
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     outcome:
       collection:
@@ -126,8 +126,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readPreference:
               mode: Secondary
@@ -177,8 +177,8 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     outcome:
       collection:
@@ -188,8 +188,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readPreference:
               mode: PrimaryPreferred
@@ -239,8 +239,8 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     outcome:
       collection:
@@ -250,8 +250,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readPreference:
               mode: Nearest
@@ -301,8 +301,8 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     outcome:
       collection:
@@ -312,8 +312,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readPreference:
               mode: Secondary
@@ -326,8 +326,8 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     outcome:
       collection:

--- a/source/transactions/tests/read-pref.yml
+++ b/source/transactions/tests/read-pref.yml
@@ -12,6 +12,7 @@ tests:
         arguments:
           session: session0
       - name: insertMany
+        object: collection
         arguments:
           documents: &insertedDocs
             - _id: 1
@@ -22,6 +23,7 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
+        object: collection
         collectionOptions:
           # The driver overrides the collection's read pref with the
           # transaction's so count runs with Primary and succeeds.
@@ -33,6 +35,7 @@ tests:
           session: session0
         result: 1
       - name: find
+        object: collection
         collectionOptions:
           readPreference:
             mode: Secondary
@@ -41,6 +44,7 @@ tests:
           session: session0
         result: *insertedDocs
       - name: aggregate
+        object: collection
         collectionOptions:
           readPreference:
             mode: Secondary
@@ -69,6 +73,7 @@ tests:
             readPreference:
               mode: Primary
       - name: insertMany
+        object: collection
         arguments:
           documents: &insertedDocs
             - _id: 1
@@ -79,6 +84,7 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
+        object: collection
         collectionOptions:
           readPreference:
             mode: Secondary
@@ -88,6 +94,7 @@ tests:
           session: session0
         result: 1
       - name: find
+        object: collection
         collectionOptions:
           readPreference:
             mode: Secondary
@@ -96,6 +103,7 @@ tests:
           session: session0
         result: *insertedDocs
       - name: aggregate
+        object: collection
         collectionOptions:
           readPreference:
             mode: Secondary
@@ -124,6 +132,7 @@ tests:
             readPreference:
               mode: Secondary
       - name: insertMany
+        object: collection
         arguments:
           documents: &insertedDocs
             - _id: 1
@@ -134,6 +143,7 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
+        object: collection
         collectionOptions:
           readPreference:
             mode: Primary
@@ -144,6 +154,7 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: find
+        object: collection
         collectionOptions:
           readPreference:
             mode: Primary
@@ -153,6 +164,7 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: aggregate
+        object: collection
         collectionOptions:
           readPreference:
             mode: Primary
@@ -182,6 +194,7 @@ tests:
             readPreference:
               mode: PrimaryPreferred
       - name: insertMany
+        object: collection
         arguments:
           documents: &insertedDocs
             - _id: 1
@@ -192,6 +205,7 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
+        object: collection
         collectionOptions:
           readPreference:
             mode: Primary
@@ -202,6 +216,7 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: find
+        object: collection
         collectionOptions:
           readPreference:
             mode: Primary
@@ -211,6 +226,7 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: aggregate
+        object: collection
         collectionOptions:
           readPreference:
             mode: Primary
@@ -240,6 +256,7 @@ tests:
             readPreference:
               mode: Nearest
       - name: insertMany
+        object: collection
         arguments:
           documents: &insertedDocs
             - _id: 1
@@ -250,6 +267,7 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
+        object: collection
         collectionOptions:
           readPreference:
             mode: Primary
@@ -260,6 +278,7 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: find
+        object: collection
         collectionOptions:
           readPreference:
             mode: Primary
@@ -269,6 +288,7 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: aggregate
+        object: collection
         collectionOptions:
           readPreference:
             mode: Primary
@@ -298,6 +318,7 @@ tests:
             readPreference:
               mode: Secondary
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1

--- a/source/transactions/tests/read-pref.yml
+++ b/source/transactions/tests/read-pref.yml
@@ -22,26 +22,29 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
-        arguments:
-          # The driver overrides the operation's read pref with the
+        collectionOptions:
+          # The driver overrides the collection's read pref with the
           # transaction's so count runs with Primary and succeeds.
           readPreference:
             mode: Secondary
+        arguments:
           filter:
             _id: 1
           session: session0
         result: 1
       - name: find
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Secondary
+        arguments:
           batchSize: 3
           session: session0
         result: *insertedDocs
       - name: aggregate
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Secondary
+        arguments:
           pipeline:
             - $project:
                 _id: 1
@@ -76,24 +79,27 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Secondary
+        arguments:
           filter:
             _id: 1
           session: session0
         result: 1
       - name: find
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Secondary
+        arguments:
           batchSize: 3
           session: session0
         result: *insertedDocs
       - name: aggregate
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Secondary
+        arguments:
           pipeline:
             - $project:
                 _id: 1
@@ -128,26 +134,29 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Primary
+        arguments:
           filter:
             _id: 1
           session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: find
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Primary
+        arguments:
           batchSize: 3
           session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: aggregate
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Primary
+        arguments:
           pipeline:
             - $project:
                 _id: 1
@@ -183,26 +192,29 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Primary
+        arguments:
           filter:
             _id: 1
           session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: find
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Primary
+        arguments:
           batchSize: 3
           session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: aggregate
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Primary
+        arguments:
           pipeline:
             - $project:
                 _id: 1
@@ -238,26 +250,29 @@ tests:
         result:
           insertedIds: {0: 1, 1: 2, 2: 3, 3: 4}
       - name: count
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Primary
+        arguments:
           filter:
             _id: 1
           session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: find
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Primary
+        arguments:
           batchSize: 3
           session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: aggregate
-        arguments:
+        collectionOptions:
           readPreference:
             mode: Primary
+        arguments:
           pipeline:
             - $project:
                 _id: 1

--- a/source/transactions/tests/reads.json
+++ b/source/transactions/tests/reads.json
@@ -88,12 +88,11 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         },
         {
           "name": "count",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -104,6 +103,7 @@
         },
         {
           "name": "count",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -114,9 +114,7 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -200,12 +198,11 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "batchSize": 3,
             "session": "session0"
@@ -227,6 +224,7 @@
         },
         {
           "name": "find",
+          "object": "collection",
           "arguments": {
             "batchSize": 3,
             "session": "session0"
@@ -248,9 +246,7 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -366,12 +362,11 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         },
         {
           "name": "aggregate",
+          "object": "collection",
           "arguments": {
             "pipeline": [
               {
@@ -400,6 +395,7 @@
         },
         {
           "name": "aggregate",
+          "object": "collection",
           "arguments": {
             "pipeline": [
               {
@@ -428,9 +424,7 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -564,9 +558,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         },
         {
           "name": "distinct",
@@ -584,9 +576,7 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/reads.json
+++ b/source/transactions/tests/reads.json
@@ -94,10 +94,10 @@
           "name": "count",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": 1
         },
@@ -105,10 +105,10 @@
           "name": "count",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": 1
         },
@@ -204,8 +204,8 @@
           "name": "find",
           "object": "collection",
           "arguments": {
-            "batchSize": 3,
-            "session": "session0"
+            "session": "session0",
+            "batchSize": 3
           },
           "result": [
             {
@@ -226,8 +226,8 @@
           "name": "find",
           "object": "collection",
           "arguments": {
-            "batchSize": 3,
-            "session": "session0"
+            "session": "session0",
+            "batchSize": 3
           },
           "result": [
             {
@@ -564,8 +564,8 @@
           "name": "distinct",
           "object": "collection",
           "arguments": {
-            "fieldName": "_id",
-            "session": "session0"
+            "session": "session0",
+            "fieldName": "_id"
           },
           "result": [
             1,

--- a/source/transactions/tests/reads.json
+++ b/source/transactions/tests/reads.json
@@ -17,6 +17,72 @@
   ],
   "tests": [
     {
+      "description": "collection readConcern without transaction",
+      "operations": [
+        {
+          "name": "find",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "readConcern": {
+                "level": "majority"
+              },
+              "lsid": "session0",
+              "txnNumber": null,
+              "startTransaction": null,
+              "autocommit": null
+            },
+            "command_name": "find",
+            "database_name": "transaction-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
       "description": "count",
       "operations": [
         {

--- a/source/transactions/tests/reads.json
+++ b/source/transactions/tests/reads.json
@@ -21,6 +21,7 @@
       "operations": [
         {
           "name": "find",
+          "object": "collection",
           "collectionOptions": {
             "readConcern": {
               "level": "majority"
@@ -569,6 +570,7 @@
         },
         {
           "name": "distinct",
+          "object": "collection",
           "arguments": {
             "fieldName": "_id",
             "session": "session0"

--- a/source/transactions/tests/reads.yml
+++ b/source/transactions/tests/reads.yml
@@ -48,9 +48,9 @@ tests:
         name: count
         object: collection
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result: 1
       - *count
       - &commitTransaction
@@ -108,8 +108,8 @@ tests:
         name: find
         object: collection
         arguments:
-          batchSize: 3
           session: session0
+          batchSize: 3
         result: *data
       - *find
       - *commitTransaction
@@ -276,8 +276,8 @@ tests:
       - name: distinct
         object: collection
         arguments:
-          fieldName: _id
           session: session0
+          fieldName: _id
         result: [1, 2, 3, 4]
       - *commitTransaction
 

--- a/source/transactions/tests/reads.yml
+++ b/source/transactions/tests/reads.yml
@@ -12,6 +12,7 @@ tests:
 
     operations:
       - name: find
+        object: collection
         collectionOptions:
           readConcern:
             level: majority
@@ -272,6 +273,7 @@ tests:
     operations:
       - *startTransaction
       - name: distinct
+        object: collection
         arguments:
           fieldName: _id
           session: session0

--- a/source/transactions/tests/reads.yml
+++ b/source/transactions/tests/reads.yml
@@ -8,6 +8,35 @@ data: &data
   - {_id: 4}
 
 tests:
+  - description: collection readConcern without transaction
+
+    operations:
+      - name: find
+        collectionOptions:
+          readConcern:
+            level: majority
+        arguments:
+          session: session0
+        result: *data
+
+    expectations:
+      - command_started_event:
+          command:
+            find: *collection_name
+            readConcern:
+              level: majority
+            lsid: session0
+            txnNumber:
+            startTransaction:
+            autocommit:
+          command_name: find
+          database_name: *database_name
+
+    outcome: &outcome
+      collection:
+        data:
+          *data
+
   - description: count
 
     operations:
@@ -69,10 +98,7 @@ tests:
           command_name: commitTransaction
           database_name: admin
 
-    outcome: &outcome
-      collection:
-        data:
-          *data
+    outcome: *outcome
 
   - description: find
 

--- a/source/transactions/tests/reads.yml
+++ b/source/transactions/tests/reads.yml
@@ -43,10 +43,10 @@ tests:
     operations:
       - &startTransaction
         name: startTransaction
-        arguments:
-          session: session0
+        object: session0
       - &count
         name: count
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -55,8 +55,7 @@ tests:
       - *count
       - &commitTransaction
         name: commitTransaction
-        arguments:
-          session: session0
+        object: session0
 
 
     expectations:
@@ -107,6 +106,7 @@ tests:
       - *startTransaction
       - &find
         name: find
+        object: collection
         arguments:
           batchSize: 3
           session: session0
@@ -185,6 +185,7 @@ tests:
       - *startTransaction
       - &aggregate
         name: aggregate
+        object: collection
         arguments:
           pipeline:
             - $project:

--- a/source/transactions/tests/retryable-writes.json
+++ b/source/transactions/tests/retryable-writes.json
@@ -11,9 +11,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -30,9 +29,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -49,9 +47,8 @@
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -68,9 +65,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertMany",

--- a/source/transactions/tests/retryable-writes.json
+++ b/source/transactions/tests/retryable-writes.json
@@ -11,8 +11,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -29,8 +28,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -47,8 +45,7 @@
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -65,8 +62,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertMany",

--- a/source/transactions/tests/retryable-writes.json
+++ b/source/transactions/tests/retryable-writes.json
@@ -17,6 +17,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -35,6 +36,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -53,6 +55,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 3
@@ -71,6 +74,7 @@
         },
         {
           "name": "insertMany",
+          "object": "collection",
           "arguments": {
             "documents": [
               {

--- a/source/transactions/tests/retryable-writes.json
+++ b/source/transactions/tests/retryable-writes.json
@@ -17,10 +17,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -34,10 +34,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -51,10 +51,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 3
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 3

--- a/source/transactions/tests/retryable-writes.yml
+++ b/source/transactions/tests/retryable-writes.yml
@@ -14,6 +14,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -25,6 +26,7 @@ tests:
           session: session0
       # Retryable write should include the next txnNumber
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 2
@@ -36,6 +38,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 3
@@ -47,6 +50,7 @@ tests:
           session: session0
       # Retryable write should include the next txnNumber
       - name: insertMany
+        object: collection
         arguments:
           documents:
             - _id: 4

--- a/source/transactions/tests/retryable-writes.yml
+++ b/source/transactions/tests/retryable-writes.yml
@@ -15,9 +15,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -26,9 +26,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 2
-          session: session0
         result:
           insertedId: 2
       # Next transaction should include the next txnNumber
@@ -37,9 +37,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 3
-          session: session0
         result:
           insertedId: 3
       - name: abortTransaction

--- a/source/transactions/tests/retryable-writes.yml
+++ b/source/transactions/tests/retryable-writes.yml
@@ -12,7 +12,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -23,7 +22,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
       # Retryable write should include the next txnNumber
       - name: insertOne
         object: collection
@@ -36,7 +34,6 @@ tests:
       # Next transaction should include the next txnNumber
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -47,7 +44,6 @@ tests:
           insertedId: 3
       - name: abortTransaction
         object: session0
-        arguments:
       # Retryable write should include the next txnNumber
       - name: insertMany
         object: collection

--- a/source/transactions/tests/retryable-writes.yml
+++ b/source/transactions/tests/retryable-writes.yml
@@ -11,8 +11,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -22,8 +22,8 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Retryable write should include the next txnNumber
       - name: insertOne
         object: collection
@@ -35,8 +35,8 @@ tests:
           insertedId: 2
       # Next transaction should include the next txnNumber
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -46,8 +46,8 @@ tests:
         result:
           insertedId: 3
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
       # Retryable write should include the next txnNumber
       - name: insertMany
         object: collection

--- a/source/transactions/tests/run-command.json
+++ b/source/transactions/tests/run-command.json
@@ -13,6 +13,7 @@
         {
           "name": "runCommand",
           "object": "database",
+          "command_name": "insert",
           "arguments": {
             "session": "session0",
             "command": {
@@ -94,6 +95,7 @@
         {
           "name": "runCommand",
           "object": "database",
+          "command_name": "insert",
           "arguments": {
             "session": "session0",
             "command": {
@@ -165,6 +167,7 @@
         {
           "name": "runCommand",
           "object": "database",
+          "command_name": "insert",
           "arguments": {
             "session": "session0",
             "command": {
@@ -239,6 +242,7 @@
         {
           "name": "runCommand",
           "object": "database",
+          "command_name": "count",
           "arguments": {
             "session": "session0",
             "command": {
@@ -271,6 +275,7 @@
         {
           "name": "runCommand",
           "object": "database",
+          "command_name": "count",
           "arguments": {
             "session": "session0",
             "command": {

--- a/source/transactions/tests/run-command.json
+++ b/source/transactions/tests/run-command.json
@@ -8,13 +8,13 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         },
         {
           "name": "runCommand",
+          "object": "database",
           "arguments": {
+            "session": "session0",
             "command": {
               "insert": "test",
               "documents": [
@@ -22,8 +22,7 @@
                   "_id": 1
                 }
               ]
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "n": 1
@@ -31,9 +30,7 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -85,8 +82,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readPreference": {
                 "mode": "Primary"
@@ -96,7 +93,9 @@
         },
         {
           "name": "runCommand",
+          "object": "database",
           "arguments": {
+            "session": "session0",
             "command": {
               "insert": "test",
               "documents": [
@@ -104,8 +103,7 @@
                   "_id": 1
                 }
               ]
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "n": 1
@@ -113,9 +111,7 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -164,13 +160,13 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         },
         {
           "name": "runCommand",
+          "object": "database",
           "arguments": {
+            "session": "session0",
             "command": {
               "insert": "test",
               "documents": [
@@ -179,7 +175,6 @@
                 }
               ]
             },
-            "session": "session0",
             "readPreference": {
               "mode": "Primary"
             }
@@ -190,9 +185,7 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -241,17 +234,16 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0"
         },
         {
           "name": "runCommand",
+          "object": "database",
           "arguments": {
+            "session": "session0",
             "command": {
               "count": "test"
             },
-            "session": "session0",
             "readPreference": {
               "mode": "Secondary"
             }
@@ -267,22 +259,23 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readPreference": {
-                "mode": "Secondary"
+                "mode": "secondary"
               }
             }
           }
         },
         {
           "name": "runCommand",
+          "object": "database",
           "arguments": {
+            "session": "session0",
             "command": {
               "count": "test"
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"

--- a/source/transactions/tests/run-command.yml
+++ b/source/transactions/tests/run-command.yml
@@ -8,26 +8,25 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
+      - name: runCommand
+        object: database
         arguments:
           session: session0
-      - name: runCommand
-        arguments:
-          command: 
+          command:
             insert: *collection_name
             documents:
               - _id : 1
-          session: session0
         result:
           n: 1
       - name: commitTransaction
-        arguments:
-          session: session0
+        object: session0
 
     expectations:
       - command_started_event:
           command:
             insert: *collection_name
-            documents: 
+            documents:
               - _id : 1
             readConcern:
             lsid: session0
@@ -57,23 +56,23 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readPreference:
               mode: Primary
       - name: runCommand
+        object: database
         arguments:
-          command: 
+          session: session0
+          command:
             insert: *collection_name
             documents:
               - _id : 1
-          session: session0
         result:
           n: 1
       - name: commitTransaction
-        arguments:
-          session: session0
+        object: session0
 
     expectations:
       - command_started_event:
@@ -100,28 +99,27 @@ tests:
             autocommit: false
             writeConcern:
           command_name: commitTransaction
-          database_name: admin 
+          database_name: admin
 
   - description: run command with explicit primary read preference
 
     operations:
       - name: startTransaction
+        object: session0
+      - name: runCommand
+        object: database
         arguments:
           session: session0
-      - name: runCommand
-        arguments:
-          command: 
+          command:
             insert: *collection_name
             documents:
               - _id : 1
-          session: session0
           readPreference:
             mode: Primary
         result:
           n: 1
       - name: commitTransaction
-        arguments:
-          session: session0
+        object: session0
 
     expectations:
       - command_started_event:
@@ -154,13 +152,13 @@ tests:
 
     operations:
       - name: startTransaction
-        arguments:
-          session: session0
+        object: session0
       - name: runCommand
+        object: database
         arguments:
-          command: 
-            count: *collection_name
           session: session0
+          command:
+            count: *collection_name
           readPreference:
             mode: Secondary
         result:
@@ -170,16 +168,17 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readPreference:
               mode: secondary
       - name: runCommand
+        object: database
         arguments:
-          command: 
-            count: *collection_name
           session: session0
+          command:
+            count: *collection_name
         result:
           errorContains: read preference in a transaction must be primary
 

--- a/source/transactions/tests/run-command.yml
+++ b/source/transactions/tests/run-command.yml
@@ -11,6 +11,7 @@ tests:
         object: session0
       - name: runCommand
         object: database
+        command_name: insert
         arguments:
           session: session0
           command:
@@ -63,6 +64,7 @@ tests:
               mode: Primary
       - name: runCommand
         object: database
+        command_name: insert
         arguments:
           session: session0
           command:
@@ -108,6 +110,7 @@ tests:
         object: session0
       - name: runCommand
         object: database
+        command_name: insert
         arguments:
           session: session0
           command:
@@ -155,6 +158,7 @@ tests:
         object: session0
       - name: runCommand
         object: database
+        command_name: count
         arguments:
           session: session0
           command:
@@ -175,6 +179,7 @@ tests:
               mode: secondary
       - name: runCommand
         object: database
+        command_name: count
         arguments:
           session: session0
           command:

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -8,8 +8,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -26,13 +25,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -49,8 +46,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -156,8 +152,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -174,13 +169,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -197,8 +190,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -319,8 +311,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -337,13 +328,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -360,8 +349,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -513,8 +501,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
@@ -545,8 +532,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -671,8 +657,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -689,13 +674,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -712,8 +695,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -834,8 +816,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -852,13 +833,11 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -875,8 +854,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -1018,8 +996,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "startTransaction",
@@ -1047,8 +1024,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -1194,8 +1170,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -1259,8 +1234,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -1290,8 +1264,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -1363,8 +1336,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -1394,8 +1366,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -1504,8 +1475,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -14,6 +14,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -38,6 +39,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -164,6 +166,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -188,6 +191,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -329,6 +333,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -353,6 +358,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -506,6 +512,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -538,6 +545,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -683,6 +691,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -707,6 +716,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -848,6 +858,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -872,6 +883,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -1015,6 +1027,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -1044,6 +1057,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 2
@@ -1177,6 +1191,7 @@
         },
         {
           "name": "bulkWrite",
+          "object": "collection",
           "arguments": {
             "requests": [
               {
@@ -1275,6 +1290,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -1287,6 +1303,7 @@
         },
         {
           "name": "count",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -1379,6 +1396,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -1391,6 +1409,7 @@
         },
         {
           "name": "count",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1
@@ -1488,6 +1507,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -1500,6 +1520,7 @@
         },
         {
           "name": "count",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 1

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -8,9 +8,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -27,15 +26,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -52,9 +49,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -160,9 +156,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -179,15 +174,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -204,9 +197,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -327,9 +319,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -346,15 +337,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -371,9 +360,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -498,8 +486,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readConcern": {
                 "level": "snapshot"
@@ -525,14 +513,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readConcern": {
                 "level": "snapshot"
@@ -558,9 +545,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -685,9 +671,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -704,15 +689,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -729,9 +712,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -852,9 +834,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -871,15 +852,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -896,9 +875,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -1016,8 +994,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readConcern": {
                 "level": "snapshot"
@@ -1040,14 +1018,13 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readConcern": {
                 "level": "snapshot"
@@ -1070,9 +1047,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -1180,8 +1156,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": 1
@@ -1218,9 +1194,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -1284,9 +1259,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -1316,9 +1290,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -1390,9 +1363,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -1422,9 +1394,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -1496,8 +1467,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "readPreference": {
                 "mode": "Secondary"
@@ -1533,9 +1504,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -14,10 +14,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -35,10 +35,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -158,10 +158,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -179,10 +179,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -317,10 +317,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -338,10 +338,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -490,10 +490,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -521,10 +521,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -663,10 +663,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -684,10 +684,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -822,10 +822,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -843,10 +843,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -985,10 +985,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -1013,10 +1013,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 2
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 2
@@ -1240,10 +1240,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -1253,10 +1253,10 @@
           "name": "count",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"
@@ -1342,10 +1342,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -1355,10 +1355,10 @@
           "name": "count",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"
@@ -1451,10 +1451,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -1464,10 +1464,10 @@
           "name": "count",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "errorContains": "read preference in a transaction must be primary"

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -12,9 +12,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -25,9 +25,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 2
-          session: session0
         result:
           insertedId: 2
       - name: abortTransaction
@@ -267,9 +267,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -285,9 +285,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 2
-          session: session0
         result:
           insertedId: 2
       - name: abortTransaction
@@ -529,9 +529,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -546,9 +546,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 2
-          session: session0
         result:
           insertedId: 2
       - name: abortTransaction
@@ -688,17 +688,17 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: count
         object: collection
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: commitTransaction
@@ -755,17 +755,17 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: count
         object: collection
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: commitTransaction
@@ -826,17 +826,17 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: count
         object: collection
         arguments:
+          session: session0
           filter:
             _id: 1
-          session: session0
         result:
           errorContains: read preference in a transaction must be primary
       - name: commitTransaction

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -9,7 +9,6 @@ tests:
     operations: &commitAbortOperations
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -20,11 +19,9 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
       # Now test abort.
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -35,7 +32,6 @@ tests:
           insertedId: 2
       - name: abortTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -278,7 +274,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
       - name: startTransaction
         object: session0
         arguments:
@@ -297,7 +292,6 @@ tests:
           insertedId: 2
       - name: abortTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -542,7 +536,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
       # Now test abort.
       - name: startTransaction
         object: session0
@@ -560,7 +553,6 @@ tests:
           insertedId: 2
       - name: abortTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -652,7 +644,6 @@ tests:
           upsertedIds: {}
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -694,7 +685,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -713,7 +703,6 @@ tests:
           errorContains: read preference in a transaction must be primary
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -763,7 +752,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -782,7 +770,6 @@ tests:
           errorContains: read preference in a transaction must be primary
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -854,7 +841,6 @@ tests:
           errorContains: read preference in a transaction must be primary
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -11,6 +11,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -25,6 +26,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 2
@@ -267,6 +269,7 @@ tests:
             writeConcern:
               w: majority
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -285,6 +288,7 @@ tests:
             writeConcern:
               w: majority
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 2
@@ -529,6 +533,7 @@ tests:
             readConcern:
               level: snapshot
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -546,6 +551,7 @@ tests:
             readConcern:
               level: snapshot
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 2
@@ -630,6 +636,7 @@ tests:
             writeConcern:
               w: 1
       - name: bulkWrite
+        object: collection
         arguments:
           requests:
             - name: insertOne
@@ -689,6 +696,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -696,6 +704,7 @@ tests:
         result:
           insertedId: 1
       - name: count
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -756,6 +765,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -763,6 +773,7 @@ tests:
         result:
           insertedId: 1
       - name: count
+        object: collection
         arguments:
           filter:
             _id: 1
@@ -826,6 +837,7 @@ tests:
             readPreference:
               mode: Secondary
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -833,6 +845,7 @@ tests:
         result:
           insertedId: 1
       - name: count
+        object: collection
         arguments:
           filter:
             _id: 1

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -8,8 +8,8 @@ tests:
 
     operations: &commitAbortOperations
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -19,12 +19,12 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Now test abort.
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -34,8 +34,8 @@ tests:
         result:
           insertedId: 2
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -261,8 +261,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readConcern:
               level: snapshot
@@ -277,11 +277,11 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readConcern:
               level: snapshot
@@ -296,8 +296,8 @@ tests:
         result:
           insertedId: 2
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -527,8 +527,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readConcern:
               level: snapshot
@@ -541,12 +541,12 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
       # Now test abort.
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readConcern:
               level: snapshot
@@ -559,8 +559,8 @@ tests:
         result:
           insertedId: 2
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -630,8 +630,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: 1
@@ -651,8 +651,8 @@ tests:
           upsertedCount: 0
           upsertedIds: {}
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -693,8 +693,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -712,8 +712,8 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -762,8 +762,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -781,8 +781,8 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -831,8 +831,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             readPreference:
               mode: Secondary
@@ -853,8 +853,8 @@ tests:
         result:
           errorContains: read preference in a transaction must be primary
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/update.json
+++ b/source/transactions/tests/update.json
@@ -223,7 +223,7 @@
       }
     },
     {
-      "description": "operation writeConcern ignored for update",
+      "description": "collection writeConcern ignored for update",
       "operations": [
         {
           "name": "startTransaction",
@@ -238,6 +238,11 @@
         },
         {
           "name": "updateOne",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "filter": {
               "_id": 4
@@ -248,9 +253,6 @@
               }
             },
             "upsert": true,
-            "writeConcern": {
-              "w": "majority"
-            },
             "session": "session0"
           },
           "result": {
@@ -262,15 +264,17 @@
         },
         {
           "name": "replaceOne",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "filter": {
               "x": 1
             },
             "replacement": {
               "y": 1
-            },
-            "writeConcern": {
-              "w": "majority"
             },
             "session": "session0"
           },
@@ -282,6 +286,11 @@
         },
         {
           "name": "updateMany",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": "majority"
+            }
+          },
           "arguments": {
             "filter": {
               "_id": {
@@ -292,9 +301,6 @@
               "$set": {
                 "z": 1
               }
-            },
-            "writeConcern": {
-              "w": "majority"
             },
             "session": "session0"
           },

--- a/source/transactions/tests/update.json
+++ b/source/transactions/tests/update.json
@@ -18,9 +18,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "updateOne",
@@ -86,9 +85,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -230,8 +228,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": "majority"
@@ -318,9 +316,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/update.json
+++ b/source/transactions/tests/update.json
@@ -24,6 +24,7 @@
         },
         {
           "name": "updateOne",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": 4
@@ -45,6 +46,7 @@
         },
         {
           "name": "replaceOne",
+          "object": "collection",
           "arguments": {
             "filter": {
               "x": 1
@@ -62,6 +64,7 @@
         },
         {
           "name": "updateMany",
+          "object": "collection",
           "arguments": {
             "filter": {
               "_id": {
@@ -223,7 +226,7 @@
       }
     },
     {
-      "description": "collection writeConcern ignored for update",
+      "description": "collections writeConcern ignored for update",
       "operations": [
         {
           "name": "startTransaction",
@@ -238,6 +241,7 @@
         },
         {
           "name": "updateOne",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"
@@ -264,6 +268,7 @@
         },
         {
           "name": "replaceOne",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"
@@ -286,6 +291,7 @@
         },
         {
           "name": "updateMany",
+          "object": "collection",
           "collectionOptions": {
             "writeConcern": {
               "w": "majority"

--- a/source/transactions/tests/update.json
+++ b/source/transactions/tests/update.json
@@ -24,6 +24,7 @@
           "name": "updateOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 4
             },
@@ -32,8 +33,7 @@
                 "x": 1
               }
             },
-            "upsert": true,
-            "session": "session0"
+            "upsert": true
           },
           "result": {
             "matchedCount": 0,
@@ -46,13 +46,13 @@
           "name": "replaceOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "x": 1
             },
             "replacement": {
               "y": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "matchedCount": 1,
@@ -64,6 +64,7 @@
           "name": "updateMany",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": {
                 "$gte": 3
@@ -73,8 +74,7 @@
               "$set": {
                 "z": 1
               }
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "matchedCount": 2,
@@ -244,6 +244,7 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": 4
             },
@@ -252,8 +253,7 @@
                 "x": 1
               }
             },
-            "upsert": true,
-            "session": "session0"
+            "upsert": true
           },
           "result": {
             "matchedCount": 0,
@@ -271,13 +271,13 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "x": 1
             },
             "replacement": {
               "y": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "matchedCount": 1,
@@ -294,6 +294,7 @@
             }
           },
           "arguments": {
+            "session": "session0",
             "filter": {
               "_id": {
                 "$gte": 3
@@ -303,8 +304,7 @@
               "$set": {
                 "z": 1
               }
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "matchedCount": 2,

--- a/source/transactions/tests/update.json
+++ b/source/transactions/tests/update.json
@@ -18,8 +18,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "updateOne",
@@ -85,8 +84,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -316,8 +314,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/update.yml
+++ b/source/transactions/tests/update.yml
@@ -14,6 +14,7 @@ tests:
         arguments:
           session: session0
       - name: updateOne
+        object: collection
         arguments:
           filter: {_id: 4}
           update:
@@ -26,6 +27,7 @@ tests:
           upsertedCount: 1
           upsertedId: 4
       - name: replaceOne
+        object: collection
         arguments:
           filter: {x: 1}
           replacement: {y: 1}
@@ -35,6 +37,7 @@ tests:
           modifiedCount: 1
           upsertedCount: 0
       - name: updateMany
+        object: collection
         arguments:
           filter:
             _id: {$gte: 3}
@@ -132,6 +135,7 @@ tests:
             writeConcern:
               w: majority
       - name: updateOne
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority
@@ -147,6 +151,7 @@ tests:
           upsertedCount: 1
           upsertedId: 4
       - name: replaceOne
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority
@@ -159,6 +164,7 @@ tests:
           modifiedCount: 1
           upsertedCount: 0
       - name: updateMany
+        object: collection
         collectionOptions:
           writeConcern:
             w: majority

--- a/source/transactions/tests/update.yml
+++ b/source/transactions/tests/update.yml
@@ -11,8 +11,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: updateOne
         object: collection
         arguments:
@@ -49,8 +49,8 @@ tests:
           modifiedCount: 2
           upsertedCount: 0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -129,8 +129,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: majority
@@ -179,8 +179,8 @@ tests:
           modifiedCount: 2
           upsertedCount: 0
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/update.yml
+++ b/source/transactions/tests/update.yml
@@ -122,7 +122,7 @@ tests:
           - {_id: 3, z: 1}
           - {_id: 4, y: 1, z: 1}
 
-  - description: operation writeConcern ignored for update
+  - description: collections writeConcern ignored for update
 
     operations:
       - name: startTransaction
@@ -132,13 +132,14 @@ tests:
             writeConcern:
               w: majority
       - name: updateOne
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           filter: {_id: 4}
           update:
             $inc: {x: 1}
           upsert: true
-          writeConcern:
-            w: majority
           session: session0
         result:
           matchedCount: 0
@@ -146,24 +147,26 @@ tests:
           upsertedCount: 1
           upsertedId: 4
       - name: replaceOne
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           filter: {x: 1}
           replacement: {y: 1}
-          writeConcern:
-            w: majority
           session: session0
         result:
           matchedCount: 1
           modifiedCount: 1
           upsertedCount: 0
       - name: updateMany
+        collectionOptions:
+          writeConcern:
+            w: majority
         arguments:
           filter:
             _id: {$gte: 3}
           update:
             $set: {z: 1}
-          writeConcern:
-            w: majority
           session: session0
         result:
           matchedCount: 2

--- a/source/transactions/tests/update.yml
+++ b/source/transactions/tests/update.yml
@@ -12,7 +12,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: updateOne
         object: collection
         arguments:
@@ -50,7 +49,6 @@ tests:
           upsertedCount: 0
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -180,7 +178,6 @@ tests:
           upsertedCount: 0
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/update.yml
+++ b/source/transactions/tests/update.yml
@@ -15,11 +15,11 @@ tests:
       - name: updateOne
         object: collection
         arguments:
+          session: session0
           filter: {_id: 4}
           update:
             $inc: {x: 1}
           upsert: true
-          session: session0
         result:
           matchedCount: 0
           modifiedCount: 0
@@ -28,9 +28,9 @@ tests:
       - name: replaceOne
         object: collection
         arguments:
+          session: session0
           filter: {x: 1}
           replacement: {y: 1}
-          session: session0
         result:
           matchedCount: 1
           modifiedCount: 1
@@ -38,11 +38,11 @@ tests:
       - name: updateMany
         object: collection
         arguments:
+          session: session0
           filter:
             _id: {$gte: 3}
           update:
             $set: {z: 1}
-          session: session0
         result:
           matchedCount: 2
           modifiedCount: 2
@@ -138,11 +138,11 @@ tests:
           writeConcern:
             w: majority
         arguments:
+          session: session0
           filter: {_id: 4}
           update:
             $inc: {x: 1}
           upsert: true
-          session: session0
         result:
           matchedCount: 0
           modifiedCount: 0
@@ -154,9 +154,9 @@ tests:
           writeConcern:
             w: majority
         arguments:
+          session: session0
           filter: {x: 1}
           replacement: {y: 1}
-          session: session0
         result:
           matchedCount: 1
           modifiedCount: 1
@@ -167,11 +167,11 @@ tests:
           writeConcern:
             w: majority
         arguments:
+          session: session0
           filter:
             _id: {$gte: 3}
           update:
             $set: {z: 1}
-          session: session0
         result:
           matchedCount: 2
           modifiedCount: 2

--- a/source/transactions/tests/write-concern.json
+++ b/source/transactions/tests/write-concern.json
@@ -21,10 +21,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -99,10 +99,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -182,10 +182,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1
@@ -256,10 +256,10 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
+            "session": "session0",
             "document": {
               "_id": 1
-            },
-            "session": "session0"
+            }
           },
           "result": {
             "insertedId": 1

--- a/source/transactions/tests/write-concern.json
+++ b/source/transactions/tests/write-concern.json
@@ -32,8 +32,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -94,8 +93,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -112,8 +110,7 @@
         },
         {
           "name": "commitTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -196,8 +193,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [
@@ -254,8 +250,7 @@
       "operations": [
         {
           "name": "startTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         },
         {
           "name": "insertOne",
@@ -272,8 +267,7 @@
         },
         {
           "name": "abortTransaction",
-          "object": "session0",
-          "arguments": null
+          "object": "session0"
         }
       ],
       "expectations": [

--- a/source/transactions/tests/write-concern.json
+++ b/source/transactions/tests/write-concern.json
@@ -19,6 +19,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -100,6 +101,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -184,6 +186,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1
@@ -261,6 +264,7 @@
         },
         {
           "name": "insertOne",
+          "object": "collection",
           "arguments": {
             "document": {
               "_id": 1

--- a/source/transactions/tests/write-concern.json
+++ b/source/transactions/tests/write-concern.json
@@ -8,8 +8,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": "majority"
@@ -32,9 +32,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -95,9 +94,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -114,9 +112,8 @@
         },
         {
           "name": "commitTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -175,8 +172,8 @@
       "operations": [
         {
           "name": "startTransaction",
+          "object": "session0",
           "arguments": {
-            "session": "session0",
             "options": {
               "writeConcern": {
                 "w": "majority"
@@ -199,9 +196,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [
@@ -258,9 +254,8 @@
       "operations": [
         {
           "name": "startTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         },
         {
           "name": "insertOne",
@@ -277,9 +272,8 @@
         },
         {
           "name": "abortTransaction",
-          "arguments": {
-            "session": "session0"
-          }
+          "object": "session0",
+          "arguments": null
         }
       ],
       "expectations": [

--- a/source/transactions/tests/write-concern.yml
+++ b/source/transactions/tests/write-concern.yml
@@ -17,9 +17,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -67,9 +67,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: commitTransaction
@@ -121,9 +121,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction
@@ -170,9 +170,9 @@ tests:
       - name: insertOne
         object: collection
         arguments:
+          session: session0
           document:
             _id: 1
-          session: session0
         result:
           insertedId: 1
       - name: abortTransaction

--- a/source/transactions/tests/write-concern.yml
+++ b/source/transactions/tests/write-concern.yml
@@ -9,8 +9,8 @@ tests:
   - description: commit with majority
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: majority
@@ -23,8 +23,8 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -64,8 +64,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -75,8 +75,8 @@ tests:
         result:
           insertedId: 1
       - name: commitTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -116,8 +116,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
           options:
             writeConcern:
               w: majority
@@ -130,8 +130,8 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:
@@ -170,8 +170,8 @@ tests:
 
     operations:
       - name: startTransaction
+        object: session0
         arguments:
-          session: session0
       - name: insertOne
         object: collection
         arguments:
@@ -181,8 +181,8 @@ tests:
         result:
           insertedId: 1
       - name: abortTransaction
+        object: session0
         arguments:
-          session: session0
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/write-concern.yml
+++ b/source/transactions/tests/write-concern.yml
@@ -24,7 +24,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -65,7 +64,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -76,7 +74,6 @@ tests:
           insertedId: 1
       - name: commitTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -131,7 +128,6 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:
@@ -171,7 +167,6 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-        arguments:
       - name: insertOne
         object: collection
         arguments:
@@ -182,7 +177,6 @@ tests:
           insertedId: 1
       - name: abortTransaction
         object: session0
-        arguments:
 
     expectations:
       - command_started_event:

--- a/source/transactions/tests/write-concern.yml
+++ b/source/transactions/tests/write-concern.yml
@@ -15,6 +15,7 @@ tests:
             writeConcern:
               w: majority
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -66,6 +67,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -120,6 +122,7 @@ tests:
             writeConcern:
               w: majority
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1
@@ -170,6 +173,7 @@ tests:
         arguments:
           session: session0
       - name: insertOne
+        object: collection
         arguments:
           document:
             _id: 1


### PR DESCRIPTION
Contains the following changes:
1. Moves collection options to collectionOptions:
```
      - name: find
        arguments:
          batchSize: 3
          session: session0
          readPreference:
            mode: Secondary
```
is now 
```
      - name: find
        object: collection
        collectionOptions:
          readPreference:
            mode: Secondary
        arguments:
          batchSize: 3
          session: session0
```
2. Introduces "object: (collection|session0|session1)":
```
      - name: startTransaction
        arguments:
          session: session0
```
is now
```
      - name: startTransaction
        object: session0
```

These changes make it very easy to start testing Database/MongoClient methods.