### PR TITLE
SPEC-1135: Add upsertedCount to missed UpdateResult

### DIFF
--- a/source/crud/tests/write/updateMany-arrayFilters.json
+++ b/source/crud/tests/write/updateMany-arrayFilters.json
@@ -98,7 +98,8 @@
       "outcome": {
         "result": {
           "matchedCount": 2,
-          "modifiedCount": 1
+          "modifiedCount": 1,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [

--- a/source/crud/tests/write/updateMany-arrayFilters.yml
+++ b/source/crud/tests/write/updateMany-arrayFilters.yml
@@ -39,6 +39,7 @@ tests:
             result:
                 matchedCount: 2
                 modifiedCount: 1
+                upsertedCount: 0
             collection:
                 data:
                     - {_id: 1, y: [{b: 2}, {b: 1}]}


### PR DESCRIPTION
@kmahar pointed out that I missed this in https://github.com/mongodb/specifications/pull/376.