### PR TITLE
SPEC-1321 test keyVaultNamespace

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -33,6 +33,7 @@ The spec tests format is an extension of `transactions spec tests <https://githu
 The semantics of `$$type` is that any actual value matching the BSON type indicated by the BSON type string is considered a match.
 
 For example, the following matches a command_started_event for an insert of a document where `random` must be of type ``binData``:
+
 ```
 - command_started_event:
     command:
@@ -83,6 +84,8 @@ Each YAML file has the following keys:
 
       - ``schema_map``: Optional, a map from namespaces to local JSON schemas.
 
+      - ``keyVaultNamespace``: Optional, a namespace to the key vault collection. Defaults to "admin.datakeys".
+
   - ``operations``: Array of documents, each describing an operation to be
     executed. Each document has the following fields:
 
@@ -125,7 +128,8 @@ Then for each element in ``tests``:
 
 #. Create a MongoClient using ``clientOptions``.
 
-   #. If ``client_side_encryption_opts`` includes ``aws`` as a KMS provider, pass in AWS credentials from the environment.
+   #. If ``autoEncryptOpts`` includes ``aws`` as a KMS provider, pass in AWS credentials from the environment.
+   #. If ``autoEncryptOpts`` does not include ``keyVaultNamespace``, default it to ``admin.datakeys``
    
 #. Create a collection object from the MongoClient, using the ``database_name``
    and ``collection_name`` fields from the YAML file.

--- a/source/client-side-encryption/tests/generate.py
+++ b/source/client-side-encryption/tests/generate.py
@@ -70,6 +70,33 @@ keys = {
         },
         "keyAltNames": ["altname", "another_altname"]
     },
