### PR TITLE
SPEC-1125 Test collection unack'd write concern is compatible with transactions

### DIFF
--- a/source/transactions/tests/write-concern.json
+++ b/source/transactions/tests/write-concern.json
@@ -15,7 +15,11 @@
   ],
   "database_name": "transaction-tests",
   "collection_name": "test",
-  "data": [],
+  "data": [
+    {
+      "_id": 0
+    }
+  ],
   "tests": [
     {
       "description": "commit with majority",
@@ -96,6 +100,9 @@
         "collection": {
           "data": [
             {
+              "_id": 0
+            },
+            {
               "_id": 1
             }
           ]
@@ -171,6 +178,9 @@
       "outcome": {
         "collection": {
           "data": [
+            {
+              "_id": 0
+            },
             {
               "_id": 1
             }
@@ -255,7 +265,11 @@
       ],
       "outcome": {
         "collection": {
-          "data": []
+          "data": [
+            {
+              "_id": 0
+            }
+          ]
         }
       }
     },
@@ -327,7 +341,11 @@
       ],
       "outcome": {
         "collection": {
-          "data": []
+          "data": [
+            {
+              "_id": 0
+            }
+          ]
         }
       }
     },
@@ -364,6 +382,898 @@
           }
         }
       ]
+    },
+    {
+      "description": "unacknowledged write concern coll insertOne",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 0
+            },
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unacknowledged write concern coll insertMany",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          },
+          "result": {
+            "insertedIds": {
+              "0": 1,
+              "1": 2
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                },
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 0
+            },
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unacknowledged write concern coll bulkWrite",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "requests": [
+              {
+                "name": "insertOne",
+                "arguments": {
+                  "document": {
+                    "_id": 1
+                  }
+                }
+              }
+            ]
+          },
+          "result": {
+            "deletedCount": 0,
+            "insertedCount": 1,
+            "insertedIds": {
+              "0": 1
+            },
+            "matchedCount": 0,
+            "modifiedCount": 0,
+            "upsertedCount": 0,
+            "upsertedIds": {}
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 0
+            },
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unacknowledged write concern coll deleteOne",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "deleteOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 0
+            }
+          },
+          "result": {
+            "deletedCount": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "test",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 0
+                  },
+                  "limit": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "delete",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "unacknowledged write concern coll deleteMany",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "deleteMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 0
+            }
+          },
+          "result": {
+            "deletedCount": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "delete": "test",
+              "deletes": [
+                {
+                  "q": {
+                    "_id": 0
+                  },
+                  "limit": 0
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "delete",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "unacknowledged write concern coll updateOne",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 0
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "upsert": true
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 0
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": false,
+                  "upsert": true
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "update",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 0,
+              "x": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unacknowledged write concern coll updateMany",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 0
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "upsert": true
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 0
+                  },
+                  "u": {
+                    "$inc": {
+                      "x": 1
+                    }
+                  },
+                  "multi": true,
+                  "upsert": true
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "update",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 0,
+              "x": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unacknowledged write concern coll findOneAndDelete",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "findOneAndDelete",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 0
+            }
+          },
+          "result": {
+            "_id": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 0
+              },
+              "remove": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "unacknowledged write concern coll findOneAndReplace",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "findOneAndReplace",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 0
+            },
+            "replacement": {
+              "x": 1
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "_id": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 0
+              },
+              "update": {
+                "x": 1
+              },
+              "new": false,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 0,
+              "x": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "unacknowledged write concern coll findOneAndUpdate",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "collectionOptions": {
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 0
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "_id": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 0
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "new": false,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 0,
+              "x": 1
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/transactions/tests/write-concern.json
+++ b/source/transactions/tests/write-concern.json
@@ -64,13 +64,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "insert",
@@ -145,13 +145,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "insert",
@@ -231,13 +231,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "insert",
@@ -309,13 +309,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "insert",
@@ -424,13 +424,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "insert",
@@ -519,13 +519,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "insert",
@@ -621,13 +621,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "insert",
@@ -708,13 +708,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "delete",
@@ -788,13 +788,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "delete",
@@ -882,13 +882,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "update",
@@ -981,13 +981,13 @@
                 }
               ],
               "ordered": true,
