### PR TITLE
SPEC-1140 Support mongos pinning for sharded transactions

### DIFF
--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -78,6 +78,12 @@ This specification does not apply to OP_GET_MORE or OP_KILL_CURSORS
 operations on cursors, which need to go to the same server that received an
 OP_QUERY and returned a cursor ID.
 
+For operations that are part of a sharded transaction this specification only
+applies to the initial operation which starts the transaction on a mongos. This
+specification does not apply to subsequent operations that are part of the
+sharded transaction because all operations in a sharded transaction need to go
+to the same mongos server.
+
 Drivers and mongos MUST conform to the semantics of this document, but SHOULD
 use language-appropriate data models or variable names.
 
@@ -1310,6 +1316,14 @@ Cursor operations OP_GET_MORE and OP_KILL_CURSOR do not go through the server
 selection process.  Cursor operations must be sent to the original server that
 received the query and sent the OP_REPLY.  For exhaust cursors, the same socket
 must be used for OP_GET_MORE until the cursor is exhausted.
+
+Sharded Transactions
+--------------------
+
+Operations that are part of a sharded transaction (after the initial command)
+do not go through the server selection process. Sharded transaction operations
+MUST be sent to the original mongos server on which the transaction was
+started.
 
 The 'text' command and mongos
 -----------------------------

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -157,6 +157,7 @@ Load each YAML (or JSON) file using a Canonical Extended JSON parser.
 
 Then for each element in ``tests``:
 
+#. If the``skipReason`` field is present, skip this test completely.
 #. Create a MongoClient and call
    ``client.admin.runCommand({killAllSessions: []})`` to clean up any open
    transactions from previous test failures.

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -159,13 +159,36 @@ Then for each element in ``tests``:
 
 #. Create a MongoClient and call
    ``client.admin.runCommand({killAllSessions: []})`` to clean up any open
-   transactions from previous test failures. The command will fail with message
-   "operation was interrupted", because it kills its own implicit session. Catch
-   the exception and continue.
+   transactions from previous test failures.
+
+   To workaround `SERVER-38335`_, ensure this command does not send
+   an implicit session, otherwise the command will fail with an
+   "operation was interrupted" error because it kills itself and (on a sharded
+   cluster) future commands may fail with:
+   "Encountered error from localhost:27217 during a transaction :: caused by :: operation was interrupted".
+
+   If your driver cannot run this command without an implicit session, then
+   either skip this step and live with the fact that previous test failures
+   may cause later tests to fail or use the `killAllSessionsByPattern` command
+   instead. During each test record all session ids sent to the server and at
+   the end of each test kill all the sessions ids (using a different session):
+
+   .. code:: python
+
+      # Be sure to use a distinct session to avoid "operation was interrupted".
+      session_for_cleanup = client.start_session()
+      recorded_session_uuids = []
+      # Run test case and record session uuids...
+      client.admin.runCommand({
+          'killAllSessionsByPattern': [
+              {'lsid': {'id': uuid}} for uuid in recorded_session_uuids]},
+          session=session_for_cleanup)
 
    - When testing against a sharded cluster, create a list of MongoClients that
-     are directly connected to each mongos. Run the killAllSessions command on
-     ALL mongoses.
+     are directly connected to each mongos. Run the `killAllSessions`
+     (or `killAllSessionsByPattern`) command on ALL mongoses.
+
+   .. _SERVER-38335: https://jira.mongodb.org/browse/SERVER-38335
 
 #. Create a collection object from the MongoClient, using the ``database_name``
    and ``collection_name`` fields of the YAML file.
@@ -315,7 +338,7 @@ instead.
         with client.start_session() as s:
           # Session is pinned to Mongos.
           with s.start_transaction():
-              client.test.test.insert_one({}, session=s)
+            client.test.test.insert_one({}, session=s)
 
           addresses = set()
           for _ in range(20):
@@ -338,7 +361,7 @@ instead.
         with client.start_session() as s:
           # Session is pinned to Mongos.
           with s.start_transaction():
-              client.test.test.insert_one({}, session=s)
+            client.test.test.insert_one({}, session=s)
 
           addresses = set()
           for _ in range(20):

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -149,7 +149,7 @@ ensure that no new bugs have been introduced related to arbiters.)
 
 A driver that implements support for sharded transactions MUST also run these
 tests against a MongoDB sharded cluster with multiple mongoses and
