### PR TITLE
fix(convenient-txns): `transactionOptions` => `options`

### DIFF
--- a/source/transactions-convenient-api/tests/transaction-options.json
+++ b/source/transactions-convenient-api/tests/transaction-options.json
@@ -287,14 +287,14 @@
                   }
                 }
               ]
-            }
-          },
-          "transactionOptions": {
-            "readConcern": {
-              "level": "snapshot"
             },
-            "writeConcern": {
-              "w": 1
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": {
+                "w": 1
+              }
             }
           }
         }
@@ -390,14 +390,14 @@
                   }
                 }
               ]
-            }
-          },
-          "transactionOptions": {
-            "readConcern": {
-              "level": "snapshot"
             },
-            "writeConcern": {
-              "w": 1
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": {
+                "w": 1
+              }
             }
           }
         }
@@ -485,14 +485,14 @@
                   }
                 }
               ]
-            }
-          },
-          "transactionOptions": {
-            "readConcern": {
-              "level": "snapshot"
             },
-            "writeConcern": {
-              "w": 1
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": {
+                "w": 1
+              }
             }
           }
         }

--- a/source/transactions-convenient-api/tests/transaction-options.yml
+++ b/source/transactions-convenient-api/tests/transaction-options.yml
@@ -148,9 +148,9 @@ tests:
                   document: { _id: 1 }
                 result:
                   insertedId: 1
-        transactionOptions:
-          readConcern: { level: snapshot }
-          writeConcern: { w: 1 }
+          options:
+            readConcern: { level: snapshot }
+            writeConcern: { w: 1 }
     expectations:
       -
         command_started_event:


### PR DESCRIPTION
`callback` was moved into the `arguments` yesterday, but we forgot
to include `transactionOptions` here as well. Additionally, the
`transactionOptions` were renamed `options` to be consistent with
the transactions spec test format.