### PR TITLE
SPEC-1206 Support maxTimeMS on transaction commit

### DIFF
--- a/source/transactions-convenient-api/tests/commit-retry.json
+++ b/source/transactions-convenient-api/tests/commit-retry.json
@@ -423,6 +423,102 @@
           ]
         }
       }
+    },
+    {
+      "description": "commit is not retried after MaxTimeMSExpired error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorCodeName": "MaxTimeMSExpired",
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
     }
   ]
 }

--- a/source/transactions-convenient-api/tests/commit-retry.json
+++ b/source/transactions-convenient-api/tests/commit-retry.json
@@ -459,6 +459,9 @@
                   }
                 }
               ]
+            },
+            "options": {
+              "maxTimeMS": 60000
             }
           },
           "result": {
@@ -505,6 +508,7 @@
                 "$numberLong": "1"
               },
               "autocommit": false,
+              "maxTimeMS": 60000,
               "readConcern": null,
               "startTransaction": null,
               "writeConcern": null

--- a/source/transactions-convenient-api/tests/commit-retry.json
+++ b/source/transactions-convenient-api/tests/commit-retry.json
@@ -461,7 +461,7 @@
               ]
             },
             "options": {
-              "maxTimeMS": 60000
+              "maxCommitTimeMS": 60000
             }
           },
           "result": {

--- a/source/transactions-convenient-api/tests/commit-retry.yml
+++ b/source/transactions-convenient-api/tests/commit-retry.yml
@@ -21,7 +21,7 @@ tests:
           failCommands: ["commitTransaction"]
           closeConnection: true
     operations:
-      -
+      - &withTransaction
         name: withTransaction
         object: session0
         arguments:
@@ -194,20 +194,7 @@ tests:
           errorCode: 10107 # NotMaster
           closeConnection: false
     operations:
-      -
-        name: withTransaction
-        object: session0
-        arguments:
-          callback:
-            operations:
-              -
-                name: insertOne
-                object: collection
-                arguments:
-                  session: session0
-                  document: { _id: 1 }
-                result:
-                  insertedId: 1
+      - *withTransaction
     expectations:
       -
         command_started_event:
@@ -270,3 +257,53 @@ tests:
       collection:
         data:
           - { _id: 1 }
+  -
+    description: commit is not retried after MaxTimeMSExpired error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 50 # MaxTimeMSExpired
+    operations:
+      - <<: *withTransaction
+        result:
+          errorCodeName: MaxTimeMSExpired
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+    expectations:
+      -
+        command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { _id: 1 }
+            ordered: true
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            startTransaction: true
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            writeConcern: ~
+          command_name: insert
+          database_name: *database_name
+      -
+        command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber: { $numberLong: "1" }
+            autocommit: false
+            # omitted fields
+            readConcern: ~
+            startTransaction: ~
+            writeConcern: ~
+          command_name: commitTransaction
+          database_name: admin
+    outcome:
+      collection:
+        # In reality, the outcome of the commit is unknown but we fabricate
+        # the error with failCommand.errorCode which does not apply the commit
+        # operation.
+        data: []

--- a/source/transactions-convenient-api/tests/commit-retry.yml
+++ b/source/transactions-convenient-api/tests/commit-retry.yml
@@ -266,7 +266,21 @@ tests:
           failCommands: ["commitTransaction"]
           errorCode: 50 # MaxTimeMSExpired
     operations:
-      - <<: *withTransaction
+      - name: withTransaction
+        object: session0
+        arguments:
+          callback:
+            operations:
+              -
+                name: insertOne
+                object: collection
+                arguments:
+                  session: session0
+                  document: { _id: 1 }
+                result:
+                  insertedId: 1
+          options:
+            maxTimeMS: 60000
         result:
           errorCodeName: MaxTimeMSExpired
           errorLabelsContain: ["UnknownTransactionCommitResult"]
@@ -295,6 +309,7 @@ tests:
             lsid: session0
             txnNumber: { $numberLong: "1" }
             autocommit: false
+            maxTimeMS: 60000
             # omitted fields
             readConcern: ~
             startTransaction: ~

--- a/source/transactions-convenient-api/tests/commit-retry.yml
+++ b/source/transactions-convenient-api/tests/commit-retry.yml
@@ -280,7 +280,7 @@ tests:
                 result:
                   insertedId: 1
           options:
-            maxTimeMS: 60000
+            maxCommitTimeMS: 60000
         result:
           errorCodeName: MaxTimeMSExpired
           errorLabelsContain: ["UnknownTransactionCommitResult"]

--- a/source/transactions-convenient-api/tests/commit-writeconcernerror.json
+++ b/source/transactions-convenient-api/tests/commit-writeconcernerror.json
@@ -493,6 +493,110 @@
           ]
         }
       }
