### PR TITLE
SPEC-1170: SDAM monitoring multi phase testing

### DIFF
--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -25,7 +25,9 @@ Each YAML file has the following keys:
 
 Each phase object has two keys:
 
-- responses: An array of "response" objects.
+- responses: (optional) An array of "response" objects. If not provided,
+  the test runner should construct the client and perform assertions specified
+  in the outcome object without processing any responses.
 - outcome: An "outcome" object representing the TopologyDescription.
 
 A response is a pair of values:

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -17,12 +17,13 @@ Format
 
 Each YAML file has the following keys:
 
-- description: Some text.
+- description: A textual description of the test.
 - uri: A connection string.
 - phases: An array of "phase" objects.
+  A phase of the test optionally sends inputs to the client,
+  then tests the client's resulting TopologyDescription.
 
-A "phase" of the test sends inputs to the client, then tests the client's
-resulting TopologyDescription. Each phase object has two keys:
+Each phase object has two keys:
 
 - responses: An array of "response" objects.
 - outcome: An "outcome" object representing the TopologyDescription.
@@ -37,8 +38,9 @@ A response is a pair of values:
   The empty response `{}` indicates a network error
   when attempting to call "ismaster".
 
-An "outcome" represents the correct TopologyDescription that results from
-processing the responses in the phases so far. It has the following keys:
+In non-monitoring tests, an "outcome" represents the correct
+TopologyDescription that results from processing the responses in the phases
+so far. It has the following keys:
 
 - topologyType: A string like "ReplicaSetNoPrimary".
 - setName: A string with the expected replica set name, or null.
@@ -59,6 +61,16 @@ current TopologyDescription. It has the following keys:
 - logicalSessionTimeoutMinutes: absent, null, or an integer.
 - minWireVersion: absent or an integer.
 - maxWireVersion: absent or an integer.
+
+In monitoring tests, an "outcome" contains a list of SDAM events that should
+have been published by the client as a result of processing ismaster responses
+in the current phase. Any SDAM events published by the client during its
+construction (that is, prior to processing any of the responses) should be
+combined with the events published during processing of ismaster responses
+of the first phase of the test. A test MAY explicitly verify events published
+during client construction by providing an empty responses array for the
+first phase.
+
 
 Use as unittests
 ----------------
@@ -93,6 +105,9 @@ Set the client's initial TopologyType to ReplicaSetNoPrimary.
 (For most clients, parsing a connection string with a "replicaSet" option
 automatically sets the TopologyType to ReplicaSetNoPrimary.)
 
+Set up a listener to collect SDAM events published by the client, including
+events published during client construction.
+
 Test Phases
 ~~~~~~~~~~~
 
@@ -100,12 +115,19 @@ For each phase in the file, parse the "responses" array.
 Pass in the responses in order to the driver code.
 If a response is the empty object `{}`, simulate a network error.
 
-Once all responses are processed, assert that the phase's "outcome" object
+For non-monitoring tests,
+once all responses are processed, assert that the phase's "outcome" object
 is equivalent to the driver's current TopologyDescription.
+
+For monitoring tests, once all responses are processed, assert that the
+events collected so far by the SDAM event listener are equivalent to the
+events specified in the phase.
 
 Some fields such as "logicalSessionTimeoutMinutes" or "compatible" were added
 later and haven't been added to all test files. If these fields are present,
 test that they are equivalent to the fields of the driver's current
 TopologyDescription.
+
+For monitoring tests, clear the list of events collected so far.
 
 Continue until all phases have been executed.

--- a/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_removal.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_removal.json
@@ -3,30 +3,7 @@
   "uri": "mongodb://a,b/",
   "phases": [
     {
-      "responses": [
-        [
-          "a:27017",
-          {
-            "ok": 1,
-            "ismaster": true,
-            "setName": "rs",
-            "setVersion": 1,
-            "primary": "a:27017",
-            "hosts": [
-              "a:27017"
-            ],
-            "minWireVersion": 0,
-            "maxWireVersion": 4
-          }
-        ],
-        [
-          "b:27017",
-          {
-            "ok": 1,
-            "ismaster": true
-          }
-        ]
-      ],
+      "responses": [],
       "outcome": {
         "events": [
           {
@@ -73,7 +50,37 @@
               "topologyId": "42",
               "address": "b:27017"
             }
-          },
+          }
+        ]
+      }
+    },
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "setName": "rs",
+            "setVersion": 1,
+            "primary": "a:27017",
+            "hosts": [
+              "a:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 4
+          }
+        ],
+        [
+          "b:27017",
+          {
+            "ok": 1,
+            "ismaster": true
+          }
+        ]
+      ],
+      "outcome": {
+        "events": [
           {
             "server_description_changed_event": {
               "topologyId": "42",

--- a/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_removal.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_removal.yml
@@ -2,22 +2,7 @@ description: "Monitoring a replica set with non member"
 uri: "mongodb://a,b/"
 phases:
   -
-    responses:
-      -
-        - "a:27017"
-        - {
-            ok: 1,
-            ismaster: true,
-            setName: "rs",
-            setVersion: 1.0,
-            primary: "a:27017",
-            hosts: [ "a:27017" ],
-            minWireVersion: 0,
-            maxWireVersion: 4
-          }
-      -
-        - "b:27017"
-        - { ok: 1, ismaster: true }
+    responses: []
     outcome:
       events:
         -
@@ -52,6 +37,25 @@ phases:
           server_opening_event:
             topologyId: "42"
             address: "b:27017"
+  -
+    responses:
+      -
+        - "a:27017"
+        - {
+            ok: 1,
+            ismaster: true,
+            setName: "rs",
+            setVersion: 1.0,
+            primary: "a:27017",
+            hosts: [ "a:27017" ],
+            minWireVersion: 0,
+            maxWireVersion: 4
+          }
+      -
+        - "b:27017"
+        - { ok: 1, ismaster: true }
+    outcome:
+      events:
         -
           server_description_changed_event:
             topologyId: "42"


### PR DESCRIPTION
Background: currently, there are tests for SDAM state transitions ("sdam") and some of the events generated by SDAM flow ("sdam monitoring"), but there are areas not covered by the existing monitoring tests, specifically:

- server removal/server close events
- some situations when the first response is not from primary
- multiple servers responding

The existing "sdam" tests cover topology outcomes in most of these cases, but those tests do not specify the order in which events should be published (or event contents, but this is a minor point).

Therefore, #410 proposes to add a number of "sdam monitoring" tests to formalize the order of sdam events being published in various situations.

In order for the new tests to be possible, a change in spec runner is necessary which is to perform assertions on events generated during cluster/topology construction prior to any responses being received from any of the servers. This PR is extracted from #410 and contains the readme change explaining how to handle the first phase consisting of assertions only without any responses, as well as a sample test broken up into two phases. The sample test illustrates having a dedicated phase for events published during client construction prior to processing any sdam responses.