### PR TITLE
Update tests to use an "operations" array

### DIFF
--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -45,10 +45,8 @@ Network Error Tests
 ===================
 
 Network error tests are expressed in YAML and should be run against a standalone,
-shard cluster, or single-node replica set. Until `SERVER-34943`_ is resolved,
-these tests cannot be run against a multi-node replicaset.
+shard cluster, or single-node replica set.
 
-.. _SERVER-34943: https://jira.mongodb.org/browse/SERVER-34943
 
 Test Format
 -----------
@@ -75,11 +73,11 @@ Each YAML file has the following keys:
   
   - ``skipReason``: Optional, string describing why this test should be skipped.
 
-  - ``failPoint``: Optional, a server failpoint to enable expressed as the
+  - ``failPoint``: Optional, a server failpoint to enable, expressed as the
     configureFailPoint command to run on the admin database.
 
-  - ``operation``: A document describing an operation to be
-    executed. The document has the following fields:
+  - ``operations``: An array of documents describing an operation to be
+    executed. Each document has the following fields:
 
     - ``name``: The name of the operation on ``object``.
 

--- a/source/retryable-reads/tests/aggregate-serverErrors.json
+++ b/source/retryable-reads/tests/aggregate-serverErrors.json
@@ -34,36 +34,38 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -128,36 +130,38 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -222,36 +226,38 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -316,36 +322,38 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -410,36 +418,38 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -504,36 +514,38 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -598,36 +610,38 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -692,36 +706,38 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -786,36 +802,38 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -880,36 +898,38 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -974,36 +994,38 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -1068,27 +1090,29 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
-            },
-            {
-              "$sort": {
-                "x": 1
-              }
-            }
-          ]
-        },
-        "error": true
-      },
+            ]
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -1153,27 +1177,29 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
-            },
-            {
-              "$sort": {
-                "x": 1
-              }
-            }
-          ]
-        },
-        "error": true
-      },
+            ]
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/aggregate-serverErrors.yml
+++ b/source/retryable-reads/tests/aggregate-serverErrors.yml
@@ -17,18 +17,19 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [aggregate], errorCode: 11600 }
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: aggregate
-                object: collection
-                arguments:
-                    pipeline:
-                        - $match:
-                            _id: {$gt: 1}
-                        - $sort: {x: 1}
-            result:
-                - {_id: 2, x: 22}
-                - {_id: 3, x: 33}
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: aggregate
+                    object: collection
+                    arguments:
+                        pipeline:
+                            - $match:
+                                _id: {$gt: 1}
+                            - $sort: {x: 1}
+                result:
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -44,7 +45,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 11602 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -55,7 +56,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -66,7 +67,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -77,7 +78,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -88,7 +89,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 189 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -99,7 +100,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 91 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -110,7 +111,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 7 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -121,7 +122,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 6 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -132,7 +133,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 89 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -143,7 +144,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 9001 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -155,9 +156,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -168,6 +170,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/aggregate.json
+++ b/source/retryable-reads/tests/aggregate.json
@@ -22,36 +22,38 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -94,36 +96,38 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
+            ]
+          },
+          "result": [
+            {
+              "_id": 2,
+              "x": 22
             },
             {
-              "$sort": {
-                "x": 1
-              }
+              "_id": 3,
+              "x": 33
             }
           ]
-        },
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ]
-      },
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -188,27 +192,29 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
-            },
-            {
-              "$sort": {
-                "x": 1
-              }
-            }
-          ]
-        },
-        "error": true
-      },
+            ]
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -251,27 +257,29 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              },
+              {
+                "$sort": {
+                  "x": 1
                 }
               }
-            },
-            {
-              "$sort": {
-                "x": 1
-              }
-            }
-          ]
-        },
-        "error": true
-      },
+            ]
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -336,30 +344,32 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "aggregate",
-        "object": "collection",
-        "arguments": {
-          "pipeline": [
-            {
-              "$match": {
-                "_id": {
-                  "$gt": 1
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
                 }
+              },
+              {
+                "$sort": {
+                  "x": 1
+                }
+              },
+              {
+                "$out": "output-collection"
               }
-            },
-            {
-              "$sort": {
-                "x": 1
-              }
-            },
-            {
-              "$out": "output-collection"
-            }
-          ]
-        },
-        "error": true
-      },
+            ]
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/aggregate.yml
+++ b/source/retryable-reads/tests/aggregate.yml
@@ -13,17 +13,18 @@ tests:
         description: "Aggregate succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: aggregate
-                object: collection
-                arguments:
-                    pipeline:
-                        - $match: {_id: {$gt: 1}}
-                        - $sort: {x: 1}
-            result:
-               - {_id: 2, x: 22}
-               - {_id: 3, x: 33}
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: aggregate
+                    object: collection
+                    arguments:
+                        pipeline:
+                            - $match: {_id: {$gt: 1}}
+                            - $sort: {x: 1}
+                result:
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -41,7 +42,7 @@ tests:
             data:
                 failCommands: [aggregate]
                 closeConnection: true
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -50,9 +51,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -62,7 +64,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -71,13 +73,13 @@ tests:
         clientOptions:
             retryReads: true
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation_fails
-            arguments:
-                pipeline:
-                    - $match: {_id: {$gt: 1}}
-                    - $sort: {x: 1}
-                    - $out: "output-collection"
+        operations:
+            -   <<: *retryable_operation_fails
+                arguments:
+                    pipeline:
+                        - $match: {_id: {$gt: 1}}
+                        - $sort: {x: 1}
+                        - $out: "output-collection"
         expectations:
              -  command_started_event:
                     command:
@@ -85,5 +87,3 @@ tests:
                       pipeline: [{$match: {_id: {$gt: 1}}}, {$sort: {x: 1}}, {$out: 'output-collection'}]
                     command_name: aggregate
                     database_name: *database_name
-
-

