### PR TITLE
Updating cmap spec tests with waitForEvent

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -64,9 +64,14 @@ Valid Unit Test Operations are the following:
 
   - ``ms``: The number of milliseconds to sleep the current thread for
 
-- ``waitFor(target)``: wait for thread ``target`` to finish executing. Propagate any errors to the main thread.
+- ``waitForThread(target)``: wait for thread ``target`` to finish executing. Propagate any errors to the main thread.
 
   - ``target``: The name of the thread to wait for.
+
+- ``waitForEvent(event, count)``: block the current thread until ``event`` has occurred ``count`` times
+
+  - ``event``: The name of the event
+  - ``count``: The number of times the event must occur (counting from the start of the test)
 
 - ``label = pool.checkOut()``: call ``checkOut`` on pool, returning the checked out connection
 
@@ -137,6 +142,8 @@ For each YAML file with ``style: unit``:
   - Assert that ``actualEvents[idx]`` exists
   - Assert that ``actualEvents[idx]`` MATCHES ``expectedEvent``
 
+
+It is important to note that the ``ignore`` list is used for calculating ``actualEvents``, but is NOT used for the ``waitForEvent`` command
 
 Prose Tests
 ===========

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.json
@@ -28,15 +28,15 @@
       "thread": "thread3"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread1"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread2"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread3"
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.json
@@ -8,16 +8,8 @@
       "target": "thread1"
     },
     {
-      "name": "wait",
-      "ms": 10
-    },
-    {
       "name": "start",
       "target": "thread2"
-    },
-    {
-      "name": "wait",
-      "ms": 20
     },
     {
       "name": "start",
@@ -51,15 +43,15 @@
   "events": [
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 2
+      "connectionId": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 3
+      "connectionId": 42
     }
   ],
   "ignore": [

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.yml
@@ -14,11 +14,11 @@ operations:
     thread: thread2
   - name: checkOut
     thread: thread3
-  - name: waitFor
+  - name: waitForThread
     target: thread1
-  - name: waitFor
+  - name: waitForThread
     target: thread2
-  - name: waitFor
+  - name: waitForThread
     target: thread3
 events:
   - type: ConnectionCheckedOut

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-multiple.yml
@@ -2,17 +2,10 @@ version: 1
 style: unit
 description: must be able to check out multiple connections at the same time
 operations:
-  # Note: this test can be somewhat non-deterministic depending on how you
-  # implement your test runner. The sleep operations should make this more
-  # consistent.
   - name: start
     target: thread1
-  - name: wait
-    ms: 10
   - name: start
     target: thread2
-  - name: wait
-    ms: 10
   - name: start
     target: thread3
   - name: checkOut
@@ -29,11 +22,11 @@ operations:
     target: thread3
 events:
   - type: ConnectionCheckedOut
-    connectionId: 1
+    connectionId: 42
   - type: ConnectionCheckedOut
-    connectionId: 2
+    connectionId: 42
   - type: ConnectionCheckedOut
-    connectionId: 3
+    connectionId: 42
 ignore:
   - ConnectionCreated
   - ConnectionReady

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
@@ -29,13 +29,6 @@
       "options": 42
     },
     {
-      "type": "ConnectionCreated",
-      "connectionId": 1
-    },
-    {
-      "type": "ConnectionCheckOutStarted"
-    },
-    {
       "type": "ConnectionCheckedOut",
       "connectionId": 1
     },
@@ -44,16 +37,9 @@
       "connectionId": 1
     },
     {
-      "type": "ConnectionCheckOutStarted"
-    },
-    {
       "type": "ConnectionClosed",
       "connectionId": 1,
       "reason": "idle"
-    },
-    {
-      "type": "ConnectionCreated",
-      "connectionId": 2
     },
     {
       "type": "ConnectionCheckedOut",
@@ -61,6 +47,8 @@
     }
   ],
   "ignore": [
-    "ConnectionReady"
+    "ConnectionReady",
+    "ConnectionCreated",
+    "ConnectionCheckOutStarted"
   ]
 }

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
@@ -15,21 +15,17 @@ events:
   - type: ConnectionPoolCreated
     address: 42
     options: 42