-**server version 4.1.5 or later**. Including multiple mongoses (and
+**server version 4.1.6 or later**. Including multiple mongoses (and
 initializing the MongoClient with multiple mongos seeds!) ensures that
 mongos transaction pinning works properly.
 
@@ -164,7 +164,7 @@ Then for each element in ``tests``:
    To workaround `SERVER-38335`_, ensure this command does not send
    an implicit session, otherwise the command will fail with an
    "operation was interrupted" error because it kills itself and (on a sharded
-   cluster) future commands may fail with:
+   cluster) future commands may fail with an error similar to:
    "Encountered error from localhost:27217 during a transaction :: caused by :: operation was interrupted".
 
    If your driver cannot run this command without an implicit session, then
@@ -331,7 +331,7 @@ instead.
 
    .. code:: python
 
-      @require_server_version(4, 1, 5)
+      @require_server_version(4, 1, 6)
       @require_mongos_count_at_least(2)
       def test_unpin_for_next_transaction(self):
         client = MongoClient(mongos_hosts)
@@ -354,7 +354,7 @@ instead.
 
    .. code:: python
 
-      @require_server_version(4, 1, 5)
+      @require_server_version(4, 1, 6)
       @require_mongos_count_at_least(2)
       def test_unpin_for_non_transaction_operation(self):
         client = MongoClient(mongos_hosts)

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -162,7 +162,11 @@ Then for each element in ``tests``:
    transactions from previous test failures. The command will fail with message
    "operation was interrupted", because it kills its own implicit session. Catch
    the exception and continue.
-##. When testing against a sharded cluster run this command on ALL mongoses.
+
+  #. When testing against a sharded cluster, create a list of MongoClients that
+     are directly connected to each mongos. Run the killAllSessions command on
+     ALL mongoses.
+
 #. Create a collection object from the MongoClient, using the ``database_name``
    and ``collection_name`` fields of the YAML file.
 #. Drop the test collection, using writeConcern "majority".
@@ -173,12 +177,18 @@ Then for each element in ``tests``:
    into the test collection, using writeConcern "majority".
 #. If ``failPoint`` is specified, its value is a configureFailPoint command.
    Run the command on the admin database to enable the fail point.
-##. When testing against a sharded cluster run this command on ALL mongoses.
+
+  #. When testing against a sharded cluster run this command on ALL mongoses.
+
 #. Create a **new** MongoClient ``client``, with Command Monitoring listeners
    enabled. (Using a new MongoClient for each test ensures a fresh session pool
    that hasn't executed any transactions previously, so the tests can assert
    actual txnNumbers, starting from 1.) Pass this test's ``clientOptions`` if
    present.
+
+  #. When testing against a sharded cluster this client MUST be created with
+     multiple (valid) mongos seed addreses.
+
 #. Call ``client.startSession`` twice to create ClientSession objects
    ``session0`` and ``session1``, using the test's "sessionOptions" if they
    are present. Save their lsids so they are available after calling
@@ -235,7 +245,9 @@ Then for each element in ``tests``:
         configureFailPoint: <fail point name>,
         mode: "off"
     });
-##. When testing against a sharded cluster run this command on ALL mongoses.
+
+  #. When testing against a sharded cluster run this command on ALL mongoses.
+
 #. For each element in ``outcome``:
 
    - If ``name`` is "collection", verify that the test collection contains

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -83,6 +83,9 @@ Each YAML file has the following keys:
 
   - ``description``: The name of the test.
 
+  - ``skipReason``: Optional, string describing why this test should be
+    skipped.
+
   - ``clientOptions``: Optional, parameters to pass to MongoClient().
 
   - ``failPoint``: Optional, a server failpoint to enable expressed as the

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -143,9 +143,15 @@ Use as integration tests
 ========================
 
 Run a MongoDB replica set with a primary, a secondary, and an arbiter,