--- a/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.json
+++ b/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.json
@@ -38,10 +38,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -100,10 +102,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -162,10 +166,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -224,10 +230,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -286,10 +294,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -348,10 +358,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -410,10 +422,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -472,10 +486,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -534,10 +550,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -596,10 +614,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -658,10 +678,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -720,11 +742,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -783,11 +807,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.yml
+++ b/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.yml
@@ -18,9 +18,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [aggregate], errorCode: 11600 }
-        operation: &retryable_operation
-            name: watch
-            object: client
+        operations:
+            - &retryable_operation
+                name: watch
+                object: client
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -38,7 +39,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -50,7 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -74,7 +75,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -86,7 +87,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -98,7 +99,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -110,7 +111,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -122,7 +123,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -134,7 +135,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -146,7 +147,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -159,9 +160,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -173,8 +175,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/changeStreams-client.watch.json
+++ b/source/retryable-reads/tests/changeStreams-client.watch.json
@@ -18,10 +18,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -63,10 +65,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -125,11 +129,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -171,11 +177,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/changeStreams-client.watch.yml
+++ b/source/retryable-reads/tests/changeStreams-client.watch.yml
@@ -12,9 +12,10 @@ tests:
         topology: [replicaset, sharded]
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: watch
-            object: client
+        operations:
+            - &retryable_operation
+                name: watch
+                object: client
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -34,7 +35,7 @@ tests:
             data:
                 failCommands: [aggregate]
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -44,9 +45,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -57,9 +59,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.json
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.json
@@ -38,10 +38,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -98,10 +100,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -158,10 +162,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -218,10 +224,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -278,10 +286,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -338,10 +348,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -398,10 +410,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -458,10 +472,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -518,10 +534,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -578,10 +596,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -638,10 +658,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -698,11 +720,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -759,11 +783,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.yml
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.yml
@@ -18,9 +18,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [aggregate], errorCode: 11600 }
-        operation: &retryable_operation
-            name: watch
-            object: collection
+        operations:
+            - &retryable_operation
+                name: watch
+                object: collection
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -38,7 +39,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -50,7 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -74,7 +75,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -86,7 +87,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -98,7 +99,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -110,7 +111,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -122,7 +123,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -134,7 +135,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -146,7 +147,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -159,9 +160,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -173,8 +175,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch.json
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch.json
@@ -18,10 +18,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -62,10 +64,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -122,11 +126,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -167,11 +173,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch.yml
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch.yml
@@ -12,9 +12,10 @@ tests:
         topology: [replicaset, sharded]
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: watch
-            object: collection
+        operations:
+            - &retryable_operation
+                name: watch
+                object: collection
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -35,7 +36,7 @@ tests:
                 failCommands:
                         - aggregate
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -45,9 +46,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -58,9 +60,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.json
+++ b/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.json
@@ -38,10 +38,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -98,10 +100,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -158,10 +162,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -218,10 +224,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -278,10 +286,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -338,10 +348,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -398,10 +410,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -458,10 +472,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -518,10 +534,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -578,10 +596,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -638,10 +658,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -698,11 +720,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -759,11 +783,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.yml
+++ b/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.yml
@@ -18,9 +18,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [aggregate], errorCode: 11600 }
-        operation: &retryable_operation
-            name: watch
-            object: database
+        operations:
+            - &retryable_operation
+                name: watch
+                object: database
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -38,7 +39,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -50,7 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -74,7 +75,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -86,7 +87,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -98,7 +99,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -110,7 +111,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -122,7 +123,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -134,7 +135,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -146,7 +147,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -159,9 +160,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -173,9 +175,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
 

--- a/source/retryable-reads/tests/changeStreams-db.watch.json
+++ b/source/retryable-reads/tests/changeStreams-db.watch.json
@@ -18,10 +18,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -62,10 +64,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -122,11 +126,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -167,11 +173,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "watch",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "watch",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/changeStreams-db.watch.yml
+++ b/source/retryable-reads/tests/changeStreams-db.watch.yml
@@ -12,9 +12,10 @@ tests:
         topology: [replicaset, sharded]
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: watch
-            object: database
+        operations:
+            - &retryable_operation
+                name: watch
+                object: database
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -34,7 +35,7 @@ tests:
             data:
                 failCommands: [aggregate]
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -44,9 +45,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -57,9 +59,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/count-serverErrors.json
+++ b/source/retryable-reads/tests/count-serverErrors.json
@@ -30,14 +30,16 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -74,14 +76,16 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -118,14 +122,16 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -162,14 +168,16 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -206,14 +214,16 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -250,14 +260,16 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -294,14 +306,16 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -338,14 +352,16 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -382,14 +398,16 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -426,14 +444,16 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -470,14 +490,16 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -514,14 +536,16 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -558,14 +582,16 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/count-serverErrors.yml
+++ b/source/retryable-reads/tests/count-serverErrors.yml
@@ -16,12 +16,13 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [count], errorCode: 11600 }
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: count
-                object: collection
-                arguments: { filter: { } }
-            result: 2
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: count
+                    object: collection
+                    arguments: { filter: { } }
+                result: 2
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -36,7 +37,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 11602 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -47,7 +48,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 10107 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -58,7 +59,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 13435 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -69,7 +70,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 13436 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -80,7 +81,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 189 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -91,7 +92,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 91 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -102,7 +103,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 7 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -113,7 +114,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 6 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -124,7 +125,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 89 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -135,7 +136,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 9001 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -147,9 +148,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [count], errorCode: 10107 }
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -160,7 +162,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 10107 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
 

--- a/source/retryable-reads/tests/count.json
+++ b/source/retryable-reads/tests/count.json
@@ -18,14 +18,16 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -54,14 +56,16 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -98,14 +102,16 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -134,14 +140,16 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "count",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/count.yml
+++ b/source/retryable-reads/tests/count.yml
@@ -12,12 +12,13 @@ tests:
         description: "Count succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: count
-                object: collection
-                arguments: { filter: { } }
-            result: 2
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: count
+                    object: collection
+                    arguments: { filter: { } }
+                result: 2
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -35,7 +36,7 @@ tests:
                 failCommands: [count]
                 closeConnection: true
 
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -44,9 +45,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -56,7 +58,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/countDocuments-serverErrors.json
+++ b/source/retryable-reads/tests/countDocuments-serverErrors.json
@@ -30,14 +30,16 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -100,14 +102,16 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -170,14 +174,16 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -240,14 +246,16 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -310,14 +318,16 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -380,14 +390,16 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -450,14 +462,16 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -520,14 +534,16 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -590,14 +606,16 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -660,14 +678,16 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -730,14 +750,16 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -800,14 +822,16 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -870,14 +894,16 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/countDocuments-serverErrors.yml
+++ b/source/retryable-reads/tests/countDocuments-serverErrors.yml
@@ -16,12 +16,13 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [aggregate], errorCode: 11600 }
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: countDocuments
-                object: collection
-                arguments: { filter: { } }
-            result: 2
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: countDocuments
+                    object: collection
+                    arguments: { filter: { } }
+                result: 2
         expectations:
              - &retryable_command_started_event
                 command_started_event:
