### PR TITLE
add sleeps to make cmap tests more consistent

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.json
@@ -8,8 +8,16 @@
       "target": "thread1"
     },
     {
+      "name": "wait",
+      "ms": 10
+    },
+    {
       "name": "start",
       "target": "thread2"
+    },
+    {
+      "name": "wait",
+      "ms": 20
     },
     {
       "name": "start",

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.yml
@@ -3,11 +3,16 @@ style: unit
 description: must be able to check out multiple connections at the same time
 operations:
   # Note: this test can be somewhat non-deterministic depending on how you
-  # implement your test runner.
+  # implement your test runner. The sleep operations should make this more
+  # consistent.
   - name: start
     target: thread1
+  - name: wait
+    ms: 10
   - name: start
     target: thread2
+  - name: wait
+    ms: 20
   - name: start
     target: thread3
   - name: checkOut

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.yml
@@ -12,7 +12,7 @@ operations:
   - name: start
     target: thread2
   - name: wait
-    ms: 20
+    ms: 10
   - name: start
     target: thread3
   - name: checkOut

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.json
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.json
@@ -1,9 +1,10 @@
 {
   "version": 1,
   "style": "unit",
-  "description": "must issue Connections to threads in the order that the threads eneterd the queue",
+  "description": "must issue Connections to threads in the order that the threads entered the queue",
   "poolOptions": {
-    "maxPoolSize": 1
+    "maxPoolSize": 1,
+    "waitQueueTimeoutMS": 1000
   },
   "operations": [
     {
@@ -20,6 +21,10 @@
       "label": "conn1"
     },
     {
+      "name": "wait",
+      "ms": 10
+    },
+    {
       "name": "start",
       "target": "thread2"
     },
@@ -29,6 +34,10 @@
       "label": "conn2"
     },
     {
+      "name": "wait",
+      "ms": 20
+    },
+    {
       "name": "start",
       "target": "thread3"
     },
@@ -36,6 +45,10 @@
       "name": "checkOut",
       "thread": "thread3",
       "label": "conn3"
+    },
+    {
+      "name": "wait",
+      "ms": 30
     },
     {
       "name": "start",

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
@@ -26,14 +26,14 @@ operations:
     thread: thread2
     label: conn2
   - name: wait
-    ms: 20
+    ms: 10
   - name: start
     target: thread3
   - name: checkOut
     thread: thread3
     label: conn3
   - name: wait
-    ms: 30
+    ms: 10
   - name: start
     target: thread4
   - name: checkOut

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
@@ -1,8 +1,9 @@
 version: 1
 style: unit
-description: must issue Connections to threads in the order that the threads eneterd the queue
+description: must issue Connections to threads in the order that the threads entered the queue
 poolOptions:
   maxPoolSize: 1
+  waitQueueTimeoutMS: 1000
 operations:
     # Check out sole connection in pool
   - name: checkOut
@@ -10,22 +11,29 @@ operations:
     # Create 4 threads, have them all queue up for connections
     # Note: this might become non-deterministic depending on how you
     # implement your test runner. The goal is for each thread to
-    # have started and begun checkOut before the next thread starts
+    # have started and begun checkOut before the next thread starts.
+    # The sleep operations should make this more consistent.
   - name: start
     target: thread1
   - name: checkOut
     thread: thread1
     label: conn1
+  - name: wait
+    ms: 10
   - name: start
     target: thread2
   - name: checkOut
     thread: thread2
     label: conn2
+  - name: wait
+    ms: 20
   - name: start
     target: thread3
   - name: checkOut
     thread: thread3
     label: conn3
+  - name: wait
+    ms: 30
   - name: start
     target: thread4
   - name: checkOut


### PR DESCRIPTION
When implementing the CMAP spec test runner, it was suggested that I have it sleep in between each operation being run in order to facilitate separate threads performing operations in a more deterministic order. Given that there are only two places in the tests where comments suggest that the operations may not be deterministic and that the spec runner description already provides a mechanism for specifying sleeps of a given length, it probably makes more sense to just add `wait` operations in the places where they're needed to save each implementation from having to do it manually. As an added bonus, this also makes the test run faster, as it greatly cuts down on the total amount of time the runner needs to sleep.