### PR TITLE
add additional sleep needed for cmap test

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/pool-create-max-size.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-max-size.json
@@ -33,6 +33,10 @@
       "thread": "thread1"
     },
     {
+      "name": "wait",
+      "ms": 10
+    },
+    {
       "name": "checkIn",
       "connection": "conn1"
     },

--- a/source/connection-monitoring-and-pooling/tests/pool-create-max-size.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-max-size.yml
@@ -16,6 +16,8 @@ operations:
     target: thread1
   - name: checkOut
     thread: thread1
+  - name: wait
+    ms: 10
   - name: checkIn
     connection: conn1
   - name: waitFor

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.json
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "wait",
-      "ms": 20
+      "ms": 10
     },
     {
       "name": "start",
@@ -48,7 +48,7 @@
     },
     {
       "name": "wait",
-      "ms": 30
+      "ms": 10
     },
     {
       "name": "start",
@@ -58,6 +58,10 @@
       "name": "checkOut",
       "thread": "thread4",
       "label": "conn4"
+    },
+    {
+      "name": "wait",
+      "ms": 10
     },
     {
       "name": "checkIn",

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
@@ -41,6 +41,8 @@ operations:
     label: conn4
     # From main thread, keep checking in connection and then wait for appropriate thread
     # Test will timeout if threads are not enqueued in proper order
+  - name: wait
+    ms: 10
   - name: checkIn
     connection: conn0
   - name: waitFor


### PR DESCRIPTION
I found another place in the CMAP tests that need a sleep. In order to ensure that the final `ConnectionCheckoutStarted` event happens before the final `ConnectionCheckedIn` event, we need to give the thread time to start the checkout. (It shouldn't actually matter what order they happen for the purpose of testing behavior, but making the events occur more deterministically makes the tests pass more easily).

I've also pushed a second commit adding a fourth wait to the wait-queue-fairness.yml test which I should have added in the previous PR.