### PR TITLE
Require that driver matches error code and not code name.

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -1390,6 +1390,8 @@ error is a "node is recovering" error or a "not master" error.
 
 If the response includes an error code, it MUST be checked first to attempt
 to determine if error is a "node is recovering" or "not master" error.
+Clients MUST match the errors by the numeric error code and not by the code
+name, as the code name can change from one server version to the next.
 
 The following error codes indicate a replica set member is temporarily
 unusable. These are called "node is recovering" errors:


### PR DESCRIPTION
Although the specification lists error code names, these names
may be changed by the server at any time (for example, 4.0 still
uses InterruptedDueToReplStateChange while 4.1 uses
InterruptedDueToStepDown for 11602). Explicitly state that
code names are not to be used for matching.