+    },
+    {
+      "description": "commitTransaction is not retried after MaxTimeMSExpired error",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 50,
+            "codeName": "MaxTimeMSExpired",
+            "errmsg": "operation exceeded time limit"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "withTransaction",
+          "object": "session0",
+          "arguments": {
+            "callback": {
+              "operations": [
+                {
+                  "name": "insertOne",
+                  "object": "collection",
+                  "arguments": {
+                    "session": "session0",
+                    "document": {
+                      "_id": 1
+                    }
+                  },
+                  "result": {
+                    "insertedId": 1
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorCodeName": "MaxTimeMSExpired",
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "withTransaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false,
+              "readConcern": null,
+              "startTransaction": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/transactions-convenient-api/tests/commit-writeconcernerror.yml
+++ b/source/transactions-convenient-api/tests/commit-writeconcernerror.yml
@@ -193,3 +193,24 @@ tests:
     expectations: *expectations_without_retries
     # failCommand with writeConcernError still applies the write operation(s)
     outcome: *outcome
+
+  -
+    description: commitTransaction is not retried after MaxTimeMSExpired error
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 50
+            codeName: MaxTimeMSExpired
+            errmsg: "operation exceeded time limit"
+    operations:
+      - <<: *operation
+        result:
+          errorCodeName: MaxTimeMSExpired
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+    expectations: *expectations_without_retries
+    # failCommand with writeConcernError still applies the write operation(s)
+    outcome: *outcome

--- a/source/transactions-convenient-api/transactions-convenient-api.rst
+++ b/source/transactions-convenient-api/transactions-convenient-api.rst
@@ -388,8 +388,8 @@ their users to design idempotent callbacks.
 
 .. _Retry Transactions and Commit Operation: https://docs.mongodb.com/manual/core/transactions/#retry-transaction-and-commit-operation
 
-The commit is retried after a write concern wtimeout error
-----------------------------------------------------------
+The commit is retried after a write concern timeout (i.e. wtimeout) error
+-------------------------------------------------------------------------
 
 Per the Transactions specification, drivers internally retry
 ``commitTransaction`` once if it fails due to a retryable error (as defined in

--- a/source/transactions-convenient-api/transactions-convenient-api.rst
+++ b/source/transactions-convenient-api/transactions-convenient-api.rst
@@ -123,11 +123,11 @@ drivers MUST enforce a 120-second timeout to limit retry behavior and safeguard
 applications from long-running (or infinite) retry loops. Drivers SHOULD use a
 monotonic clock to determine elapsed time.
 
-If an UnknownTransactionCommitResult error is encountered for a commit and the
-error is not MaxTimeMSExpired and the retry timeout has not been exceeded, the
-driver MUST retry the commit. If the retry timeout has been exceeded, drivers
-MUST NOT retry the commit and allow ``withTransaction`` to propagate the
-error to its caller.
+If an UnknownTransactionCommitResult error is encountered for a commit, the
+driver MUST retry the commit if and only if the error is not MaxTimeMSExpired
+and the retry timeout has not been exceeded. Otherwise, the driver MUST NOT
+retry the commit and allow ``withTransaction`` to propagate the error to its
+caller.
 
 If a TransientTransactionError is encountered at any point, the entire
 transaction may be retried. If the retry timeout has not been exceeded, the
@@ -499,4 +499,5 @@ Changes
 
 2019-04-24: withTransaction does not retry when commit fails with
             MaxTimeMSExpired.
+
 2018-02-13: withTransaction should retry commits after a wtimeout

--- a/source/transactions-convenient-api/transactions-convenient-api.rst
+++ b/source/transactions-convenient-api/transactions-convenient-api.rst
@@ -3,14 +3,14 @@ Convenient API for Transactions
 ===============================
 
 :Spec Title: Convenient API for Transactions
-:Spec Version: 1.1
+:Spec Version: 1.2
 :Author: Jeremy Mikola
 :Lead: Jeff Yemin
 :Advisors: A\. Jesse Jiryu Davis, Kris Brandow, Oleg Pudeyev, Sam Ritter, Tess Avitabile
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 4.0
-:Last Modified: 2019-02-13
+:Last Modified: 2019-04-24
 
 .. contents::
 
@@ -123,11 +123,10 @@ drivers MUST enforce a 120-second timeout to limit retry behavior and safeguard
 applications from long-running (or infinite) retry loops. Drivers SHOULD use a
 monotonic clock to determine elapsed time.
 
-If an UnknownTransactionCommitResult is encountered for a commit, the commit
-operation may be retried. If the retry timeout has not been exceeded, the driver
-MUST retry a commit that fails with an error bearing the
-"UnknownTransactionCommitResult" label. If the retry timeout has been exceeded,
-drivers MUST NOT retry the commit and allow ``withTransaction`` to propagate the
+If an UnknownTransactionCommitResult error is encountered for a commit and the
+error is not MaxTimeMSExpired and the retry timeout has not been exceeded, the
+driver MUST retry the commit. If the retry timeout has been exceeded, drivers
+MUST NOT retry the commit and allow ``withTransaction`` to propagate the
 error to its caller.
 
 If a TransientTransactionError is encountered at any point, the entire
@@ -204,9 +203,10 @@ This method should perform the following sequence of actions:
 9. If ``commitTransaction`` reported an error:
 
    a. If the ``commitTransaction`` error includes a
-      "UnknownTransactionCommitResult" label and the elapsed time of
-      ``withTransaction`` is less than 120 seconds, jump back to step eight. We
-      will trust ``commitTransaction`` to apply a majority write concern on
+      "UnknownTransactionCommitResult" label and the error is not
+      MaxTimeMSExpired and the elapsed time of ``withTransaction`` is less
+      than 120 seconds, jump back to step eight. We will trust
+      ``commitTransaction`` to apply a majority write concern on
       retry attempts (see:
       `Majority write concern is used when retrying commitTransaction`_).
 
@@ -268,7 +268,14 @@ This method can be expressed by the following pseudo-code:
                      * being retried (see: DRIVERS-601) */
                     this.commitTransaction();
                 } catch (error) {
-                    if (error.hasErrorLabel("UnknownTransactionCommitResult") &&
+                    /* Note: a maxTimeMS error will have the MaxTimeMSExpired
+                     * code (50) and can be reported as a top-level error or
+                     * inside writeConcernError, ie:
+                     * {ok:0, code: 50, codeName: "MaxTimeMSExpired"}
+                     * {ok:1, writeConcernError: {code: 50, codeName: "MaxTimeMSExpired"}}
+                     */
+                    if (!isMaxTimeMSExpiredError(error) &&
+                        error.hasErrorLabel("UnknownTransactionCommitResult") &&
                         Date.now() - startTime < 120000) {
                         continue retryCommit;
                     }
@@ -381,14 +388,14 @@ their users to design idempotent callbacks.
 
 .. _Retry Transactions and Commit Operation: https://docs.mongodb.com/manual/core/transactions/#retry-transaction-and-commit-operation
 
-The commit is retried after a write concern timeout error
----------------------------------------------------------
+The commit is retried after a write concern wtimeout error
+----------------------------------------------------------
 
 Per the Transactions specification, drivers internally retry
 ``commitTransaction`` once if it fails due to a retryable error (as defined in
 the `Retryable Writes`_ specification). Beyond that, applications may manually
 retry ``commitTransaction`` if it fails with any error bearing the
-`UnknownTransactionCommitResult`_ error label. This lable is applied for the
+`UnknownTransactionCommitResult`_ error label. This label is applied for the
 the following errors:
 
 .. _Retryable Writes: ../retryable-writes/retryable-writes.rst#terms
@@ -399,6 +406,8 @@ the following errors:
 - Retryable error (as defined in the `Retryable Writes`_ specification)
 - Write concern failure or timeout (excluding UnsatisfiableWriteConcern and
   UnknownReplWriteConcern)
+- MaxTimeMSExpired errors, ie ``{ok:0, code: 50, codeName: "MaxTimeMSExpired"}``
+  and ``{ok:1, writeConcernError: {code: 50, codeName: "MaxTimeMSExpired"}}``.
 
 A previous design for ``withTransaction`` retried for all of these errors
 *except* for write concern timeouts, so as not to exceed the user's original
@@ -411,6 +420,13 @@ This change was made in light of the forthcoming Client-side Operations Timeout
 specification (see: `Future Work`_), which we expect will allow the current
 120-second timeout for ``withTransaction`` to be customized and also obviate the
 need for users to specify ``wtimeout``.
+
+The commit is not retried after a MaxTimeMSExpired error
+--------------------------------------------------------
+
+This specification intentionally chooses not to retry commit operations after a
+MaxTimeMSExpired error as doing so would exceed the user's original intention
+for ``maxTimeMS``.
 
 The transaction and commit may be retried any number of times within a timeout period
 -------------------------------------------------------------------------------------
@@ -481,4 +497,6 @@ client-side operation timeout, withTransaction can continue to use the
 Changes
 =======
 
+2019-04-24: withTransaction does not retry when commit fails with
+            MaxTimeMSExpired.
 2018-02-13: withTransaction should retry commits after a wtimeout

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -1717,7 +1717,7 @@
               "writeConcern": {
                 "w": "majority"
               },
-              "maxTimeMS": 60000
+              "maxCommitTimeMS": 60000
             }
           }
         },
@@ -1851,7 +1851,7 @@
               "writeConcern": {
                 "w": "majority"
               },
-              "maxTimeMS": 60000
+              "maxCommitTimeMS": 60000
             }
           }
         },

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -1566,7 +1566,7 @@
       }
     },
     {
-      "description": "do_not_add_unknown_commit_label_to_MaxTimeMSExpired_inside_transactions",
+      "description": "do not add unknown commit label to MaxTimeMSExpired inside transactions",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
@@ -1664,7 +1664,8 @@
               "txnNumber": {
                 "$numberLong": "1"
               },
-              "autocommit": false
+              "autocommit": false,
+              "maxTimeMS": 60000
             },
             "command_name": "aggregate",
             "database_name": "transaction-tests"
