### PR TITLE
Add empty cursor document to aggregate started event expectations

### DIFF
--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -595,6 +595,7 @@
                   }
                 }
               ],
+              "cursor": {},
               "readConcern": null,
               "lsid": "session0",
               "txnNumber": {

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -361,6 +361,7 @@ tests:
             pipeline:
               - $project:
                   _id: 1
+            cursor: {}
             readConcern:
             lsid: session0
             txnNumber:

--- a/source/transactions/tests/read-concern.json
+++ b/source/transactions/tests/read-concern.json
@@ -93,6 +93,7 @@
                   }
                 }
               ],
+              "cursor": {},
               "lsid": "session0",
               "readConcern": {
                 "level": "snapshot"
@@ -128,6 +129,7 @@
                   }
                 }
               ],
+              "cursor": {},
               "lsid": "session0",
               "readConcern": null,
               "txnNumber": {

--- a/source/transactions/tests/read-concern.yml
+++ b/source/transactions/tests/read-concern.yml
@@ -40,6 +40,7 @@ tests:
             pipeline:
               - $match: {_id: {$gte: 2}}
               - $group: {_id: null, n: {$sum: 1}}
+            cursor: {}
             lsid: session0
             readConcern:
               level: snapshot
@@ -55,6 +56,7 @@ tests:
             pipeline:
               - $match: {_id: {$gte: 2}}
               - $group: {_id: null, n: {$sum: 1}}
+            cursor: {}
             lsid: session0
             readConcern:  # No readConcern
             txnNumber:


### PR DESCRIPTION
Justification

1. We were careful to include all fields in command expectations until now.  Let's not diverge from that.
2. As we start using command monitoring for more of our spec tests, include CRUD, it becomes more important for drivers to assert on _all_ fields in the command, not just a partial list of fields that the test happens to include.  The Java driver currently does this, and it has helped to catch more than one bug during the dev cycle