### PR TITLE
Remove FindOneAndUpdateOptions note about opcodes

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -1530,7 +1530,6 @@ Find And Modify
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
      * For servers < 3.6, the driver MUST raise an error if the caller explicitly provides a value.
-     * For unacknowledged writes using opcodes, the driver MUST raise an error if the caller explicitly provides a value.
      *
      * @see https://docs.mongodb.com/manual/reference/command/update/
      */


### PR DESCRIPTION
This removes a line that was added in 1d765dd6b7c8452c4664794e1e69b4590d001bdc. The findAndModify command does not use opcodes, so the note combining arrayFilters with an unacknowledged write concern does not apply.

@saghm I believe the original addition in your commit was a copy/paste error, but please confirm.