### PR TITLE
Move error field under operations (like result)

### DIFF
--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -92,8 +92,8 @@ Each YAML file has the following keys:
       field may be a scalar (e.g. in the case of a count), a single document, or
       an array of documents in the case of a multi-document read.
       
-  - ``error``: Optional. If ``true``, the test should expect an error or
-    exception.
+    - ``error``: Optional. If ``true``, the test should expect an error or
+      exception.
         
   - ``expectations``: Optional list of command-started events.
 


### PR DESCRIPTION
@vincentkam: I think this was an oversight in #431. The tests have `error` as a child of `operations`, but the README file showed it one level up (sibling of `operations` and `expectations`).