### PR TITLE
split WaitQueueTimeoutError into two separate errors

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -645,6 +645,15 @@ a manner idiomatic to the Driver and Language.
 .. code:: typescript
 
     /**
+     *  Thrown when a driver times out when attempting to check out
+     *  a Connection from a Pool
+     */
+    interface MaxPoolSizeTimeoutError {
+      message: 'Unable to check out a connection within the timeout due to the max pool size';
+      address: <pool address>;
+    }
+
+    /**
      *  Thrown when the driver attempts to check out a
      *  Connection from a closed Connection Pool
      */
@@ -658,7 +667,7 @@ a manner idiomatic to the Driver and Language.
      *  a Connection from a Pool
      */
     interface WaitQueueTimeoutError {
-      message: 'Timed out while checking out a connection from connection pool';
+      message: 'Timed out while waiting to check out a connection from the pool';
       address: <pool address>;
     }
 


### PR DESCRIPTION
This pull request splits `WaitQueueTimeoutError` into two errors based on whether the checkout
timed out while the thread was waiting to reach the front of the wait queue or due to the max pool size being reached and no connections being checked back in before the timeout.

I'm not sure what the best name for the new error is, so I put in something arbitrary to at least start the bikeshedding off of. I'm also not sure how best to test this, given that timing a `WaitQueueTimeoutError` to occur without also triggering a `MaxPoolSizeTimeoutError` (or whatever the final name is) requires some precise threading, so maybe this would best be tested with a prose test.