### PR TITLE
Correct prose test for not resuming during an aggregate

### DIFF
--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -148,7 +148,8 @@ The following tests have not yet been automated, but MUST still be tested
 #. ``ChangeStream`` must continuously track the last seen ``resumeToken``
 #. ``ChangeStream`` will throw an exception if the server response is missing the resume token
 #. ``ChangeStream`` will automatically resume one time on a resumable error (including `not master`) with the initial pipeline and options, except for the addition/update of a ``resumeToken``.
-#. ``ChangeStream`` will not attempt to resume on a server error
+#. ``ChangeStream`` will not attempt to resume on any error encountered while executing an ``aggregate`` command.
+#. ``ChangeStream`` will not attempt to resume after encountering error code 11601 (Interrupted), 136 (CappedPositionLost), or 237 (CursorKilled) while executing a ``getMore`` command.
 #. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
 #. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
 #. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -145,12 +145,12 @@ Prose Tests
 
 The following tests have not yet been automated, but MUST still be tested
 
-1. ``ChangeStream`` must continuously track the last seen ``resumeToken``
-2. ``ChangeStream`` will throw an exception if the server response is missing the resume token
-3. ``ChangeStream`` will automatically resume one time on a resumable error (including `not master`) with the initial pipeline and options, except for the addition/update of a ``resumeToken``.
-4. ``ChangeStream`` will not attempt to resume on a server error
-5. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
-6. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
-7. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
-8. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a changestream.
-9. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
+#. ``ChangeStream`` must continuously track the last seen ``resumeToken``
+#. ``ChangeStream`` will throw an exception if the server response is missing the resume token
+#. ``ChangeStream`` will automatically resume one time on a resumable error (including `not master`) with the initial pipeline and options, except for the addition/update of a ``resumeToken``.
+#. ``ChangeStream`` will not attempt to resume on a server error
+#. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
+#. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
+#. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
+#. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a changestream.
+#. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.


### PR DESCRIPTION
This test appears to date back to the original spec commit in 9784d5d2fd52f36b15ff41d262ab171d3968ab0a; however, it does not jive with the spec's current language, which states that errors on aggregate commands are never to be retried. Only errors from getMore commands may be considered resumable.

Adding @mbroadst since this was his original commit and @kevinAlbs since he recently worked on error logic in https://github.com/mongodb/specifications/commit/7021f759c4c2a918808660a2e4e55ba1f4e4acb5.