### PR TITLE
 SPEC-1085 Test that writes are not retried inside a transaction

### DIFF
--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -31,7 +31,7 @@ commands listed in the "failCommands" field. See `SERVER-35004`_ and
 
 The ``failCommand`` fail point may be configured like so::
 
-    db.runCommand({
+    db.adminCommand({
         configureFailPoint: "failCommand",
         mode: <string|document>,
         data: {

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -97,7 +97,7 @@ Each YAML file has the following keys:
     - ``name``: The name of the operation on ``object``.
 
     - ``object``: The name of the object to perform the operation on. Can be
-      "database", collection", "session0", or "session1".
+      "database", "collection", "session0", or "session1".
 
     - ``collectionOptions``: Optional, parameters to pass to the Collection()
       used for this operation.

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -190,22 +190,25 @@ Then for each element in ``tests``:
      method threw an exception or returned an error, and that the value of the
      "errorContains" field matches the error string. "errorContains" is a
      substring (case-insensitive) of the actual error message.
+
      If the result document has an "errorCodeName" field, verify that the
      method threw a command failed exception or returned an error, and that
      the value of the "errorCodeName" field matches the "codeName" in the
      server error response.
-     If the operation returns a raw command response, eg from ``runCommand``,
-     then compare only the fields present in the expected result document.
-     Otherwise, compare the method's return value to ``result`` using the same
-     logic as the CRUD Spec Tests runner.
+
      If the result document has an "errorLabelsContain" field, verify that the
      method threw an exception or returned an error. Verify that all of the
      error labels in "errorLabelsContain" are present in the error or exception
      using the ``hasErrorLabel`` method.
+
      If the result document has an "errorLabelsOmit" field, verify that the
      method threw an exception or returned an error. Verify that none of the
      error labels in "errorLabelsOmit" are present in the error or exception
      using the ``hasErrorLabel`` method.
+   - If the operation returns a raw command response, eg from ``runCommand``,
+     then compare only the fields present in the expected result document.
+     Otherwise, compare the method's return value to ``result`` using the same
+     logic as the CRUD Spec Tests runner.
 
 #. Call ``session0.endSession()`` and ``session1.endSession``.
 #. If the test includes a list of command-started events in ``expectations``,

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -97,34 +97,34 @@ Each YAML file has the following keys:
   - ``operations``: Array of documents, each describing an operation to be
     executed. Each document has the following fields:
 
-      - ``name``: The name of the operation on ``object``.
+    - ``name``: The name of the operation on ``object``.
 
-      - ``object``: The name of the object to perform the operation on. Can be
-        "database", collection", "session0", or "session1".
+    - ``object``: The name of the object to perform the operation on. Can be
+      "database", collection", "session0", or "session1".
 
-      - ``collectionOptions``: Optional, parameters to pass to the Collection()
-        used for this operation.
+    - ``collectionOptions``: Optional, parameters to pass to the Collection()
+      used for this operation.
 
-      - ``command_name``: Present only when ``name`` is "runCommand". The name
-        of the command to run. Required for languages that are unable preserve
-        the order keys in the "command" argument when parsing JSON/YAML.
+    - ``command_name``: Present only when ``name`` is "runCommand". The name
+      of the command to run. Required for languages that are unable preserve
+      the order keys in the "command" argument when parsing JSON/YAML.
 
-      - ``arguments``: Optional, the names and values of arguments.
+    - ``arguments``: Optional, the names and values of arguments.
 
-      - ``result``: The return value from the operation, if any. If the
-        operation is expected to return an error, the ``result`` has one of
-        the following fields:
+    - ``result``: The return value from the operation, if any. If the
+      operation is expected to return an error, the ``result`` has one of
+      the following fields:
 
-          - ``errorContains``, A substring of the expected error message.
+      - ``errorContains``: A substring of the expected error message.
 
-          - ``errorCodeName``, The expected "codeName" field in the server
-            error response.
+      - ``errorCodeName``: The expected "codeName" field in the server
+        error response.
 
-          - ``errorLabelsContain``, A list of error label strings that the
-            error is expected to have.
+      - ``errorLabelsContain``: A list of error label strings that the
+        error is expected to have.
 
-          - ``errorLabelsOmit``, A list of error label strings that the
-            error is not expected to have.
+      - ``errorLabelsOmit``: A list of error label strings that the
+        error is expected not to have.
 
   - ``expectations``: Optional list of command-started events.
 
@@ -132,10 +132,10 @@ Each YAML file has the following keys:
     the collection after the operation is executed. Contains the following
     fields:
 
-      - ``collection``:
+    - ``collection``:
 
-        - ``data``: The data that should exist in the collection after the
-          operations have run.
+      - ``data``: The data that should exist in the collection after the
+        operations have run.
 
 Use as integration tests
 ========================

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -23,9 +23,11 @@ Server Fail Point
 Some tests depend on a server fail point, expressed in the ``failPoint`` field.
 For example the ``failCommand`` fail point allows the client to force the
 server to return an error. Keep in mind that the fail point only triggers for
-commands listed in the "failCommands" field. See `SERVER-35004`_ for more
-information.
+commands listed in the "failCommands" field. See `SERVER-35004`_ and
+`SERVER-35083`_ for more information.
 
+.. _SERVER-35004: https://jira.mongodb.org/browse/SERVER-35004
+.. _SERVER-35083: https://jira.mongodb.org/browse/SERVER-35083
 
 The ``failCommand`` fail point may be configured like so::
 
@@ -64,11 +66,6 @@ control the fail point's behavior. ``failCommand`` supports the following
   server will return this document in the "writeConcernError" field. This
   failure response only applies to commands that support write concern and
   happens *after* the command finishes (regardless of success or failure).
-  See `SERVER-35083`_ for more information.
-
-
-.. _SERVER-35004: https://jira.mongodb.org/browse/SERVER-35004
-.. _SERVER-35083: https://jira.mongodb.org/browse/SERVER-35083
 
 Test Format
 ===========

--- a/source/transactions/tests/retryable-writes.json
+++ b/source/transactions/tests/retryable-writes.json
@@ -235,6 +235,95 @@
           ]
         }
       }
+    },
+    {
+      "description": "writes are not retried",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
     }
   ]
 }

--- a/source/transactions/tests/retryable-writes.yml
+++ b/source/transactions/tests/retryable-writes.yml
@@ -148,3 +148,61 @@ tests:
           - _id: 2
           - _id: 4
           - _id: 5
+
+  - description: writes are not retried
+
+    clientOptions:
+      retryWrites: true
+
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 1 }
+        data:
+            failCommands: ["insert"]
+            closeConnection: true
+
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          errorLabelsContain: ["TransientTransactionError"]
+      - name: abortTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data: []


### PR DESCRIPTION
Adds a test to ensure that drivers do not retry insert operations within a transaction even when retryWrites=true. Also adds errorLabelsContain and ErrorLabelsOmit to verify that the insert operation raises an exception with the "TransientTransactionError" error label.

I've only added a single test (of insertOne) for now. We can expand this to test more write operations when we agree on the format. 