### PR TITLE
Verify max set version and max election id on topologies

### DIFF
--- a/source/server-discovery-and-monitoring/tests/rs/equal_electionids.json
+++ b/source/server-discovery-and-monitoring/tests/rs/equal_electionids.json
@@ -60,7 +60,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     }
   ]

--- a/source/server-discovery-and-monitoring/tests/rs/equal_electionids.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/equal_electionids.yml
@@ -48,6 +48,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     }
 ]

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_new_electionid.json
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_new_electionid.json
@@ -41,7 +41,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     },
     {
@@ -83,7 +87,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     },
     {
@@ -125,7 +133,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     }
   ]

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_new_electionid.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_new_electionid.yml
@@ -36,6 +36,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     },
 
@@ -71,6 +73,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     },
 
@@ -105,6 +109,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     }
 ]

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_new_setversion.json
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_new_setversion.json
@@ -41,7 +41,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     },
     {
@@ -83,7 +87,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     },
     {
@@ -125,7 +133,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     }
   ]

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_new_setversion.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_new_setversion.yml
@@ -36,6 +36,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     },
 
@@ -71,6 +73,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     },
 
@@ -105,6 +109,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     }
 ]

--- a/source/server-discovery-and-monitoring/tests/rs/null_election_id.json
+++ b/source/server-discovery-and-monitoring/tests/rs/null_election_id.json
@@ -42,7 +42,8 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1
       }
     },
     {
@@ -90,7 +91,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     },
     {
@@ -133,7 +138,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     },
     {
@@ -179,7 +188,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     }
   ]

--- a/source/server-discovery-and-monitoring/tests/rs/null_election_id.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/null_election_id.yml
@@ -40,6 +40,7 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
         }
     },
 
@@ -80,6 +81,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     },
 
@@ -118,6 +121,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     },
 
@@ -159,6 +164,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     }
 ]

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_electionid.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_electionid.json
@@ -59,7 +59,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     },
     {
@@ -84,7 +88,11 @@
         },
         "topologyType": "ReplicaSetNoPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     },
     {
@@ -123,7 +131,11 @@
         },
         "topologyType": "ReplicaSetNoPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     },
     {
@@ -165,7 +177,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000003"
+        }
       }
     },
     {
@@ -203,7 +219,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000003"
+        }
       }
     }
   ]

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_electionid.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_electionid.yml
@@ -46,6 +46,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     },
 
@@ -70,6 +72,8 @@ phases: [
             topologyType: "ReplicaSetNoPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     },
 
@@ -103,6 +107,8 @@ phases: [
             topologyType: "ReplicaSetNoPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     },
 
@@ -137,6 +143,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000003"},
         }
     },
 
@@ -169,6 +177,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000003"},
         }
     }
 ]

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_setversion.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_setversion.json
@@ -59,7 +59,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     },
     {
@@ -84,7 +88,11 @@
         },
         "topologyType": "ReplicaSetNoPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     },
     {
@@ -123,7 +131,11 @@
         },
         "topologyType": "ReplicaSetNoPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     },
     {
@@ -165,7 +177,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     },
     {
@@ -203,7 +219,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2,
+        "maxElectionId": {
+          "$oid": "000000000000000000000002"
+        }
       }
     }
   ]

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_setversion.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_setversion.yml
@@ -46,6 +46,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     },
 
@@ -70,6 +72,8 @@ phases: [
             topologyType: "ReplicaSetNoPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     },
 
@@ -103,6 +107,8 @@ phases: [
             topologyType: "ReplicaSetNoPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     },
 
@@ -137,6 +143,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     },
 
@@ -169,6 +177,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
+            maxElectionId: {"$oid": "000000000000000000000002"},
         }
     }
 ]

--- a/source/server-discovery-and-monitoring/tests/rs/setversion_without_electionid.json
+++ b/source/server-discovery-and-monitoring/tests/rs/setversion_without_electionid.json
@@ -36,7 +36,8 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2
       }
     },
     {
@@ -73,7 +74,8 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2
       }
     }
   ]

--- a/source/server-discovery-and-monitoring/tests/rs/setversion_without_electionid.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/setversion_without_electionid.yml
@@ -35,6 +35,7 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
         }
     },
 
@@ -70,6 +71,7 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
         }
     }
 ]

--- a/source/server-discovery-and-monitoring/tests/rs/use_setversion_without_electionid.json
+++ b/source/server-discovery-and-monitoring/tests/rs/use_setversion_without_electionid.json
@@ -41,7 +41,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 1,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     },
     {
@@ -77,7 +81,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     },
     {
@@ -116,7 +124,11 @@
         },
         "topologyType": "ReplicaSetWithPrimary",
         "logicalSessionTimeoutMinutes": null,
-        "setName": "rs"
+        "setName": "rs",
+        "maxSetVersion": 2,
+        "maxElectionId": {
+          "$oid": "000000000000000000000001"
+        }
       }
     }
   ]

--- a/source/server-discovery-and-monitoring/tests/rs/use_setversion_without_electionid.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/use_setversion_without_electionid.yml
@@ -36,6 +36,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 1,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     },
 
@@ -69,6 +71,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     },
 
@@ -103,6 +107,8 @@ phases: [
             topologyType: "ReplicaSetWithPrimary",
             logicalSessionTimeoutMinutes: null,
             setName: "rs",
+            maxSetVersion: 2,
+            maxElectionId: {"$oid": "000000000000000000000001"},
         }
     }
 ]


### PR DESCRIPTION
Existing specs verify set version & election id on individual servers. This PR adds verification of max of both of those on topologies.

Implemented in Ruby in https://github.com/mongodb/mongo-ruby-driver/pull/1117.