-  - type: ConnectionCreated
-    connectionId: 1
-  - type: ConnectionCheckOutStarted
   - type: ConnectionCheckedOut
     connectionId: 1
   - type: ConnectionCheckedIn
     connectionId: 1
   # In between these, wait so connection becomes idle
-  - type: ConnectionCheckOutStarted
   - type: ConnectionClosed
     connectionId: 1
     reason: idle
-  - type: ConnectionCreated
-    connectionId: 2
   - type: ConnectionCheckedOut
     connectionId: 2
 ignore:
   - ConnectionReady
+  - ConnectionCreated
+  - ConnectionCheckOutStarted

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
@@ -8,7 +8,8 @@
       "label": "conn"
     },
     {
-      "name": "checkIn"
+      "name": "checkIn",
+      "connection": "conn"
     },
     {
       "name": "clear"
@@ -24,34 +25,30 @@
       "options": 42
     },
     {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 1
+    },
+    {
       "type": "ConnectionPoolCleared",
       "address": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
-    },
-    {
       "type": "ConnectionClosed",
-      "connectionId": 42,
-      "reason": "stale"
-    },
-    {
-      "type": "ConnectionClosed",
-      "connectionId": 42,
-      "reason": "stale"
-    },
-    {
-      "type": "ConnectionClosed",
-      "connectionId": 42,
+      "connectionId": 1,
       "reason": "stale"
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 42
+      "connectionId": 2
     }
   ],
   "ignore": [
     "ConnectionReady",
-    "ConnectionCreated"
+    "ConnectionCreated",
+    "ConnectionCheckOutStarted"
   ]
 }

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
@@ -2,14 +2,13 @@
   "version": 1,
   "style": "unit",
   "description": "must destroy and must not check out a stale connection if found while iterating available connections",
-  "poolOptions": {
-    "minPoolSize": 3
-  },
   "operations": [
     {
-      "name": "waitForEvent",
-      "event": "ConnectionCreated",
-      "count": 3
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "checkIn"
     },
     {
       "name": "clear"

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
@@ -7,8 +7,9 @@
   },
   "operations": [
     {
-      "name": "wait",
-      "ms": 20
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 3
     },
     {
       "name": "clear"
@@ -47,11 +48,11 @@
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 4
+      "connectionId": 42
     }
   ],
   "ignore": [
-    "ConnectionCreated",
-    "ConnectionReady"
+    "ConnectionReady",
+    "ConnectionCreated"
   ]
 }

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
@@ -4,8 +4,9 @@ description: must destroy and must not check out a stale connection if found whi
 poolOptions:
   minPoolSize: 3
 operations:
-  - name: wait
-    ms: 20
+  - name: waitForEvent
+    event: ConnectionCreated
+    count: 3
   - name: clear
   - name: checkOut
 events:
@@ -28,7 +29,7 @@ events:
     connectionId: 42
     reason: stale
   - type: ConnectionCheckedOut
-    connectionId: 4
+    connectionId: 42
 ignore:
-  - ConnectionCreated
   - ConnectionReady
+  - ConnectionCreated

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
@@ -1,12 +1,10 @@
 version: 1
 style: unit
 description: must destroy and must not check out a stale connection if found while iterating available connections
-poolOptions:
-  minPoolSize: 3
 operations:
-  - name: waitForEvent
-    event: ConnectionCreated
-    count: 3
+  - name: checkOut
+    label: conn
+  - name: checkIn
   - name: clear
   - name: checkOut
 events:

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
@@ -5,29 +5,25 @@ operations:
   - name: checkOut
     label: conn
   - name: checkIn
+    connection: conn
   - name: clear
   - name: checkOut
 events:
   - type: ConnectionPoolCreated
     address: 42
     options: 42
