### PR TITLE
SPEC-1071 Specify which commands to fail in failCommand

### DIFF
--- a/source/retryable-writes/tests/retryableErrors.json
+++ b/source/retryable-writes/tests/retryableErrors.json
@@ -9,7 +9,7 @@
       "x": 22
     }
   ],
-  "minServerVersion": "4.0.0",
+  "minServerVersion": "4.1.0",
   "tests": [
     {
       "description": "InsertOne succeeds after connection failure",

--- a/source/retryable-writes/tests/retryableErrors.json
+++ b/source/retryable-writes/tests/retryableErrors.json
@@ -9,16 +9,22 @@
       "x": 22
     }
   ],
-  "minServerVersion": "3.7.9",
+  "minServerVersion": "4.0.0",
   "tests": [
     {
       "description": "InsertOne succeeds after connection failure",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "closeConnection": true
         }
       },
@@ -55,12 +61,18 @@
     },
     {
       "description": "InsertOne succeeds after NotMaster",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 10107,
           "closeConnection": false
         }
@@ -98,12 +110,18 @@
     },
     {
       "description": "InsertOne succeeds after NotMasterOrSecondary",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 13436,
           "closeConnection": false
         }
@@ -141,12 +159,18 @@
     },
     {
       "description": "InsertOne succeeds after NotMasterNoSlaveOk",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 13435,
           "closeConnection": false
         }
@@ -184,12 +208,18 @@
     },
     {
       "description": "InsertOne succeeds after InterruptedDueToReplStateChange",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 11602,
           "closeConnection": false
         }
@@ -227,12 +257,18 @@
     },
     {
       "description": "InsertOne succeeds after InterruptedAtShutdown",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 11600,
           "closeConnection": false
         }
@@ -270,12 +306,18 @@
     },
     {
       "description": "InsertOne succeeds after PrimarySteppedDown",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 189,
           "closeConnection": false
         }
@@ -313,12 +355,18 @@
     },
     {
       "description": "InsertOne succeeds after ShutdownInProgress",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 91,
           "closeConnection": false
         }
@@ -356,12 +404,18 @@
     },
     {
       "description": "InsertOne succeeds after HostNotFound",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 7,
           "closeConnection": false
         }
@@ -399,12 +453,18 @@
     },
     {
       "description": "InsertOne succeeds after HostUnreachable",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 6,
           "closeConnection": false
         }
@@ -442,12 +502,18 @@
     },
     {
       "description": "InsertOne succeeds after SocketException",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 9001,
           "closeConnection": false
         }
@@ -485,12 +551,18 @@
     },
     {
       "description": "InsertOne succeeds after NetworkTimeout",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 89,
           "closeConnection": false
         }
@@ -528,12 +600,18 @@
     },
     {
       "description": "InsertOne fails after Interrupted",
+      "clientOptions": {
+        "retryWrites": true
+      },
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
           "times": 1
         },
         "data": {
+          "failCommands": [
+            "insert"
+          ],
           "errorCode": 11601,
           "closeConnection": false
         }

--- a/source/retryable-writes/tests/retryableErrors.yml
+++ b/source/retryable-writes/tests/retryableErrors.yml
@@ -2,7 +2,9 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-minServerVersion: '4.0.0'
+# TODO: this should change to 4.0.0 once a 4.0 version is released that has
+# SERVER-35004.
+minServerVersion: '4.1.0'
 
 tests:
     -

--- a/source/retryable-writes/tests/retryableErrors.yml
+++ b/source/retryable-writes/tests/retryableErrors.yml
@@ -2,17 +2,18 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-# The failCommand failpoint will be in the next release after 3.7.9 but the
-# server does not plan to do another release for a few weeks.
-minServerVersion: '3.7.9'
+minServerVersion: '4.0.0'
 
 tests:
     -
         description: "InsertOne succeeds after connection failure"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 closeConnection: true
         operation:
             name: "insertOne"
@@ -28,10 +29,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after NotMaster"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 10107
                 closeConnection: false
         operation:
@@ -48,10 +52,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after NotMasterOrSecondary"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 13436
                 closeConnection: false
         operation:
@@ -68,10 +75,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after NotMasterNoSlaveOk"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 13435
                 closeConnection: false
         operation:
@@ -88,10 +98,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after InterruptedDueToReplStateChange"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 11602
                 closeConnection: false
         operation:
@@ -108,10 +121,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after InterruptedAtShutdown"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 11600
                 closeConnection: false
         operation:
@@ -128,10 +144,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after PrimarySteppedDown"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 189
                 closeConnection: false
         operation:
@@ -148,10 +167,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after ShutdownInProgress"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 91
                 closeConnection: false
         operation:
@@ -168,10 +190,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after HostNotFound"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 7
                 closeConnection: false
         operation:
@@ -188,10 +213,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after HostUnreachable"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 6
                 closeConnection: false
         operation:
@@ -208,10 +236,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after SocketException"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 9001
                 closeConnection: false
         operation:
@@ -228,10 +259,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne succeeds after NetworkTimeout"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 89
                 closeConnection: false
         operation:
@@ -248,10 +282,13 @@ tests:
                     - { _id: 3, x: 33 }
     -
         description: "InsertOne fails after Interrupted"
+        clientOptions:
+            retryWrites: true
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data:
+                failCommands: ["insert"]
                 errorCode: 11601
                 closeConnection: false
         operation:


### PR DESCRIPTION
Update the failCommand failpoint with "failCommands" so that the failpoint is reliable on a multi-member replica set (https://jira.mongodb.org/browse/SERVER-34943).

The "failCommands" argument was added in SERVER-35004.