@@ -1837,7 +1838,6 @@
           ],
           "writeConcernError": {
             "code": 50,
-            "codeName": "MaxTimeMSExpired",
             "errmsg": "operation exceeded time limit"
           }
         }

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -1564,6 +1564,400 @@
           ]
         }
       }
+    },
+    {
+      "description": "do_not_add_unknown_commit_label_to_MaxTimeMSExpired_inside_transactions",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "aggregate"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "aggregate",
+          "object": "collection",
+          "arguments": {
+            "pipeline": [
+              {
+                "$project": {
+                  "_id": 1
+                }
+              }
+            ],
+            "maxTimeMS": 60000,
+            "session": "session0"
+          },
+          "result": {
+            "errorLabelsOmit": [
+              "UnknownTransactionCommitResult",
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "aggregate": "test",
+              "pipeline": [
+                {
+                  "$project": {
+                    "_id": 1
+                  }
+                }
+              ],
+              "cursor": {},
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "autocommit": false
+            },
+            "command_name": "aggregate",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
+      "description": "add unknown commit label to MaxTimeMSExpired",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "errorCode": 50
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxTimeMS": 60000
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "add unknown commit label to writeConcernError MaxTimeMSExpired",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "commitTransaction"
+          ],
+          "writeConcernError": {
+            "code": 50,
+            "codeName": "MaxTimeMSExpired",
+            "errmsg": "operation exceeded time limit"
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxTimeMS": 60000
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "result": {
+            "errorLabelsContain": [
+              "UnknownTransactionCommitResult"
+            ],
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority"
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": {
+                "w": "majority",
+                "wtimeout": 10000
+              },
+              "maxTimeMS": 60000
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -1056,7 +1056,7 @@ tests:
           options:
             writeConcern:
               w: majority
-            maxTimeMS: 60000
+            maxCommitTimeMS: 60000
       - name: insertOne
         object: collection
         arguments:
@@ -1139,7 +1139,7 @@ tests:
           options:
             writeConcern:
               w: majority
-            maxTimeMS: 60000
+            maxCommitTimeMS: 60000
       - name: insertOne
         object: collection
         arguments:

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -960,7 +960,7 @@ tests:
         data:
           - _id: 1
 
-  - description: do_not_add_unknown_commit_label_to_MaxTimeMSExpired_inside_transactions
+  - description: do not add unknown commit label to MaxTimeMSExpired inside transactions
 
     failPoint:
       configureFailPoint: failCommand
@@ -1021,6 +1021,7 @@ tests:
             txnNumber:
               $numberLong: "1"
             autocommit: false
+            maxTimeMS: 60000
           command_name: aggregate
           database_name: *database_name
       - command_started_event:
@@ -1128,8 +1129,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           writeConcernError:
-            code: 50
-            codeName: MaxTimeMSExpired
+            code: 50  # MaxTimeMSExpired
             errmsg: operation exceeded time limit
 
     operations:

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -959,3 +959,247 @@ tests:
       collection:
         data:
           - _id: 1
+
+  - description: do_not_add_unknown_commit_label_to_MaxTimeMSExpired_inside_transactions
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+        failCommands: ["aggregate"]
+        errorCode: 50  # MaxTimeMSExpired
+
+    operations:
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: aggregate
+        object: collection
+        arguments:
+          pipeline:
+            - $project:
+                _id: 1
+          maxTimeMS: 60000
+          session: session0
+        result:
+          errorLabelsOmit: ["UnknownTransactionCommitResult", "TransientTransactionError"]
+      - name: abortTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            aggregate: *collection_name
+            pipeline:
+              - $project:
+                  _id: 1
+            cursor: {}
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            autocommit: false
+          command_name: aggregate
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data: []
+
+  - description: add unknown commit label to MaxTimeMSExpired
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          errorCode: 50  # MaxTimeMSExpired
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            writeConcern:
+              w: majority
+            maxTimeMS: 60000
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+        result:
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+      - name: commitTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+              w: majority
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            # commitTransaction applies w:majority on retries
+            writeConcern: { w: majority, wtimeout: 10000 }
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1
+
+  - description: add unknown commit label to writeConcernError MaxTimeMSExpired
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["commitTransaction"]
+          writeConcernError:
+            code: 50
+            codeName: MaxTimeMSExpired
+            errmsg: operation exceeded time limit
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            writeConcern:
+              w: majority
+            maxTimeMS: 60000
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+        result:
+          errorLabelsContain: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["TransientTransactionError"]
+      - name: commitTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+              w: majority
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            # commitTransaction applies w:majority on retries
+            writeConcern: { w: majority, wtimeout: 10000 }
+            maxTimeMS: 60000
+          command_name: commitTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -81,7 +81,8 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": null,
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -98,7 +99,8 @@
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -123,7 +125,8 @@
               "readConcern": {
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -140,7 +143,8 @@
               "startTransaction": null,
               "autocommit": false,
               "readConcern": null,
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -227,7 +231,8 @@
               "readConcern": {
                 "level": "local"
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -246,7 +251,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": 1
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -272,7 +278,8 @@
                 "level": "local",
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -291,7 +298,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": 1
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -318,7 +326,8 @@
             },
             "writeConcern": {
               "w": 1
-            }
+            },
+            "maxTimeMS": 60000
           }
         }
       },
