### PR TITLE
SPEC-1145 Update auth spec for ismaster not erroring

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -6,7 +6,7 @@ Driver Authentication
 =====================
 
 :Spec: 100
-:Spec Version: 1.8
+:Spec Version: 1.7.1
 :Title: Driver Authentication
 :Author: Craig Wilson, David Golden
 :Advisors: Andy Schwerin, Bernie Hacket, Jeff Yemin, David Golden
@@ -878,7 +878,7 @@ Q: Why does SCRAM sometimes SASLprep and sometimes not?
 Version History
 ===============
 
-Version 1.8 Changes
+Version 1.7.1 Changes
     * Unknown users don't cause ismaster errors. This was changed before
       server 4.0 GA in SERVER-34421, so the auth spec no longer refers to
       such a possibility.

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -6,7 +6,7 @@ Driver Authentication
 =====================
 
 :Spec: 100
-:Spec Version: 1.7
+:Spec Version: 1.8
 :Title: Driver Authentication
 :Author: Craig Wilson, David Golden
 :Advisors: Andy Schwerin, Bernie Hacket, Jeff Yemin, David Golden
@@ -177,12 +177,7 @@ The username MUST NOT be modified from the form provided by the user (i.e.  do
 not normalize with SASLprep), as the server uses the raw form to look for
 conflicts with legacy credentials.
 
-If the ``isMaster`` command fails with error code 11 (UserNotFound), drivers
-must consider authentication to have failed.  In such a case, drivers MUST
-raise an error that is equivalent to what they would have raised if the
-authentication mechanism were specified and the server responded the same way.
-
-If the ``isMaster`` command succeeds and the response includes a
+If the ``isMaster`` response includes a
 ``saslSupportedMechs`` field, then drivers MUST use the contents of that field
 to select a default mechanism as described later.  If the command succeeds and
 the response does not include a ``saslSupportedMechs`` field, then drivers MUST
@@ -770,10 +765,10 @@ the other mechanism fails.
 For a non-existent username, verify that not specifying a mechanism when
 connecting fails with the same error type that would occur with a correct
 username but incorrect password or mechanism.  (Because negotiation with a
-non-existent user name causes an isMaster error, we want to verify this is
-seen by users as similar to other authentication errors, not as a network or
-database command error.)
-
+non-existent user name at one point during server development caused an
+isMaster error, we want to verify this is seen by users as similar to other
+authentication errors, not as a network or database command error on the 'ismaster'
+command itself.)
 
 Step 4
 ------
@@ -882,6 +877,11 @@ Q: Why does SCRAM sometimes SASLprep and sometimes not?
 
 Version History
 ===============
+
+Version 1.8 Changes
+    * Unknown users don't cause ismaster errors. This was changed before
+      server 4.0 GA in SERVER-34421, so the auth spec no longer refers to
+      such a possibility.
 
 Version 1.7 Changes
     * Clarify authSource defaults


### PR DESCRIPTION
When the auth spec was developed, the server would give an ismaster
error for unknown users.  That was fixed in SERVER-34421 before the 4.0
GA.  This commit removes language that implies the server will error.
