### PR TITLE
Note that drivers can ignore killAllSessions interruptions

### DIFF
--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -195,7 +195,9 @@ Then for each element in ``tests``:
 #. If the ``skipReason`` field is present, skip this test completely.
 #. Create a MongoClient and call
    ``client.admin.runCommand({killAllSessions: []})`` to clean up any open
-   transactions from previous test failures.
+   transactions from previous test failures. Ignore a command failure with
+   error code 11601 ("Interrupted") to work around
+   [SERVER-38335](https://jira.mongodb.org/browse/SERVER-38335).
 
    - Running ``killAllSessions`` cleans up any open transactions from
      a previously failed test to prevent the current test from blocking.

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -198,8 +198,6 @@ Then for each element in ``tests``:
    transactions from previous test failures. Ignore a command failure with
    error code 11601 ("Interrupted") to work around `SERVER-38335`_.
 
-.. _SERVER-38335: https://jira.mongodb.org/browse/SERVER-38335
-
    - Running ``killAllSessions`` cleans up any open transactions from
      a previously failed test to prevent the current test from blocking.
      It is sufficient to run this command once before starting the test suite
@@ -297,6 +295,8 @@ Then for each element in ``tests``:
      latest data by using **primary read preference** with
      **local read concern** even when the MongoClient is configured with
      another read preference or read concern.
+
+.. _SERVER-38335: https://jira.mongodb.org/browse/SERVER-38335
 
 Special Test Operations
 ```````````````````````

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -196,8 +196,9 @@ Then for each element in ``tests``:
 #. Create a MongoClient and call
    ``client.admin.runCommand({killAllSessions: []})`` to clean up any open
    transactions from previous test failures. Ignore a command failure with
-   error code 11601 ("Interrupted") to work around
-   [SERVER-38335](https://jira.mongodb.org/browse/SERVER-38335).
+   error code 11601 ("Interrupted") to work around `SERVER-38335`_.
+
+.. _SERVER-38335: https://jira.mongodb.org/browse/SERVER-38335
 
    - Running ``killAllSessions`` cleans up any open transactions from
      a previously failed test to prevent the current test from blocking.


### PR DESCRIPTION
Prior to SERVER-38335, killAllSessions might kill its own session (implicit or explicit). In practice, this does not pose a risk for blocking subsequent tests due to a lingering, open transaction so drivers should be OK to simply disregard this error.