### PR TITLE
Server selection: additional test for application-provided server selectors

### DIFF
--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -262,10 +262,16 @@ Application-Provided Server Selector
 
 The Server Selection spec allows drivers to configure registration of a server selector
 function that filters the list of suitable servers.  Drivers implementing this part
-of the spec MUST test that the application-provided server selector is executed
-as part of the server selection process.
+of the spec MUST test that:
 
-For example, execute a test against a replica set: Register a server selector that selects
-the suitable server with the highest port number. Execute 10 queries with nearest read
-preference and, using command monitoring, assert that all the operations execute on the
-member with the highest port number.
+- The application-provided server selector is executed as part of the server selection process when
+  there are a nonzero number of candidate or eligible servers. For example, execute a test against a replica
+  set: Register a server selector that selects the suitable server with the highest port number. Execute 10
+  queries with nearest read preference and, using command monitoring, assert that all the operations execute
+  on the member with the highest port number.
+
+- The application-provided server selector is not executed as part of the server selection process when
+  there are no candidate or eligible servers. For example, execute a test against a replica set
+  with no primary: Register a server selector that increments an internal counter (starting at 0) each time
+  it is called. Attempt server selection with primary read preference, catch the resulting server selection
+  timeout exception, and assert that the internal counter of the server selector is still 0.


### PR DESCRIPTION
Adds a test case to ensure the application-provided server selector is not executed when there are no candidate/eligible servers. 

The new test described herein has been implemented in `pymongo`: https://github.com/mongodb/mongo-python-driver/pull/371