@@ -37,7 +38,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 11602 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -48,7 +49,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -59,7 +60,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13435 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -70,7 +71,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 13436 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -81,7 +82,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 189 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -92,7 +93,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 91 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -103,7 +104,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 7 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -114,7 +115,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 6 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -125,7 +126,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 89 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -136,7 +137,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 9001 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -148,9 +149,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -161,6 +163,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [aggregate], errorCode: 10107 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/countDocuments.json
+++ b/source/retryable-reads/tests/countDocuments.json
@@ -18,14 +18,16 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -67,14 +69,16 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -137,14 +141,16 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -186,14 +192,16 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "countDocuments",
-        "object": "collection",
-        "arguments": {
-          "filter": {}
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/countDocuments.yml
+++ b/source/retryable-reads/tests/countDocuments.yml
@@ -12,12 +12,13 @@ tests:
         description: "CountDocuments succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: countDocuments
-                object: collection
-                arguments: { filter: { } }
-            result: 2
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: countDocuments
+                    object: collection
+                    arguments: { filter: { } }
+                result: 2
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -35,7 +36,7 @@ tests:
             data:
                 failCommands: [aggregate]
                 closeConnection: true
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -44,9 +45,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -56,7 +58,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/distinct-serverErrors.json
+++ b/source/retryable-reads/tests/distinct-serverErrors.json
@@ -34,22 +34,24 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -98,22 +100,24 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -162,22 +166,24 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -226,22 +232,24 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -290,22 +298,24 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -354,22 +364,24 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -418,22 +430,24 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -482,22 +496,24 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -546,22 +562,24 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -610,22 +628,24 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -674,22 +694,24 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -738,19 +760,21 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "error": true
-      },
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -799,19 +823,21 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "error": true
-      },
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/distinct-serverErrors.yml
+++ b/source/retryable-reads/tests/distinct-serverErrors.yml
@@ -17,14 +17,15 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [distinct], errorCode: 11600 }
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: distinct
-                object: collection
-                arguments: { fieldName: "x", filter: { _id: { $gt: 1 } } }
-            result:
-                - 22
-                - 33
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: distinct
+                    object: collection
+                    arguments: { fieldName: "x", filter: { _id: { $gt: 1 } } }
+                result:
+                    - 22
+                    - 33
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -42,7 +43,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 11602 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -53,7 +54,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 10107 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -64,7 +65,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 13435 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -75,7 +76,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 13436 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -86,7 +87,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 189 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -97,7 +98,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 91 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -108,7 +109,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 7 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -119,7 +120,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 6 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -130,7 +131,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 89 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -141,7 +142,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 9001 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -153,9 +154,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [distinct], errorCode: 10107 }
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -166,7 +168,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [distinct], errorCode: 10107 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
 

--- a/source/retryable-reads/tests/distinct.json
+++ b/source/retryable-reads/tests/distinct.json
@@ -22,22 +22,24 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -72,22 +74,24 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "result": [
-          22,
-          33
-        ]
-      },
+          },
+          "result": [
+            22,
+            33
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -136,19 +140,21 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "error": true
-      },
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -183,19 +189,21 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "distinct",
-        "object": "collection",
-        "arguments": {
-          "fieldName": "x",
-          "filter": {
-            "_id": {
-              "$gt": 1
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
             }
-          }
-        },
-        "error": true
-      },
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/distinct.yml
+++ b/source/retryable-reads/tests/distinct.yml
@@ -13,14 +13,15 @@ tests:
         description: "Distinct succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: distinct
-                object: collection
-                arguments: { fieldName: "x", filter: { _id: { $gt: 1 } } }
-            result:
-                - 22
-                - 33
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: distinct
+                    object: collection
+                    arguments: { fieldName: "x", filter: { _id: { $gt: 1 } } }
+                result:
+                    - 22
+                    - 33
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -40,7 +41,7 @@ tests:
             data:
                 failCommands: [distinct]
                 closeConnection: true
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -49,9 +50,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
 
@@ -62,7 +64,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/estimatedDocumentCount-serverErrors.json
+++ b/source/retryable-reads/tests/estimatedDocumentCount-serverErrors.json
@@ -30,11 +30,13 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -71,11 +73,13 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -112,11 +116,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -153,11 +159,13 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -194,11 +202,13 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -235,11 +245,13 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -276,11 +288,13 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -317,11 +331,13 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -358,11 +374,13 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -399,11 +417,13 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -440,11 +460,13 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -481,11 +503,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -522,11 +546,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/estimatedDocumentCount-serverErrors.yml
+++ b/source/retryable-reads/tests/estimatedDocumentCount-serverErrors.yml
@@ -16,11 +16,12 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [count], errorCode: 11600 }
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: estimatedDocumentCount
-                object: collection
-            result: 2
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: estimatedDocumentCount
+                    object: collection
+                result: 2
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -35,7 +36,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 11602 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -46,7 +47,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 10107 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -57,7 +58,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 13435 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -68,7 +69,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 13436 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -79,7 +80,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 189 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -90,7 +91,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 91 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -101,7 +102,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 7 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -112,7 +113,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 6 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -123,7 +124,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 89 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -134,7 +135,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 9001 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -146,9 +147,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [count], errorCode: 10107 }
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -159,6 +161,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [count], errorCode: 10107 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/estimatedDocumentCount.json
+++ b/source/retryable-reads/tests/estimatedDocumentCount.json
@@ -18,11 +18,13 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -51,11 +53,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "result": 2
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "result": 2
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -92,11 +96,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -125,11 +131,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "estimatedDocumentCount",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/estimatedDocumentCount.yml
+++ b/source/retryable-reads/tests/estimatedDocumentCount.yml
@@ -12,11 +12,12 @@ tests:
         description: "EstimatedDocumentCount succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: estimatedDocumentCount
