### PR TITLE
SPEC-1253: Retryable read tests require mongos 4.1.7

### DIFF
--- a/source/retryable-reads/tests/aggregate-serverErrors.json
+++ b/source/retryable-reads/tests/aggregate-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/aggregate-serverErrors.yml
+++ b/source/retryable-reads/tests/aggregate-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/aggregate.json
+++ b/source/retryable-reads/tests/aggregate.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/aggregate.yml
+++ b/source/retryable-reads/tests/aggregate.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.json
+++ b/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.json
@@ -3,7 +3,12 @@
     {
       "minServerVersion": "4.0",
       "topology": [
-        "replicaset",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
         "sharded"
       ]
     }

--- a/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.yml
+++ b/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.yml
@@ -1,7 +1,10 @@
 runOn:
     -
         minServerVersion: "4.0"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/changeStreams-client.watch.json
+++ b/source/retryable-reads/tests/changeStreams-client.watch.json
@@ -3,7 +3,12 @@
     {
       "minServerVersion": "4.0",
       "topology": [
-        "replicaset",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
         "sharded"
       ]
     }

--- a/source/retryable-reads/tests/changeStreams-client.watch.yml
+++ b/source/retryable-reads/tests/changeStreams-client.watch.yml
@@ -1,7 +1,10 @@
 runOn:
     -
         minServerVersion: "4.0"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.json
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.json
@@ -3,7 +3,12 @@
     {
       "minServerVersion": "4.0",
       "topology": [
-        "replicaset",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
         "sharded"
       ]
     }

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.yml
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.yml
@@ -1,7 +1,10 @@
 runOn:
     -
         minServerVersion: "4.0"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch.json
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch.json
@@ -3,7 +3,12 @@
     {
       "minServerVersion": "4.0",
       "topology": [
-        "replicaset",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
         "sharded"
       ]
     }

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch.yml
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch.yml
@@ -1,7 +1,10 @@
 runOn:
     -
         minServerVersion: "4.0"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.json
+++ b/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.json
@@ -3,7 +3,12 @@
     {
       "minServerVersion": "4.0",
       "topology": [
-        "replicaset",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
         "sharded"
       ]
     }

--- a/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.yml
+++ b/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.yml
@@ -1,7 +1,10 @@
 runOn:
     -
         minServerVersion: "4.0"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/changeStreams-db.watch.json
+++ b/source/retryable-reads/tests/changeStreams-db.watch.json
@@ -3,7 +3,12 @@
     {
       "minServerVersion": "4.0",
       "topology": [
-        "replicaset",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
         "sharded"
       ]
     }

--- a/source/retryable-reads/tests/changeStreams-db.watch.yml
+++ b/source/retryable-reads/tests/changeStreams-db.watch.yml
@@ -1,7 +1,10 @@
 runOn:
     -
         minServerVersion: "4.0"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/count-serverErrors.json
