### PR TITLE
Minor fixes to change stream spec tests README

### DIFF
--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -44,9 +44,10 @@ Each YAML file has the following keys:
   - ``changeStreamPipeline``: An array of additional aggregation pipeline stages to add to the change stream
   - ``changeStreamOptions``: Additional options to add to the changeStream
   - ``operations``: Array of documents, each describing an operation. Each document has the following fields:
+
     - ``database``: Database against which to run the operation
     - ``collection``: Collection against which to run the operation
-    - ``commandName``: Name of the command to run
+    - ``name``: Name of the command to run
     - ``arguments``: Object of arguments for the command (ex: document to insert)
 
   - ``expectations``: Optional list of command-started events in Extended JSON format


### PR DESCRIPTION
Fixes:
- Formatting issue that was causing subfields of 'operations' to show up as a paragraph instead on a nested, bulleted list.
- The field corresponding to the name of the command to be run was specified incorrectly as `commandName` instead of `name`.