@@ -405,7 +414,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": 1
-              }
+              },
+              "maxTimeMS": 60000
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -481,7 +491,8 @@
             },
             "writeConcern": {
               "w": 1
-            }
+            },
+            "maxTimeMS": 30000
           }
         }
       },
@@ -496,7 +507,8 @@
               },
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": 60000
             }
           }
         },
@@ -569,7 +581,8 @@
               "readConcern": {
                 "level": "snapshot"
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -588,7 +601,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": 60000
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -614,7 +628,8 @@
                 "level": "snapshot",
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -633,7 +648,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"
@@ -664,7 +680,8 @@
             },
             "writeConcern": {
               "w": "majority"
-            }
+            },
+            "maxTimeMS": 60000
           }
         }
       },
@@ -732,7 +749,8 @@
               "readConcern": {
                 "level": "snapshot"
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -751,7 +769,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": 60000
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -777,7 +796,8 @@
                 "level": "snapshot",
                 "afterClusterTime": 42
               },
-              "writeConcern": null
+              "writeConcern": null,
+              "maxTimeMS": null
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -796,7 +816,8 @@
               "readConcern": null,
               "writeConcern": {
                 "w": "majority"
-              }
+              },
+              "maxTimeMS": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -327,7 +327,7 @@
             "writeConcern": {
               "w": 1
             },
