### PR TITLE
SPEC-1136: Add insertedCount to BulkWriteResult

### DIFF
--- a/source/crud/tests/write/bulkWrite-arrayFilters.json
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.json
@@ -28,48 +28,57 @@
     {
       "description": "BulkWrite with arrayFilters",
       "operation": {
+        "name": "bulkWrite",
         "arguments": {
-          "options": {
-            "ordered": true
-          },
           "requests": [
             {
+              "name": "updateOne",
               "arguments": {
+                "filter": {},
+                "update": {
+                  "$set": {
+                    "y.$[i].b": 2
+                  }
+                },
                 "arrayFilters": [
                   {
                     "i.b": 3
                   }
-                ],
+                ]
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
                 "filter": {},
                 "update": {
                   "$set": {
                     "y.$[i].b": 2
                   }
-                }
-              },
-              "name": "updateOne"
-            },
-            {
-              "arguments": {
+                },
                 "arrayFilters": [
                   {
                     "i.b": 1
                   }
-                ],
-                "filter": {},
-                "update": {
-                  "$set": {
-                    "y.$[i].b": 2
-                  }
-                }
-              },
-              "name": "updateMany"
+                ]
+              }
             }
-          ]
-        },
-        "name": "bulkWrite"
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
       },
       "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 3,
+          "modifiedCount": 3,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
         "collection": {
           "data": [
             {
@@ -95,14 +104,6 @@
               ]
             }
           ]
-        },
-        "result": {
-          "deletedCount": 0,
-          "insertedIds": {},
-          "matchedCount": 3,
-          "modifiedCount": 3,
-          "upsertedCount": 0,
-          "upsertedIds": {}
         }
       }
     }

--- a/source/crud/tests/write/bulkWrite-arrayFilters.yml
+++ b/source/crud/tests/write/bulkWrite-arrayFilters.yml
@@ -33,6 +33,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
+                insertedCount: 0
                 insertedIds: {}
                 matchedCount: 3
                 modifiedCount: 3

--- a/source/retryable-writes/tests/bulkWrite-serverErrors.json
+++ b/source/retryable-writes/tests/bulkWrite-serverErrors.json
@@ -71,6 +71,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 3
           },
@@ -156,6 +157,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 3
           },

--- a/source/retryable-writes/tests/bulkWrite-serverErrors.yml
+++ b/source/retryable-writes/tests/bulkWrite-serverErrors.yml
@@ -37,6 +37,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 1
                 insertedIds: { 1: 3 }
                 matchedCount: 1
                 modifiedCount: 1
@@ -79,6 +80,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 1
                 insertedIds: { 1: 3 }
                 matchedCount: 1
                 modifiedCount: 1

--- a/source/retryable-writes/tests/bulkWrite.json
+++ b/source/retryable-writes/tests/bulkWrite.json
@@ -61,6 +61,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -178,6 +179,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 3,
           "insertedIds": {
             "0": 2,
             "2": 3,
@@ -271,6 +273,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -352,6 +355,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -416,6 +420,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 2,
           "insertedIds": {
             "0": 2,
             "1": 3
@@ -501,6 +506,7 @@
         "error": true,
         "result": {
           "deletedCount": 0,
+          "insertedCount": 0,
           "insertedIds": {},
           "matchedCount": 0,
           "modifiedCount": 0,
@@ -575,6 +581,7 @@
         "error": true,
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -660,6 +667,7 @@
         "error": true,
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 2
           },
@@ -726,6 +734,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 2
           },
@@ -793,6 +802,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 2
           },

--- a/source/retryable-writes/tests/bulkWrite.yml
+++ b/source/retryable-writes/tests/bulkWrite.yml
@@ -32,6 +32,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 1
                 insertedIds: { 0: 2 }
                 matchedCount: 1
                 modifiedCount: 1
@@ -90,6 +91,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 3
                 insertedIds: { 0: 2, 2: 3, 4: 5 }
                 matchedCount: 2
                 modifiedCount: 2
@@ -130,6 +132,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 0: 2 }
                 matchedCount: 2
                 modifiedCount: 2
@@ -168,6 +171,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 0: 2 }
                 matchedCount: 2
                 modifiedCount: 2
@@ -200,6 +204,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
+                insertedCount: 2
                 insertedIds: { 0: 2, 1: 3 }
                 matchedCount: 0
                 modifiedCount: 0
@@ -240,6 +245,7 @@ tests:
             error: true
             result:
                 deletedCount: 0
+                insertedCount: 0
                 insertedIds: { }
                 matchedCount: 0
                 modifiedCount: 0
@@ -278,6 +284,7 @@ tests:
             error: true
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 0: 2 }
                 matchedCount: 0
                 modifiedCount: 0
@@ -318,6 +325,7 @@ tests:
             error: true
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 1: 2 }
                 matchedCount: 1
                 modifiedCount: 1
@@ -355,6 +363,7 @@ tests:
         outcome:
             result:
                 deletedCount: 1
+                insertedCount: 1
                 insertedIds: { 1: 2 }
                 matchedCount: 0
                 modifiedCount: 0
@@ -392,6 +401,7 @@ tests:
         outcome:
             result:
                 deletedCount: 0
+                insertedCount: 1
                 insertedIds: { 1: 2 }
                 matchedCount: 1
                 modifiedCount: 1

--- a/source/transactions/tests/bulk.json
+++ b/source/transactions/tests/bulk.json
@@ -184,6 +184,7 @@
           },
           "result": {
             "deletedCount": 4,
+            "insertedCount": 6,
             "insertedIds": {
               "0": 1,
               "3": 3,

--- a/source/transactions/tests/bulk.yml
+++ b/source/transactions/tests/bulk.yml
@@ -84,6 +84,7 @@ tests:
                 filter: {_id: {$gte: 6}}
         result:
           deletedCount: 4
+          insertedCount: 6
           insertedIds: {0: 1, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7}
           matchedCount: 7
           modifiedCount: 7

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -1159,6 +1159,7 @@
           },
           "result": {
             "deletedCount": 0,
+            "insertedCount": 1,
             "insertedIds": {
               "0": 1
             },

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -637,6 +637,7 @@ tests:
           session: session0
         result:
           deletedCount: 0
+          insertedCount: 1
           insertedIds: {0: 1}
           matchedCount: 0
           modifiedCount: 0


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1136

`insertedCount` is a required BulkWriteResult field, so there's no reason we shouldn't include it in the expectation.