-**server version 4.0.0-rc4 or later**. (Including a secondary ensures that
+**server version 4.0.0 or later**. (Including a secondary ensures that
 server selection in a transaction works properly. Including an arbiter helps
 ensure that no new bugs have been introduced related to arbiters.)
+
+A driver that implements support for sharded transactions MUST also run these
+tests against a MongoDB sharded cluster with multiple mongoses and
+**server version 4.1.5 or later**. Including multiple mongoses (and
+initializing the MongoClient with multiple mongos seeds!) ensures that
+mongos transaction pinning works properly.
 
 Load each YAML (or JSON) file using a Canonical Extended JSON parser.
 
@@ -156,6 +162,7 @@ Then for each element in ``tests``:
    transactions from previous test failures. The command will fail with message
    "operation was interrupted", because it kills its own implicit session. Catch
    the exception and continue.
+##. When testing against a sharded cluster run this command on ALL mongoses.
 #. Create a collection object from the MongoClient, using the ``database_name``
    and ``collection_name`` fields of the YAML file.
 #. Drop the test collection, using writeConcern "majority".
@@ -166,6 +173,7 @@ Then for each element in ``tests``:
    into the test collection, using writeConcern "majority".
 #. If ``failPoint`` is specified, its value is a configureFailPoint command.
    Run the command on the admin database to enable the fail point.
+##. When testing against a sharded cluster run this command on ALL mongoses.
 #. Create a **new** MongoClient ``client``, with Command Monitoring listeners
    enabled. (Using a new MongoClient for each test ensures a fresh session pool
    that hasn't executed any transactions previously, so the tests can assert
@@ -227,7 +235,7 @@ Then for each element in ``tests``:
         configureFailPoint: <fail point name>,
         mode: "off"
     });
-
+##. When testing against a sharded cluster run this command on ALL mongoses.
 #. For each element in ``outcome``:
 
    - If ``name`` is "collection", verify that the test collection contains

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -163,7 +163,7 @@ Then for each element in ``tests``:
    "operation was interrupted", because it kills its own implicit session. Catch
    the exception and continue.
 
-  #. When testing against a sharded cluster, create a list of MongoClients that
+   - When testing against a sharded cluster, create a list of MongoClients that
      are directly connected to each mongos. Run the killAllSessions command on
      ALL mongoses.
 
@@ -178,7 +178,7 @@ Then for each element in ``tests``:
 #. If ``failPoint`` is specified, its value is a configureFailPoint command.
    Run the command on the admin database to enable the fail point.
 
-  #. When testing against a sharded cluster run this command on ALL mongoses.
+   - When testing against a sharded cluster run this command on ALL mongoses.
 
 #. Create a **new** MongoClient ``client``, with Command Monitoring listeners
    enabled. (Using a new MongoClient for each test ensures a fresh session pool
@@ -186,7 +186,7 @@ Then for each element in ``tests``:
    actual txnNumbers, starting from 1.) Pass this test's ``clientOptions`` if
    present.
 
-  #. When testing against a sharded cluster this client MUST be created with
+   - When testing against a sharded cluster this client MUST be created with
      multiple (valid) mongos seed addreses.
 
 #. Call ``client.startSession`` twice to create ClientSession objects
@@ -246,7 +246,7 @@ Then for each element in ``tests``:
         mode: "off"
     });
 
-  #. When testing against a sharded cluster run this command on ALL mongoses.
+   - When testing against a sharded cluster run this command on ALL mongoses.
 
 #. For each element in ``outcome``:
 

