### PR TITLE
add test that "ok: 0" from secondary is ignored

### DIFF
--- a/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.json
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.json
@@ -1,0 +1,81 @@
+{
+  "description": "New primary",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "b:27017",
+          {
+            "ok": 0,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.yml
@@ -1,0 +1,85 @@
+description: "New primary"
+
+uri: "mongodb://a,b/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 0,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]


### PR DESCRIPTION
This tests the bug that was found in the SDAM implementation of the Ruby driver. I verified that it failed the test before the fix and passes the test after.