### PR TITLE
SPEC-1222 Standardize units of bytes

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -436,9 +436,9 @@ A driver SHOULD attempt to kill the cursor on the server on which the cursor is 
 Notes and Restrictions
 ^^^^^^^^^^^^^^^^^^^^^^
 
-**1. `fullDocument: updateLookup` can result in change documents larger than 16MB**
+**1. `fullDocument: updateLookup` can result in change documents larger than 16 MiB**
 
-There is a risk that if there is a large change to a large document, the full document and delta might result in a document larger than the 16MB limitation on BSON documents.  If that happens the cursor will be closed, and a server error will be returned.
+There is a risk that if there is a large change to a large document, the full document and delta might result in a document larger than the 16 MiB limitation on BSON documents.  If that happens the cursor will be closed, and a server error will be returned.
 
 **2. Users can remove the resume token with aggregation stages**
 

--- a/source/driver-bulk-update.rst
+++ b/source/driver-bulk-update.rst
@@ -229,11 +229,11 @@ Internally the driver will execute 3 write commands. One each for the inserts, u
 Request Size Limits
 -------------------
 
-Supporting unlimited batch sizes poses two problems - the BSONObj internal size limit is 16MB + small overhead (for commands), and a small write operation may have a much larger response.  In order to ensure a batch can be correctly processed, two limits must be respected.
+Supporting unlimited batch sizes poses two problems - the BSONObj internal size limit is 16 MiB + small overhead (for commands), and a small write operation may have a much larger response.  In order to ensure a batch can be correctly processed, two limits must be respected.
 
 Both of these limits can be found using isMaster():
 
-* ``maxBsonObjectSize`` : currently 16MB, this is the maximum size of writes (excepting command overhead)
+* ``maxBsonObjectSize`` : currently 16 MiB, this is the maximum size of writes (excepting command overhead)
   that should be sent to the server.  Documents to be inserted, query documents for updates and 
   deletes, and update expression documents must be <= this size.
 
@@ -1233,13 +1233,13 @@ Test Case 2:
 
         Same for initializeOrderedBulkOp().
 
-        We can upsert() a 16MB document—the driver can make a command document slightly larger than the max document size.
+        We can upsert() a 16 MiB document—the driver can make a command document slightly larger than the max document size.
 
         Empty collection.
         
         .. code:: javascript
 
-            var bigstring = “string of length 16MB - 30 bytes”
+            var bigstring = “string of length 16 MiB - 30 bytes”
             batch = initializeUnorderedBulkOp()
             batch.find({key: 1}).upsert().update({$set: {x: bigstring}})
             batch.execute() succeeds.
@@ -1559,16 +1559,16 @@ Empty collection, unique index on 'a’.
 
 BATCH SPLITTING: maxBsonObjectSize
 ----------------------------------
-More than 16MB worth of inserts are split into multiple messages, and error indexes are rewritten. An unordered batch continues on error and returns the error after all messages are sent.
+More than 16 MiB worth of inserts are split into multiple messages, and error indexes are rewritten. An unordered batch continues on error and returns the error after all messages are sent.
 
 Empty collection.
 
 .. code:: javascript
 
-    // Verify that the driver splits inserts into 16-MB messages:
+    // Verify that the driver splits inserts into 16-MiB messages:
     batch = initializeOrderedBulkOp()
     for (i = 0; i < 6; i++) {
-    batch.insert({_id: i, a: '4 MB STRING'});
+    batch.insert({_id: i, a: '4 MiB STRING'});
     }
 
     batch.insert({_id: 0})  // will fail

--- a/source/gridfs/gridfs-spec.rst
+++ b/source/gridfs/gridfs-spec.rst
@@ -21,7 +21,7 @@ Abstract
 
 GridFS is a convention drivers use to store and retrieve BSON binary
 data (type “\\x05”) that exceeds MongoDB’s BSON-document size limit of
-16MB. When this data, called a **user file**, is written to the system,
+16 MiB. When this data, called a **user file**, is written to the system,
 GridFS divides the file into **chunks** that are stored as distinct
 documents in a **chunks collection**. To retrieve a stored file, GridFS
 locates and returns all of its component chunks. Internally, GridFS
@@ -56,7 +56,7 @@ Bucket name
 
 Chunk
   A section of a user file, stored as a single document in the ‘chunks’ collection of a GridFS bucket.
-  The default size for the data field in chunks is 255KB. Chunk documents have the following form:
+  The default size for the data field in chunks is 255 KiB. Chunk documents have the following form:
 
   .. code:: javascript
   
@@ -106,7 +106,7 @@ Files collection document
   :_id: a unique ID for this document. Usually this will be of type ObjectId, but a custom _id value provided by
     the application may be of any type.
   :length: the length of this stored file, in bytes
