### PR TITLE
Add collectionOptions to command monitoring tests

### DIFF
--- a/source/command-monitoring/tests/unacknowledgedBulkWrite.json
+++ b/source/command-monitoring/tests/unacknowledgedBulkWrite.json
@@ -13,6 +13,11 @@
       "comment": "On a 2.4 server, no GLE is sent and requires a client-side manufactured reply",
       "operation": {
         "name": "bulkWrite",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        },
         "arguments": {
           "requests": [
             {
@@ -27,9 +32,6 @@
           ],
           "options": {
             "ordered": false
-          },
-          "writeConcern": {
-            "w": 0
           }
         }
       },

--- a/source/command-monitoring/tests/unacknowledgedBulkWrite.yml
+++ b/source/command-monitoring/tests/unacknowledgedBulkWrite.yml
@@ -10,13 +10,14 @@ tests:
     comment: "On a 2.4 server, no GLE is sent and requires a client-side manufactured reply"
     operation:
       name: "bulkWrite"
+      collectionOptions:
+        writeConcern: { w: 0 }
       arguments:
         requests:
           - name: "insertOne"
             arguments:
               document: { _id: "unorderedBulkWriteInsertW0", x: 44 }
         options: { ordered: false }
-        writeConcern: { w: 0 }
     expectations:
       -
         command_started_event:


### PR DESCRIPTION
This commit aligns the command monitoring tests with the format we agreed on for transaction spec tests for specifying the collection options to apply before executing an operation