--- a/source/transactions/tests/commit.json
+++ b/source/transactions/tests/commit.json
@@ -350,6 +350,7 @@
     },
     {
       "description": "write concern error on commit",
+      "skipReason": "SERVER-37458 Mongos does not yet support writeConcern on commit",
       "operations": [
         {
           "name": "startTransaction",

--- a/source/transactions/tests/commit.yml
+++ b/source/transactions/tests/commit.yml
@@ -225,7 +225,7 @@ tests:
           - _id: 1
 
   - description: write concern error on commit
-
+    skipReason: "SERVER-37458 Mongos does not yet support writeConcern on commit"
     operations:
       - name: startTransaction
         object: session0

--- a/source/transactions/tests/pin-mongos.json
+++ b/source/transactions/tests/pin-mongos.json
@@ -1,0 +1,546 @@
+{
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [
+    {
+      "_id": 1
+    },
+    {
+      "_id": 2
+    }
+  ],
+  "tests": [
+    {
+      "description": "countDocuments",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "distinct",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "_id",
+            "session": "session0"
+          },
+          "result": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "_id",
+            "session": "session0"
+          },
+          "result": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "_id",
+            "session": "session0"
+          },
+          "result": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "_id",
+            "session": "session0"
+          },
+          "result": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "_id",
+            "session": "session0"
+          },
+          "result": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "_id",
+            "session": "session0"
+          },
+          "result": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "_id",
+            "session": "session0"
+          },
+          "result": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "_id",
+            "session": "session0"
+          },
+          "result": [
+            1,
+            2
+          ]
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "find",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 2
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 2
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 2
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 2
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 2
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 2
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 2
+            }
+          ]
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": [
+            {
+              "_id": 2
+            }
+          ]
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "insertOne",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 3
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 4
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 4
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 5
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 5
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 6
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 6
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 7
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 7
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 8
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 8
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 9
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 9
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 10
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 10
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            },
+            {
+              "_id": 7
+            },
+            {
+              "_id": 8
+            },
+            {
+              "_id": 9
+            },
+            {
+              "_id": 10
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/transactions/tests/pin-mongos.json
+++ b/source/transactions/tests/pin-mongos.json
@@ -541,6 +541,254 @@
           ]
         }
       }
