### PR TITLE
Do not require unknown topology type when user specified connection t…

### DIFF
--- a/source/server-discovery-and-monitoring/tests/monitoring/required_replica_set.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/required_replica_set.json
@@ -32,7 +32,7 @@
             "topology_description_changed_event": {
               "topologyId": "42",
               "previousDescription": {
-                "topologyType": "Unknown",
+                "topologyType": null,
                 "servers": []
               },
               "newDescription": {

--- a/source/server-discovery-and-monitoring/tests/monitoring/required_replica_set.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/required_replica_set.yml
@@ -24,7 +24,8 @@ phases:
           topology_description_changed_event:
             topologyId: "42"
             previousDescription:
-              topologyType: "Unknown"
+              # Can be "Unknown" or "ReplicaSetNoPrimary"
+              topologyType:
               servers: []
             newDescription:
               topologyType: "ReplicaSetNoPrimary"


### PR DESCRIPTION
…o replica set.

https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#initial-topologytype
specifies the following for initial topology type:

> The user MAY be able to initialize it to ReplicaSetNoPrimary.
> This provides the user a way to tell the client it can only connect
> to replica set members. Similarly the user MAY be able to
> initialize it to Sharded, to connect only to mongoses.

Ruby driver does offer users the option to force a topology type via
:connect and :replica_set options, and this test gives an explicit
replica set name which puts the driver into forced topology mode
rather than discovering the topology from the cluster. In this mode
the Ruby driver starts out in Replica Set topology rather than Unknown.