### PR TITLE
SPEC-1279: Fix recoveryToken fields in tests

### DIFF
--- a/source/transactions/tests/mongos-pin-auto-tests.py
+++ b/source/transactions/tests/mongos-pin-auto-tests.py
@@ -204,7 +204,7 @@ tests:
             startTransaction:
             autocommit: false
             writeConcern:
-            recoveryToken:
+            recoveryToken: 42
           command_name: abortTransaction
           database_name: admin
 

--- a/source/transactions/tests/mongos-pin-auto.json
+++ b/source/transactions/tests/mongos-pin-auto.json
@@ -296,7 +296,7 @@
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null,
-              "recoveryToken": null
+              "recoveryToken": 42
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/source/transactions/tests/mongos-pin-auto.yml
+++ b/source/transactions/tests/mongos-pin-auto.yml
@@ -191,7 +191,7 @@ tests:
             startTransaction:
             autocommit: false
             writeConcern:
-            recoveryToken:
+            recoveryToken: 42
           command_name: abortTransaction
           database_name: admin
 

--- a/source/transactions/tests/pin-mongos.json
+++ b/source/transactions/tests/pin-mongos.json
@@ -1049,7 +1049,7 @@
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null,
-              "recoveryToken": null
+              "recoveryToken": 42
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/source/transactions/tests/pin-mongos.yml
+++ b/source/transactions/tests/pin-mongos.yml
@@ -425,7 +425,7 @@ tests:
             startTransaction:
             autocommit: false
             writeConcern:
-            recoveryToken:
+            recoveryToken: 42
           command_name: abortTransaction
           database_name: admin
 


### PR DESCRIPTION
Found some recoveryToken fields that needed to be updated while implementing [SPEC-1279](https://jira.mongodb.org/browse/SPEC-1279) in [CSHARP-2598](https://jira.mongodb.org/browse/CSHARP-2598).