### PR TITLE
SPEC-1298 Add "connectionError" as a valid reason for ConnectionCheckOutFailedEvent

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -572,7 +572,7 @@ Events
        * Current valid values are:
        *   - "stale":           The pool was cleared, making the connection no longer valid
        *   - "idle":            The connection became stale by being available for too long
-       *   - "connectionError": The connection experienced an error, making it no longer valid
+       *   - "error":           The connection experienced an error, making it no longer valid
        *   - "poolClosed":      The pool was closed, making the connection no longer valid
        */
       reason: string|Enum;

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -572,7 +572,7 @@ Events
        * Current valid values are:
        *   - "stale":           The pool was cleared, making the connection no longer valid
        *   - "idle":            The connection became stale by being available for too long
-       *   - "error":           The connection experienced an error, making it no longer valid
+       *   - "connectionError": The connection experienced an error, making it no longer valid
        *   - "poolClosed":      The pool was closed, making the connection no longer valid
        */
       reason: string|Enum;
@@ -602,9 +602,9 @@ Events
        *  A reason explaining why connection check out failed.
        *  Can be implemented as a string or enum.
        *  Current valid values are:
-       *   - "poolClosed": The pool was previously closed, and cannot provide new connections
-       *   - "timeout":    The connection check out attempt exceeded the specified timeout
-       *   - "error":      The connection check out attempt experienced an error while setting up a new connection
+       *   - "poolClosed":      The pool was previously closed, and cannot provide new connections
+       *   - "timeout":         The connection check out attempt exceeded the specified timeout
+       *   - "connectionError": The connection check out attempt experienced an error while setting up a new connection
        */
       reason: string|Enum;
     }

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -9,7 +9,7 @@ Connection Monitoring and Pooling
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: June 6, 2019
+:Last Modified: June 11, 2019
 :Version: 1.1.0
 
 .. contents::
@@ -738,4 +738,4 @@ Exhaust Cursors may require changes to how we close connections in the future, s
 Change log
 ==========
 
-:2019-06-06: Add "error" as a valid reason for ConnectionCheckOutFailedEvent
+:2019-06-06: Add "connectionError" as a valid reason for ConnectionCheckOutFailedEvent

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -155,4 +155,4 @@ The following tests have not yet been automated, but MUST still be tested
 #. A user MUST be able to specify all ConnectionPoolOptions via a URI string
 #. A user MUST be able to subscribe to Connection Monitoring Events in a manner idiomatic to their language and driver
 #. When a check out attempt fails because connection set up throws an error,
-   assert that a ConnectionCheckOutFailedEvent with reason="error" is emitted.
+   assert that a ConnectionCheckOutFailedEvent with reason="connectionError" is emitted.

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -154,3 +154,5 @@ The following tests have not yet been automated, but MUST still be tested
 #. All ConnectionPoolOptions MUST be the same for all pools created by a MongoClient
 #. A user MUST be able to specify all ConnectionPoolOptions via a URI string
 #. A user MUST be able to subscribe to Connection Monitoring Events in a manner idiomatic to their language and driver
+#. When a check out attempt fails because connection set up throws an error,
+   assert that a ConnectionCheckOutFailedEvent with reason="error" is emitted.

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-error-closed.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-error-closed.json
@@ -29,22 +29,36 @@
       "options": 42
     },
     {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
       "type": "ConnectionCheckedOut",
+      "address": 42,
       "connectionId": 42
     },
     {
       "type": "ConnectionCheckedIn",
+      "address": 42,
       "connectionId": 42
     },
     {
       "type": "ConnectionPoolClosed",
       "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "address": 42,
+      "reason": "poolClosed"
     }
   ],
   "ignore": [
     "ConnectionCreated",
     "ConnectionReady",
-    "ConnectionClosed",
-    "ConnectionCheckOutStarted"
+    "ConnectionClosed"
   ]
 }

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-error-closed.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-error-closed.yml
@@ -15,14 +15,22 @@ events:
   - type: ConnectionPoolCreated
     address: 42
     options: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
   - type: ConnectionCheckedOut
+    address: 42
     connectionId: 42
   - type: ConnectionCheckedIn
+    address: 42
     connectionId: 42
   - type: ConnectionPoolClosed
     address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutFailed
+    address: 42
+    reason: poolClosed
 ignore:
   - ConnectionCreated
   - ConnectionReady
   - ConnectionClosed
-  - ConnectionCheckOutStarted


### PR DESCRIPTION
Is there any way to add a spec test for this? If not I can add a prose test.