-              "readConcern": null,
               "lsid": "session0",
               "txnNumber": {
                 "$numberLong": "1"
               },
               "startTransaction": true,
               "autocommit": false,
+              "readConcern": null,
               "writeConcern": null
             },
             "command_name": "update",

--- a/source/transactions/tests/write-concern.yml
+++ b/source/transactions/tests/write-concern.yml
@@ -43,13 +43,14 @@ tests:
             documents:
               - _id: 1
             ordered: true
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
+            <<: &transactionCommandArgs
+              lsid: session0
+              txnNumber:
+                $numberLong: "1"
+              startTransaction: true
+              autocommit: false
+              readConcern:
+              writeConcern:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -94,13 +95,7 @@ tests:
             documents:
               - _id: 1
             ordered: true
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: insert
           database_name: *database_name
       - &commitWithDefaultWCEvent
@@ -149,13 +144,7 @@ tests:
             documents:
               - _id: 1
             ordered: true
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -198,13 +187,7 @@ tests:
             documents:
               - _id: 1
             ordered: true
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -254,9 +237,10 @@ tests:
       - *startTransaction
       - name: insertOne
         object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: &collection_w0
+          object: collection
+          collectionOptions:
+            writeConcern: { w: 0 }
         arguments:
           session: session0
           document:
@@ -280,10 +264,7 @@ tests:
     operations:
       - *startTransaction
       - name: insertMany
-        object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: *collection_w0
         arguments:
           session: session0
           documents:
@@ -301,13 +282,7 @@ tests:
               - _id: 1
               - _id: 2
             ordered: true
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: insert
           database_name: *database_name
       - *commitWithDefaultWCEvent
@@ -324,10 +299,7 @@ tests:
     operations:
       - *startTransaction
       - name: bulkWrite
-        object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: *collection_w0
         arguments:
           session: session0
           requests:
@@ -360,10 +332,7 @@ tests:
     operations:
       - *startTransaction
       - name: deleteOne
-        object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: *collection_w0
         arguments:
           session: session0
           filter:
@@ -380,13 +349,7 @@ tests:
               - q: {_id: 0}
                 limit: 1
             ordered: true
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: delete
           database_name: *database_name
       - *commitWithDefaultWCEvent
@@ -400,10 +363,7 @@ tests:
     operations:
       - *startTransaction
       - name: deleteMany
-        object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: *collection_w0
         arguments:
           session: session0
           filter:
@@ -420,13 +380,7 @@ tests:
               - q: {_id: 0}
                 limit: 0
             ordered: true
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: delete
           database_name: *database_name
       - *commitWithDefaultWCEvent
@@ -440,10 +394,7 @@ tests:
     operations:
       - *startTransaction
       - name: updateOne
-        object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: *collection_w0
         arguments:
           session: session0
           filter: {_id: 0}
@@ -466,13 +417,7 @@ tests:
                 multi: false
                 upsert: true
             ordered: true
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: update
           database_name: *database_name
       - *commitWithDefaultWCEvent
@@ -487,10 +432,7 @@ tests:
     operations:
       - *startTransaction
       - name: updateMany
-        object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: *collection_w0
         arguments:
           session: session0
           filter: {_id: 0}
@@ -513,13 +455,7 @@ tests:
                 multi: true
                 upsert: true
             ordered: true
-            readConcern:
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: update
           database_name: *database_name
       - *commitWithDefaultWCEvent
@@ -534,10 +470,7 @@ tests:
     operations:
       - *startTransaction
       - name: findOneAndDelete
-        object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: *collection_w0
         arguments:
           session: session0
           filter: {_id: 0}
