### PR TITLE
SPEC-1263: Fix server version for addition of postBatchResumeToken

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -10,7 +10,7 @@ Change Streams
 :Type: Standards
 :Minimum Server Version: 3.6
 :Last Modified: April 3, 2019
-:Version: 1.6.0
+:Version: 1.6.1
 
 .. contents::
 
@@ -508,7 +508,7 @@ Exposing All Resume Tokens
 
 :since: 4.0.7
 
-Users can inspect the _id on each ``ChangeDocument`` to use as a resume token. But since MongoDB 4.2, aggregate and getMore responses also include a ``postBatchResumeToken``. Drivers use one or the other when automatically resuming, as described in `Resume Process`_.
+Users can inspect the _id on each ``ChangeDocument`` to use as a resume token. But since MongoDB 4.0.7, aggregate and getMore responses also include a ``postBatchResumeToken``. Drivers use one or the other when automatically resuming, as described in `Resume Process`_.
 
 Drivers MUST expose a mechanism to retrieve the same resume token that would be used to automatically resume. It MUST be possible to use this mechanism after iterating every document. It MUST be possible for users to use this mechanism periodically even when no documents are getting returned (i.e. ``getMore`` has returned empty batches). Drivers have two options to implement this.
 
@@ -773,4 +773,6 @@ Changelog
 |            | ``postBatchResumeToken``.                                  |
 +------------+------------------------------------------------------------+
 | 2019-04-12 | Clarified caching process for resume token.                |
++------------+------------------------------------------------------------+
+| 2019-06-20 | Fix server version for addition of postBatchResumeToken    |
 +------------+------------------------------------------------------------+


### PR DESCRIPTION
Fixes a typo introduced in https://github.com/mongodb/specifications/commit/dece0402de347817fe1a812be5de1bdf2cef2608#diff-875f237661962b4ca9b2e58d97449831R510 for [SPEC-1263](https://jira.mongodb.org/browse/SPEC-1263). Per [SPEC-1194](https://jira.mongodb.org/browse/SPEC-1194) and [SERVER-35740](https://jira.mongodb.org/browse/SERVER-35740), this was introduced in 4.0.7.