### PR TITLE
Only examine non-unknown server descriptions to determine incompatibi…

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -869,7 +869,7 @@ is replaced with the new ServerDescription.
 Checking wire protocol compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ServerDescription is incompatible if:
+A ServerDescription which is not Unknown is incompatible if:
 
 * minWireVersion > clientMaxWireVersion, or
 * maxWireVersion < clientMinWireVersion

--- a/source/server-discovery-and-monitoring/tests/rs/compatible_unknown.json
+++ b/source/server-discovery-and-monitoring/tests/rs/compatible_unknown.json
@@ -1,0 +1,39 @@
+{
+  "description": "Replica set member and an unknown server",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/rs/compatible_unknown.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/compatible_unknown.yml
@@ -1,0 +1,31 @@
+description: "Replica set member and an unknown server"
+uri: "mongodb://a,b/?replicaSet=rs"
+phases: [
+    {
+        responses: [
+                ["a:27017", {
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }],
+        ],
+        outcome: {
+            servers: {
+                "a:27017": {
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+                "b:27017": {
+                    type: "Unknown",
+                }
+            },
+            topologyType: "ReplicaSetWithPrimary",
+            setName: "rs",
+            logicalSessionTimeoutMinutes: null,
+            compatible: true
+        }
+    }
+]

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_arbiter.json
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_arbiter.json
@@ -1,0 +1,54 @@
+{
+  "description": "Incompatible arbiter",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "arbiterOnly": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 1
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": false
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_arbiter.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_arbiter.yml
@@ -1,0 +1,32 @@
+description: "Incompatible arbiter"
+uri: "mongodb://a,b/?replicaSet=rs"
+phases:
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          ismaster: true
+          setName: "rs"
+          hosts: ["a:27017", "b:27017"]
+          minWireVersion: 0
+          maxWireVersion: 6
+      -
+        - "b:27017"
+        - ok: 1
+          arbiterOnly: true
+          setName: "rs"
+          hosts: ["a:27017", "b:27017"]
+          minWireVersion: 0
+          maxWireVersion: 1
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSPrimary"
+          setName: "rs"
+        "b:27017":
+          type: "RSArbiter"
+          setName: "rs"
+      topologyType: "ReplicaSetWithPrimary"
+      setName: "rs"
+      logicalSessionTimeoutMinutes: ~
+      compatible: false

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.json
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.json
@@ -1,5 +1,5 @@
 {
-  "description": "Compatible topology with incompatible ghost",
+  "description": "Incompatible ghost",
   "uri": "mongodb://a,b/?replicaSet=rs",
   "phases": [
     {

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.json
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.json
@@ -1,0 +1,54 @@
+{
+  "description": "Compatible topology with incompatible ghost",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "isreplicaset": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 1
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSGhost",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": false
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.yml
@@ -1,4 +1,4 @@
-description: "Compatible topology with incompatible ghost"
+description: "Incompatible ghost"
 uri: "mongodb://a,b/?replicaSet=rs"
 phases:
   - responses:

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.yml
@@ -1,0 +1,32 @@
+description: "Compatible topology with incompatible ghost"
+uri: "mongodb://a,b/?replicaSet=rs"
+phases:
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          ismaster: true
+          setName: "rs"
+          hosts: ["a:27017", "b:27017"]
+          minWireVersion: 0
+          maxWireVersion: 6
+      -
+        - "b:27017"
+        - ok: 1
+          isreplicaset: true
+          setName: "rs"
+          hosts: ["a:27017", "b:27017"]
+          minWireVersion: 0
+          maxWireVersion: 1
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSPrimary"
+          setName: "rs"
+        "b:27017":
+          type: "RSGhost"
+          setName: "rs"
+      topologyType: "ReplicaSetWithPrimary"
+      setName: "rs"
+      logicalSessionTimeoutMinutes: ~
+      compatible: false

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_other.json
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_other.json
@@ -1,5 +1,5 @@
 {
-  "description": "Compatible topology with incompatible other",
+  "description": "Incompatible other",
   "uri": "mongodb://a,b/?replicaSet=rs",
   "phases": [
     {

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_other.json
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_other.json
@@ -1,0 +1,54 @@
+{
+  "description": "Compatible topology with incompatible other",
+  "uri": "mongodb://a,b/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "hidden": true,
+            "setName": "rs",
+            "hosts": [
+              "a:27017",
+              "b:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 1
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": false
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_other.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_other.yml
@@ -1,4 +1,4 @@
-description: "Compatible topology with incompatible other"
+description: "Incompatible other"
 uri: "mongodb://a,b/?replicaSet=rs"
 phases:
   - responses:

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_other.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_other.yml
@@ -1,0 +1,32 @@
+description: "Compatible topology with incompatible other"
+uri: "mongodb://a,b/?replicaSet=rs"
+phases:
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          ismaster: true
+          setName: "rs"
+          hosts: ["a:27017", "b:27017"]
+          minWireVersion: 0
+          maxWireVersion: 6
+      -
+        - "b:27017"
+        - ok: 1
+          hidden: true
+          setName: "rs"
+          hosts: ["a:27017", "b:27017"]
+          minWireVersion: 0
+          maxWireVersion: 1
+    outcome:
+      servers:
+        "a:27017":
+          type: "RSPrimary"
+          setName: "rs"
+        "b:27017":
+          type: "RSOther"
+          setName: "rs"
+      topologyType: "ReplicaSetWithPrimary"
+      setName: "rs"
+      logicalSessionTimeoutMinutes: ~
+      compatible: false


### PR DESCRIPTION
…lity

Without this, a replica set topology where the client received a response from primary and is waiting for a response from secondary is considered incompatible, since the secondary's wire version is taken to be 0.

https://jira.mongodb.org/browse/RUBY-1583