### PR TITLE
SPEC-1179 Transaction tests require local read concern for final find

### DIFF
--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -228,9 +228,10 @@ Then for each element in ``tests``:
 #. For each element in ``outcome``:
 
    - If ``name`` is "collection", verify that the test collection contains
-     exactly the documents in the ``data`` array. Ensure this find uses
-     Primary read preference even when the MongoClient is configured with
-     another read preference.
+     exactly the documents in the ``data`` array. Ensure this find reads the
+     latest data by using **primary read preference** with
+     **local read concern** even when the MongoClient is configured with
+     another read preference or read concern.
 
 Command-Started Events
 ``````````````````````


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/SPEC-1179
Discovered and fixed in PyMongo: https://jira.mongodb.org/browse/PYTHON-1691

We must use "local" to ensure we read our own writes even when a test runs a write with w=1 and the find would otherwise be run with "majority" read concern.