@@ -550,13 +483,7 @@ tests:
             findAndModify: *collection_name
             query: {_id: 0}
             remove: True
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            readConcern:
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: findAndModify
           database_name: *database_name
       - *commitWithDefaultWCEvent
@@ -570,10 +497,7 @@ tests:
     operations:
       - *startTransaction
       - name: findOneAndReplace
-        object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: *collection_w0
         arguments:
           session: session0
           filter: {_id: 0}
@@ -589,13 +513,7 @@ tests:
             query: {_id: 0}
             update: {x: 1}
             new: false
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            readConcern:
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: findAndModify
           database_name: *database_name
       - *commitWithDefaultWCEvent
@@ -610,10 +528,7 @@ tests:
     operations:
       - *startTransaction
       - name: findOneAndUpdate
-        object: collection
-        collectionOptions:
-          writeConcern:
-            w: 0
+        <<: *collection_w0
         arguments:
           session: session0
           filter: {_id: 0}
@@ -630,13 +545,7 @@ tests:
             query: {_id: 0}
             update: {$inc: {x: 1}}
             new: false
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            readConcern:
-            writeConcern:
+            <<: *transactionCommandArgs
           command_name: findAndModify
           database_name: *database_name
       - *commitWithDefaultWCEvent

--- a/source/transactions/tests/write-concern.yml
+++ b/source/transactions/tests/write-concern.yml
@@ -236,7 +236,6 @@ tests:
     operations:
       - *startTransaction
       - name: insertOne
-        object: collection
         <<: &collection_w0
           object: collection
           collectionOptions:

--- a/source/transactions/tests/write-concern.yml
+++ b/source/transactions/tests/write-concern.yml
@@ -11,7 +11,8 @@ runOn:
 database_name: &database_name "transaction-tests"
 collection_name: &collection_name "test"
 
-data: []
+data: &data
+  - _id: 0
 
 tests:
   - description: commit with majority
@@ -30,11 +31,13 @@ tests:
             _id: 1
         result:
           insertedId: 1
-      - name: commitTransaction
+      - &commitTransaction
+        name: commitTransaction
         object: session0
 
     expectations:
-      - command_started_event:
+      - &insertOneEvent
+        command_started_event:
           command:
             insert: *collection_name
             documents:
@@ -65,12 +68,14 @@ tests:
     outcome:
       collection:
         data:
+          - _id: 0
           - _id: 1
 
   - description: commit with default
 
     operations:
-      - name: startTransaction
+      - &startTransaction
+        name: startTransaction
         object: session0
       - name: insertOne
         object: collection
@@ -80,8 +85,7 @@ tests:
             _id: 1
         result:
           insertedId: 1
-      - name: commitTransaction
-        object: session0
+      - *commitTransaction
 
     expectations:
       - command_started_event:
@@ -99,7 +103,8 @@ tests:
             writeConcern:
           command_name: insert
           database_name: *database_name
-      - command_started_event:
+      - &commitWithDefaultWCEvent
+        command_started_event:
           command:
             commitTransaction: 1
             lsid: session0
@@ -114,7 +119,7 @@ tests:
     outcome:
       collection:
         data:
-
+          - _id: 0
           - _id: 1
 
   - description: abort with majority
@@ -168,7 +173,7 @@ tests:
 
     outcome:
       collection:
-        data: []
+        data: *data
 
   - description: abort with default
 
@@ -216,7 +221,7 @@ tests:
 
     outcome:
       collection:
-        data: []
+        data: *data
 
   - description: start with unacknowledged write concern
 
@@ -242,3 +247,401 @@ tests:
         result:
           # Client-side error.
           errorContains: transactions do not support unacknowledged write concern
