### PR TITLE
Clarify failCommand behavior for writes

### DIFF
--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -74,7 +74,8 @@ failCommand
 Some tests depend on a server fail point, ``failCommand``, which allows the
 client to force the server to return an error. Unlike
 ``onPrimaryTransactionalWrite``, ``failCommand`` does not allow the client to
-control whether the server will commit the operation. See:
+directly control whether the server will commit the operation (execution of the
+write depends entirely on whether the ``errorCode`` option is specified). See:
 `failCommand <../../transactions/tests#failcommand>`_ in the Transactions spec
 test suite for more information.
 

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -75,9 +75,9 @@ Some tests depend on a server fail point, ``failCommand``, which allows the
 client to force the server to return an error. Unlike
 ``onPrimaryTransactionalWrite``, ``failCommand`` does not allow the client to
 directly control whether the server will commit the operation (execution of the
-write depends entirely on whether the ``errorCode`` option is specified). See:
-`failCommand <../../transactions/tests#failcommand>`_ in the Transactions spec
-test suite for more information.
+write depends on whether the ``closeConnection`` and/or ``errorCode`` options
+are specified). See: `failCommand <../../transactions/tests#failcommand>`_ in
+the Transactions spec test suite for more information.
 
 Disabling Fail Points after Test Execution
 ------------------------------------------

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -63,8 +63,9 @@ control the fail point's behavior. ``failCommand`` supports the following
 - ``closeConnection``: Boolean option, which defaults to ``false``. If
   ``true``, the connection on which the command is executed will be closed
   and the client will see a network error.
-- ``errorCode``: Integer option, which is unset by default. If set, the
-  specified command error code will be returned as a command error.
+- ``errorCode``: Integer option, which is unset by default. If set, the command
+  will not be executed and the specified command error code will be returned as
+  a command error.
 - ``writeConcernError``: A document, which is unset by default. If set, the
   server will return this document in the "writeConcernError" field. This
   failure response only applies to commands that support write concern and

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -61,8 +61,8 @@ control the fail point's behavior. ``failCommand`` supports the following
 
 - ``failCommands``: Required, the list of command names to fail.
 - ``closeConnection``: Boolean option, which defaults to ``false``. If
-  ``true``, the connection on which the command is executed will be closed
-  and the client will see a network error.
+  ``true``, the command will not be executed, the connection will be closed, and
+  the client will see a network error.
 - ``errorCode``: Integer option, which is unset by default. If set, the command
   will not be executed and the specified command error code will be returned as
   a command error.


### PR DESCRIPTION
If this looks good, I'll update the [`failCommand` wiki page](https://github.com/mongodb/mongo/wiki/The-%22failCommand%22-fail-point#failcommand-parameters) after merging. That page should clarify exactly whether the command is executed if `closeConnection` or `errorCode` is used.

cc: @lankas can you chime in here, since you originally implemented [SERVER-35004](https://jira.mongodb.org/browse/SERVER-35004)?