### PR TITLE
SPEC-1161 do not inherit read concern in transaction options test

### DIFF
--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -210,9 +210,6 @@
               },
               "startTransaction": true,
               "autocommit": false,
-              "readConcern": {
-                "level": "local"
-              },
               "writeConcern": null
             },
             "command_name": "insert",
@@ -255,7 +252,6 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "local",
                 "afterClusterTime": 42
               },
               "writeConcern": null

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -115,8 +115,6 @@ tests:
               $numberLong: "1"
             startTransaction: true
             autocommit: false
-            readConcern:
-              level: local
             writeConcern:
           command_name: insert
           database_name: *database_name
@@ -145,7 +143,6 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: local
               afterClusterTime: 42
             writeConcern:
           command_name: insert


### PR DESCRIPTION
cf7248b2574b1a5397a6e18362acfe66f2b55a43 prohibited inheriting read
concern from client when starting a transaction, however this test
attempts to inherit the read concern in this way.