+++ b/source/retryable-reads/tests/count-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/count-serverErrors.yml
+++ b/source/retryable-reads/tests/count-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/count.json
+++ b/source/retryable-reads/tests/count.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/count.yml
+++ b/source/retryable-reads/tests/count.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/countDocuments-serverErrors.json
+++ b/source/retryable-reads/tests/countDocuments-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/countDocuments-serverErrors.yml
+++ b/source/retryable-reads/tests/countDocuments-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/countDocuments.json
+++ b/source/retryable-reads/tests/countDocuments.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/countDocuments.yml
+++ b/source/retryable-reads/tests/countDocuments.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/distinct-serverErrors.json
+++ b/source/retryable-reads/tests/distinct-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/distinct-serverErrors.yml
+++ b/source/retryable-reads/tests/distinct-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/distinct.json
+++ b/source/retryable-reads/tests/distinct.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/distinct.yml
+++ b/source/retryable-reads/tests/distinct.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/estimatedDocumentCount-serverErrors.json
+++ b/source/retryable-reads/tests/estimatedDocumentCount-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/estimatedDocumentCount-serverErrors.yml
+++ b/source/retryable-reads/tests/estimatedDocumentCount-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/estimatedDocumentCount.json
+++ b/source/retryable-reads/tests/estimatedDocumentCount.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/estimatedDocumentCount.yml
+++ b/source/retryable-reads/tests/estimatedDocumentCount.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/find-serverErrors.json
+++ b/source/retryable-reads/tests/find-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/find-serverErrors.yml
+++ b/source/retryable-reads/tests/find-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/find.json
+++ b/source/retryable-reads/tests/find.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/find.yml
+++ b/source/retryable-reads/tests/find.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/findOne-serverErrors.json
+++ b/source/retryable-reads/tests/findOne-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/findOne-serverErrors.yml
+++ b/source/retryable-reads/tests/findOne-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/findOne.json
+++ b/source/retryable-reads/tests/findOne.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/findOne.yml
+++ b/source/retryable-reads/tests/findOne.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/gridfs-download-serverErrors.json
+++ b/source/retryable-reads/tests/gridfs-download-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/gridfs-download-serverErrors.yml
+++ b/source/retryable-reads/tests/gridfs-download-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/source/retryable-reads/tests/gridfs-download.json
+++ b/source/retryable-reads/tests/gridfs-download.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/gridfs-download.yml
+++ b/source/retryable-reads/tests/gridfs-download.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.json
+++ b/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.yml
+++ b/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/source/retryable-reads/tests/gridfs-downloadByName.json
+++ b/source/retryable-reads/tests/gridfs-downloadByName.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/gridfs-downloadByName.yml
+++ b/source/retryable-reads/tests/gridfs-downloadByName.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/source/retryable-reads/tests/listCollectionNames-serverErrors.json
+++ b/source/retryable-reads/tests/listCollectionNames-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listCollectionNames-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollectionNames-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollectionNames.json
+++ b/source/retryable-reads/tests/listCollectionNames.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listCollectionNames.yml
+++ b/source/retryable-reads/tests/listCollectionNames.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollectionObjects-serverErrors.json
+++ b/source/retryable-reads/tests/listCollectionObjects-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listCollectionObjects-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollectionObjects-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollectionObjects.json
+++ b/source/retryable-reads/tests/listCollectionObjects.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listCollectionObjects.yml
+++ b/source/retryable-reads/tests/listCollectionObjects.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollections-serverErrors.json
+++ b/source/retryable-reads/tests/listCollections-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listCollections-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollections-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollections.json
+++ b/source/retryable-reads/tests/listCollections.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listCollections.yml
+++ b/source/retryable-reads/tests/listCollections.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabaseNames-serverErrors.json
+++ b/source/retryable-reads/tests/listDatabaseNames-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listDatabaseNames-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabaseNames-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabaseNames.json
+++ b/source/retryable-reads/tests/listDatabaseNames.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listDatabaseNames.yml
+++ b/source/retryable-reads/tests/listDatabaseNames.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabaseObjects-serverErrors.json
+++ b/source/retryable-reads/tests/listDatabaseObjects-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listDatabaseObjects-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabaseObjects-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabaseObjects.json
+++ b/source/retryable-reads/tests/listDatabaseObjects.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listDatabaseObjects.yml
+++ b/source/retryable-reads/tests/listDatabaseObjects.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabases-serverErrors.json
+++ b/source/retryable-reads/tests/listDatabases-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listDatabases-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabases-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabases.json
+++ b/source/retryable-reads/tests/listDatabases.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listDatabases.yml
+++ b/source/retryable-reads/tests/listDatabases.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listIndexNames-serverErrors.json
+++ b/source/retryable-reads/tests/listIndexNames-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listIndexNames-serverErrors.yml
+++ b/source/retryable-reads/tests/listIndexNames-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listIndexNames.json
+++ b/source/retryable-reads/tests/listIndexNames.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listIndexNames.yml
+++ b/source/retryable-reads/tests/listIndexNames.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listIndexes-serverErrors.json
+++ b/source/retryable-reads/tests/listIndexes-serverErrors.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listIndexes-serverErrors.yml
+++ b/source/retryable-reads/tests/listIndexes-serverErrors.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listIndexes.json
+++ b/source/retryable-reads/tests/listIndexes.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/listIndexes.yml
+++ b/source/retryable-reads/tests/listIndexes.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/mapReduce.json
+++ b/source/retryable-reads/tests/mapReduce.json
@@ -1,7 +1,17 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.0"
+      "minServerVersion": "4.0",
+      "topology": [
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topology": [
+        "sharded"
+      ]
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/mapReduce.yml
+++ b/source/retryable-reads/tests/mapReduce.yml
@@ -1,5 +1,10 @@
 runOn:
-    - { minServerVersion: "4.0" }
+    -
+        minServerVersion: "4.0"
+        topology: ["single", "replicaset"]
+    -
+        minServerVersion: "4.1.7"
+        topology: ["sharded"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1253

Tests using failCommand fail point require mongos 4.1.5 (SERVER-35518), but we use 4.1.7 to ensure internal commands are ignored (SERVER-34943).

Fixes an issue @ShaneHarvey raised in https://github.com/mongodb/specifications/pull/523#discussion_r267861685. The requirement here mimics what I did previously for retryable writes in https://github.com/mongodb/specifications/commit/338cdd0e59a7e819d62e20c5b81dd9bef73fb4c9#diff-c6814387f7c24babd2c62a30a8bc1aa0.