### PR TITLE
Update tests for read concern levels

### DIFF
--- a/source/read-write-concern/tests/connection-string/read-concern.json
+++ b/source/read-write-concern/tests/connection-string/read-concern.json
@@ -24,6 +24,24 @@
       "readConcern": {
         "level": "majority"
       }
+    },
+    {
+      "description": "linearizable specified",
+      "uri": "mongodb://localhost/?readConcernLevel=linearizable",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "linearizable"
+      }
+    },
+    {
+      "description": "available specified",
+      "uri": "mongodb://localhost/?readConcernLevel=available",
+      "valid": true,
+      "warning": false,
+      "readConcern": {
+        "level": "available"
+      }
     }
   ]
 }

--- a/source/read-write-concern/tests/connection-string/read-concern.yml
+++ b/source/read-write-concern/tests/connection-string/read-concern.yml
@@ -17,3 +17,16 @@ tests:
         valid: true
         warning: false
         readConcern: { level: "majority" }
+    -
+        description: "linearizable specified"
+        uri: "mongodb://localhost/?readConcernLevel=linearizable"
+        valid: true
+        warning: false
+        readConcern: { level: "linearizable" }
+    -
+        description: "available specified"
+        uri: "mongodb://localhost/?readConcernLevel=available"
+        valid: true
+        warning: false
+        readConcern: { level: "available" }
+        

--- a/source/read-write-concern/tests/document/read-concern.json
+++ b/source/read-write-concern/tests/document/read-concern.json
@@ -28,6 +28,39 @@
         "level": "local"
       },
       "isServerDefault": false
+    },
+    {
+      "description": "Linearizable",
+      "valid": true,
+      "readConcern": {
+        "level": "linearizable"
+      },
+      "readConcernDocument": {
+        "level": "linearizable"
+      },
+      "isServerDefault": false
+    },
+    {
+      "description": "Snapshot",
+      "valid": true,
+      "readConcern": {
+        "level": "snapshot"
+      },
+      "readConcernDocument": {
+        "level": "snapshot"
+      },
+      "isServerDefault": false
+    },
+    {
+      "description": "Available",
+      "valid": true,
+      "readConcern": {
+        "level": "available"
+      },
+      "readConcernDocument": {
+        "level": "available"
+      },
+      "isServerDefault": false
     }
   ]
 }

--- a/source/read-write-concern/tests/document/read-concern.yml
+++ b/source/read-write-concern/tests/document/read-concern.yml
@@ -17,3 +17,21 @@ tests:
         readConcern: { level: "local" }
         readConcernDocument: { level: "local" }
         isServerDefault: false
+    -
+        description: "Linearizable"
+        valid: true
+        readConcern: { level: "linearizable" }
+        readConcernDocument: { level: "linearizable" }
+        isServerDefault: false
+    -
+        description: "Snapshot"
+        valid: true
+        readConcern: { level: "snapshot" }
+        readConcernDocument: {level: "snapshot" }
+        isServerDefault: false
+    -
+        description: "Available"
+        valid: true
+        readConcern: { level: "available" }
+        readConcernDocument: { level: "available" }
+        isServerDefault: false


### PR DESCRIPTION
Specification tests were missing a few read concern levels. This commit updates document tests to include linearizable, snapshot, and available. It also updates connection-string tests to include linearizable and available.