### PR TITLE
SPEC-870: Additional bulkWrite() spec tests

### DIFF
--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -2,15 +2,27 @@
 CRUD Tests
 ==========
 
+.. contents::
+
+----
+
+Introduction
+============
+
 The YAML and JSON files in this directory tree are platform-independent tests
-meant to exercise the translation from the API to underlying commands that
-MongoDB understands. Given the variety of languages and implementations and
-limited nature of a description of a test, there are a number of things that
-aren't testable. For instance, none of these tests assert that maxTimeMS was
-properly sent to the server. This would involve a lot of infrastructure to
-define and setup. Therefore, these YAML tests are in no way a replacement for
-more thorough testing. However, they can provide an initial verification of your
+that drivers can use to prove their conformance to the CRUD spec.
+
+Given the variety of languages and implementations and limited nature of a
+description of a test, there are a number of things that aren't testable. For
+instance, none of these tests assert that maxTimeMS was properly sent to the
+server. This would involve a lot of infrastructure to define and setup.
+Therefore, these YAML tests are in no way a replacement for more thorough
+testing. However, they can provide an initial verification of your
 implementation.
+
+Running these integration tests will require a running MongoDB server or
+cluster with server versions 2.6.0 or later. Some tests have specific server
+version requirements as noted by ``minServerVersion`` and ``maxServerVersion``.
 
 Version
 =======
@@ -51,11 +63,7 @@ Each YAML file has the following keys:
     the collection after the operation is executed. This will have some or all
     of the following fields:
 
-        - ``result``: The return value from the operation. Note that some tests
-          specify an ``upsertedCount`` field when the server does not provide
-          one in the result document. In these cases, an ``upsertedCount`` field
-          with a value of 0 should be manually added to the document received
-          from the server to facilitate comparison.
+      - ``result``: The return value from the operation.
 
       - ``collection``:
 
@@ -65,10 +73,10 @@ Each YAML file has the following keys:
         - ``data``: The data that should exist in the collection after the
           operation has been run.
 
-Use as integration tests
-========================
+Expectations
+============
 
-Running these as integration tests will require a running mongod server. Each of
-these tests is valid against a standalone mongod, a replica set, and a sharded
-system for server version 3.0 and later. Many of them will run against 2.6, but
-some will require conditional code.
+Expected results for some tests may include optional fields, such as
+``insertedId`` (for InsertOneResult), ``insertedIds`` (for InsertManyResult),
+and ``upsertedCount`` (for UpdateResult). Drivers that do not implement these
+fields can ignore them.

