### PR TITLE
Revise description for bulkWrite() method

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -665,7 +665,7 @@ Basic
   interface Collection {
 
     /**
-     * Sends a batch of writes to the server at the same time.
+     * Executes multiple write operations.
      *
      * An error MUST be raised if the requests parameter is empty.
      *


### PR DESCRIPTION
This came up in https://github.com/mongodb/mongo-swift-driver/pull/83#discussion_r199623171.

The doc block here already includes a reference to "FAQ about the previous bulk API and how it relates to this". I feel that's going to do a better job of explaining how the implementation should operate.

The existing text seemed odd because `requests` is really split into one or more batches depending on the operation types, their order in the array, and value of the `ordered` option. Also "at the same time" may be misleading (depending on how it is understood), since batches are sent in sequence and not concurrently.