### PR TITLE
SPEC-1197: Remove skip in withTransaction test

### DIFF
--- a/source/transactions-convenient-api/tests/commit-writeconcernerror.json
+++ b/source/transactions-convenient-api/tests/commit-writeconcernerror.json
@@ -5,7 +5,6 @@
   "tests": [
     {
       "description": "commitTransaction is not retried after WriteConcernFailed timeout error",
-      "skipReason": "SPEC-1197 Drivers should not retry commit after wtimeout error",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/source/transactions-convenient-api/tests/commit-writeconcernerror.yml
+++ b/source/transactions-convenient-api/tests/commit-writeconcernerror.yml
@@ -6,7 +6,6 @@ data: []
 tests:
   -
     description: commitTransaction is not retried after WriteConcernFailed timeout error
-    skipReason: SPEC-1197 Drivers should not retry commit after wtimeout error
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 1 }
@@ -36,7 +35,8 @@ tests:
         result:
           errorCodeName: WriteConcernFailed
           # Per transactions spec, drivers add UnknownTransactionCommitResult
-          # label for WriteConcernFailed errors
+          # label for WriteConcernFailed errors; however, neither the driver
+          # nor withTransaction() will retry the commit in this case.
           errorLabelsContain: ["UnknownTransactionCommitResult"]
           errorLabelsOmit: ["TransientTransactionError"]
     expectations:


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1197

No driver changes were needed for SPEC-1197, so this test should not be skipped.