-            "maxTimeMS": 60000
+            "maxCommitTimeMS": 60000
           }
         }
       },
@@ -492,7 +492,7 @@
             "writeConcern": {
               "w": 1
             },
-            "maxTimeMS": 30000
+            "maxCommitTimeMS": 30000
           }
         }
       },
@@ -508,7 +508,7 @@
               "writeConcern": {
                 "w": "majority"
               },
-              "maxTimeMS": 60000
+              "maxCommitTimeMS": 60000
             }
           }
         },
@@ -681,7 +681,7 @@
             "writeConcern": {
               "w": "majority"
             },
-            "maxTimeMS": 60000
+            "maxCommitTimeMS": 60000
           }
         }
       },

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -55,6 +55,7 @@ tests:
             autocommit: false
             readConcern:
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -67,6 +68,7 @@ tests:
             autocommit: false
             readConcern:
             writeConcern:
+            maxTimeMS:
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -83,6 +85,7 @@ tests:
             readConcern:
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -95,6 +98,7 @@ tests:
             autocommit: false
             readConcern:
             writeConcern:
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 
@@ -126,6 +130,7 @@ tests:
             readConcern:
               level: local
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -139,6 +144,7 @@ tests:
             readConcern:
             writeConcern:
               w: 1
+            maxTimeMS:
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -156,6 +162,7 @@ tests:
               level: local
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -169,6 +176,7 @@ tests:
             readConcern:
             writeConcern:
               w: 1
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 
@@ -183,6 +191,7 @@ tests:
             level: snapshot
           writeConcern:
             w: 1