--- a/source/crud/tests/write/bulkWrite.json
+++ b/source/crud/tests/write/bulkWrite.json
@@ -1,0 +1,648 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "minServerVersion": "2.6",
+  "tests": [
+    {
+      "description": "BulkWrite with deleteOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                }
+              }
+            },
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 1,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with deleteMany operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lt": 11
+                  }
+                }
+              }
+            },
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lte": 22
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 2,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with insertOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "insertedIds": {
+            "0": 3,
+            "1": 4
+          },
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with replaceOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "replacement": {
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                },
+                "replacement": {
+                  "_id": 1,
+                  "x": 11
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                },
+                "replacement": {
+                  "x": 12
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "replacement": {
+                  "x": 33
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 2,
+          "modifiedCount": 1,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "3": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with updateOne operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 0
+                },
+                "update": {
+                  "$set": {
+                    "x": 0
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                },
+                "update": {
+                  "$set": {
+                    "x": 11
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "update": {
+                  "$set": {
+                    "x": 33
+                  }
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 2,
+          "modifiedCount": 1,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "3": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with updateMany operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lt": 11
+                  }
+                },
+                "update": {
+                  "$set": {
+                    "x": 0
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lte": 22
+                  }
+                },
+                "update": {
+                  "$unset": {
+                    "y": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$lte": 22
+                  }
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "update": {
+                  "$set": {
+                    "x": 33
+                  }
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 4,
+          "modifiedCount": 2,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "3": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with mixed ordered operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
+                "filter": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            },
+            {
+              "name": "deleteMany",
+              "arguments": {
+                "filter": {
+                  "x": {
+                    "$nin": [
+                      24,
+                      34
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 4
+                },
+                "replacement": {
+                  "_id": 4,
+                  "x": 44
+                },
+                "upsert": true
+              }
+            }
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 2,
+          "insertedCount": 2,
+          "insertedIds": {
+            "0": 3,
+            "3": 4
+          },
+          "matchedCount": 3,
+          "modifiedCount": 3,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "5": 4
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 24
+            },
+            {
+              "_id": 3,
+              "x": 34
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite with mixed unordered operations",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "replaceOne",
+              "arguments": {
+                "filter": {
+                  "_id": 3
+                },
+                "replacement": {
+                  "_id": 3,
+                  "x": 33
+                },
+                "upsert": true
+              }
+            },
+            {
+              "name": "deleteOne",
+              "arguments": {
+                "filter": {
+                  "_id": 1
+                }
+              }
+            },
+            {
+              "name": "updateOne",
+              "arguments": {
+                "filter": {
+                  "_id": 2
+                },
+                "update": {
+                  "$inc": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 1,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 1,
+          "modifiedCount": 1,
+          "upsertedCount": 1,
+          "upsertedIds": {
+            "0": 3
+          }
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 2,
+              "x": 23
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/crud/tests/write/bulkWrite.yml
+++ b/source/crud/tests/write/bulkWrite.yml
@@ -1,0 +1,334 @@
+data:
+    - {_id: 1, x: 11}
+    - {_id: 2, x: 22}
+
+minServerVersion: '2.6'
+
+tests:
+    -
+        description: "BulkWrite with deleteOne operations"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                # Note: as in the "DeleteOne when many documents match" test in
+                # deleteOne.yml, we omit a deleteOne operation that might match
+                # multiple documents as that would hinder our ability to assert
+                # the final state of the collection under test.
+                requests:
+                    -
+                        # does not match an existing document
+                        name: "deleteOne"
+                        arguments:
+                            filter: { _id: 3 }
+                    -
+                        # deletes the matched document
+                        name: "deleteOne"
+                        arguments:
+                            filter: { _id: 2 }
+                options: { ordered: true }
+        outcome:
+            result:
+                deletedCount: 1
+                insertedCount: 0
+                insertedIds: {}
+                matchedCount: 0
+                modifiedCount: 0
+                upsertedCount: 0
+                upsertedIds: {}
+            collection:
+                data:
+                    - {_id: 1, x: 11 }
+    -
+        description: "BulkWrite with deleteMany operations"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                requests:
+                    -
+                        # does not match any existing documents
+                        name: "deleteMany"
+                        arguments:
+                            filter: { x: { $lt: 11 } }
+                    -
+                        # deletes the matched documents
+                        name: "deleteMany"
+                        arguments:
+                            filter: { x: { $lte: 22 } }
+                options: { ordered: true }
+        outcome:
+            result:
+                deletedCount: 2
+                insertedCount: 0
+                insertedIds: {}
+                matchedCount: 0
+                modifiedCount: 0
+                upsertedCount: 0
+                upsertedIds: {}
+            collection:
+                data: []
+    -
+        description: "BulkWrite with insertOne operations"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                requests:
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 3, x: 33 }
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 4, x: 44 }
+                options: { ordered: true }
+        outcome:
+            result:
+                deletedCount: 0
+                insertedCount: 2
+                insertedIds: { 0: 3, 1: 4 }
+                matchedCount: 0
+                modifiedCount: 0
+                upsertedCount: 0
+                upsertedIds: {}
+            collection:
+                data:
+                    - {_id: 1, x: 11 }
+                    - {_id: 2, x: 22 }
+                    - {_id: 3, x: 33 }
+                    - {_id: 4, x: 44 }
+    -
+        description: "BulkWrite with replaceOne operations"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                # Note: as in the "ReplaceOne when many documents match" test in
+                # replaceOne.yml, we omit a replaceOne operation that might
+                # match multiple documents as that would hinder our ability to
+                # assert the final state of the collection under test.
+                requests:
+                    -
+                        # does not match an existing document
+                        name: "replaceOne"
+                        arguments:
+                            filter: { _id: 3 }
+                            replacement: { x: 33 }
+                    -
+                        # does not modify the matched document
+                        name: "replaceOne"
+                        arguments:
+                            filter: { _id: 1 }
+                            # Repeat _id in replacement document so the server
+                            # does not report a modification for this update.
+                            # See: https://jira.mongodb.org/browse/SERVER-36405
+                            replacement: { _id: 1, x: 11 }
+                    -
+                        # modifies the matched document
+                        name: "replaceOne"
+                        arguments:
+                            filter: { _id: 1 }
+                            replacement: { x: 12 }
+                    -
+                        # does not match an existing document and upserts
+                        name: "replaceOne"
+                        arguments:
+                            filter: { _id: 3 }
+                            replacement: { x: 33 }
+                            upsert: true
+                options: { ordered: true }
+        outcome:
+            result:
+                deletedCount: 0
+                insertedCount: 0
+                insertedIds: {}
+                matchedCount: 2
+                modifiedCount: 1
+                upsertedCount: 1
+                upsertedIds: { 3: 3 }
+            collection:
+                data:
+                    - {_id: 1, x: 12 }
+                    - {_id: 2, x: 22 }
+                    - {_id: 3, x: 33 }
+    -
+        description: "BulkWrite with updateOne operations"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                # Note: as in the "UpdateOne when many documents match" test in
+                # updateOne.yml, we omit an updateOne operation that might match
+                # multiple documents as that would hinder our ability to assert
+                # the final state of the collection under test.
+                requests:
+                    -
+                        # does not match an existing document
+                        name: "updateOne"
+                        arguments:
+                            filter: { _id: 0 }
+                            update: { $set: { x: 0 } }
+                    -
+                        # does not modify the matched document
+                        name: "updateOne"
+                        arguments:
+                            filter: { _id: 1 }
+                            update: { $set: { x: 11 } }
+                    -
+                        # modifies the matched document
+                        name: "updateOne"
+                        arguments:
+                            filter: { _id: 2 }
+                            update: { $inc: { x: 1 } }
+                    -
+                        # does not match an existing document and upserts
+                        name: "updateOne"
+                        arguments:
+                            filter: { _id: 3 }
+                            update: { $set: { x: 33 } }
+                            upsert: true
+                options: { ordered: true }
+        outcome:
+            result:
+                deletedCount: 0
+                insertedCount: 0
+                insertedIds: {}
+                matchedCount: 2
+                modifiedCount: 1
+                upsertedCount: 1
+                upsertedIds: { 3: 3 }
+            collection:
+                data:
+                    - {_id: 1, x: 11 }
+                    - {_id: 2, x: 23 }
+                    - {_id: 3, x: 33 }
+    -
+        description: "BulkWrite with updateMany operations"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                requests:
+                    -
+                        # does not match any existing documents
+                        name: "updateMany"
+                        arguments:
+                            filter: { x: { $lt: 11 } }
+                            update: { $set: { x: 0 } }
+                    -
+                        # does not modify the matched documents
+                        name: "updateMany"
+                        arguments:
+                            filter: { x: { $lte: 22 } }
+                            update: { $unset: { y: 1 } }
+                    -
+                        # modifies the matched documents
+                        name: "updateMany"
+                        arguments:
+                            filter: { x: { $lte: 22 } }
+                            update: { $inc: { x: 1 } }
+                    -
+                        # does not match any existing documents and upserts
+                        name: "updateMany"
+                        arguments:
+                            filter: { _id: 3 }
+                            update: { $set: { x: 33 } }
+                            upsert: true
+                options: { ordered: true }
+        outcome:
+            result:
+                deletedCount: 0
+                insertedCount: 0
+                insertedIds: {}
+                matchedCount: 4
+                modifiedCount: 2
+                upsertedCount: 1
+                upsertedIds: { 3: 3 }
+            collection:
+                data:
+                    - {_id: 1, x: 12 }
+                    - {_id: 2, x: 23 }
+                    - {_id: 3, x: 33 }
+    -
+        description: "BulkWrite with mixed ordered operations"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                requests:
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 3, x: 33 }
+                    -
+                        name: "updateOne"
+                        arguments:
+                            filter: { _id: 2 }
+                            update: { $inc: { x: 1 } }
+                    -
+                        name: "updateMany"
+                        arguments:
+                            filter: { _id: { $gt: 1 } }
+                            update: { $inc: { x: 1 } }
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 4, x: 44 }
+                    -
+                        name: "deleteMany"
+                        arguments:
+                            filter: { x: { $nin: [ 24, 34 ] } }
+                    -
+                        name: "replaceOne"
+                        arguments:
+                            filter: { _id: 4 }
+                            replacement: { _id: 4, x: 44 }
+                            upsert: true
+                options: { ordered: true }
+        outcome:
+            result:
+                deletedCount: 2
+                insertedCount: 2
+                insertedIds: { 0: 3, 3: 4 }
+                matchedCount: 3
+                modifiedCount: 3
+                upsertedCount: 1
+                upsertedIds: { 5: 4 }
+            collection:
+                data:
+                    - {_id: 2, x: 24 }
+                    - {_id: 3, x: 34 }
+                    - {_id: 4, x: 44 }
+    -
+        description: "BulkWrite with mixed unordered operations"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                # We omit inserting multiple documents and updating documents
+                # that may not exist at the start of this test as we cannot
+                # assume the order in which the operations will execute.
+                requests:
+                    -
+                        name: "replaceOne"
+                        arguments:
+                            filter: { _id: 3 }
+                            replacement: { _id: 3, x: 33 }
+                            upsert: true
+                    -
+                        name: "deleteOne"
+                        arguments:
+                            filter: { _id: 1 }
+                    -
+                        name: "updateOne"
+                        arguments:
+                            filter: { _id: 2 }
+                            update: { $inc: { x: 1 } }
+                options: { ordered: false }
+        outcome:
+            result:
+                deletedCount: 1
+                insertedCount: 0
+                insertedIds: {}
+                matchedCount: 1
+                modifiedCount: 1
+                upsertedCount: 1
+                upsertedIds: { 0: 3 }
+            collection:
+                data:
+                    - {_id: 2, x: 23 }
+                    - {_id: 3, x: 33 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-870

Note: this does not entail testing expected commands with APM (to be done [SPEC-1133](https://jira.mongodb.org/browse/SPEC-1133)). We're just adding additional tests for `bulkWrite()` using the existing format.

The JSON tests in this PR have been successfully tested against the PHP and Swift drivers, both of which assert all fields in the result document (including spec-optional fields such as `insertedIds`).