### PR TITLE
Update transaction-related note in sessions spec 

### DIFF
--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -160,18 +160,8 @@ Applications end a session like this:
 
     session.endSession()
 
-While this specification does not deal with multi-document transactions (which
-don't even exist yet), it is expected that when they are implemented they will
-be based upon sessions. We can speculate that in the future we might have some
-additional transaction-related methods for sessions such as:
-
-.. code:: typescript
-
-    transaction = session.beginTransaction()
-    transaction.commit()
-    transaction.abort()
-
-However, multi-document transactions are out of scope for this specification.
+While this specification does not deal with multi-document transactions, which
+are covered in their own specification.
 
 MongoClient changes
 ===================

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -160,8 +160,8 @@ Applications end a session like this:
 
     session.endSession()
 
-While this specification does not deal with multi-document transactions, which
-are covered in their own specification.
+This specification does not deal with multi-document transactions, which
+are covered in `their own specification <../transactions/transactions.rst>`_.
 
 MongoClient changes
 ===================


### PR DESCRIPTION
Since transactions have been implemented, language referring to transactions in the future tense can be updated.