+          maxTimeMS: 60000
 
     operations: *commitAbortOperations
 
@@ -214,6 +223,7 @@ tests:
             readConcern:
             writeConcern:
               w: 1
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -262,6 +272,7 @@ tests:
             level: majority
           writeConcern:
             w: 1
+          maxTimeMS: 30000
 
     operations:
       - name: startTransaction
@@ -272,6 +283,7 @@ tests:
               level: snapshot
             writeConcern:
               w: majority
+            maxTimeMS: 60000
       - name: insertOne
         object: collection
         arguments:
@@ -316,6 +328,7 @@ tests:
             readConcern:
               level: snapshot
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -329,6 +342,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -346,6 +360,7 @@ tests:
               level: snapshot
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -359,6 +374,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 
@@ -377,6 +393,7 @@ tests:
             level: snapshot
           writeConcern:
             w: majority
+          maxTimeMS: 60000
 
     operations: *commitAbortOperations
 
@@ -395,6 +412,7 @@ tests:
             readConcern:
               level: snapshot
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -408,6 +426,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS: 60000
           command_name: commitTransaction
           database_name: admin
       - command_started_event:
@@ -425,6 +444,7 @@ tests:
               level: snapshot
               afterClusterTime: 42
             writeConcern:
+            maxTimeMS:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -438,6 +458,7 @@ tests:
             readConcern:
             writeConcern:
               w: majority
+            maxTimeMS:
           command_name: abortTransaction
           database_name: admin
 

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -191,7 +191,7 @@ tests:
             level: snapshot
           writeConcern:
             w: 1
-          maxTimeMS: 60000
+          maxCommitTimeMS: 60000
 
     operations: *commitAbortOperations
 
@@ -272,7 +272,7 @@ tests:
             level: majority
           writeConcern:
             w: 1
-          maxTimeMS: 30000
+          maxCommitTimeMS: 30000
 
     operations:
       - name: startTransaction
@@ -283,7 +283,7 @@ tests:
               level: snapshot
             writeConcern:
               w: majority
-            maxTimeMS: 60000
+            maxCommitTimeMS: 60000
       - name: insertOne
         object: collection
         arguments:
@@ -393,7 +393,7 @@ tests:
             level: snapshot
           writeConcern:
             w: majority
-          maxTimeMS: 60000
+          maxCommitTimeMS: 60000
 
     operations: *commitAbortOperations
 

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -3,7 +3,7 @@ Driver Transactions Specification
 =================================
 
 :Spec Title: Driver Transactions Specification
-:Spec Version: 1.4
+:Spec Version: 1.5
 :Author: Shane Harvey
 :Spec Lead: A\. Jesse Jiryu Davis
 :Advisory Group: A\. Jesse Jiryu Davis, Matt Broadstone, Robert Stam, Jeff Yemin, Spencer Brody
@@ -12,7 +12,7 @@ Driver Transactions Specification
 :Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
 :Type: Standards
 :Minimum Server Version: 4.0 (The minimum server version this spec applies to)
-:Last Modified: 19-February-2019
+:Last Modified: 24-April-2019
 
 .. contents::
 
