### PR TITLE
SPEC-1223: Remove bulkWrite test operation whose result depends on document key-order

### DIFF
--- a/source/crud/tests/v1/write/bulkWrite.json
+++ b/source/crud/tests/v1/write/bulkWrite.json
@@ -195,18 +195,6 @@
                   "_id": 1
                 },
                 "replacement": {
-                  "_id": 1,
-                  "x": 11
-                }
-              }
-            },
-            {
-              "name": "replaceOne",
-              "arguments": {
-                "filter": {
-                  "_id": 1
-                },
-                "replacement": {
                   "x": 12
                 }
               }
@@ -234,11 +222,11 @@
           "deletedCount": 0,
           "insertedCount": 0,
           "insertedIds": {},
-          "matchedCount": 2,
+          "matchedCount": 1,
           "modifiedCount": 1,
           "upsertedCount": 1,
           "upsertedIds": {
-            "3": 3
+            "2": 3
           }
         },
         "collection": {

--- a/source/crud/tests/v1/write/bulkWrite.yml
+++ b/source/crud/tests/v1/write/bulkWrite.yml
@@ -113,15 +113,6 @@ tests:
                             filter: { _id: 3 }
                             replacement: { x: 33 }
                     -
-                        # does not modify the matched document
-                        name: "replaceOne"
-                        arguments:
-                            filter: { _id: 1 }
-                            # Repeat _id in replacement document so the server
-                            # does not report a modification for this update.
-                            # See: https://jira.mongodb.org/browse/SERVER-36405
-                            replacement: { _id: 1, x: 11 }
-                    -
                         # modifies the matched document
                         name: "replaceOne"
                         arguments:
@@ -140,10 +131,10 @@ tests:
                 deletedCount: 0
                 insertedCount: 0
                 insertedIds: {}
-                matchedCount: 2
+                matchedCount: 1
                 modifiedCount: 1
                 upsertedCount: 1
-                upsertedIds: { 3: 3 }
+                upsertedIds: { 2: 3 }
             collection:
                 data:
                     - {_id: 1, x: 12 }


### PR DESCRIPTION
Closes https://jira.mongodb.org/browse/SPEC-1223