### PR TITLE
Update blurb about spec file versioning

### DIFF
--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -16,13 +16,7 @@ Version
 =======
 
 Files in the "specifications" repository have no version scheme. They are not
-tied to a MongoDB server version, and it is our intention that each
-specification moves from "draft" to "final" with no further revisions; it is
-superseded by a future spec, not revised.
-
-However, implementers must have stable sets of tests to target. As test files
-evolve they will occasionally be tagged like "crud-tests-YYYY-MM-DD", until the
-spec is final.
+tied to a MongoDB server version.
 
 Format
 ======

--- a/source/read-write-concern/tests/README.rst
+++ b/source/read-write-concern/tests/README.rst
@@ -10,13 +10,7 @@ Version
 -------
 
 Files in the "specifications" repository have no version scheme. They are not
-tied to a MongoDB server version, and it is our intention that each
-specification moves from "draft" to "final" with no further versions; it is
-superseded by a future spec, not revised.
-
-However, implementers must have stable sets of tests to target. As test files
-evolve they will be occasionally tagged like "uri-tests-tests-2015-07-16", until
-the spec is final.
+tied to a MongoDB server version.
 
 Format
 ------

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -9,14 +9,8 @@ Server Discovery And Monitoring Spec.
 Version
 -------
 
-Files in the "specifications" repository have no version scheme.
-They are not tied to a MongoDB server version,
-and it is our intention that each specification moves from "draft" to "final"
-with no further versions; it is superseded by a future spec, not revised.
-
-However, implementers must have stable sets of tests to target.
-As test files evolve they will be occasionally tagged like
-"server-discovery-tests-2014-09-10", until the spec is final.
+Files in the "specifications" repository have no version scheme. They are not
+tied to a MongoDB server version.
 
 Format
 ------

--- a/source/server-selection/tests/README.rst
+++ b/source/server-selection/tests/README.rst
@@ -10,14 +10,8 @@ whichever format is more convenient for them.
 Version
 -------
 
-Specifications have no version scheme.
-They are not tied to a MongoDB server version,
-and it is our intention that each specification moves from "draft" to "final"
-with no further versions; it is superseded by a future spec, not revised.
-
-However, implementers must have stable sets of tests to target.
-As test files evolve they will be occasionally tagged like
-"server-selection-tests-2015-01-04", until the spec is final.
+Files in the "specifications" repository have no version scheme. They are not
+tied to a MongoDB server version.
 
 Test Format and Use
 -------------------


### PR DESCRIPTION
This copypasta was no longer accurate, as specs are still revised after being initially published and tags are not used consistently.