@@ -150,6 +150,22 @@ This section is an overview of the public API for transactions:
          * The readPreference to use for this transaction.
          */
         Optional<ReadPreference> readPreference;
+
+        /**
+         * The readPreference to use for this transaction.
+         */
+        Optional<ReadPreference> readPreference;
+
+        /**
+         * The maximum amount of time to allow the *commit* to run.
+         *
+         * This option is only sent with the commitTransaction command and
+         * only if the caller explicitly provides a value.
+         * The default is to not send a value.
+         *
+         * @see https://docs.mongodb.com/manual/reference/command/commitTransaction/
+         */
+        Optional<Int64> maxTimeMS;
     }
 
     class SessionOptions {
@@ -290,6 +306,14 @@ See `Why is readPreference part of TransactionOptions?`_.
 In the future, we might relax this restriction and allow any read
 preference on a transaction.
 
+maxTimeMS
+^^^^^^^^^
+
+The maximum amount of time to allow the *commit* to run.
+
+This option is only sent with the commitTransaction command(s) and only if the
+caller explicitly provides a value. The default is to not send a value.
+
 **SessionOptions changes**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -385,11 +409,11 @@ commitTransaction
 ^^^^^^^^^^^^^^^^^
 
 This method commits the currently active transaction on this session.
-Drivers MUST run a commitTransaction command with the writeConcern from
-TransactionOptions. Drivers MUST report an error when the command fails
-or the command succeeds but contains a writeConcernError. This session
-is in the "transaction committed" state after this method returns — even
-on error.
+Drivers MUST run a commitTransaction command with the writeConcern and,
+if configured, the maxTimeMS from TransactionOptions.
+Drivers MUST report an error when the command fails or the command succeeds
+but contains a writeConcernError. This session is in the
+"transaction committed" state after this method returns — even on error.
 
 If this session is in the "no transaction" state, then Drivers MUST
 raise an error containing the message "No transaction started".
@@ -713,6 +737,7 @@ The commitTransaction server command has the following format:
         txnNumber : <Int64>,
         autocommit : false,
         writeConcern : {...},
+        maxTimeMS: <Int64>,
         recoveryToken : {...}
     }
 
@@ -882,7 +907,7 @@ state of the transaction.
 
 The driver MUST add the "UnknownTransactionCommitResult" error label when
 commitTransaction fails with a server selection error, network error, retryable
