### PR TITLE
test(crud): remove `result` expectation for $out agg test

### DIFF
--- a/source/crud/tests/v1/read/aggregate-out.json
+++ b/source/crud/tests/v1/read/aggregate-out.json
@@ -41,16 +41,6 @@
         }
       },
       "outcome": {
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ],
         "collection": {
           "name": "other_test_collection",
           "data": [
@@ -92,16 +82,6 @@
         }
       },
       "outcome": {
-        "result": [
-          {
-            "_id": 2,
-            "x": 22
-          },
-          {
-            "_id": 3,
-            "x": 33
-          }
-        ],
         "collection": {
           "name": "other_test_collection",
           "data": [

--- a/source/crud/tests/v1/read/aggregate-out.yml
+++ b/source/crud/tests/v1/read/aggregate-out.yml
@@ -18,13 +18,6 @@ tests:
                 batchSize: 2
 
         outcome:
-            # Note: drivers are not required to return a cursor for aggregate
-            # pipelines using $out, but those that do may use this result to
-            # assert that the returned cursor points to the output collection.
-            # Drivers that do not return cursors for $out should ignore this.
-            result:
-                - {_id: 2, x: 22}
-                - {_id: 3, x: 33}
             collection:
                 name: "other_test_collection"
                 data:
@@ -43,9 +36,6 @@ tests:
                 batchSize: 0
 
         outcome:
-            result:
-                - {_id: 2, x: 22}
-                - {_id: 3, x: 33}
             collection:
                 name: "other_test_collection"
                 data:


### PR DESCRIPTION
Drivers are not required to provide a cursor against the collection
indicated in a `$out`. The presence of a `result` as well as
`collection` fields in this test is inconsistent with the rest of
the crud tests, and makes it difficult for implementations to
share common code for checking expectations without writing very
specific code to check for this isolated case.