### PR TITLE
Add more variants of the TLS-related URI options tests

### DIFF
--- a/source/uri-options/tests/tls-options.json
+++ b/source/uri-options/tests/tls-options.json
@@ -174,6 +174,24 @@
       "options": {}
     },
     {
+      "description": "ssl=true and tls=true doesn't warn",
+      "uri": "mongodb://example.com/?ssl=true&tls=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "ssl=false and tls=false doesn't warn",
+      "uri": "mongodb://example.com/?ssl=false&tls=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
       "description": "tls=false and ssl=true raises error",
       "uri": "mongodb://example.com/?tls=false&ssl=true",
       "valid": false,

--- a/source/uri-options/tests/tls-options.json
+++ b/source/uri-options/tests/tls-options.json
@@ -102,6 +102,24 @@
       "options": {}
     },
     {
+      "description": "tlsAllowInvalidCertificates and tlsInsecure both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsInsecure=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidCertificates and tlsInsecure both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsInsecure=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
       "description": "tlsInsecure and tlsAllowInvalidHostnames both present (and true) raises an error",
       "uri": "mongodb://example.com/?tlsInsecure=true&tlsAllowInvalidHostnames=true",
       "valid": false,
@@ -113,6 +131,24 @@
     {
       "description": "tlsInsecure and tlsAllowInvalidHostnames both present (and false) raises an error",
       "uri": "mongodb://example.com/?tlsInsecure=false&tlsAllowInvalidHostnames=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidHostnames and tlsInsecure both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidHostnames=true&tlsInsecure=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidHostnames and tlsInsecure both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsAllowInvalidHostnames=false&tlsInsecure=false",
       "valid": false,
       "warning": false,
       "hosts": null,
@@ -149,6 +185,24 @@
     {
       "description": "tls=true and ssl=false raises error",
       "uri": "mongodb://example.com/?tls=true&ssl=false",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "ssl=false and tls=true raises error",
+      "uri": "mongodb://example.com/?ssl=false&tls=true",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "ssl=true and tls=false raises error",
+      "uri": "mongodb://example.com/?ssl=true&tls=false",
       "valid": false,
       "warning": false,
       "hosts": null,

--- a/source/uri-options/tests/tls-options.yml
+++ b/source/uri-options/tests/tls-options.yml
@@ -151,6 +151,22 @@ tests:
         auth: ~
         options: {}
     -
+        description: "ssl=true and tls=true doesn't warn"
+        uri: "mongodb://example.com/?ssl=true&tls=true"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "ssl=false and tls=false doesn't warn"
+        uri: "mongodb://example.com/?ssl=false&tls=false"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
         description: "tls=false and ssl=true raises error"
         uri: "mongodb://example.com/?tls=false&ssl=true"
         valid: false

--- a/source/uri-options/tests/tls-options.yml
+++ b/source/uri-options/tests/tls-options.yml
@@ -87,6 +87,22 @@ tests:
         auth: ~
         options: {}
     -
+        description: "tlsAllowInvalidCertificates and tlsInsecure both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsInsecure=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsAllowInvalidCertificates and tlsInsecure both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsInsecure=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
         description: "tlsInsecure and tlsAllowInvalidHostnames both present (and true) raises an error"
         uri: "mongodb://example.com/?tlsInsecure=true&tlsAllowInvalidHostnames=true"
         valid: false
@@ -97,6 +113,22 @@ tests:
     -
         description: "tlsInsecure and tlsAllowInvalidHostnames both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsInsecure=false&tlsAllowInvalidHostnames=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsAllowInvalidHostnames and tlsInsecure both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidHostnames=true&tlsInsecure=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "tlsAllowInvalidHostnames and tlsInsecure both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsAllowInvalidHostnames=false&tlsInsecure=false"
         valid: false
         warning: false
         hosts: ~
@@ -134,4 +166,19 @@ tests:
         hosts: ~
         auth: ~
         options: {}
-
+    -
+        description: "ssl=false and tls=true raises error"
+        uri: "mongodb://example.com/?ssl=false&tls=true"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "ssl=true and tls=false raises error"
+        uri: "mongodb://example.com/?ssl=true&tls=false"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}


### PR DESCRIPTION
I realized that some implementations would have order-dependent processing of the TLS options, so added some more variants that test the reverse order.