-                object: collection
-            result: 2
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: estimatedDocumentCount
+                    object: collection
+                result: 2
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -33,7 +34,7 @@ tests:
             data:
                 failCommands: [count]
                 closeConnection: true
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -42,9 +43,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -54,7 +56,7 @@ tests:
         failPoint:
           <<: *failCommand_failPoint
           mode: { times: 2 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/find-serverErrors.json
+++ b/source/retryable-reads/tests/find-serverErrors.json
@@ -42,35 +42,37 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -117,35 +119,37 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -192,35 +196,37 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -267,35 +273,37 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -342,35 +350,37 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -417,35 +427,37 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -492,35 +504,37 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -567,35 +581,37 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -642,35 +658,37 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -717,35 +735,37 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -792,35 +812,37 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -867,18 +889,20 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "error": true
-      },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -925,18 +949,20 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "error": true
-      },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/find-serverErrors.yml
+++ b/source/retryable-reads/tests/find-serverErrors.yml
@@ -19,16 +19,17 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [find], errorCode: 11600 }
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: find
-                object: collection
-                arguments: { filter: {}, sort: { _id: 1 }, limit: 4 }
-            result:
-                - {_id: 1, x: 11}
-                - {_id: 2, x: 22}
-                - {_id: 3, x: 33}
-                - {_id: 4, x: 44}
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: find
+                    object: collection
+                    arguments: { filter: {}, sort: { _id: 1 }, limit: 4 }
+                result:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+                    - {_id: 4, x: 44}
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -46,7 +47,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 11602 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -57,7 +58,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -68,7 +69,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13435 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -79,7 +80,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13436 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -90,7 +91,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 189 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -101,7 +102,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 91 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -112,7 +113,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 7 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -123,7 +124,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 6 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -134,7 +135,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 89 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -145,7 +146,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 9001 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -157,9 +158,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [find], errorCode: 10107 }
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -170,7 +172,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
 

--- a/source/retryable-reads/tests/find.json
+++ b/source/retryable-reads/tests/find.json
@@ -30,35 +30,37 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -92,35 +94,37 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "result": [
-          {
-            "_id": 1,
-            "x": 11
-          },
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          },
-          {
-            "_id": 4,
-            "x": 44
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -167,18 +171,20 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "error": true
-      },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -212,18 +218,20 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "find",
-        "object": "collection",
-        "arguments": {
-          "filter": {},
-          "sort": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "limit": 4
           },
-          "limit": 4
-        },
-        "error": true
-      },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/find.yml
+++ b/source/retryable-reads/tests/find.yml
@@ -15,19 +15,20 @@ tests:
         description: "Find succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: find
-                object: collection
-                arguments:
-                    filter: {}
-                    sort: {_id: 1}
-                    limit: 4
-            result:
-                - {_id: 1, x: 11}
-                - {_id: 2, x: 22}
-                - {_id: 3, x: 33}
-                - {_id: 4, x: 44}
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: find
+                    object: collection
+                    arguments:
+                        filter: {}
+                        sort: {_id: 1}
+                        limit: 4
+                result:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+                    - {_id: 4, x: 44}
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -47,7 +48,7 @@ tests:
             data:
                 failCommands: [find]
                 closeConnection: true
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -56,9 +57,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -68,7 +70,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/findOne-serverErrors.json
+++ b/source/retryable-reads/tests/findOne-serverErrors.json
@@ -42,19 +42,21 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -97,19 +99,21 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -152,19 +156,21 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -207,19 +213,21 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -262,19 +270,21 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -317,19 +327,21 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -372,19 +384,21 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -427,19 +441,21 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -482,19 +498,21 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -537,19 +555,21 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -592,19 +612,21 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -647,16 +669,18 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
-          }
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -699,16 +723,18 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
-          }
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/findOne-serverErrors.yml
+++ b/source/retryable-reads/tests/findOne-serverErrors.yml
@@ -19,13 +19,14 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [find], errorCode: 11600 }
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: findOne
-                object: collection
-                arguments:
-                    filter: {_id: 1}
-            result: {_id: 1, x: 11}
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: findOne
+                    object: collection
+                    arguments:
+                        filter: {_id: 1}
+                result: {_id: 1, x: 11}
         expectations:
              - &retryable_command_started_event
                  command_started_event:
@@ -41,7 +42,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 11602 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -52,7 +53,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -63,7 +64,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13435 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -74,7 +75,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13436 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -85,7 +86,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 189 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -96,7 +97,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 91 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -107,7 +108,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 7 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -118,7 +119,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 6 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -129,7 +130,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 89 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -140,7 +141,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 9001 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -152,9 +153,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [find], errorCode: 10107 }
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -165,6 +167,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/findOne.json
+++ b/source/retryable-reads/tests/findOne.json
@@ -30,19 +30,21 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -74,19 +76,21 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
           }
-        },
-        "result": {
-          "_id": 1,
-          "x": 11
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -129,16 +133,18 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
-          }
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -170,16 +176,18 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "findOne",
-        "object": "collection",
-        "arguments": {
-          "filter": {
-            "_id": 1
-          }
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "findOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/findOne.yml
+++ b/source/retryable-reads/tests/findOne.yml
@@ -15,12 +15,13 @@ tests:
         description: "FindOne succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: findOne
-                object: collection
-                arguments: {filter: {_id: 1 }}
-            result: {_id: 1, x: 11}
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: findOne
+                    object: collection
+                    arguments: {filter: {_id: 1 }}
+                result: {_id: 1, x: 11}
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -38,7 +39,7 @@ tests:
             data:
               failCommands: [find]
               closeConnection: true
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -47,9 +48,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -59,7 +61,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/gridfs-download-serverErrors.json
+++ b/source/retryable-reads/tests/gridfs-download-serverErrors.json
@@ -53,15 +53,17 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -124,15 +126,17 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -195,15 +199,17 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -266,15 +272,17 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -337,15 +345,17 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -408,15 +418,17 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -479,15 +491,17 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -550,15 +564,17 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -621,15 +637,17 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -692,15 +710,17 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -763,15 +783,17 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -834,16 +856,18 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
-          }
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -890,16 +914,18 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
-          }
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/gridfs-download-serverErrors.yml
+++ b/source/retryable-reads/tests/gridfs-download-serverErrors.yml
@@ -24,10 +24,11 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [find], errorCode: 11600 }
-        operation: &retryable_operation
-            name: download
-            object: gridfsbucket
-            arguments: { id: { "$oid" : "000000000000000000000001" } }
+        operations:
+            - &retryable_operation
+                name: download
+                object: gridfsbucket
+                arguments: { id: { "$oid" : "000000000000000000000001" } }
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -50,7 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -74,7 +75,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -86,7 +87,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -98,7 +99,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -110,7 +111,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -122,7 +123,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -134,7 +135,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -146,7 +147,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -158,7 +159,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -171,9 +172,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [find], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -184,8 +186,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/gridfs-download.json
+++ b/source/retryable-reads/tests/gridfs-download.json
@@ -41,15 +41,17 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -99,15 +101,17 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
           }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -170,16 +174,18 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
