### PR TITLE
SPEC-1142: Test continue-on-error behavior with unordered insertMany() and bulkWrite()

### DIFF
--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -55,23 +55,34 @@ Each YAML file has the following keys:
   - ``operation``: Document describing the operation to be executed. This will
     have the following fields:
 
-      - ``name``: The name of the operation as defined in the specification.
+    - ``name``: The name of the operation as defined in the specification.
 
-      - ``arguments``: The names and values of arguments from the specification.
+    - ``arguments``: The names and values of arguments from the specification.
 
   - ``outcome``: Document describing the return value and/or expected state of
     the collection after the operation is executed. This will have some or all
     of the following fields:
 
-      - ``result``: The return value from the operation.
+    - ``error``: If ``true``, the test should expect an error or exception. Note
+      that some drivers may report server-side errors as a write error within a
+      write result object.
 
-      - ``collection``:
+    - ``result``: The return value from the operation. This will correspond to
+      an operation's result object as defined in the CRUD specification. This
+      field may be omitted if ``error`` is ``true``. If this field is present
+      and ``error`` is ``true`` (generally for multi-statement tests), the
+      result reports information about operations that succeeded before an
+      unrecoverable failure. In that case, drivers may choose to check the
+      result object if their BulkWriteException (or equivalent) provides access
+      to a write result object.
 
-        - ``name`` (optional): The name of the collection to verify. If this
-          isn't present then use the collection under test.
+    - ``collection``:
 
-        - ``data``: The data that should exist in the collection after the
-          operation has been run.
+      - ``name`` (optional): The name of the collection to verify. If this isn't
+        present then use the collection under test.
+
+      - ``data``: The data that should exist in the collection after the
+        operation has been run.
 
 Expectations
 ============

--- a/source/crud/tests/write/bulkWrite.json
+++ b/source/crud/tests/write/bulkWrite.json
@@ -643,6 +643,148 @@
           ]
         }
       }
+    },
+    {
+      "description": "BulkWrite continue-on-error behavior with unordered (preexisting duplicate key)",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 2,
+                  "x": 22
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "BulkWrite continue-on-error behavior with unordered (duplicate key in requests)",
+      "operation": {
+        "name": "bulkWrite",
+        "arguments": {
+          "requests": [
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 3,
+                  "x": 33
+                }
+              }
+            },
+            {
+              "name": "insertOne",
+              "arguments": {
+                "document": {
+                  "_id": 4,
+                  "x": 44
+                }
+              }
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/crud/tests/write/bulkWrite.yml
+++ b/source/crud/tests/write/bulkWrite.yml
@@ -332,3 +332,79 @@ tests:
                 data:
                     - {_id: 2, x: 23 }
                     - {_id: 3, x: 33 }
+    -
+        description: "BulkWrite continue-on-error behavior with unordered (preexisting duplicate key)"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                requests:
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 2, x: 22 }
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 3, x: 33 }
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 4, x: 44 }
+                options: { ordered: false }
+        outcome:
+            error: true
+            result:
+                deletedCount: 0
+                insertedCount: 2
+                # Since the map of insertedIds is generated before execution it
+                # could indicate inserts that did not actually succeed. We omit
+                # this field rather than expect drivers to provide an accurate
+                # map filtered by write errors.
+                matchedCount: 0
+                modifiedCount: 0
+                upsertedCount: 0
+                upsertedIds: { }
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }
+                    - { _id: 4, x: 44 }
+    -
+        description: "BulkWrite continue-on-error behavior with unordered (duplicate key in requests)"
+        operation:
+            name: "bulkWrite"
+            arguments:
+                requests:
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 3, x: 33 }
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 3, x: 33 }
+                    -
+                        name: "insertOne"
+                        arguments:
+                            document: { _id: 4, x: 44 }
+                options: { ordered: false }
+        outcome:
+            error: true
+            result:
+                deletedCount: 0
+                insertedCount: 2
+                # Since the map of insertedIds is generated before execution it
+                # could indicate inserts that did not actually succeed. We omit
+                # this field rather than expect drivers to provide an accurate
+                # map filtered by write errors.
+                matchedCount: 0
+                modifiedCount: 0
+                upsertedCount: 0
+                upsertedIds: { }
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }
+                    - { _id: 4, x: 44 }

--- a/source/crud/tests/write/insertMany.json
+++ b/source/crud/tests/write/insertMany.json
@@ -47,6 +47,110 @@
           ]
         }
       }
+    },
+    {
+      "description": "InsertMany continue-on-error behavior with unordered (preexisting duplicate key)",
+      "operation": {
+        "name": "insertMany",
+        "arguments": {
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "InsertMany continue-on-error behavior with unordered (duplicate key in requests)",
+      "operation": {
+        "name": "insertMany",
+        "arguments": {
+          "documents": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ],
+          "options": {
+            "ordered": false
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 2,
+          "matchedCount": 0,
+          "modifiedCount": 0,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/crud/tests/write/insertMany.json
+++ b/source/crud/tests/write/insertMany.json
@@ -20,7 +20,10 @@
               "_id": 3,
               "x": 33
             }
-          ]
+          ],
+          "options": {
+            "ordered": true
+          }
         }
       },
       "outcome": {

--- a/source/crud/tests/write/insertMany.yml
+++ b/source/crud/tests/write/insertMany.yml
@@ -19,3 +19,59 @@ tests:
                     - {_id: 1, x: 11}
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
+    -
+        description: "InsertMany continue-on-error behavior with unordered (preexisting duplicate key)"
+        operation:
+            name: "insertMany"
+            arguments:
+                documents:
+                    - { _id: 1, x: 11 }
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }
+                options: { ordered: false }
+        outcome:
+            error: true
+            result:
+                deletedCount: 0
+                insertedCount: 2
+                # Since the map of insertedIds is generated before execution it
+                # could indicate inserts that did not actually succeed. We omit
+                # this field rather than expect drivers to provide an accurate
+                # map filtered by write errors.
+                matchedCount: 0
+                modifiedCount: 0
+                upsertedCount: 0
+                upsertedIds: { }
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }
+    -
+        description: "InsertMany continue-on-error behavior with unordered (duplicate key in requests)"
+        operation:
+            name: "insertMany"
+            arguments:
+                documents:
+                    - { _id: 2, x: 22 }
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }
+                options: { ordered: false }
+        outcome:
+            error: true
+            result:
+                deletedCount: 0
+                insertedCount: 2
+                # Since the map of insertedIds is generated before execution it
+                # could indicate inserts that did not actually succeed. We omit
+                # this field rather than expect drivers to provide an accurate
+                # map filtered by write errors.
+                matchedCount: 0
+                modifiedCount: 0
+                upsertedCount: 0
+                upsertedIds: { }
+            collection:
+                data:
+                    - { _id: 1, x: 11 }
+                    - { _id: 2, x: 22 }
+                    - { _id: 3, x: 33 }

--- a/source/crud/tests/write/insertMany.yml
+++ b/source/crud/tests/write/insertMany.yml
@@ -10,7 +10,7 @@ tests:
                 documents: 
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
-
+                options: { ordered: true }
         outcome:
             result:
                 insertedIds: { 0: 2, 1: 3 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1142

These are the first CRUD tests to trigger an error (and use ordered=false, if that matters). Some test harnesses may need revisions to detect the error and possibly extract a write result from the error for additional assertions.

I had to update PHPLIB's test runner and am currently in the process of updating Swift's.