### PR TITLE
test(db-aggregate): only check local operations in $currentOp test

### DIFF
--- a/source/crud/tests/v2/db-aggregate.json
+++ b/source/crud/tests/v2/db-aggregate.json
@@ -13,7 +13,8 @@
               {
                 "$currentOp": {
                   "allUsers": false,
-                  "idleConnections": false
+                  "idleConnections": false,
+                  "localOps": true
                 }
               },
               {
@@ -43,7 +44,8 @@
                   {
                     "$currentOp": {
                       "allUsers": false,
-                      "idleConnections": false
+                      "idleConnections": false,
+                      "localOps": true
                     }
                   },
                   {
@@ -83,7 +85,8 @@
               {
                 "$currentOp": {
                   "allUsers": true,
-                  "idleConnections": true
+                  "idleConnections": true,
+                  "localOps": true
                 }
               },
               {
@@ -114,7 +117,8 @@
                   {
                     "$currentOp": {
                       "allUsers": true,
-                      "idleConnections": true
+                      "idleConnections": true,
+                      "localOps": true
                     }
                   },
                   {

--- a/source/crud/tests/v2/db-aggregate.yml
+++ b/source/crud/tests/v2/db-aggregate.yml
@@ -11,7 +11,7 @@ tests:
         object: database
         arguments:
           pipeline:
-            - $currentOp: { allUsers: false, idleConnections: false }
+            - $currentOp: { allUsers: false, idleConnections: false, localOps: true }
             - $match: { command.aggregate: { $eq: 1 } }
             - $project: { command: 1 }
             - $project: { command.lsid: 0 }
@@ -20,7 +20,7 @@ tests:
             command:
               aggregate: 1
               pipeline:
-                - $currentOp: { allUsers: false, idleConnections: false }
+                - $currentOp: { allUsers: false, idleConnections: false, localOps: true }
                 - $match: { command.aggregate: { $eq: 1 } }
                 - $project: { command: 1 }
                 - $project: { command.lsid: 0 }
@@ -34,7 +34,7 @@ tests:
         object: database
         arguments:
           pipeline:
-            - $currentOp: { allUsers: true, idleConnections: true }
+            - $currentOp: { allUsers: true, idleConnections: true, localOps: true }
             - $match: { command.aggregate: {$eq: 1} }
             - $project: { command: 1 }
             - $project: { command.lsid: 0 }
@@ -44,7 +44,7 @@ tests:
             command:
               aggregate: 1
               pipeline:
-                - $currentOp: { allUsers: true, idleConnections: true }
+                - $currentOp: { allUsers: true, idleConnections: true, localOps: true }
                 - $match: { command.aggregate: { $eq: 1 } }
                 - $project: { command: 1 }
                 - $project: { command.lsid: 0 }


### PR DESCRIPTION
When running these CRUD tests against a sharded cluster the
`$currentOp` stage will likely return many results, occasionally
too many to return the initiating aggregtion command we expect
to see in the results. Limiting the stage to return only local
operations corrects the race condition.