-          }
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -213,16 +219,18 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "download",
-        "object": "gridfsbucket",
-        "arguments": {
-          "id": {
-            "$oid": "000000000000000000000001"
-          }
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "download",
+          "object": "gridfsbucket",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            }
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/gridfs-download.yml
+++ b/source/retryable-reads/tests/gridfs-download.yml
@@ -20,10 +20,11 @@ tests:
         description: "Download succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: download
-            object: gridfsbucket
-            arguments: { id: { "$oid" : "000000000000000000000001" } }
+        operations:
+            - &retryable_operation
+                name: download
+                object: gridfsbucket
+                arguments: { id: { "$oid" : "000000000000000000000001" } }
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -48,7 +49,7 @@ tests:
             data:
                 failCommands: [find]
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -58,9 +59,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -70,9 +72,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.json
+++ b/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.json
@@ -53,13 +53,15 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -118,13 +120,15 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -183,13 +187,15 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -248,13 +254,15 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -313,13 +321,15 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -378,13 +388,15 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -443,13 +455,15 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -508,13 +522,15 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -573,13 +589,15 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -638,13 +656,15 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -703,13 +723,15 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -768,14 +790,16 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -818,14 +842,16 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.yml
+++ b/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.yml
@@ -24,11 +24,12 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [find], errorCode: 11600 }
-        operation: &retryable_operation
-            name: download_by_name
-            object: gridfsbucket
-            arguments:
-                filename: abc
+        operations:
+            - &retryable_operation
+                name: download_by_name
+                object: gridfsbucket
+                arguments:
+                    filename: abc
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -51,7 +52,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -63,7 +64,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -75,7 +76,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -87,7 +88,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -99,7 +100,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -111,7 +112,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -123,7 +124,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -135,7 +136,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -147,7 +148,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -159,7 +160,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -172,9 +173,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [find], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -185,8 +187,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [find], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/gridfs-downloadByName.json
+++ b/source/retryable-reads/tests/gridfs-downloadByName.json
@@ -41,13 +41,15 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -95,13 +97,15 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          }
         }
-      },
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -160,14 +164,16 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -199,14 +205,16 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "download_by_name",
-        "object": "gridfsbucket",
-        "arguments": {
-          "filename": "abc"
-        },
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "download_by_name",
+          "object": "gridfsbucket",
+          "arguments": {
+            "filename": "abc"
+          },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/gridfs-downloadByName.yml
+++ b/source/retryable-reads/tests/gridfs-downloadByName.yml
@@ -20,10 +20,11 @@ tests:
         description: "DownloadByName succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: download_by_name
-            object: gridfsbucket
-            arguments: { filename: "abc" }
+        operations:
+            - &retryable_operation
+                name: download_by_name
+                object: gridfsbucket
+                arguments: { filename: "abc" }
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -48,7 +49,7 @@ tests:
             data:
                 failCommands: [find]
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -58,9 +59,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -70,9 +72,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listCollectionNames-serverErrors.json
+++ b/source/retryable-reads/tests/listCollectionNames-serverErrors.json
@@ -21,10 +21,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -59,10 +61,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -97,10 +101,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -135,10 +141,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -173,10 +181,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -211,10 +221,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -249,10 +261,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -287,10 +301,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -325,10 +341,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -363,10 +381,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -401,10 +421,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -439,11 +461,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -478,11 +502,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listCollectionNames-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollectionNames-serverErrors.yml
@@ -13,9 +13,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [listCollections], errorCode: 11600 }
-        operation:  &retryable_operation
-            name: listCollectionNames
-            object: database
+        operations:
+            - &retryable_operation
+                name: listCollectionNames
+                object: database
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -29,7 +30,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -40,7 +41,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -51,7 +52,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -73,7 +74,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -84,7 +85,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -95,7 +96,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -106,7 +107,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -117,7 +118,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -128,7 +129,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -140,9 +141,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [listCollections], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -153,8 +155,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listCollectionNames.json
+++ b/source/retryable-reads/tests/listCollectionNames.json
@@ -9,10 +9,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -40,10 +42,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -78,11 +82,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -110,11 +116,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listCollectionNames",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollectionNames",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listCollectionNames.yml
+++ b/source/retryable-reads/tests/listCollectionNames.yml
@@ -9,9 +9,10 @@ tests:
         description: "ListCollectionNames succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: listCollectionNames
-            object: database
+        operations:
+            - &retryable_operation
+                name: listCollectionNames
+                object: database
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -28,7 +29,7 @@ tests:
                 failCommands:
                         - listCollections
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -37,9 +38,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -49,9 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listCollectionObjects-serverErrors.json
+++ b/source/retryable-reads/tests/listCollectionObjects-serverErrors.json
@@ -21,10 +21,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -59,10 +61,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -97,10 +101,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -135,10 +141,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -173,10 +181,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -211,10 +221,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -249,10 +261,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -287,10 +301,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -325,10 +341,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -363,10 +381,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -401,10 +421,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -439,11 +461,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -478,11 +502,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listCollectionObjects-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollectionObjects-serverErrors.yml
@@ -13,9 +13,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [listCollections], errorCode: 11600 }
-        operation:  &retryable_operation
-            name: listCollectionObjects
-            object: database
+        operations:
+            - &retryable_operation
+                name: listCollectionObjects
+                object: database
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -29,7 +30,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -40,7 +41,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -51,7 +52,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -73,7 +74,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -84,7 +85,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -95,7 +96,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -106,7 +107,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -117,7 +118,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -128,7 +129,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -140,9 +141,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [listCollections], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -153,9 +155,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
 

