### PR TITLE
SPEC-1160 Test delete/updateMany with retryWrites

### DIFF
--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -24,7 +24,7 @@ the cluster.
 Server Fail Point
 =================
 
-The tests depend on a server fail point, ``onPrimaryTransactionalWrite``, which
+Some tests depend on a server fail point, ``onPrimaryTransactionalWrite``, which
 allows us to force a network error before the server would return a write result
 to the client. The fail point also allows control whether the server will
 successfully commit the write via its ``failBeforeCommitExceptionCode`` option.
@@ -140,8 +140,8 @@ Each YAML file has the following keys:
 
   - ``clientOptions``: Parameters to pass to MongoClient().
 
-  - ``failPoint``: The ``configureFailPoint`` command document to run to
-    configure a fail point on the primary server. Drivers must ensure that
+  - ``failPoint`` (optional): The ``configureFailPoint`` command document to run
+    to configure a fail point on the primary server. Drivers must ensure that
     ``configureFailPoint`` is the first field in the command.
 
   - ``operation``: Document describing the operation to be executed. The

--- a/source/retryable-writes/tests/deleteMany.json
+++ b/source/retryable-writes/tests/deleteMany.json
@@ -1,0 +1,35 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "minServerVersion": "3.6",
+  "tests": [
+    {
+      "description": "DeleteMany ignores retryWrites",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "operation": {
+        "name": "deleteMany",
+        "arguments": {
+          "filter": {}
+        }
+      },
+      "outcome": {
+        "result": {
+          "deletedCount": 2
+        },
+        "collection": {
+          "data": []
+        }
+      }
+    }
+  ]
+}

--- a/source/retryable-writes/tests/deleteMany.yml
+++ b/source/retryable-writes/tests/deleteMany.yml
@@ -1,0 +1,20 @@
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+minServerVersion: '3.6'
+
+tests:
+    -
+        description: "DeleteMany ignores retryWrites"
+        clientOptions:
+            retryWrites: true
+        operation:
+            name: "deleteMany"
+            arguments:
+                filter: { }
+        outcome:
+            result:
+                deletedCount: 2
+            collection:
+                data: []

--- a/source/retryable-writes/tests/updateMany.json
+++ b/source/retryable-writes/tests/updateMany.json
@@ -1,0 +1,51 @@
+{
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "minServerVersion": "3.6",
+  "tests": [
+    {
+      "description": "UpdateMany ignores retryWrites",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "operation": {
+        "name": "updateMany",
+        "arguments": {
+          "filter": {},
+          "update": {
+            "$inc": {
+              "x": 1
+            }
+          }
+        }
+      },
+      "outcome": {
+        "result": {
+          "matchedCount": 2,
+          "modifiedCount": 2,
+          "upsertedCount": 0
+        },
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 23
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/retryable-writes/tests/updateMany.yml
+++ b/source/retryable-writes/tests/updateMany.yml
@@ -1,0 +1,25 @@
+data:
+    - { _id: 1, x: 11 }
+    - { _id: 2, x: 22 }
+
+minServerVersion: '3.6'
+
+tests:
+    -
+        description: "UpdateMany ignores retryWrites"
+        clientOptions:
+            retryWrites: true
+        operation:
+            name: "updateMany"
+            arguments:
+                filter: { }
+                update: { $inc: { x : 1 }}
+        outcome:
+            result:
+                matchedCount: 2
+                modifiedCount: 2
+                upsertedCount: 0
+            collection:
+                data:
+                  - { _id: 1, x: 12 }
+                  - { _id: 2, x: 23 }


### PR DESCRIPTION
These CRUD operations are not retryable, so they should ignore
retryWrites=true in the URI and not set the txnId.