-  :chunkSize: the size, in bytes, of each data chunk of this file. This value is configurable by file. The default is 255KB.
+  :chunkSize: the size, in bytes, of each data chunk of this file. This value is configurable by file. The default is 255 KiB.
   :uploadDate: the date and time this file was added to GridFS, stored as a BSON datetime value. The value of this
     field MUST be the datetime when the upload completed, not the datetime when it was begun.
   :md5: DEPRECATED, a hash of the contents of the stored file
@@ -267,7 +267,7 @@ Configurable GridFSBucket class
     bucketName : String optional;
     
     /**
-     * The chunk size in bytes. Defaults to 255KB.
+     * The chunk size in bytes. Defaults to 255 KiB.
      */
     chunkSizeBytes : Int32 optional;
     
@@ -320,7 +320,7 @@ configurable:
 - **chunkSizeBytes:** the number of bytes stored in chunks for new
   user files added through this GridFSBucket object. This will not
   reformat existing files in the system that use a different chunk
-  size. Defaults to 255KB.
+  size. Defaults to 255 KiB.
 
 IF a driver supports configuring readConcern, readPreference or writeConcern
 at the database or collection level, then GridFSBucket objects MUST also allow
@@ -957,11 +957,11 @@ that are undesirable or incorrect.
 Design Rationale
 ================
 
-Why is the default chunk size 255KB?
+Why is the default chunk size 255 KiB?
   On MMAPv1, the server provides documents with extra padding to allow for
-  in-place updates. When the ‘data’ field of a chunk is limited to 255KB,
+  in-place updates. When the ‘data’ field of a chunk is limited to 255 KiB,
   it ensures that the whole chunk document (the chunk data along with an
-  _id and other information) will fit into a 256KB section of memory,
+  _id and other information) will fit into a 256 KiB section of memory,
   making the best use of the provided padding. Users setting custom chunk
   sizes are advised not to use round power-of-two values, as the whole
   chunk document is likely to exceed that space and demand extra padding

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -187,9 +187,9 @@ The YAML tests specify bulk write operations that are split by command type
 operations may also be split due to ``maxWriteBatchSize``,
 ``maxBsonObjectSize``, or ``maxMessageSizeBytes``.
 
-For instance, an insertMany operation with five 10 MB documents executed using
+For instance, an insertMany operation with five 10 MiB documents executed using
 OP_MSG payload type 0 (i.e. entire command in one document) would be split into
-five insert commands in order to respect the 16 MB ``maxBsonObjectSize`` limit.
+five insert commands in order to respect the 16 MiB ``maxBsonObjectSize`` limit.
 The same insertMany operation executed using OP_MSG payload type 1 (i.e. command
 arguments pulled out into a separate payload vector) would be split into two
 insert commands in order to respect the 48 MB ``maxMessageSizeBytes`` limit.

--- a/source/server_write_commands.rst
+++ b/source/server_write_commands.rst
@@ -132,17 +132,17 @@ we'd like to perform.
 Request Size Limits
 ~~~~~~~~~~~~~~~~~~~
 
-Supporting unlimited batch sizes poses two problems - the BSONObj internal size limit is 16MB + 16KB
+Supporting unlimited batch sizes poses two problems - the BSONObj internal size limit is 16 MiB + 16 KiB
 (for command overhead), and a small write operation may have a much larger response.  In order to
 ensure a batch can be correctly processed, two limits must be respected.
 
 Both of these limits can be found using isMaster():
 
-* ``maxBsonObjectSize`` : currently 16MB, this is the maximum size of writes (excluding command overhead)
+* ``maxBsonObjectSize`` : currently 16 MiB, this is the maximum size of writes (excluding command overhead)
   that should be sent to the server.  Documents to be inserted, query documents for updates and
   deletes, and update expression documents must be <= this size.  Once these documents have been
   assembled into a write command the total size may exceed ``maxBsonObjectSize`` by a maximum of
-  16KB, allowing users to insert documents up to ``maxBsonObjectSize``.
+  16 KiB, allowing users to insert documents up to ``maxBsonObjectSize``.
 
 * ``maxWriteBatchSize`` : currently 1000, this is the maximum number of inserts, updates, or deletes that 
   can be included in a write batch.  If more than this number of writes are included, the server cannot


### PR DESCRIPTION
[SPEC-1222](https://jira.mongodb.com/browse/SPEC-1222)

I didn't update any of the changelogs since this *should not* require changes in behavior in any of the drivers, since they have been interpreting KB as KiB already. This is just a clarification for new drivers.

`MaxMessageSizeBytes` is defined to be actually 48MB (in SI units, so 48,000,000 bytes).
The benchmarking spec explicitly uses the SI definition of MB, so that has also been left unchanged.