--- a/source/retryable-reads/tests/listCollectionObjects.json
+++ b/source/retryable-reads/tests/listCollectionObjects.json
@@ -9,10 +9,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -40,10 +42,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -78,11 +82,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -110,11 +116,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listCollectionObjects",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollectionObjects",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listCollectionObjects.yml
+++ b/source/retryable-reads/tests/listCollectionObjects.yml
@@ -9,9 +9,10 @@ tests:
         description: "ListCollectionObjects succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: listCollectionObjects
-            object: database
+        operations:
+            - &retryable_operation
+                name: listCollectionObjects
+                object: database
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -28,7 +29,7 @@ tests:
                 failCommands:
                         - listCollections
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -37,9 +38,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -49,9 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listCollections-serverErrors.json
+++ b/source/retryable-reads/tests/listCollections-serverErrors.json
@@ -21,10 +21,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -59,10 +61,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -97,10 +101,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -135,10 +141,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -173,10 +181,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -211,10 +221,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -249,10 +261,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -287,10 +301,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -325,10 +341,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -363,10 +381,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -401,10 +421,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -439,11 +461,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -478,11 +502,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listCollections-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollections-serverErrors.yml
@@ -13,9 +13,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [listCollections], errorCode: 11600 }
-        operation:  &retryable_operation
-            name: listCollections
-            object: database
+        operations:
+            - &retryable_operation
+                name: listCollections
+                object: database
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -29,7 +30,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -40,7 +41,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -51,7 +52,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -73,7 +74,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -84,7 +85,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -95,7 +96,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -106,7 +107,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -117,7 +118,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -128,7 +129,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -140,9 +141,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [listCollections], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -153,8 +155,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listCollections], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listCollections.json
+++ b/source/retryable-reads/tests/listCollections.json
@@ -9,10 +9,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -40,10 +42,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database"
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -78,11 +82,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -110,11 +116,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listCollections",
-        "object": "database",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listCollections.yml
+++ b/source/retryable-reads/tests/listCollections.yml
@@ -9,9 +9,10 @@ tests:
         description: "ListCollections succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: listCollections
-            object: database
+        operations:
+            - &retryable_operation
+                name: listCollections
+                object: database
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -28,7 +29,7 @@ tests:
                 failCommands:
                         - listCollections
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -37,9 +38,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -49,9 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listDatabaseNames-serverErrors.json
+++ b/source/retryable-reads/tests/listDatabaseNames-serverErrors.json
@@ -21,10 +21,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -59,10 +61,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -97,10 +101,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -135,10 +141,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -173,10 +181,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -211,10 +221,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -249,10 +261,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -287,10 +301,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -325,10 +341,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -363,10 +381,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -401,10 +421,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -439,11 +461,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -478,11 +502,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listDatabaseNames-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabaseNames-serverErrors.yml
@@ -13,9 +13,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [listDatabases], errorCode: 11600 }
-        operation:  &retryable_operation
-            name: listDatabaseNames
-            object: client
+        operations:
+            - &retryable_operation
+                name: listDatabaseNames
+                object: client
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -29,7 +30,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -40,7 +41,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -51,7 +52,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -73,7 +74,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -84,7 +85,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -95,7 +96,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -106,7 +107,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -117,7 +118,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -128,7 +129,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -140,9 +141,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [listDatabases], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -153,8 +155,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listDatabaseNames.json
+++ b/source/retryable-reads/tests/listDatabaseNames.json
@@ -9,10 +9,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -40,10 +42,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -78,11 +82,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -110,11 +116,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listDatabaseNames",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabaseNames",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listDatabaseNames.yml
+++ b/source/retryable-reads/tests/listDatabaseNames.yml
@@ -9,9 +9,10 @@ tests:
         description: "ListDatabaseNames succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: listDatabaseNames
-            object: client
+        operations:
+            - &retryable_operation
+                name: listDatabaseNames
+                object: client
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -28,7 +29,7 @@ tests:
                 failCommands:
                         - listDatabases
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -37,9 +38,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -49,9 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listDatabaseObjects-serverErrors.json
+++ b/source/retryable-reads/tests/listDatabaseObjects-serverErrors.json
@@ -21,10 +21,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -59,10 +61,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -97,10 +101,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -135,10 +141,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -173,10 +181,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -211,10 +221,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -249,10 +261,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -287,10 +301,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -325,10 +341,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -363,10 +381,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -401,10 +421,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -439,11 +461,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -478,11 +502,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listDatabaseObjects-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabaseObjects-serverErrors.yml
@@ -13,9 +13,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [listDatabases], errorCode: 11600 }
-        operation:  &retryable_operation
-            name: listDatabaseObjects
-            object: client
+        operations:
+            - &retryable_operation
+                name: listDatabaseObjects
+                object: client
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -29,7 +30,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -40,7 +41,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -51,7 +52,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -73,7 +74,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -84,7 +85,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -95,7 +96,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -106,7 +107,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -117,7 +118,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -128,7 +129,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -140,9 +141,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [listDatabases], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -153,9 +155,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
 

--- a/source/retryable-reads/tests/listDatabaseObjects.json
+++ b/source/retryable-reads/tests/listDatabaseObjects.json
@@ -9,10 +9,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -40,10 +42,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -78,11 +82,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -110,11 +116,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listDatabaseObjects",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabaseObjects",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listDatabaseObjects.yml
+++ b/source/retryable-reads/tests/listDatabaseObjects.yml
@@ -9,9 +9,10 @@ tests:
         description: "ListDatabaseObjects succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: listDatabaseObjects