+    },
+    {
+      "description": "mixed read write operations",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 3
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 3
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 3
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 3
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 3
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 3
+            },
+            "session": "session0"
+          },
+          "result": 1
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 4
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 4
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 5
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 5
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 6
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 6
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 7
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 7
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            },
+            {
+              "_id": 7
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "multiple commits",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ],
+            "session": "session0"
+          },
+          "result": {
+            "insertedIds": {
+              "0": 3,
+              "1": 4
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/transactions/tests/pin-mongos.yml
+++ b/source/transactions/tests/pin-mongos.yml
@@ -1,0 +1,177 @@
+# Test that all the operations go to the same mongos.
+#
+# The assertion is implicit: that all the read operations succeed,
+# as if the driver does not properly pin to a mongos then one of them
+# will eventually be sent to a different server, which is unaware of the
+# transaction, and it will report an error.
+#
+# This test doesn't check contents of command-started events.
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+data: &data
+  - {_id: 1}
+  - {_id: 2}
+
+tests:
+  - description: countDocuments
+    operations:
+      - name: startTransaction
+        object: session0
+      - &countDocuments
+        name: countDocuments
+        object: collection
+        arguments:
+          filter:
+            _id: 2
+          session: session0
+        result: 1
+      - *countDocuments
+      - *countDocuments
+      - *countDocuments
+      - *countDocuments
+      - *countDocuments
+      - *countDocuments
+      - *countDocuments
+      - name: commitTransaction
+        object: session0
+
+    outcome:
+      collection:
+        data: *data
+
+  - description: distinct
+    operations:
+      - name: startTransaction
+        object: session0
+      - &distinct
+        name: distinct
+        object: collection
+        arguments:
+          fieldName: _id
+          session: session0
+        result: [1, 2]
+      - *distinct
+      - *distinct
+      - *distinct
+      - *distinct
+      - *distinct
+      - *distinct
+      - *distinct
+      - name: commitTransaction
+        object: session0
+
+    outcome:
+      collection:
+        data: *data
+
+  - description: find
+    operations:
+      - name: startTransaction
+        object: session0
+      - &find
+        name: find
+        object: collection
+        arguments:
+          filter:
+            _id: 2
+          session: session0
+        result:
+          - {_id: 2}
+      - *find
+      - *find
+      - *find
+      - *find
+      - *find
+      - *find
+      - *find
+      - name: commitTransaction
+        object: session0
+
+    outcome:
+      collection:
+        data: *data
+
+  - description: insertOne
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 3
+          session: session0
+        result:
+          insertedId: 3
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 4
+          session: session0
+        result:
+          insertedId: 4
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 5
+          session: session0
+        result:
+          insertedId: 5
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 6
+          session: session0
+        result:
+          insertedId: 6
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 7
+          session: session0
+        result:
+          insertedId: 7
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 8
+          session: session0
+        result:
+          insertedId: 8
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 9
+          session: session0
+        result:
+          insertedId: 9
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 10
+          session: session0
+        result:
+          insertedId: 10
+      - name: commitTransaction
+        object: session0
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+          - {_id: 3}
+          - {_id: 4}
+          - {_id: 5}
+          - {_id: 6}
+          - {_id: 7}
+          - {_id: 8}
+          - {_id: 9}
+          - {_id: 10}

--- a/source/transactions/tests/pin-mongos.yml
+++ b/source/transactions/tests/pin-mongos.yml
@@ -1,9 +1,17 @@
 # Test that all the operations go to the same mongos.
 #
-# The assertion is implicit: that all the read operations succeed,
-# as if the driver does not properly pin to a mongos then one of them
-# will eventually be sent to a different server, which is unaware of the
-# transaction, and it will report an error.
+# The assertion is implicit: that all the read operations succeed.
+# If the driver does not properly pin to a single mongos then one of the
+# operations in a transaction will eventually be sent to a different mongos,
+# which is unaware of the transaction, and the mongos will return a command
+# error. An example of such an error is:
+# {
+#   'ok': 0.0,
+#   'errmsg': 'cannot continue txnId -1 for session 28938f50-9d29-4ca5-8de5-ddaf261267c4 - 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU= with txnId 1',
+#   'code': 251,
+#   'codeName': 'NoSuchTransaction',
+#   'errorLabels': ['TransientTransactionError']
+# }
 #
 # This test doesn't check contents of command-started events.
 # Note: these tests should also pass when run against a replica set.

--- a/source/transactions/tests/pin-mongos.yml
+++ b/source/transactions/tests/pin-mongos.yml
@@ -6,6 +6,7 @@
 # transaction, and it will report an error.
 #
 # This test doesn't check contents of command-started events.
+# Note: these tests should also pass when run against a replica set.
 database_name: &database_name "transaction-tests"
 collection_name: &collection_name "test"
 data: &data
@@ -175,3 +176,115 @@ tests:
           - {_id: 8}
           - {_id: 9}
           - {_id: 10}
+
+  - description: mixed read write operations
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 3
+          session: session0
+        result:
+          insertedId: 3
+      - &countDocuments
+        name: countDocuments
+        object: collection
+        arguments:
+          filter:
+            _id: 3
+          session: session0
+        result: 1
+      - *countDocuments
+      - *countDocuments
+      - *countDocuments
+      - *countDocuments
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 4
+          session: session0
+        result:
+          insertedId: 4
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 5
+          session: session0
+        result:
+          insertedId: 5
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 6
+          session: session0
+        result:
+          insertedId: 6
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 7
+          session: session0
+        result:
+          insertedId: 7
+      - name: commitTransaction
+        object: session0
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+          - {_id: 3}
+          - {_id: 4}
+          - {_id: 5}
+          - {_id: 6}
+          - {_id: 7}
+
+  - description: multiple commits
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertMany
+        object: collection
+        arguments:
+          documents:
+            - _id: 3
+            - _id: 4
+          session: session0
+        result:
+          insertedIds: {0: 3, 1: 4}
+      - name: commitTransaction
+        object: session0
+      - name: commitTransaction
+        object: session0
+      - name: commitTransaction
+        object: session0
+      - name: commitTransaction
+        object: session0
+      - name: commitTransaction
+        object: session0
+      - name: commitTransaction
+        object: session0
+      - name: commitTransaction
+        object: session0
+      - name: commitTransaction
+        object: session0
+      - name: commitTransaction
+        object: session0
+      - name: commitTransaction
+        object: session0
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+          - {_id: 3}
+          - {_id: 4}

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -147,7 +147,7 @@
       "description": "transaction options inherited from client",
       "clientOptions": {
         "w": 1,
-        "readConcernLevel": "majority"
+        "readConcernLevel": "local"
       },
       "operations": [
         {
@@ -211,7 +211,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "majority"
+                "level": "local"
               },
               "writeConcern": null
             },
@@ -255,7 +255,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "majority",
+                "level": "local",
                 "afterClusterTime": 42
               },
               "writeConcern": null
@@ -800,7 +800,7 @@
       }
     },
     {
-      "description": "readConcern majority in defaultTransactionOptions",
+      "description": "readConcern local in defaultTransactionOptions",
       "clientOptions": {
         "w": 1
       },
@@ -808,7 +808,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "majority"
+              "level": "local"
             }
           }
         }
@@ -875,7 +875,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "majority"
+                "level": "local"
               },
               "writeConcern": null
             },
