### PR TITLE
Don't assert results for basic CRUD ops with w:0

### DIFF
--- a/source/transactions/tests/write-concern.json
+++ b/source/transactions/tests/write-concern.json
@@ -403,9 +403,6 @@
             "document": {
               "_id": 1
             }
-          },
-          "result": {
-            "insertedId": 1
           }
         },
         {
@@ -492,12 +489,6 @@
                 "_id": 2
               }
             ]
-          },
-          "result": {
-            "insertedIds": {
-              "0": 1,
-              "1": 2
-            }
           }
         },
         {
@@ -592,17 +583,6 @@
                 }
               }
             ]
-          },
-          "result": {
-            "deletedCount": 0,
-            "insertedCount": 1,
-            "insertedIds": {
-              "0": 1
-            },
-            "matchedCount": 0,
-            "modifiedCount": 0,
-            "upsertedCount": 0,
-            "upsertedIds": {}
           }
         },
         {
@@ -684,9 +664,6 @@
             "filter": {
               "_id": 0
             }
-          },
-          "result": {
-            "deletedCount": 1
           }
         },
         {
@@ -764,9 +741,6 @@
             "filter": {
               "_id": 0
             }
-          },
-          "result": {
-            "deletedCount": 1
           }
         },
         {
@@ -850,11 +824,6 @@
               }
             },
             "upsert": true
-          },
-          "result": {
-            "matchedCount": 1,
-            "modifiedCount": 1,
-            "upsertedCount": 0
           }
         },
         {
@@ -949,11 +918,6 @@
               }
             },
             "upsert": true
-          },
-          "result": {
-            "matchedCount": 1,
-            "modifiedCount": 1,
-            "upsertedCount": 0
           }
         },
         {

--- a/source/transactions/tests/write-concern.yml
+++ b/source/transactions/tests/write-concern.yml
@@ -244,8 +244,7 @@ tests:
           session: session0
           document:
             _id: 1
-        result:
-          insertedId: 1
+        # avoid assertion since result fields are inaccessible for unacknowledged write concern
       - *commitTransaction
 
     expectations:
@@ -269,8 +268,7 @@ tests:
           documents:
             - _id: 1
             - _id: 2
-        result:
-          insertedIds: {0: 1, 1: 2}
+        # avoid assertion since result fields are inaccessible for unacknowledged write concern
       - *commitTransaction
 
     expectations:
@@ -305,14 +303,7 @@ tests:
             - name: insertOne
               arguments:
                 document: {_id: 1}
-        result:
-          deletedCount: 0
-          insertedCount: 1
-          insertedIds: {0: 1}
-          matchedCount: 0
-          modifiedCount: 0
-          upsertedCount: 0
-          upsertedIds: {}
+        # avoid assertion since result fields are inaccessible for unacknowledged write concern
       - *commitTransaction
 
     expectations:
@@ -336,8 +327,7 @@ tests:
           session: session0
           filter:
             _id: 0
-        result:
-          deletedCount: 1
+        # avoid assertion since result fields are inaccessible for unacknowledged write concern
       - *commitTransaction
 
     expectations:
@@ -367,8 +357,7 @@ tests:
           session: session0
           filter:
             _id: 0
-        result:
-          deletedCount: 1
+        # avoid assertion since result fields are inaccessible for unacknowledged write concern
       - *commitTransaction
 
     expectations:
@@ -400,10 +389,7 @@ tests:
           update:
             $inc: {x: 1}
           upsert: true
-        result:
-          matchedCount: 1
-          modifiedCount: 1
-          upsertedCount: 0
+        # avoid assertion since result fields are inaccessible for unacknowledged write concern
       - *commitTransaction
 
     expectations:
@@ -438,10 +424,7 @@ tests:
           update:
             $inc: {x: 1}
           upsert: true
-        result:
-          matchedCount: 1
-          modifiedCount: 1
-          upsertedCount: 0
+        # avoid assertion since result fields are inaccessible for unacknowledged write concern
       - *commitTransaction
 
     expectations:
@@ -473,6 +456,7 @@ tests:
         arguments:
           session: session0
           filter: {_id: 0}
+        # findAndModify still returns result for unacknowledged write concern
         result: {_id: 0}
       - *commitTransaction
 
@@ -502,6 +486,7 @@ tests:
           filter: {_id: 0}
           replacement: {x: 1}
           returnDocument: Before
+        # findAndModify still returns result for unacknowledged write concern
         result: {_id: 0}
       - *commitTransaction
 
@@ -534,6 +519,7 @@ tests:
           update:
             $inc: {x: 1}
           returnDocument: Before
+        # findAndModify still returns result for unacknowledged write concern
         result: {_id: 0}
       - *commitTransaction
 


### PR DESCRIPTION
Per the CRUD spec, results fields are inaccessible for w:0 writes (including inserted count and ids).

Came across this while implementing [PHPLIB-365](https://jira.mongodb.org/browse/PHPLIB-365). See [Results](https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#results) in the CRUD specification for additional context.

While we could replace these `result` field with a single `isAcknowledged: false` field, I think that would be even less portable for drivers that chose not to implement that API. My understanding from [Test Format](https://github.com/mongodb/specifications/blob/master/source/transactions/tests/README.rst#test-format) is that `result` is optional (due to "if any") language, so I think the most correct thing to do here is to avoid any assertion at all.