### PR TITLE
SPEC-1312 Project out all relevant fields in database-level aggregation tests

### DIFF
--- a/source/crud/tests/v2/db-aggregate.json
+++ b/source/crud/tests/v2/db-aggregate.json
@@ -26,12 +26,9 @@
               },
               {
                 "$project": {
-                  "command": 1
-                }
-              },
-              {
-                "$project": {
-                  "command.lsid": 0
+                  "command.aggregate": 1,
+                  "command.cursor": 1,
+                  "command.pipeline": 1
                 }
               }
             ]
@@ -57,17 +54,13 @@
                   },
                   {
                     "$project": {
-                      "command": 1
-                    }
-                  },
-                  {
-                    "$project": {
-                      "command.lsid": 0
+                      "command.aggregate": 1,
+                      "command.cursor": 1,
+                      "command.pipeline": 1
                     }
                   }
                 ],
-                "cursor": {},
-                "$db": "admin"
+                "cursor": {}
               }
             }
           ]
@@ -98,12 +91,10 @@
               },
               {
                 "$project": {
-                  "command": 1
-                }
-              },
-              {
-                "$project": {
-                  "command.lsid": 0
+                  "command.aggregate": 1,
+                  "command.cursor": 1,
+                  "command.pipeline": 1,
+                  "command.allowDiskUse": 1
                 }
               }
             ],
@@ -130,18 +121,15 @@
                   },
                   {
                     "$project": {
-                      "command": 1
-                    }
-                  },
-                  {
-                    "$project": {
-                      "command.lsid": 0
+                      "command.aggregate": 1,
+                      "command.cursor": 1,
+                      "command.pipeline": 1,
+                      "command.allowDiskUse": 1
                     }
                   }
                 ],
                 "allowDiskUse": true,
-                "cursor": {},
-                "$db": "admin"
+                "cursor": {}
               }
             }
           ]

--- a/source/crud/tests/v2/db-aggregate.yml
+++ b/source/crud/tests/v2/db-aggregate.yml
@@ -13,8 +13,7 @@ tests:
           pipeline:
             - $currentOp: { allUsers: false, idleConnections: false, localOps: true }
             - $match: { command.aggregate: { $eq: 1 } }
-            - $project: { command: 1 }
-            - $project: { command.lsid: 0 }
+            - $project: { command.aggregate: 1, command.cursor: 1, command.pipeline: 1}
         result:
           -
             command:
@@ -22,10 +21,8 @@ tests:
               pipeline:
                 - $currentOp: { allUsers: false, idleConnections: false, localOps: true }
                 - $match: { command.aggregate: { $eq: 1 } }
-                - $project: { command: 1 }
-                - $project: { command.lsid: 0 }
+                - $project: { command.aggregate: 1, command.cursor: 1, command.pipeline: 1}
               cursor: {}
-              $db: "admin"
   -
     description: "Aggregate with $currentOp and allowDiskUse"
     operations:
@@ -36,8 +33,7 @@ tests:
           pipeline:
             - $currentOp: { allUsers: true, idleConnections: true, localOps: true }
             - $match: { command.aggregate: {$eq: 1} }
-            - $project: { command: 1 }
-            - $project: { command.lsid: 0 }
+            - $project: { command.aggregate: 1, command.cursor: 1, command.pipeline: 1, command.allowDiskUse: 1}
           allowDiskUse: true
         result:
           -
@@ -46,8 +42,6 @@ tests:
               pipeline:
                 - $currentOp: { allUsers: true, idleConnections: true, localOps: true }
                 - $match: { command.aggregate: { $eq: 1 } }
-                - $project: { command: 1 }
-                - $project: { command.lsid: 0 }
+                - $project: { command.aggregate: 1, command.cursor: 1, command.pipeline: 1, command.allowDiskUse: 1}
               allowDiskUse: true
               cursor: {}
-              $db: "admin"


### PR DESCRIPTION
Closes [SPEC-1312](https://jira.mongodb.org/browse/SPEC-1312).

Note that `$project` does not support fields with names starting in `$`. Here is the relevant error message:
```
FieldPath field names may not start with '$'.
```

Consequently, I have removed the `$db` field from `result`. However, this doesn't seem to be an issue since the `$currentOp` pipeline stage cannot be run against any other database:
```
MongoDB Enterprise mongos> db.aggregate([{ "$currentOp" : {}}])
2019-06-06T13:01:33.928-0700 E QUERY    [js] Error: command failed: {
    "ok" : 0,
    "errmsg" : "$currentOp must be run against the 'admin' database with {aggregate: 1}",
    "code" : 73,
    "codeName" : "InvalidNamespace",
    "operationTime" : Timestamp(1559851290, 2),
    "$clusterTime" : {
        "clusterTime" : Timestamp(1559851290, 2),
        "signature" : {
            "hash" : BinData(0,"AAAAAAAAAAAAAAAAAAAAAAAAAAA="),
            "keyId" : NumberLong(0)
        }
    }
```