@@ -919,7 +919,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "majority",
+                "level": "local",
                 "afterClusterTime": 42
               },
               "writeConcern": null

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -147,7 +147,7 @@
       "description": "transaction options inherited from client",
       "clientOptions": {
         "w": 1,
-        "readConcernLevel": "local"
+        "readConcernLevel": "majority"
       },
       "operations": [
         {
@@ -211,7 +211,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "local"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -255,7 +255,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "local",
+                "level": "majority",
                 "afterClusterTime": 42
               },
               "writeConcern": null
@@ -800,7 +800,7 @@
       }
     },
     {
-      "description": "readConcern local in defaultTransactionOptions",
+      "description": "readConcern majority in defaultTransactionOptions",
       "clientOptions": {
         "w": 1
       },
@@ -808,7 +808,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "local"
+              "level": "majority"
             }
           }
         }
@@ -875,7 +875,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "local"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -919,7 +919,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "local",
+                "level": "majority",
                 "afterClusterTime": 42
               },
               "writeConcern": null
@@ -959,7 +959,7 @@
       }
     },
     {
-      "description": "readConcern local in startTransaction options",
+      "description": "readConcern snapshot in startTransaction options",
       "sessionOptions": {
         "session0": {
           "defaultTransactionOptions": {

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -99,7 +99,7 @@ tests:
 
     clientOptions:
       w: 1
-      readConcernLevel: local
+      readConcernLevel: majority
 
     operations: *commitAbortOperations
 
@@ -116,7 +116,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: local
+              level: majority
             writeConcern:
           command_name: insert
           database_name: *database_name
@@ -145,7 +145,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: local
+              level: majority
               afterClusterTime: 42
             writeConcern:
           command_name: insert
@@ -435,7 +435,7 @@ tests:
 
     outcome: *outcome
 
-  - description: readConcern local in defaultTransactionOptions
+  - description: readConcern majority in defaultTransactionOptions
 
     clientOptions:
       w: 1
@@ -444,7 +444,7 @@ tests:
       session0:
         defaultTransactionOptions:
           readConcern:
-            level: local
+            level: majority
 
     operations: *commitAbortOperations
 
@@ -461,7 +461,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: local
+              level: majority
             writeConcern:
           command_name: insert
           database_name: *database_name
@@ -490,7 +490,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: local
+              level: majority
               afterClusterTime: 42
             writeConcern:
           command_name: insert
@@ -511,7 +511,7 @@ tests:
 
     outcome: *outcome
 
-  - description: readConcern local in startTransaction options
+  - description: readConcern snapshot in startTransaction options
 
     sessionOptions:
       session0:

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -99,7 +99,7 @@ tests:
 
     clientOptions:
       w: 1
-      readConcernLevel: majority
+      readConcernLevel: local
 
     operations: *commitAbortOperations
 
@@ -116,7 +116,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: majority
+              level: local
             writeConcern:
           command_name: insert
           database_name: *database_name
@@ -145,7 +145,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: majority
+              level: local
               afterClusterTime: 42
             writeConcern:
           command_name: insert
@@ -435,7 +435,7 @@ tests:
 
     outcome: *outcome
 
-  - description: readConcern majority in defaultTransactionOptions
+  - description: readConcern local in defaultTransactionOptions
 
     clientOptions:
       w: 1
@@ -444,7 +444,7 @@ tests:
       session0:
         defaultTransactionOptions:
           readConcern:
-            level: majority
+            level: local
 
     operations: *commitAbortOperations
 
@@ -461,7 +461,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: majority
+              level: local
             writeConcern:
           command_name: insert
           database_name: *database_name
@@ -490,7 +490,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: majority
+              level: local
               afterClusterTime: 42
             writeConcern:
           command_name: insert

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -346,7 +346,7 @@ transactions are not supported by the deployment. A deployment does not
 support transactions when the deployment does not support sessions, or
 maxWireVersion < 7, or the maxWireVersion < 8 and the topology type is Sharded,
 see `How to Check Whether a Deployment Supports Sessions
- <https://github.com/mongodb/specifications/blob/master/source/sessions driver-sessions.rst#how-to-check-whether-a-deployment-supports-sessions>`_.
+ <https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst#how-to-check-whether-a-deployment-supports-sessions>`_.
 Note that checking the maxWireVersion does not guarantee that the
 deployment supports transactions, for example a MongoDB 4.0 replica set
 using MMAPv1 will report maxWireVersion 7 but does not support

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -746,6 +746,11 @@ send all commands that are part of the same transaction, including
 commitTransaction and abortTransaction and any retries thereof, to the
 same mongos.
 
+Starting a new transaction on a pinned ClientSession MUST unpin the
+session. Additionally, any non-transaction operation using a pinned
+ClientSession MUST unpin the session and the operation MUST perform normal
+server selection.
+
 Error Reporting and Retrying Transactions
 -----------------------------------------
 

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -3,7 +3,7 @@ Driver Transactions Specification
 =================================
 
 :Spec Title: Driver Transactions Specification
-:Spec Version: 1.1
+:Spec Version: 1.2
 :Author: Shane Harvey
 :Spec Lead: A\. Jesse Jiryu Davis
 :Advisory Group: A\. Jesse Jiryu Davis, Matt Broadstone, Robert Stam, Jeff Yemin, Spencer Brody
@@ -344,9 +344,9 @@ progress" state, then Drivers MUST raise an error containing the message
 startTransaction SHOULD report an error if the driver can detect that
 transactions are not supported by the deployment. A deployment does not
 support transactions when the deployment does not support sessions, or
-maxWireVersion < 7, or the topology type is Sharded, see `How to Check
-Whether a Deployment Supports
-Sessions <https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst#how-to-check-whether-a-deployment-supports-sessions>`__.
+maxWireVersion < 7, or the maxWireVersion < 8 and the topology type is Sharded,
+see `How to Check Whether a Deployment Supports Sessions
+ <https://github.com/mongodb/specifications/blob/master/source/sessions driver-sessions.rst#how-to-check-whether-a-deployment-supports-sessions>`_.
 Note that checking the maxWireVersion does not guarantee that the
 deployment supports transactions, for example a MongoDB 4.0 replica set
 using MMAPv1 will report maxWireVersion 7 but does not support
@@ -732,6 +732,19 @@ format:
 .. code:: typescript
 
     { ok : 1, writeConcernError: {code: <Number>, errmsg : "..."} }
+
+Mongos Pinning for Sharded Transactions
+---------------------------------------
+
+The server supports sharded transactions starting in MongoDB 4.2 (
+maxWireVersion 8). The server requires that drivers MUST send all commands for
+a single transaction to the same mongos.
+
+After the driver selects a mongos for the first command within a transaction,
+the driver MUST pin the ClientSession to the selected mongos. Drivers MUST
+send all commands that are part of the same transaction, including
+commitTransaction and abortTransaction and any retries thereof, to the
+same mongos.
 
 Error Reporting and Retrying Transactions
 -----------------------------------------
@@ -1198,6 +1211,7 @@ Applications should not run such commands inside a transaction.
 **Changelog**
 -------------
 
+:2018-11-13: Add mongos pinning to support sharded transaction.
 :2018-06-18: Explicit readConcern and/or writeConcern are prohibited within
              transactions, with a client-side error.
 :2018-06-07: The count command is not supported within transactions.


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/SPEC-1140

This change adds the "Mongos Pinning for Sharded Transactions" section to the transactions spec and updates the tests for 4.2 sharded transactions.

I have run the tests against a 4.1.6 sharded cluster with two mongoses, see [PYTHON-1673](https://jira.mongodb.org/browse/PYTHON-1673).

Some open questions:
- [X] Done added two prose tests for unpinning: A buggy driver could still satisfy these spec tests by always selecting a single mongos for all operations on a session -- regardless if those operations are part of a transaction or not. Is it possible to test that drivers un-pinn a session properly? Eg:
  ```python
  with client.start_session() as s:
    # All operations in this block use the same mongos.
    with s.start_transaction():
      client.test.test.insert_one({}, session=s) 
      client.test.test.find_one({}, session=s)
    # Can we test that this next operation is not pinned to the previous mongos?
    doc = client.test.test.find_one({}, session=s)
  ```
- [X] Done updated the server selection spec: Should we update the server selection spec to mention that sharded transactions do not go through the normal server selection process? Similar to cursors: https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#cursors
- [X] Done: Should we specify what happens the pinned mongos becomes unavailable? Does any spec cover the same for cursors? 