### PR TITLE
Added new wire protocol versions

### DIFF
--- a/source/wireversion-featurelist.rst
+++ b/source/wireversion-featurelist.rst
@@ -49,6 +49,13 @@ Server Wire version and Feature List
        | Causally Consistent Reads
        | Logical Sessions
        | update "arrayFilters" option
+       
+   * - 4.0
+     - 7
+     - | ReplicaSet transactions
 
+   * - 4.2
+     - 8
+     - | Sharded transactions
 
 For more information see MongoDB Server repo: https://github.com/mongodb/mongo/blob/master/src/mongo/db/wire_version.h

--- a/source/wireversion-featurelist.rst
+++ b/source/wireversion-featurelist.rst
@@ -44,7 +44,7 @@ Server Wire version and Feature List
    * - 3.6
      - 6
      - | Supports OP_MSG
-       | ChangeStream support
+       | Collection-level ChangeStream support
        | Retryable Writes
        | Causally Consistent Reads
        | Logical Sessions
@@ -53,6 +53,7 @@ Server Wire version and Feature List
    * - 4.0
      - 7
      - | ReplicaSet transactions
+       | Database and cluster-level change streams and startAtOperationTime option
 
    * - 4.2
      - 8


### PR DESCRIPTION
With data from https://github.com/mongodb/mongo/blob/master/src/mongo/db/wire_version.h, but potentially not complete in the description