### PR TITLE
Transactions convenient API updates for retryable writes on by default

### DIFF
--- a/source/transactions-convenient-api/tests/callback-aborts.json
+++ b/source/transactions-convenient-api/tests/callback-aborts.json
@@ -126,6 +126,9 @@
     {
       "description": "withTransaction still succeeds if callback aborts and runs extra op",
       "useMultipleMongoses": true,
+      "clientOptions": {
+        "retryWrites": false
+      },
       "operations": [
         {
           "name": "withTransaction",

--- a/source/transactions-convenient-api/tests/callback-aborts.yml
+++ b/source/transactions-convenient-api/tests/callback-aborts.yml
@@ -89,6 +89,8 @@ tests:
     # Session state will be NO_TXN when callback returns to withTransaction
     description: withTransaction still succeeds if callback aborts and runs extra op
     useMultipleMongoses: true
+    clientOptions:
+      retryWrites: false
     operations:
       -
         name: withTransaction

--- a/source/transactions-convenient-api/tests/callback-commits.json
+++ b/source/transactions-convenient-api/tests/callback-commits.json
@@ -143,6 +143,9 @@
     {
       "description": "withTransaction still succeeds if callback commits and runs extra op",
       "useMultipleMongoses": true,
+      "clientOptions": {
+        "retryWrites": false
+      },
       "operations": [
         {
           "name": "withTransaction",

--- a/source/transactions-convenient-api/tests/callback-commits.yml
+++ b/source/transactions-convenient-api/tests/callback-commits.yml
@@ -97,6 +97,8 @@ tests:
     # Session state will be NO_TXN when callback returns to withTransaction
     description: withTransaction still succeeds if callback commits and runs extra op
     useMultipleMongoses: true
+    clientOptions:
+      retryWrites: false
     operations:
       -
         name: withTransaction


### PR DESCRIPTION
SPEC-1256: add retryWrites:false client option to tests that write outside of a transaction