### PR TITLE
SPEC-1121 Test only initial commands include readConcern

### DIFF
--- a/source/transactions/tests/read-concern.json
+++ b/source/transactions/tests/read-concern.json
@@ -1,0 +1,835 @@
+{
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    },
+    {
+      "_id": 3
+    },
+    {
+      "_id": 4
+    }
+  ],
+  "tests": [
+    {
+      "description": "only first countDocuments includes readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 2
+              }
+            }
+          },
+          "result": 3
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": {
+                "$gte": 2
+              }
+            }
+          },
+          "result": 3
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gte": 2
+                    }
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": null,
+                    "n": {
+                      "$sum": 1
+                    }
+                  }
+                }
+              ],
+              "lsid": "session0",
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$match": {
+                    "_id": {
+                      "$gte": 2
+                    }
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": null,
+                    "n": {
+                      "$sum": 1
+                    }
+                  }
+                }
+              ],
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "only first find includes readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "batchSize": 3
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "batchSize": 3
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false
+            },
+            "command_name": "find",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": {
+                "$numberLong": "42"
+              },
+              "collection": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "getMore",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "find",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": {
+                "$numberLong": "42"
+              },
+              "collection": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "getMore",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "only first aggregate includes readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "batchSize": 3,
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$project": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "cursor": {
+                "batchSize": 3
+              },
+              "lsid": "session0",
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": {
+                "$numberLong": "42"
+              },
+              "collection": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "getMore",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$project": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "cursor": {
+                "batchSize": 3
+              },
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "getMore": {
+                "$numberLong": "42"
+              },
+              "collection": "test",
+              "batchSize": 3,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false
+            },
+            "command_name": "getMore",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "only first distinct includes readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "fieldName": "_id"
+          },
+          "result": [
+            1,
+            2,
+            3,
+            4
+          ]
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "collectionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "fieldName": "_id"
+          },
+          "result": [
+            1,
+            2,
+            3,
+            4
+          ]
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "distinct": "test",
+              "key": "_id",
+              "lsid": "session0",
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "distinct",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "distinct": "test",
+              "key": "_id",
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "distinct",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "only first runCommand includes readConcern",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "command_name": "find",
+          "arguments": {
+            "session": "session0",
+            "command": {
+              "find": "test"
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "command_name": "find",
+          "arguments": {
+            "session": "session0",
+            "command": {
+              "find": "test"
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "lsid": "session0",
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "find",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "find",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "readConcern": null,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/transactions/tests/read-concern.yml
+++ b/source/transactions/tests/read-concern.yml
@@ -1,0 +1,343 @@
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: &data
+  - {_id: 1}
+  - {_id: 2}
+  - {_id: 3}
+  - {_id: 4}
+
+tests:
+  - description: only first countDocuments includes readConcern
+
+    operations:
+      - &startTransaction
+        name: startTransaction
+        object: session0
+        arguments:
+          options:
+            readConcern:
+              level: snapshot
+      - &countDocuments
+        name: countDocuments
+        object: collection
+        collectionOptions:
+          readConcern:
+            level: majority
+        arguments:
+          session: session0
+          filter: {_id: {$gte: 2}}
+        result: 3
+      - *countDocuments
+      - &commitTransaction
+        name: commitTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline:
+              - $match: {_id: {$gte: 2}}
+              - $group: {_id: null, n: {$sum: 1}}
+            lsid: session0
+            readConcern:
+              level: snapshot
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+          command_name: aggregate
+          database_name: *database_name
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline:
+              - $match: {_id: {$gte: 2}}
+              - $group: {_id: null, n: {$sum: 1}}
+            lsid: session0
+            readConcern:  # No readConcern
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+          command_name: aggregate
+          database_name: *database_name
+      - &commitTransactionEvent
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            readConcern:
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome: &outcome
+      collection:
+        data:
+          *data
+
+  - description: only first find includes readConcern
+
+    operations:
+      - *startTransaction
+      - &find
+        name: find
+        object: collection
+        collectionOptions:
+          readConcern:
+            level: majority
+        arguments:
+          session: session0
+          batchSize: 3
+        result: *data
+      - *find
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            find: *collection_name
+            batchSize: 3
+            lsid: session0
+            readConcern:
+              level: snapshot
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+          command_name: find
+          database_name: *database_name
+      - command_started_event:
+          command:
+            getMore:
+              # 42 is a fake placeholder value for the cursorId.
+              $numberLong: '42'
+            collection: *collection_name
+            batchSize: 3
+            lsid: session0
+            readConcern:  # No readConcern
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+          command_name: getMore
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            batchSize: 3
+            lsid: session0
+            readConcern:  # No readConcern
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+          command_name: find
+          database_name: *database_name
+      - command_started_event:
+          command:
+            getMore:
+              $numberLong: '42'
+            collection: *collection_name
+            batchSize: 3
+            lsid: session0
+            readConcern:  # No readConcern
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+          command_name: getMore
+          database_name: *database_name
+      - *commitTransactionEvent
+
+    outcome: &outcome
+      collection:
+        data:
+          *data
+
+  - description: only first aggregate includes readConcern
+
+    operations:
+      - *startTransaction
+      - &aggregate
+        name: aggregate
+        object: collection
+        collectionOptions:
+          readConcern:
+            level: majority
+        arguments:
+          pipeline:
+            - $project:
+                _id: 1
+          batchSize: 3
+          session: session0
+        result: *data
+      - *aggregate
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline:
+              - $project:
+                  _id: 1
+            cursor:
+              batchSize: 3
+            lsid: session0
+            readConcern:
+              level: snapshot
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+          command_name: aggregate
+          database_name: *database_name
+      - command_started_event:
+          command:
+            getMore:
+              # 42 is a fake placeholder value for the cursorId.
+              $numberLong: '42'
+            collection: *collection_name
+            batchSize: 3
+            lsid: session0
+            readConcern:  # No readConcern
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+          command_name: getMore
+          database_name: *database_name
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline:
+              - $project:
+                  _id: 1
+            cursor:
+              batchSize: 3
+            lsid: session0
+            readConcern:  # No readConcern
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+          command_name: aggregate
+          database_name: *database_name
+      - command_started_event:
+          command:
+            getMore:
+              $numberLong: '42'
+            collection: *collection_name
+            batchSize: 3
+            lsid: session0
+            readConcern:  # No readConcern
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+          command_name: getMore
+          database_name: *database_name
+      - *commitTransactionEvent
+
+    outcome: *outcome
+
+  - description: only first distinct includes readConcern
+
+    operations:
+      - *startTransaction
+      - &distinct
+        name: distinct
+        object: collection
+        collectionOptions:
+          readConcern:
+            level: majority
+        arguments:
+          session: session0
+          fieldName: _id
+        result: [1, 2, 3, 4]
+      - *distinct
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            distinct: *collection_name
+            key: _id
+            lsid: session0
+            readConcern:
+              level: snapshot
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: distinct
+          database_name: *database_name
+      - command_started_event:
+          command:
+            distinct: *collection_name
+            key: _id
+            lsid: session0
+            readConcern:  # No readConcern
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: distinct
+          database_name: *database_name
+      - *commitTransactionEvent
+
+    outcome: *outcome
+
+  - description: only first runCommand includes readConcern
+
+    operations:
+      - *startTransaction
+      - &runCommand
+        name: runCommand
+        object: database
+        command_name: find
+        arguments:
+          session: session0
+          command:
+            find: *collection_name
+      - *runCommand
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            find: *collection_name
+            lsid: session0
+            readConcern:
+              level: snapshot
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: find
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            lsid: session0
+            readConcern:  # No readConcern
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: find
+          database_name: *database_name
+      - *commitTransactionEvent
+
+    outcome: *outcome


### PR DESCRIPTION
Adds tests that readConcern is only added for the initial command in a transaction. None of the existing tests cover this case. Tests countDocuments, find, aggregate, distinct, and runCommand.

These changes are tested by the python driver.