### PR TITLE
SPEC-1168 Drivers must disable targetedFailPoint

### DIFF
--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -460,12 +460,12 @@ Note that mongo-orchestration >=0.6.13 automatically sets this timeout to 3
 seconds so drivers using mongo-orchestration do not need to run these commands
 manually.
 
-.. _SERVER-39349: https://jira.mongodb.org/browse/SERVER-39726
+.. _SERVER-39726: https://jira.mongodb.org/browse/SERVER-39726
 
 .. _SERVER-39349: https://jira.mongodb.org/browse/SERVER-39349
 
 **Changelog**
--------------
+=============
 
 :2019-02-13: Modify test format for 4.2 sharded transactions, including
              "useMultipleMongoses", ``object: testRunner``, the

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -279,6 +279,15 @@ determined by the "session" argument (either "session0" or "session1").
 The session must already be pinned to a mongos server. The "failPoint" argument
 is the ``configureFailPoint`` command to run.
 
+If a test uses ``targetedFailPoint``, disable the fail point after running
+all ``operations`` to avoid spurious failures in subsequent tests. The fail
+point may be disabled like so::
+
+    db.adminCommand({
+        configureFailPoint: <fail point name>,
+        mode: "off"
+    });
+
 Here is an example which instructs the test runner to enable the failCommand
 fail point on the mongos server which "session0" is pinned to::
 

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -988,7 +988,7 @@ abortTransaction throws "Cannot call abortTransaction after
 commitTransaction".
 
 Drivers add the "TransientTransactionError" label to network errors
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When any non-commitTransaction command fails with a network error within
 a transaction Drivers add the "TransientTransactionError" label because


### PR DESCRIPTION
Also fixes some rst syntax errors found via:
```
pip install docutils
rst2html.py transactions/transactions.rst > output.html
transactions/transactions.rst:991: (WARNING/2) Title underline too short.

Drivers add the "TransientTransactionError" label to network errors
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
transactions/transactions.rst:991: (WARNING/2) Title underline too short.

Drivers add the "TransientTransactionError" label to network errors
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
```
rst2html.py transactions/tests/README.rst > output.html
transactions/tests/README.rst:465: (WARNING/2) Duplicate explicit target name: "server-39349".
transactions/tests/README.rst:467: (SEVERE/4) Title level inconsistent:

**Changelog**
-------------
Exiting due to level-4 (SEVERE) system message.
```