### PR TITLE
Updated change stream tests

### DIFF
--- a/source/change-streams/tests/change-streams.json
+++ b/source/change-streams/tests/change-streams.json
@@ -247,56 +247,6 @@
       }
     },
     {
-      "description": "A fresh ChangeStream against a server >=4.0 will always include startAtOperationTime in the $changeStream stage.",
-      "minServerVersion": "3.8.0",
-      "target": "collection",
-      "topology": [
-        "replicaset"
-      ],
-      "changeStreamPipeline": [],
-      "changeStreamOptions": {},
-      "operations": [
-        {
-          "database": "change-stream-tests",
-          "collection": "test",
-          "name": "insertOne",
-          "arguments": {
-            "document": {
-              "x": 1
-            }
-          }
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "aggregate": "test",
-              "cursor": {},
-              "pipeline": [
-                {
-                  "$changeStream": {
-                    "fullDocument": "default",
-                    "startAtOperationTime": {
-                      "$timestamp": {
-                        "i": 42,
-                        "t": 42
-                      }
-                    }
-                  }
-                }
-              ]
-            },
-            "command_name": "aggregate",
-            "database_name": "change-stream-tests"
-          }
-        }
-      ],
-      "result": {
-        "success": []
-      }
-    },
-    {
       "description": "Executing a watch helper on a Database results in notifications for changes to all collections in the specified database.",
       "minServerVersion": "3.8.0",
       "target": "database",
@@ -348,13 +298,7 @@
               "pipeline": [
                 {
                   "$changeStream": {
-                    "fullDocument": "default",
-                    "startAtOperationTime": {
-                      "$timestamp": {
-                        "i": 42,
-                        "t": 42
-                      }
-                    }
+                    "fullDocument": "default"
                   }
                 }
               ]
@@ -446,13 +390,7 @@
                 {
                   "$changeStream": {
                     "fullDocument": "default",
-                    "allChangesForCluster": true,
-                    "startAtOperationTime": {
-                      "$timestamp": {
-                        "i": 42,
-                        "t": 42
-                      }
-                    }
+                    "allChangesForCluster": true
                   }
                 }
               ]

--- a/source/change-streams/tests/change-streams.yml
+++ b/source/change-streams/tests/change-streams.yml
@@ -167,40 +167,6 @@ tests:
             z:
               $numberInt: "3"
   -
-    description:  A fresh ChangeStream against a server >=4.0 will always include startAtOperationTime in the $changeStream stage.
-    minServerVersion: "3.8.0"
-    target: collection
-    topology:
-      - replicaset
-    changeStreamPipeline: []
-    changeStreamOptions: {}
-    operations:
-      -
-        database: *database_name
-        collection: *collection_name
-        name: insertOne
-        arguments:
-          document:
-            x: 1
-    expectations:
-      - 
-        command_started_event:
-          command:
-            aggregate: *collection_name
-            cursor: {}
-            pipeline:
-              - 
-                $changeStream:
-                  fullDocument: default
-                  startAtOperationTime:
-                    $timestamp:
-                      i: 42
-                      t: 42
-          command_name: aggregate
-          database_name: *database_name
-    result:
-      success: []
-  -
     description: Executing a watch helper on a Database results in notifications for changes to all collections in the specified database.
     minServerVersion: "3.8.0"
     target: database
@@ -241,10 +207,6 @@ tests:
               - 
                 $changeStream:
                   fullDocument: default
-                  startAtOperationTime:
-                    $timestamp:
-                      i: 42
-                      t: 42
           command_name: aggregate
           database_name: *database_name
     result:
@@ -307,10 +269,6 @@ tests:
                 $changeStream:
                   fullDocument: default
                   allChangesForCluster: true
-                  startAtOperationTime:
-                    $timestamp:
-                      i: 42
-                      t: 42
           command_name: aggregate
           database_name: admin
     result:


### PR DESCRIPTION
startAtOperation time is no longer automatically added to the command - so examples can be removed from the tests.

SPEC-1114