### PR TITLE
fix(convenient-txns): don't send `closeConnection` to fail command

### DIFF
--- a/source/transactions-convenient-api/tests/commit-writeconcernerror.json
+++ b/source/transactions-convenient-api/tests/commit-writeconcernerror.json
@@ -121,7 +121,6 @@
           "failCommands": [
             "commitTransaction"
           ],
-          "closeConnection": false,
           "writeConcernError": {
             "code": 64,
             "codeName": "WriteConcernFailed",

--- a/source/transactions-convenient-api/tests/commit-writeconcernerror.yml
+++ b/source/transactions-convenient-api/tests/commit-writeconcernerror.yml
@@ -86,7 +86,8 @@ tests:
       mode: { times: 2 }
       data:
           failCommands: ["commitTransaction"]
-          closeConnection: false
+          # Can reenable the following line when SERVER-39292 is fixed
+          # closeConnection: false
           writeConcernError:
             code: 64
             codeName: WriteConcernFailed


### PR DESCRIPTION
Until SERVER-39292 is completed, we cannot specify a `closeConnection`
with a `failCommand` that includes a `writeConcernError`.