### PR TITLE
Handling for mismatched RS name should be the same as me mismatch

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -1108,6 +1108,8 @@ updateRSWithPrimaryFromMember
     # SetName is never null here.
     if topologyDescription.setName != description.setName:
         remove this server from topologyDescription and stop monitoring it
+        checkIfHasPrimary()
+        return
 
     if description.address != description.me:
         remove this server from topologyDescription and stop monitoring it


### PR DESCRIPTION
Which is to stop processing & possibly transition to no primary if affected server was a primary.