### PR TITLE
SPEC-1221 DuplicateKey error is not reported as a top-level command error

### DIFF
--- a/source/transactions-convenient-api/tests/callback-retry.json
+++ b/source/transactions-convenient-api/tests/callback-retry.json
@@ -207,7 +207,6 @@
                     }
                   },
                   "result": {
-                    "errorCodeName": "DuplicateKey",
                     "errorLabelsOmit": [
                       "TransientTransactionError",
                       "UnknownTransactionCommitResult"
@@ -218,7 +217,6 @@
             }
           },
           "result": {
-            "errorCodeName": "DuplicateKey",
             "errorLabelsOmit": [
               "TransientTransactionError",
               "UnknownTransactionCommitResult"

--- a/source/transactions-convenient-api/tests/callback-retry.yml
+++ b/source/transactions-convenient-api/tests/callback-retry.yml
@@ -149,10 +149,11 @@ tests:
                   session: session0
                   document: { _id: 1 }
                 result:
-                  errorCodeName: DuplicateKey
                   errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
         result:
-          errorCodeName: DuplicateKey
+          # Don't assert on errorCodeName because (after SERVER-38583) the
+          # DuplicateKey is reported in writeErrors, not as a top-level
+          # command error.
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
     expectations:
       -

--- a/source/transactions/tests/abort.json
+++ b/source/transactions/tests/abort.json
@@ -441,7 +441,6 @@
             }
           },
           "result": {
-            "errorCodeName": "DuplicateKey",
             "errorLabelsOmit": [
               "TransientTransactionError",
               "UnknownTransactionCommitResult"

--- a/source/transactions/tests/abort.yml
+++ b/source/transactions/tests/abort.yml
@@ -297,7 +297,9 @@ tests:
           document:
             _id: 1
         result:
-          errorCodeName: DuplicateKey
+          # Don't assert on errorCodeName because (after SERVER-38583) the
+          # DuplicateKey is reported in writeErrors, not as a top-level
+          # command error.
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
       # Make sure the server aborted the transaction.
       - name: insertOne

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -25,7 +25,6 @@
             ]
           },
           "result": {
-            "errorCodeName": "DuplicateKey",
             "errorLabelsOmit": [
               "TransientTransactionError",
               "UnknownTransactionCommitResult"

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -17,7 +17,9 @@ tests:
             - _id: 1
             - _id: 1
         result:
-          errorCodeName: DuplicateKey
+          # Don't assert on errorCodeName because (after SERVER-38583) the
+          # DuplicateKey is reported in writeErrors, not as a top-level
+          # command error.
           errorLabelsOmit: ["TransientTransactionError", "UnknownTransactionCommitResult"]
       - name: abortTransaction
         object: session0


### PR DESCRIPTION
The old behavior was:
```
> session.startTransaction()
> session.getDatabase("test").runCommand({
   insert: 'c', 
   documents: [{_id: 0}, {_id: 0}]
})
{
    "ok" : 0,
    "errmsg" : "duplicate key error",
    "code" : 11000,
    "codeName" : "DuplicateKey"
}
```
The behavior after https://jira.mongodb.org/browse/SERVER-38583 is:
```
{
    "ok" : 1,
    "n" : 1,
    "writeErrors" : [
        {
            "index" : 1,
            "code" : 11000,
            "errmsg" : "duplicate key error"
        }
    ]
}
```

This error reporting change is going to be backported to 4.0.

For now I simply removed the `errorCodeName: DuplicateKey` assertions to get the tests to pass regardless of how the error is reported. Alternatively we could change the definition of `errorCodeName` to also look at error codes in `writeErrors` but since writeErrors don't have `codeName` we would either need to (re)introduce `errorCode: 11000` or use the existing `errorContains: duplicate key error`.