### PR TITLE
Clarify FAQ about not automatically retrying commit after wtimeout

### DIFF
--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -1210,13 +1210,18 @@ The following commands are allowed inside transactions:
 
 10. geoSearch
 
-Why don’t drivers retry after write concern timeout errors?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Why don’t drivers automatically retry commit after a write concern timeout error?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A write concern timeout error indicates that the command succeeded but
 failed to meet the specified writeConcern within the given time limit.
 Attempting to retry would implicitly double the application’s wtimeout
-value so drivers do not retry.
+value so drivers do not automatically retry.
+
+Note: this applies only to the driver's internal retry-once behavior.
+Write concern timeout errors will be labeled with
+"UnknownTransactionCommitResult", which signals that higher-level code
+may retry.
 
 What happens when a command object passed to RunCommand already contains a transaction field (eg. lsid, txnNumber, etc...)?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Related to some questions @jyemin brought up in Slack about interpreting the “Why don’t drivers retry after write concern timeout errors?” FAQ entry in light of the `withTransaction()` spec, which _does_ retry for wtimeout errors (see: #478). @ShaneHarvey suggested rephrasing this question so it's clear that it only pertains to the internal retry-once logic discussed in the Transactions spec.

I only refer to `commitTransaction` here, as `abortTransaction` doesn't talk about wtimeout errors at all. `abortTransaction` is only retried once after a retryable error, which excludes wtimeout. Drivers also don't report errors for `abortTransaction` (so there is no label to check) and applications aren't supposed to call abort a second time, so I don't think there's any need to discuss aborts for this FAQ entry.