+    "different_id": {
+        "status": 1,
+        "_id": {
+            "$binary": {
+                "base64": "BBBBBBBBBBBBBBBBBBBBBB==",
+                "subType": "04"
+            }
+        },
+        "masterKey": master_keys["aws"],
+        "updateDate": {
+            "$date": {
+                "$numberLong": "1552949630483"
+            }
+        },
+        "keyMaterial": {
+            "$binary": {
+                "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gF9FSYZL9Ze8TvTA3WBd3nmAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDLV3GHktEO8AlpsYBwIBEIB7ho0DQF7hEQPRz/8b61AHm2czX53Y9BNu5z+oyGYsoP643M58aTGsaHQzkTaAmGKlZTAEOjJkRJ4gZoabVuv4g6aJqf4k4w8pK7iIgHwMNy4nbUAqOWmqtnKpHZgy6jcFN2DzZzHIi4SNFsCkFc6Aw30ixtvqIDQPAXMW",
+                "subType": "00"
+            }
+        },
+        "creationDate": {
+            "$date": {
+                "$numberLong": "1552949630483"
+            }
+        },
+        "keyAltNames": []
+    },
     "local": {
         "_id": {
             "$binary": {

--- a/source/client-side-encryption/tests/missingKey.json
+++ b/source/client-side-encryption/tests/missingKey.json
@@ -61,12 +61,48 @@
         },
         "bsonType": "object"
     },
-    "key_vault_data": [],
+    "key_vault_data": [
+        {
+            "status": 1,
+            "_id": {
+                "$binary": {
+                    "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                    "subType": "04"
+                }
+            },
+            "masterKey": {
+                "provider": "aws",
+                "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+                "region": "us-east-1"
+            },
+            "updateDate": {
+                "$date": {
+                    "$numberLong": "1552949630483"
+                }
+            },
+            "keyMaterial": {
+                "$binary": {
+                    "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gF9FSYZL9Ze8TvTA3WBd3nmAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDLV3GHktEO8AlpsYBwIBEIB7ho0DQF7hEQPRz/8b61AHm2czX53Y9BNu5z+oyGYsoP643M58aTGsaHQzkTaAmGKlZTAEOjJkRJ4gZoabVuv4g6aJqf4k4w8pK7iIgHwMNy4nbUAqOWmqtnKpHZgy6jcFN2DzZzHIi4SNFsCkFc6Aw30ixtvqIDQPAXMW",
+                    "subType": "00"
+                }
+            },
+            "creationDate": {
+                "$date": {
+                    "$numberLong": "1552949630483"
+                }
+            },
+            "keyAltNames": [
+                "altname",
+                "another_altname"
+            ]
+        }
+    ],
     "tests": [
         {
             "description": "Insert with encryption on a missing key",
             "clientOptions": {
                 "autoEncryptOpts": {
+                    "keyVaultNamespace": "admin.different",
                     "kmsProviders": {
                         "aws": {}
                     }
@@ -91,7 +127,64 @@
                 "collection": {
                     "data": []
                 }
-            }
+            },
+            "expectations": [
+                {
+                    "command_started_event": {
+                        "command": {
+                            "listCollections": 1,
+                            "cursor": {},
+                            "filter": {
+                                "name": "default"
+                            }
+                        },
+                        "command_name": "listCollections"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "listCollections": 1,
+                            "cursor": {},
+                            "filter": {
+                                "name": "different"
+                            },
+                            "$db": "admin"
+                        },
+                        "command_name": "listCollections"
+                    }
+                },
+                {
+                    "command_started_event": {
+                        "command": {
+                            "find": "different",
+                            "filter": {
+                                "$or": [
+                                    {
+                                        "_id": {
+                                            "$in": [
+                                                {
+                                                    "$binary": {
+                                                        "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                                                        "subType": "04"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "keyAltNames": {
+                                            "$in": []
+                                        }
+                                    }
+                                ]
+                            },
+                            "$db": "admin"
+                        },
+                        "command_name": "find"
+                    }
+                }
+            ]
         }
     ]
 }

--- a/source/client-side-encryption/tests/missingKey.yml
+++ b/source/client-side-encryption/tests/missingKey.yml
@@ -5,12 +5,13 @@ collection_name: &collection_name "default"
 
 data: []
 json_schema: {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
-key_vault_data: [] # key vault data is empty
+key_vault_data: [{'status': 1, '_id': {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}, 'masterKey': {'provider': 'aws', 'key': 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0', 'region': 'us-east-1'}, 'updateDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyMaterial': {'$binary': {'base64': 'AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gF9FSYZL9Ze8TvTA3WBd3nmAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDLV3GHktEO8AlpsYBwIBEIB7ho0DQF7hEQPRz/8b61AHm2czX53Y9BNu5z+oyGYsoP643M58aTGsaHQzkTaAmGKlZTAEOjJkRJ4gZoabVuv4g6aJqf4k4w8pK7iIgHwMNy4nbUAqOWmqtnKpHZgy6jcFN2DzZzHIi4SNFsCkFc6Aw30ixtvqIDQPAXMW', 'subType': '00'}}, 'creationDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyAltNames': ['altname', 'another_altname']}]
 
 tests:
   - description: "Insert with encryption on a missing key"
     clientOptions:
       autoEncryptOpts:
+        keyVaultNamespace: "admin.different"
         kmsProviders:
           aws: {} # Credentials filled in from environment.
     operations:
@@ -23,3 +24,27 @@ tests:
       collection:
         # Outcome is checked using a separate MongoClient without auto encryption.
         data: []
+    expectations:
+      # Auto encryption will request the collection info.
+      - command_started_event:
+          command:
+            listCollections: 1
+            cursor: {}
+            filter:
+              name: *collection_name
+          command_name: listCollections
+      - command_started_event:
+          command:
+            listCollections: 1
+            cursor: {}
+            filter:
+              name: "different"
+            $db: admin
+          command_name: listCollections
+      # Then key is fetched from the key vault.
+      - command_started_event:
+          command:
+            find: different
+            filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
+            $db: admin
+          command_name: find

--- a/source/client-side-encryption/tests/missingKey.yml.template
+++ b/source/client-side-encryption/tests/missingKey.yml.template
@@ -5,12 +5,13 @@ collection_name: &collection_name "default"
 
 data: []
 json_schema: {{schema()}}
-key_vault_data: [] # key vault data is empty
+key_vault_data: [{{key()}}]
 
 tests:
   - description: "Insert with encryption on a missing key"
     clientOptions:
       autoEncryptOpts:
+        keyVaultNamespace: "admin.different"
         kmsProviders:
           aws: {} # Credentials filled in from environment.
     operations:
@@ -23,3 +24,27 @@ tests:
       collection:
         # Outcome is checked using a separate MongoClient without auto encryption.
         data: []
+    expectations:
+      # Auto encryption will request the collection info.
+      - command_started_event:
+          command:
+            listCollections: 1
+            cursor: {}
+            filter:
+              name: *collection_name
+          command_name: listCollections
+      - command_started_event:
+          command:
+            listCollections: 1
+            cursor: {}
+            filter:
+              name: "different"
+            $db: admin
+          command_name: listCollections
+      # Then key is fetched from the key vault.
+      - command_started_event:
+          command:
+            find: different
+            filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
+            $db: admin
+          command_name: find


### PR DESCRIPTION
Now explicitly says that "admin.datakeys" is the default. And changes the "missingKeys" test to validate that we pass the keyVaultNamespace option through and use it.

I validated on the old Java test runner (on j3071) with a change to add keyVaultNamespace. Though the Java test runner has changed a lot, so I don't have a PR for the newest test runner.