-            object: client
+        operations:
+            - &retryable_operation
+                name: listDatabaseObjects
+                object: client
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -28,7 +29,7 @@ tests:
                 failCommands:
                         - listDatabases
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -37,9 +38,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -49,9 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listDatabases-serverErrors.json
+++ b/source/retryable-reads/tests/listDatabases-serverErrors.json
@@ -21,10 +21,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -59,10 +61,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -97,10 +101,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -135,10 +141,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -173,10 +181,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -211,10 +221,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -249,10 +261,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -287,10 +301,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -325,10 +341,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -363,10 +381,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -401,10 +421,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -439,11 +461,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -478,11 +502,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listDatabases-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabases-serverErrors.yml
@@ -13,9 +13,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [listDatabases], errorCode: 11600 }
-        operation:  &retryable_operation
-            name: listDatabases
-            object: client
+        operations:
+            - &retryable_operation
+                name: listDatabases
+                object: client
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -29,7 +30,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -40,7 +41,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -51,7 +52,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -62,7 +63,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -73,7 +74,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -84,7 +85,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -95,7 +96,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -106,7 +107,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -117,7 +118,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -128,7 +129,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -140,9 +141,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [listDatabases], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -153,9 +155,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listDatabases], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
 

--- a/source/retryable-reads/tests/listDatabases.json
+++ b/source/retryable-reads/tests/listDatabases.json
@@ -9,10 +9,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -40,10 +42,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client"
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -78,11 +82,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -110,11 +116,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listDatabases",
-        "object": "client",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listDatabases.yml
+++ b/source/retryable-reads/tests/listDatabases.yml
@@ -9,9 +9,10 @@ tests:
         description: "ListDatabases succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: listDatabases
-            object: client
+        operations:
+            - &retryable_operation
+                name: listDatabases
+                object: client
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -28,7 +29,7 @@ tests:
                 failCommands:
                         - listDatabases
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -37,9 +38,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -49,9 +51,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listIndexNames-serverErrors.json
+++ b/source/retryable-reads/tests/listIndexNames-serverErrors.json
@@ -21,10 +21,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -61,10 +63,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -101,10 +105,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -141,10 +147,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -181,10 +189,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -221,10 +231,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -261,10 +273,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -301,10 +315,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -341,10 +357,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -381,10 +399,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -421,10 +441,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -461,11 +483,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -502,11 +526,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listIndexNames-serverErrors.yml
+++ b/source/retryable-reads/tests/listIndexNames-serverErrors.yml
@@ -13,9 +13,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [listIndexes], errorCode: 11600 }
-        operation:  &retryable_operation
-            name: listIndexNames
-            object: collection
+        operations:
+            - &retryable_operation
+                name: listIndexNames
+                object: collection
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -30,7 +31,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -41,7 +42,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -52,7 +53,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -63,7 +64,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -74,7 +75,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -85,7 +86,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -96,7 +97,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -107,7 +108,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -118,7 +119,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -129,7 +130,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -141,9 +142,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [listIndexes], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -154,8 +156,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listIndexNames.json
+++ b/source/retryable-reads/tests/listIndexNames.json
@@ -9,10 +9,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -41,10 +43,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -81,11 +85,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -114,11 +120,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listIndexNames",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listIndexNames",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listIndexNames.yml
+++ b/source/retryable-reads/tests/listIndexNames.yml
@@ -9,9 +9,10 @@ tests:
         description: "ListIndexNames succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: listIndexNames
-            object: collection
+        operations:
+            - &retryable_operation
+                name: listIndexNames
+                object: collection
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -29,7 +30,7 @@ tests:
                 failCommands:
                         - listIndexes
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -38,9 +39,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -50,9 +52,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/listIndexes-serverErrors.json
+++ b/source/retryable-reads/tests/listIndexes-serverErrors.json
@@ -21,10 +21,12 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -61,10 +63,12 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -101,10 +105,12 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -141,10 +147,12 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -181,10 +189,12 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -221,10 +231,12 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -261,10 +273,12 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -301,10 +315,12 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -341,10 +357,12 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -381,10 +399,12 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -421,10 +441,12 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -461,11 +483,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -502,11 +526,13 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listIndexes-serverErrors.yml
+++ b/source/retryable-reads/tests/listIndexes-serverErrors.yml
@@ -13,9 +13,10 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [listIndexes], errorCode: 11600 }
-        operation:  &retryable_operation
-            name: listIndexes
-            object: collection
+        operations:
+            - &retryable_operation
+                name: listIndexes
+                object: collection
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -30,7 +31,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 11602 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -41,7 +42,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 10107 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -52,7 +53,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 13435 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -63,7 +64,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 13436 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -74,7 +75,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 189 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -85,7 +86,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 91 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -96,7 +97,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 7 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -107,7 +108,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 6 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -118,7 +119,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 89 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -129,7 +130,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 9001 }
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -141,9 +142,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [listIndexes], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -154,9 +156,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [listIndexes], errorCode: 10107 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
 

--- a/source/retryable-reads/tests/listIndexes.json
+++ b/source/retryable-reads/tests/listIndexes.json
@@ -9,10 +9,12 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -41,10 +43,12 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection"
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection"
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -81,11 +85,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -114,11 +120,13 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "listIndexes",
-        "object": "collection",
-        "error": true
-      },
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection",
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/listIndexes.yml
+++ b/source/retryable-reads/tests/listIndexes.yml
@@ -9,9 +9,10 @@ tests:
         description: "ListIndexes succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation
-            name: listIndexes
-            object: collection
+        operations:
+            - &retryable_operation
+                name: listIndexes
+                object: collection
         expectations:
             -  &retryable_command_started_event
                 command_started_event:
@@ -29,7 +30,7 @@ tests:
                 failCommands:
                         - listIndexes
                 closeConnection: true
