### PR TITLE
Specify that startAtOperationTime is a changeStream option

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -279,6 +279,7 @@ Driver API
      * operation time obtained from the server before the change stream was created.
      * @since 4.0
      * @see https://docs.mongodb.com/manual/reference/method/db.runCommand/
+     * @note this is an option of the `$changeStream` pipeline stage.
      */
     startAtOperationTime: Optional<Timestamp>;
   }


### PR DESCRIPTION
The spec clearly states for each change stream option whether it is (a) an option of the `$changeStream` aggregation stage or (b) an aggregation command option. This had not been the case for the recently added `startAtOperationTime` option and this change fixes that.