### PR TITLE
Note that sessionOptions is a map

### DIFF
--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -122,8 +122,8 @@ Each YAML file has the following keys:
     configureFailPoint command to run on the admin database. This option and
     ``useMultipleMongoses: true`` are mutually exclusive.
 
-  - ``sessionOptions``: Optional, parameters to pass to
-    MongoClient.startSession().
+  - ``sessionOptions``: Optional, map of session names (e.g. "session0") to
+    parameters to pass to MongoClient.startSession() when creating that session.
 
   - ``operations``: Array of documents, each describing an operation to be
     executed. Each document has the following fields:


### PR DESCRIPTION
This was not immediately clear to me when implementing the test runner in PHPLIB. As a result, I was passing the map itself to `startSession`, which resulted in all options being ignored.