### PR TITLE
Fix incompatible ghost spec test

### DIFF
--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.json
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.json
@@ -23,11 +23,6 @@
           {
             "ok": 1,
             "isreplicaset": true,
-            "setName": "rs",
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
             "minWireVersion": 0,
             "maxWireVersion": 1
           }
@@ -41,7 +36,7 @@
           },
           "b:27017": {
             "type": "RSGhost",
-            "setName": "rs"
+            "setName": null
           }
         },
         "topologyType": "ReplicaSetWithPrimary",

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.yml
@@ -14,8 +14,6 @@ phases:
         - "b:27017"
         - ok: 1
           isreplicaset: true
-          setName: "rs"
-          hosts: ["a:27017", "b:27017"]
           minWireVersion: 0
           maxWireVersion: 1
     outcome:
@@ -25,7 +23,7 @@ phases:
           setName: "rs"
         "b:27017":
           type: "RSGhost"
-          setName: "rs"
+          setName:
       topologyType: "ReplicaSetWithPrimary"
       setName: "rs"
       logicalSessionTimeoutMinutes: ~


### PR DESCRIPTION
Ghosts are not expected to have either a setName or a hosts list