### PR TITLE
SPEC-1194: Add tests for `postBatchResumeToken` support.

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -9,7 +9,7 @@ Change Streams
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: January 3, 2019
+:Last Modified: April 3, 2019
 :Version: 1.6.0
 
 .. contents::
@@ -169,7 +169,7 @@ The responses to a change stream aggregate or getMore have the following structu
          id: Int64,
          firstBatch: Array<ChangeStreamDocument>,
          /**
-          * postBatchResumeToken is returned in MongoDB 4.2 and later.
+          * postBatchResumeToken is returned in MongoDB 4.0.7 and later.
           */
          postBatchResumeToken: Document
       },
@@ -187,7 +187,7 @@ The responses to a change stream aggregate or getMore have the following structu
          id: Int64,
          nextBatch: Array<ChangeStreamDocument>
          /**
-          * postBatchResumeToken is returned in MongoDB 4.2 and later.
+          * postBatchResumeToken is returned in MongoDB 4.0.7 and later.
           */
          postBatchResumeToken: Document
       },
@@ -211,7 +211,7 @@ Driver API
 
     /**
      * The most recent postBatchResumeToken returned in an aggregate or
-     * getMore response. For pre-4.2 versions of MongoDB, this remains unset.
+     * getMore response. For pre-4.0.7 versions of MongoDB, this remains unset.
      */
     private postBatchResumeToken: Document;
 
@@ -335,7 +335,7 @@ Driver API
      *
      * The server will report an error if `startAfter` and `resumeAfter` are both specified.
      *
-     * @since 4.2
+     * @since 4.0.7
      * @see https://docs.mongodb.com/master/changeStreams/#change-stream-start-after
      * @note this is an option of the `$changeStream` pipeline stage.
      */
@@ -525,9 +525,9 @@ A driver SHOULD attempt to kill the cursor on the server on which the cursor is 
 Exposing All Resume Tokens
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:since: 4.2
+:since: 4.0.7
 
-Users can retrieve the ``documentResumeToken`` by inspecting the _id on each ``ChangeDocument``. But since MongoDB 4.2, aggregate and getMore responses also include a ``postBatchResumeToken``. Drivers use one or the other when automatically resuming, as described in `Resume Process`_.
+Users can retrieve the ``documentResumeToken`` by inspecting the _id on each ``ChangeDocument``. But since MongoDB 4.0.7, aggregate and getMore responses also include a ``postBatchResumeToken``. Drivers use one or the other when automatically resuming, as described in `Resume Process`_.
 
 Drivers MUST expose a mechanism to retrieve the same resume token that would be used to automatically resume. It MUST be possible to use this mechanism after iterating every document. It MUST be possible for users to use this mechanism periodically even when no documents are getting returned (i.e. ``getMore`` has returned empty batches). Drivers have two options to implement this.
 
@@ -774,4 +774,7 @@ Changelog
 | 2018-11-06 | Added handling of ``postBatchResumeToken``.                |
 +------------+------------------------------------------------------------+
 | 2019-01-10 | Clarified error handling for killing the cursor.           |
++------------+------------------------------------------------------------+
+| 2019-04-03 | Updated the lowest server version that supports            |
+|            | ``postBatchResumeToken``.                                  |
 +------------+------------------------------------------------------------+

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -158,4 +158,46 @@ The following tests have not yet been automated, but MUST still be tested
 #. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
 #. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a changestream.
 #. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
-
+#. - For a ``ChangeStream`` under these conditions:
+      - Running against a server ``>=4.0.7``.
+      - The batch is empty or has been iterated to the last document.
+   - Expected result: 
+       - ``getResumeToken`` must return the ``postBatchResumeToken`` from the current command response.
+#. - For a ``ChangeStream`` under these conditions:
+      - Running against a server ``<4.0.7``.
+      - The batch is empty or has been iterated to the last document.
+   - Expected result: 
+      - ``getResumeToken`` must return the ``_id`` of the last document returned if one exists.
+      - ``getResumeToken`` must return ``startAfter`` from the initial aggregate if the option was specified.
+      - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
+      - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.
+#. - For a ``ChangeStream`` under these conditions:
+      - The batch is not empty.
+      - The batch has been iterated up to but not including the last element.
+   - Expected result:
+      - ``getResumeToken`` must return the ``_id`` of the previous document returned.
+#. - For a ``ChangeStream`` under these conditions:
+      - The batch is not empty.
+      - The batch hasn’t been iterated at all.
+      - Only the initial ``aggregate`` command has been executed.
+   - Expected result:
+      - ``getResumeToken`` must return ``startAfter`` from the initial aggregate if the option was specified.
+      - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
+      - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.
+#. - For a ``ChangeStream`` under these conditions:
+      - Running against a server ``>=4.0.7``.
+      - The batch is not empty.
+      - The batch hasn’t been iterated at all.
+      - The stream has iterated beyond a previous batch and a ``getMore`` command has just been executed.
+   - Expected result:
+      - ``getResumeToken`` must return the ``postBatchResumeToken`` from the previous command response.
+#. - For a ``ChangeStream`` under these conditions:
+      - Running against a server ``<4.0.7``.
+      - The batch is not empty.
+      - The batch hasn’t been iterated at all.
+      - The stream has iterated beyond a previous batch and a ``getMore`` command has just been executed.
+   - Expected result:
+      - ``getResumeToken`` must return the ``_id`` of the previous document returned if one exists.
+      - ``getResumeToken`` must return ``startAfter`` from the initial aggregate if the option was specified.
+      - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
+      - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.


### PR DESCRIPTION
As it was proposed in the ticket and discussed in the slack with @kevinAlbs, I've added only `prose` tests.
In addition to the tests which were proposed/discussed with Kevin, I also added one more common test for tracking `postBatchResumeToken`.