-        operation: *retryable_operation
+        operations: [*retryable_operation]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -38,9 +39,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -50,9 +52,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation:
-            <<: *retryable_operation
-            error: true
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/mapReduce-serverErrors.json
+++ b/source/retryable-reads/tests/mapReduce-serverErrors.json
@@ -34,27 +34,29 @@
           "errorCode": 11600
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -109,27 +111,29 @@
           "errorCode": 11602
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -184,27 +188,29 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -259,27 +265,29 @@
           "errorCode": 13435
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -334,27 +342,29 @@
           "errorCode": 13436
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -409,27 +419,29 @@
           "errorCode": 189
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -484,27 +496,29 @@
           "errorCode": 91
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -559,27 +573,29 @@
           "errorCode": 7
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -634,27 +650,29 @@
           "errorCode": 6
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -709,27 +727,29 @@
           "errorCode": 89
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -784,27 +804,29 @@
           "errorCode": 9001
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -859,22 +881,24 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "error": true
-      },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -929,22 +953,24 @@
           "errorCode": 10107
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "error": true
-      },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/mapReduce-serverErrors.yml
+++ b/source/retryable-reads/tests/mapReduce-serverErrors.yml
@@ -17,15 +17,16 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 1 }
             data: { failCommands: [mapReduce], errorCode: 11600 }
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: mapReduce
-                object: collection
-                arguments:
-                    map: { $code: "function inc() { return emit(0, this.x + 1) }" }
-                    reduce: { $code:  "function sum(key, values) { return values.reduce((acc, x) => acc + x); }" }
-                    out: { inline: 1 }
-            result: [ {  "_id" : 0, "value" : 6 } ]
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: mapReduce
+                    object: collection
+                    arguments:
+                        map: { $code: "function inc() { return emit(0, this.x + 1) }" }
+                        reduce: { $code:  "function sum(key, values) { return values.reduce((acc, x) => acc + x); }" }
+                        out: { inline: 1 }
+                result: [ {  "_id" : 0, "value" : 6 } ]
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -43,7 +44,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 11602 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -54,7 +55,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 10107 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -65,7 +66,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 13435 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -76,7 +77,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 13436 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -87,7 +88,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 189 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -98,7 +99,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 91 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -109,7 +110,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 7 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -120,7 +121,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 6 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -131,7 +132,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 89 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -142,7 +143,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 9001 }
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -154,9 +155,10 @@ tests:
             <<: *failCommand_failPoint
             mode: { times: 2 }
             data: { failCommands: [mapReduce], errorCode: 10107 }
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -167,6 +169,6 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             data: { failCommands: [mapReduce], errorCode: 10107 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event

--- a/source/retryable-reads/tests/mapReduce.json
+++ b/source/retryable-reads/tests/mapReduce.json
@@ -22,27 +22,29 @@
       "clientOptions": {
         "retryReads": true
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -80,27 +82,29 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "result": [
-          {
-            "_id": 0,
-            "value": 6
-          }
-        ]
-      },
+          "result": [
+            {
+              "_id": 0,
+              "value": 6
+            }
+          ]
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -155,22 +159,24 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "error": true
-      },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -208,22 +214,24 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": {
+              "inline": 1
+            }
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": {
-            "inline": 1
-          }
-        },
-        "error": true
-      },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {
@@ -278,20 +286,22 @@
           "closeConnection": true
         }
       },
-      "operation": {
-        "name": "mapReduce",
-        "object": "collection",
-        "arguments": {
-          "map": {
-            "$code": "function inc() { return emit(0, this.x + 1) }"
+      "operations": [
+        {
+          "name": "mapReduce",
+          "object": "collection",
+          "arguments": {
+            "map": {
+              "$code": "function inc() { return emit(0, this.x + 1) }"
+            },
+            "reduce": {
+              "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
+            },
+            "out": "output-collection"
           },
-          "reduce": {
-            "$code": "function sum(key, values) { return values.reduce((acc, x) => acc + x); }"
-          },
-          "out": "output-collection"
-        },
-        "error": true
-      },
+          "error": true
+        }
+      ],
       "expectations": [
         {
           "command_started_event": {

--- a/source/retryable-reads/tests/mapReduce.yml
+++ b/source/retryable-reads/tests/mapReduce.yml
@@ -13,15 +13,16 @@ tests:
         description: "MapReduce succeeds on first attempt"
         clientOptions:
             retryReads: true
-        operation: &retryable_operation_succeeds
-            <<: &retryable_operation
-                name: mapReduce
-                object: collection
-                arguments:
-                    map: { $code: "function inc() { return emit(0, this.x + 1) }" }
-                    reduce: { $code:  "function sum(key, values) { return values.reduce((acc, x) => acc + x); }" }
-                    out: { inline: 1 }
-            result: [ {  "_id" : 0, "value" : 6 } ]
+        operations:
+            - &retryable_operation_succeeds
+                <<: &retryable_operation
+                    name: mapReduce
+                    object: collection
+                    arguments:
+                        map: { $code: "function inc() { return emit(0, this.x + 1) }" }
+                        reduce: { $code:  "function sum(key, values) { return values.reduce((acc, x) => acc + x); }" }
+                        out: { inline: 1 }
+                result: [ {  "_id" : 0, "value" : 6 } ]
         expectations:
             - &retryable_command_started_event
                 command_started_event:
@@ -41,7 +42,7 @@ tests:
             data:
                 failCommands: [mapReduce]
                 closeConnection: true
-        operation: *retryable_operation_succeeds
+        operations: [*retryable_operation_succeeds]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -50,9 +51,10 @@ tests:
         clientOptions:
             retryReads: false
         failPoint: *failCommand_failPoint
-        operation: &retryable_operation_fails
-            <<: *retryable_operation
-            error: true
+        operations:
+            - &retryable_operation_fails
+                <<: *retryable_operation
+                error: true
         expectations:
              - *retryable_command_started_event
     -
@@ -62,7 +64,7 @@ tests:
         failPoint:
             <<: *failCommand_failPoint
             mode: { times: 2 }
-        operation: *retryable_operation_fails
+        operations: [*retryable_operation_fails]
         expectations:
              - *retryable_command_started_event
              - *retryable_command_started_event
@@ -71,12 +73,12 @@ tests:
         clientOptions:
             retryReads: true
         failPoint: *failCommand_failPoint
-        operation:
-            <<: *retryable_operation_fails
-            arguments:
-                map: { $code: "function inc() { return emit(0, this.x + 1) }" }
-                reduce: { $code: "function sum(key, values) { return values.reduce((acc, x) => acc + x); }" }
-                out: output-collection
+        operations:
+            -   <<: *retryable_operation_fails
+                arguments:
+                    map: { $code: "function inc() { return emit(0, this.x + 1) }" }
+                    reduce: { $code: "function sum(key, values) { return values.reduce((acc, x) => acc + x); }" }
+                    out: output-collection
         expectations:
              -  command_started_event:
                     command:


### PR DESCRIPTION
- Update README to reflect the use of an array named  "operations"
  instead single "operation"