-writes error, or write concern failed / timeout. (See
+writes error, MaxTimeMSExpired error, or write concern failed / timeout. (See
 `A server selection error is labeled UnknownTransactionCommitResult`_
 for justification.) The approximate meaning of the
 UnknownTransactionCommitResult label is, "We don't know if your commit
@@ -1350,6 +1375,8 @@ durable, which achieves the primary objective of avoiding duplicate commits.
 **Changelog**
 -------------
 
+:2019-04-24: Add support for maxTimeMS on transaction commit, MaxTimeMSExpired
+             errors on commit are labelled UnknownTransactionCommitResult.
 :2019-02-19: Add support for sharded transaction recoveryToken.
 :2019-02-19: Clarify FAQ entry for not retrying commit on wtimeout
 :2019-01-18: Apply majority write concern when retrying commitTransaction

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -119,9 +119,9 @@ StartTransaction or start_transaction instead of startTransaction.
 
 A non-exhaustive list of acceptable naming deviations are as follows:
 
-* Using "maxTimeMS" as an example, .NET would use "MaxTime" where it's type is
-  a TimeSpan structure that includes units. However, calling it "MaximumTime"
-  would not be acceptable.
+* Using "maxCommitTimeMS" as an example, .NET would use "MaxCommitTime" where
+  it's type is a TimeSpan structure that includes units. However, calling it
+  "MaximumCommitTime" would not be acceptable.
 
 **Transaction API**
 ~~~~~~~~~~~~~~~~~~~
@@ -158,15 +158,10 @@ This section is an overview of the public API for transactions:
         Optional<ReadPreference> readPreference;
 
         /**
-         * The maximum amount of time to allow the *commit* to run.
-         *
-         * This option is only sent with the commitTransaction command and
-         * only if the caller explicitly provides a value.
-         * The default is to not send a value.
-         *
-         * @see https://docs.mongodb.com/manual/reference/command/commitTransaction/
+         * The maximum amount of time to allow a single commitTransaction
+         * command to run.
          */
-        Optional<Int64> maxTimeMS;
+        Optional<Int64> maxCommitTimeMS;
     }
 
     class SessionOptions {
@@ -307,13 +302,16 @@ See `Why is readPreference part of TransactionOptions?`_.
 In the future, we might relax this restriction and allow any read
 preference on a transaction.
 
-maxTimeMS
-^^^^^^^^^
+maxCommitTimeMS
+^^^^^^^^^^^^^^^
 
-The maximum amount of time to allow the *commit* to run.
+The maximum amount of time to allow a single commitTransaction command to run.
 
 This option is only sent with the commitTransaction command(s) and only if the
 caller explicitly provides a value. The default is to not send a value.
+
+Note, this option is an alias for the `maxTimeMS` commitTransaction command
+option.
 
 **SessionOptions changes**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -411,7 +409,7 @@ commitTransaction
 
 This method commits the currently active transaction on this session.
 Drivers MUST run a commitTransaction command with the writeConcern and,
-if configured, the maxTimeMS from TransactionOptions.
+if configured, the maxCommitTimeMS from TransactionOptions.
 Drivers MUST report an error when the command fails or the command succeeds
 but contains a writeConcernError. This session is in the
 "transaction committed" state after this method returns — even on error.

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -117,6 +117,12 @@ where your driver's and/or language's naming conventions differ you
 SHOULD continue to use them instead. For example, you might use
 StartTransaction or start_transaction instead of startTransaction.
 
+A non-exhaustive list of acceptable naming deviations are as follows:
+
+* Using "maxTimeMS" as an example, .NET would use "MaxTime" where it's type is
+  a TimeSpan structure that includes units. However, calling it "MaximumTime"
+  would not be acceptable.
+
 **Transaction API**
 ~~~~~~~~~~~~~~~~~~~
 
@@ -145,11 +151,6 @@ This section is an overview of the public API for transactions:
          * The writeConcern to use for this transaction.
          */
         Optional<WriteConcern> writeConcern;
-
-        /**
-         * The readPreference to use for this transaction.
-         */
-        Optional<ReadPreference> readPreference;
 
         /**
          * The readPreference to use for this transaction.

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -12,7 +12,7 @@ Driver Transactions Specification
 :Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
 :Type: Standards
 :Minimum Server Version: 4.0 (The minimum server version this spec applies to)
-:Last Modified: 24-April-2019
+:Last Modified: 13-May-2019
 
 .. contents::
 
@@ -310,7 +310,7 @@ The maximum amount of time to allow a single commitTransaction command to run.
 This option is only sent with the commitTransaction command(s) and only if the
 caller explicitly provides a value. The default is to not send a value.
 
-Note, this option is an alias for the `maxTimeMS` commitTransaction command
+Note, this option is an alias for the ``maxTimeMS`` commitTransaction command
 option.
 
 **SessionOptions changes**
@@ -1374,7 +1374,7 @@ durable, which achieves the primary objective of avoiding duplicate commits.
 **Changelog**
 -------------
 
-:2019-04-24: Add support for maxTimeMS on transaction commit, MaxTimeMSExpired
+:2019-05-13: Add support for maxTimeMS on transaction commit, MaxTimeMSExpired
              errors on commit are labelled UnknownTransactionCommitResult.
 :2019-02-19: Add support for sharded transaction recoveryToken.
 :2019-02-19: Clarify FAQ entry for not retrying commit on wtimeout


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/SPEC-1206

Changes:
- TransactionOptions gains a new max_time_ms option. 
- MaxTimeMSExpired errors on commit (both `{ok:0, code: 50, codeName: "MaxTimeMSExpired"}` and `{ok:1, writeConcernError: {code: 50, codeName: "MaxTimeMSExpired"}}`) are labelled UnknownTransactionCommitResult.
- withTransaction does not retry commit after a MaxTimeMSExpired error. Aly requested that MaxTimeMSExpired halt any retry attempts.

I have a POC in pymongo implemented here: https://github.com/ShaneHarvey/mongo-python-driver/tree/SPEC-1206
Here is a passing patch build: https://evergreen.mongodb.com/version/5cc0e14230661576bcab0b82 (note the failures are due to [PYTHON-1796](https://jira.mongodb.org/browse/PYTHON-1796)/[SERVER-40685](https://jira.mongodb.org/browse/SERVER-40685))