+
+  - description: unacknowledged write concern coll insertOne
+
+    operations:
+      - *startTransaction
+      - name: insertOne
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - *commitTransaction
+
+    expectations:
+      - *insertOneEvent
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data:
+          - _id: 0
+          - _id: 1
+
+  - description: unacknowledged write concern coll insertMany
+
+    operations:
+      - *startTransaction
+      - name: insertMany
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          documents:
+            - _id: 1
+            - _id: 2
+        result:
+          insertedIds: {0: 1, 1: 2}
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+              - _id: 2
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data:
+          - _id: 0
+          - _id: 1
+          - _id: 2
+
+  - description: unacknowledged write concern coll bulkWrite
+
+    operations:
+      - *startTransaction
+      - name: bulkWrite
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          requests:
+            - name: insertOne
+              arguments:
+                document: {_id: 1}
+        result:
+          deletedCount: 0
+          insertedCount: 1
+          insertedIds: {0: 1}
+          matchedCount: 0
+          modifiedCount: 0
+          upsertedCount: 0
+          upsertedIds: {}
+      - *commitTransaction
+
+    expectations:
+      - *insertOneEvent
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data:
+          - _id: 0
+          - _id: 1
+
+
+  - description: unacknowledged write concern coll deleteOne
+
+    operations:
+      - *startTransaction
+      - name: deleteOne
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          filter:
+            _id: 0
+        result:
+          deletedCount: 1
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              - q: {_id: 0}
+                limit: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: delete
+          database_name: *database_name
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data: []
+
+  - description: unacknowledged write concern coll deleteMany
+
+    operations:
+      - *startTransaction
+      - name: deleteMany
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          filter:
+            _id: 0
+        result:
+          deletedCount: 1
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            delete: *collection_name
+            deletes:
+              - q: {_id: 0}
+                limit: 0
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: delete
+          database_name: *database_name
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data: []
+
+  - description: unacknowledged write concern coll updateOne
+
+    operations:
+      - *startTransaction
+      - name: updateOne
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          filter: {_id: 0}
+          update:
+            $inc: {x: 1}
+          upsert: true
+        result:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - q: {_id: 0}
+                u: {$inc: {x: 1}}
+                multi: false
+                upsert: true
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: update
+          database_name: *database_name
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data:
+          - {_id: 0, x: 1}
+
+  - description: unacknowledged write concern coll updateMany
+
+    operations:
+      - *startTransaction
+      - name: updateMany
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          filter: {_id: 0}
+          update:
+            $inc: {x: 1}
+          upsert: true
+        result:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              - q: {_id: 0}
+                u: {$inc: {x: 1}}
+                multi: true
+                upsert: true
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: update
+          database_name: *database_name
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data:
+          - {_id: 0, x: 1}
+
+  - description: unacknowledged write concern coll findOneAndDelete
+
+    operations:
+      - *startTransaction
+      - name: findOneAndDelete
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          filter: {_id: 0}
+        result: {_id: 0}
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 0}
+            remove: True
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data: []
+
+  - description: unacknowledged write concern coll findOneAndReplace
+
+    operations:
+      - *startTransaction
+      - name: findOneAndReplace
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          filter: {_id: 0}
+          replacement: {x: 1}
+          returnDocument: Before
+        result: {_id: 0}
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 0}
+            update: {x: 1}
+            new: false
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data:
+          - {_id: 0, x: 1}
+
+  - description: unacknowledged write concern coll findOneAndUpdate
+
+    operations:
+      - *startTransaction
+      - name: findOneAndUpdate
+        object: collection
+        collectionOptions:
+          writeConcern:
+            w: 0
+        arguments:
+          session: session0
+          filter: {_id: 0}
+          update:
+            $inc: {x: 1}
+          returnDocument: Before
+        result: {_id: 0}
+      - *commitTransaction
+
+    expectations:
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 0}
+            update: {$inc: {x: 1}}
+            new: false
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - *commitWithDefaultWCEvent
+
+    outcome:
+      collection:
+        data:
+          - {_id: 0, x: 1}


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/SPEC-1125

These tests prove that a collection configured with WriteConcern(w=0) can still be used within a transaction. I added tests for all the supported CRUD methods for completeness.

Passing python driver patch: https://evergreen.mongodb.com/version/5ca66d46e3c33119ed332b5c