### PR TITLE
Rollback use of $exists in spec tests

### DIFF
--- a/source/crud/tests/v2/bulkWrite-arrayFilters.json
+++ b/source/crud/tests/v2/bulkWrite-arrayFilters.json
@@ -116,9 +116,7 @@
                   ]
                 }
               ],
-              "ordered": true,
-              "writeConcern": null,
-              "bypassDocumentValidation": null
+              "ordered": true
             },
             "command_name": "update",
             "database_name": "crud-tests"

--- a/source/crud/tests/v2/bulkWrite-arrayFilters.json
+++ b/source/crud/tests/v2/bulkWrite-arrayFilters.json
@@ -117,12 +117,8 @@
                 }
               ],
               "ordered": true,
-              "writeConcern": {
-                "$exists": false
-              },
-              "bypassDocumentValidation": {
-                "$exists": false
-              }
+              "writeConcern": null,
+              "bypassDocumentValidation": null
             },
             "command_name": "update",
             "database_name": "crud-tests"

--- a/source/crud/tests/v2/bulkWrite-arrayFilters.yml
+++ b/source/crud/tests/v2/bulkWrite-arrayFilters.yml
@@ -54,8 +54,10 @@ tests:
                 multi: true
                 arrayFilters: [ { "i.b": 1 } ]
             ordered: true
-            writeConcern: null
-            bypassDocumentValidation: null
+            # TODO: check that these fields do not exist once
+            # https://jira.mongodb.org/browse/SPEC-1215 has been resolved.
+            # writeConcern: null
+            # bypassDocumentValidation: null
           command_name: update
           database_name: *database_name
     outcome:

--- a/source/crud/tests/v2/bulkWrite-arrayFilters.yml
+++ b/source/crud/tests/v2/bulkWrite-arrayFilters.yml
@@ -54,8 +54,8 @@ tests:
                 multi: true
                 arrayFilters: [ { "i.b": 1 } ]
             ordered: true
-            writeConcern: { $exists: false }
-            bypassDocumentValidation: { $exists: false }
+            writeConcern: null
+            bypassDocumentValidation: null
           command_name: update
           database_name: *database_name
     outcome:


### PR DESCRIPTION
PR to remove the use of `$exists` from spec tests that had started using it prematurely. [SPEC-1215](https://jira.mongodb.org/browse/SPEC-1215) is tracking the discussion/work of coming up with appropriate keywords for such situations.