### PR TITLE
SPEC-1049: Do not expect default upsert/multi values for update

### DIFF
--- a/source/command-monitoring/tests/bulkWrite.json
+++ b/source/command-monitoring/tests/bulkWrite.json
@@ -86,9 +86,7 @@
                     "$set": {
                       "x": 333
                     }
-                  },
-                  "upsert": false,
-                  "multi": false
+                  }
                 }
               ],
               "ordered": true

--- a/source/command-monitoring/tests/bulkWrite.yml
+++ b/source/command-monitoring/tests/bulkWrite.yml
@@ -39,7 +39,7 @@ tests:
           command:
             update: *collection_name
             updates:
-              - { q: {_id: 3 }, u: { $set: { x: 333 } }, upsert: false, multi: false }
+              - { q: {_id: 3 }, u: { $set: { x: 333 } } }
             ordered: true
           command_name: "update"
           database_name: *database_name

--- a/source/command-monitoring/tests/updateMany.json
+++ b/source/command-monitoring/tests/updateMany.json
@@ -51,8 +51,7 @@
                       "x": 1
                     }
                   },
-                  "multi": true,
-                  "upsert": false
+                  "multi": true
                 }
               ]
             },
@@ -106,8 +105,7 @@
                       "x": 1
                     }
                   },
-                  "multi": true,
-                  "upsert": false
+                  "multi": true
                 }
               ]
             },

--- a/source/command-monitoring/tests/updateMany.yml
+++ b/source/command-monitoring/tests/updateMany.yml
@@ -27,7 +27,6 @@ tests:
                 q: { _id: { $gt: 1 }}
                 u: { $inc: { x: 1 }}
                 multi: true
-                upsert: false
           command_name: "update"
           database_name: *database_name
       -
@@ -54,7 +53,6 @@ tests:
                 q: { _id: { $gt: 1 }}
                 u: { $nothing: { x: 1 }}
                 multi: true
-                upsert: false
           command_name: "update"
           database_name: *database_name
       -

--- a/source/command-monitoring/tests/updateOne.json
+++ b/source/command-monitoring/tests/updateOne.json
@@ -50,9 +50,7 @@
                     "$inc": {
                       "x": 1
                     }
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 }
               ]
             },
@@ -103,7 +101,6 @@
                       "x": 1
                     }
                   },
-                  "multi": false,
                   "upsert": true
                 }
               ]
@@ -163,9 +160,7 @@
                     "$nothing": {
                       "x": 1
                     }
-                  },
-                  "multi": false,
-                  "upsert": false
+                  }
                 }
               ]
             },

--- a/source/command-monitoring/tests/updateOne.yml
+++ b/source/command-monitoring/tests/updateOne.yml
@@ -26,8 +26,6 @@ tests:
               -
                 q: { _id: { $gt: 1 }}
                 u: { $inc: { x: 1 }}
-                multi: false
-                upsert: false
           command_name: "update"
           database_name: *database_name
       -
@@ -54,7 +52,6 @@ tests:
               -
                 q: { _id: 4 }
                 u: { $inc: { x: 1 } }
-                multi: false
                 upsert: true
           command_name: "update"
           database_name: *database_name
@@ -81,8 +78,6 @@ tests:
               -
                 q: { _id: { $gt: 1 }}
                 u: { $nothing: { x: 1 }}
-                multi: false
-                upsert: false
           command_name: "update"
           database_name: *database_name
       -


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1049

CRUD spec does not require drivers to always specify a value for these fields. Note that some drivers do always specify a value (mostly for historical reasons, when we expected a future database version might change its default), but the spec tests should not be so strict.