+  - type: ConnectionCheckedOut
+    connectionId: 1
+  - type: ConnectionCheckedIn
+    connectionId: 1
   - type: ConnectionPoolCleared
     address: 42
-  - type: ConnectionCheckOutStarted
-
-  # Note: we cannot deterministically assert which connections get destroyed in which order,
-  # just that they will all be destroyed before connection check out.
   - type: ConnectionClosed
-    connectionId: 42
-    reason: stale
-  - type: ConnectionClosed
-    connectionId: 42
-    reason: stale
-  - type: ConnectionClosed
-    connectionId: 42
+    connectionId: 1
     reason: stale
   - type: ConnectionCheckedOut
-    connectionId: 42
+    connectionId: 2
 ignore:
   - ConnectionReady
   - ConnectionCreated
+  - ConnectionCheckOutStarted

--- a/source/connection-monitoring-and-pooling/tests/pool-create-max-size.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-max-size.json
@@ -33,15 +33,16 @@
       "thread": "thread1"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 5
     },
     {
       "name": "checkIn",
       "connection": "conn1"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread1"
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/pool-create-max-size.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-max-size.yml
@@ -16,11 +16,12 @@ operations:
     target: thread1
   - name: checkOut
     thread: thread1
-  - name: wait
-    ms: 10
+  - name: waitForEvent
+    event: ConnectionCheckOutStarted
+    count: 5
   - name: checkIn
     connection: conn1
-  - name: waitFor
+  - name: waitForThread
     target: thread1
 events:
   - type: ConnectionPoolCreated

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size.json
@@ -3,9 +3,14 @@
   "style": "unit",
   "description": "must be able to start a pool with minPoolSize connections",
   "poolOptions": {
-    "minPoolSize": 5
+    "minPoolSize": 3
   },
   "operations": [
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 3
+    },
     {
       "name": "checkOut"
     }
@@ -15,14 +20,6 @@
       "type": "ConnectionPoolCreated",
       "address": 42,
       "options": 42
-    },
-    {
-      "type": "ConnectionCreated",
-      "connectionId": 42
-    },
-    {
-      "type": "ConnectionCreated",
-      "connectionId": 42
     },
     {
       "type": "ConnectionCreated",

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size.json
@@ -7,10 +7,6 @@
   },
   "operations": [
     {
-      "name": "wait",
-      "ms": 50
-    },
-    {
       "name": "checkOut"
     }
   ],
@@ -41,15 +37,13 @@
       "connectionId": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
-    },
-    {
       "type": "ConnectionCheckedOut",
       "connectionId": 42
     }
   ],
   "ignore": [
     "ConnectionReady",
-    "ConnectionClosed"
+    "ConnectionClosed",
+    "ConnectionCheckOutStarted"
   ]
 }

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size.yml
@@ -4,8 +4,6 @@ description: must be able to start a pool with minPoolSize connections
 poolOptions:
   minPoolSize: 5
 operations:
-  - name: wait
-    ms: 50
   - name: checkOut
 events:
   - type: ConnectionPoolCreated
@@ -22,9 +20,9 @@ events:
   - type: ConnectionCreated
     connectionId: 42
   # Ensures that by the time pool is closed, there are at least 5 connections
-  - type: ConnectionCheckOutStarted
   - type: ConnectionCheckedOut
     connectionId: 42
 ignore:
   - ConnectionReady
   - ConnectionClosed
+  - ConnectionCheckOutStarted

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size.yml
@@ -2,8 +2,11 @@ version: 1
 style: unit
 description: must be able to start a pool with minPoolSize connections
 poolOptions:
-  minPoolSize: 5
+  minPoolSize: 3
 operations:
+  - name: waitForEvent
+    event: ConnectionCreated
+    count: 3
   - name: checkOut
 events:
   - type: ConnectionPoolCreated
@@ -15,11 +18,7 @@ events:
     connectionId: 42
   - type: ConnectionCreated
     connectionId: 42
-  - type: ConnectionCreated
-    connectionId: 42
-  - type: ConnectionCreated
-    connectionId: 42
-  # Ensures that by the time pool is closed, there are at least 5 connections
+  # Ensures that by the time pool is closed, there are at least 3 connections
   - type: ConnectionCheckedOut
     connectionId: 42
 ignore:

--- a/source/connection-monitoring-and-pooling/tests/pool-create-with-options.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-with-options.json
@@ -9,8 +9,9 @@
   },
   "operations": [
     {
-      "name": "wait",
-      "ms": 20
+      "name": "waitForEvent",
+      "event": "ConnectionPoolCreated",
+      "count": 1
     }
   ],
   "events": [

--- a/source/connection-monitoring-and-pooling/tests/pool-create-with-options.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-with-options.yml
@@ -6,8 +6,9 @@ poolOptions:
   minPoolSize: 5
   maxIdleTimeMS: 100
 operations:
-  - name: wait
-    ms: 20
+  - name: waitForEvent
+    event: ConnectionPoolCreated
+    count: 1
 events:
   - type: ConnectionPoolCreated
     address: 42

--- a/source/connection-monitoring-and-pooling/tests/pool-create.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create.json
@@ -4,8 +4,9 @@
   "description": "must be able to create a pool",
   "operations": [
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionPoolCreated",
+      "count": 1
     }
   ],
   "events": [

--- a/source/connection-monitoring-and-pooling/tests/pool-create.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create.yml
@@ -2,8 +2,9 @@ version: 1
 style: unit
 description: must be able to create a pool
 operations:
-  - name: wait
-    ms: 10
+  - name: waitForEvent
+    event: ConnectionPoolCreated
+    count: 1
 events:
   - type: ConnectionPoolCreated
     address: 42

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.json
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.json
@@ -21,8 +21,8 @@
       "label": "conn1"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted"
     },
     {
       "name": "start",
@@ -34,8 +34,8 @@
       "label": "conn2"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted"
     },
     {
       "name": "start",
@@ -47,8 +47,8 @@
       "label": "conn3"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted"
     },
     {
       "name": "start",
@@ -60,8 +60,8 @@
       "label": "conn4"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted"
     },
     {
       "name": "checkIn",

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.json
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.json
@@ -22,7 +22,8 @@
     },
     {
       "name": "waitForEvent",
-      "event": "ConnectionCheckOutStarted"
+      "event": "ConnectionCheckOutStarted",
+      "count": 2
     },
     {
       "name": "start",
@@ -35,7 +36,8 @@
     },
     {
       "name": "waitForEvent",
-      "event": "ConnectionCheckOutStarted"
+      "event": "ConnectionCheckOutStarted",
+      "count": 3
     },
     {
       "name": "start",
@@ -48,7 +50,8 @@
     },
     {
       "name": "waitForEvent",
-      "event": "ConnectionCheckOutStarted"
+      "event": "ConnectionCheckOutStarted",
+      "count": 4
     },
     {
       "name": "start",
@@ -61,14 +64,15 @@
     },
     {
       "name": "waitForEvent",
-      "event": "ConnectionCheckOutStarted"
+      "event": "ConnectionCheckOutStarted",
+      "count": 5
     },
     {
       "name": "checkIn",
       "connection": "conn0"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread1"
     },
     {
@@ -76,7 +80,7 @@
       "connection": "conn1"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread2"
     },
     {
@@ -84,7 +88,7 @@
       "connection": "conn2"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread3"
     },
     {
@@ -92,7 +96,7 @@
       "connection": "conn3"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread4"
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
@@ -20,6 +20,7 @@ operations:
     label: conn1
   - name: waitForEvent
     event: ConnectionCheckOutStarted
+    count: 2
   - name: start
     target: thread2
   - name: checkOut
@@ -27,6 +28,7 @@ operations:
     label: conn2
   - name: waitForEvent
     event: ConnectionCheckOutStarted
+    count: 3
   - name: start
     target: thread3
   - name: checkOut
@@ -34,30 +36,32 @@ operations:
     label: conn3
   - name: waitForEvent
     event: ConnectionCheckOutStarted
+    count: 4
   - name: start
     target: thread4
   - name: checkOut
     thread: thread4
     label: conn4
-    # From main thread, keep checking in connection and then wait for appropriate thread
-    # Test will timeout if threads are not enqueued in proper order
   - name: waitForEvent
     event: ConnectionCheckOutStarted
+    count: 5
+    # From main thread, keep checking in connection and then wait for appropriate thread
+    # Test will timeout if threads are not enqueued in proper order
   - name: checkIn
     connection: conn0
-  - name: waitFor
+  - name: waitForThread
     target: thread1
   - name: checkIn
     connection: conn1
-  - name: waitFor
+  - name: waitForThread
     target: thread2
   - name: checkIn
     connection: conn2
-  - name: waitFor
+  - name: waitForThread
     target: thread3
   - name: checkIn
     connection: conn3
-  - name: waitFor
+  - name: waitForThread
     target: thread4
 events:
   - type: ConnectionCheckOutStarted

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-fairness.yml
@@ -18,22 +18,22 @@ operations:
   - name: checkOut
     thread: thread1
     label: conn1
-  - name: wait
-    ms: 10
+  - name: waitForEvent
+    event: ConnectionCheckOutStarted
   - name: start
     target: thread2
   - name: checkOut
     thread: thread2
     label: conn2
-  - name: wait
-    ms: 10
+  - name: waitForEvent
+    event: ConnectionCheckOutStarted
   - name: start
     target: thread3
   - name: checkOut
     thread: thread3
     label: conn3
-  - name: wait
-    ms: 10
+  - name: waitForEvent
+    event: ConnectionCheckOutStarted
   - name: start
     target: thread4
   - name: checkOut
@@ -41,8 +41,8 @@ operations:
     label: conn4
     # From main thread, keep checking in connection and then wait for appropriate thread
     # Test will timeout if threads are not enqueued in proper order
-  - name: wait
-    ms: 10
+  - name: waitForEvent
+    event: ConnectionCheckOutStarted
   - name: checkIn
     connection: conn0
   - name: waitFor

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-timeout.json
@@ -21,14 +21,15 @@
     },
     {
       "name": "waitForEvent",
-      "event": "ConnectionCheckOutFailed"
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
     },
     {
       "name": "checkIn",
       "connection": "conn0"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread1"
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-timeout.json
@@ -20,8 +20,8 @@
       "thread": "thread1"
     },
     {
-      "name": "wait",
-      "ms": 40
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed"
     },
     {
       "name": "checkIn",

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-timeout.yml
@@ -16,10 +16,11 @@ operations:
   # Wait for other thread to time out, then check in connection
   - name: waitForEvent
     event: ConnectionCheckOutFailed
+    count: 1
   - name: checkIn
     connection: conn0
   # Rejoin thread1, should experience error
-  - name: waitFor
+  - name: waitForThread
     target: thread1
 error:
   type: WaitQueueTimeoutError

--- a/source/connection-monitoring-and-pooling/tests/wait-queue-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/wait-queue-timeout.yml
@@ -13,9 +13,9 @@ operations:
     target: thread1
   - name: checkOut
     thread: thread1
-  # Wait long enough for other thread to time out, then check in connection
-  - name: wait
-    ms: 40
+  # Wait for other thread to time out, then check in connection
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
   - name: checkIn
     connection: conn0
   # Rejoin thread1, should experience error


### PR DESCRIPTION
This is the solution that I arrived at to address the race conditions we were seeing: I added a `waitForEvent` command which operates as follows:

- Every thread keeps track of what events have occurred in a queue*
- When a `waitForEvent` command happens on a thread, the thread dequeues events until the necessary event is found
- If the event was not in the queue, the thread blocks until the event occurs.

Does this sound like a reasonable solution? If so, I'll update the README to include this command.