### PR TITLE
SPEC-1339 add FLE corpus test

### DIFF
--- a/source/client-side-encryption/corpus/corpus-encrypted.json
+++ b/source/client-side-encryption/corpus/corpus-encrypted.json
@@ -1,0 +1,1397 @@
+{
+  "_id": "client_side_encryption_corpus",
+  "altname_aws": "aws",
+  "altname_local": "local",
+  "aws_double_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAABEOvVX2kOfuy/2K7qMnehmMNH3qkkMUr511WsqHvn11dWapX77AFS6wvZ38kuRUiWtT5WZ+HM40JyWRRk6JmLsQ==",
+      "subType": "06"
+    }
+  },
+  "aws_double_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAABWJP88eldRVwYwjHxYBkkMdJ/d3YoVEGhzD4BNd9+bgUtMNzEhx/6Lb2+T9MYqlI1Jjt2r4tfi8I40HKPuKmlag==",
+      "subType": "06"
+    }
+  },
+  "aws_double_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAABSN1R51nW75Tj/mZ7rSB5F0Nu/JZbGYNbN3cyyW2sG0wcCdiT8s4EADteMFvwStYweddaWt8zr+9WBo/9xkgA7w==",
+      "subType": "06"
+    }
+  },
+  "aws_double_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAABaq0RAo+JTXZpC/3oBo3WvKouNmEPB1A3MN+32q2DgBGsQZxjKRal6e61GAMs13lCBUvAEbBbzFPRmssrL6+tCQ==",
+      "subType": "06"
+    }
+  },
+  "aws_string_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAACM3OC43fPVHA+GHoW0k8u4g/gf9SIEgbUfPrClrCOuH2dOBU2Wf1inZJMaiIY9RTds4DBam8VA4sE2ojCOMPJjg==",
+      "subType": "06"
+    }
+  },
+  "aws_string_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAACl10wcrH+chI8fT1HNdNSsner2kHSaxrfy8cQnuyp4oOoE/lKj18E8bWuPd6l2zbObxH8jMhjNZskD7450hfUPA==",
+      "subType": "06"
+    }
+  },
+  "aws_string_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAACpY4Xzg7dTcXBXXfZ6Q4JJ6lOccuTTLc+F76ztrg/5Klo4N3hoghBqzrBJwkVu0oPG5qXDu1qysSxaSAz+dIaOA==",
+      "subType": "06"
+    }
+  },
+  "aws_string_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAACkPg6mJExUvKEpNnMNEeI6dmssUwgt6/b0f+0keMxn3StieZ4CoKQnzj15CFmwl4+d/1v8KC5F+5IsISYt5mAgA==",
+      "subType": "06"
+    }
+  },
+  "aws_string_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
+      "subType": "06"
+    }
+  },
+  "aws_string_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
+      "subType": "06"
+    }
+  },
+  "aws_string_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
+      "subType": "06"
+    }
+  },
+  "aws_string_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
+      "subType": "06"
+    }
+  },
+  "aws_object_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAADb1b5ZDZFX78poGH8Xvuh14FKjFyg+WdiKUvV/Vqbj6jgQfheoYzSJjjS1XLCDpc2/xtBqH9gR1lXph0gR2FQUg==",
+      "subType": "06"
+    }
+  },
+  "aws_object_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAADc+SGkdBGLHCRZIbC0MqcDSlyV98c7my0ft3b6t+tTIIq1JJlxOsE5kK3VU4w+kFP+Q1DP3f5ItpgY5rESeduHA==",
+      "subType": "06"
+    }
+  },
+  "aws_object_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAADazF+X3yF1cX/F83WXRQGxGT+NMETVOaLEYOZ8h5swxzMK6FOfeRn+fjffRLVIWLYD4j06VI6S6h8Mk4xmeqfUw==",
+      "subType": "06"
+    }
+  },
+  "aws_object_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAADlbzc4V938eJe/7n9OlXEsllDEMN8I01VWmmOzKw7oCqO+aCr0Hxe5MNQA4xHC9KKEL23rUMNHWIOjTKhTOzeSQ==",
+      "subType": "06"
+    }
+  },
+  "aws_array_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAEnT8OVWD7ibHhq88xRDGZNfXtfsIUbPIB6GLpDPkQZq00HrwRGtgrq8pBC5ZnEbez1LFX1TYnY+BNw4wldArV+XiAWw23jBGp0d47IrQorUM=",
+      "subType": "06"
+    }
+  },
+  "aws_array_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAEDxq5MZ5Pwu4pKMIJfeLA6PiGJle3YJ7kSsbNrTaqwV52CFB+zbxyuc1A2fis88rvycuLampc8PNwCahZdQ35eDpfe8VIpPEzkPhbJpCe3Zc=",
+      "subType": "06"
+    }
+  },
+  "aws_array_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAELOLzw4vLPQpMuVL9PRmqulkx04FfJEi/KO0N1/9KJtYIwqidt32Pc0P+5tBHxNZVE7aHygoLq3RCoofoQoQj6JDyNAfvxclWJbuRZJcsfb4=",
+      "subType": "06"
+    }
+  },
+  "aws_array_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAENBJ9GIHyZ6oDnH0lYexLSOUcXC2pj7aV9dzAO2J/ZcNPQcoxMLa79AFnEAZx8rr/cLge/c67mSvPRnCVRMxWNf5TiCmanty6pGfbe4RER10=",
+      "subType": "06"
+    }
+  },
+  "aws_binData=00_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAF86rpuvp1dXgtd8CUfVhA18gym+2MmHJeVkL+F0kdHkSBiDVzkRZAHxeih5yQMjM4h9IUV5dUZGZqUPKBdUqKBg==",
+      "subType": "06"
+    }
+  },
+  "aws_binData=00_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAF7as6ZrLq8CXpTw+2HhDa+gb8CcLnIuVMar5HkAlSS8MlvYCtghwEmiXThBahrfvCVyPUTiJ6vrPnSyuKBLYwgw==",
+      "subType": "06"
+    }
+  },
+  "aws_binData=00_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFBXSTm25j2KPeuhWguIg1JAww6IAtk5ezIzpCb1LBUOdHd3DcR62mV2caa7RrbeIJCLi0MH1mHXMilKux1uAfSw==",
+      "subType": "06"
+    }
+  },
+  "aws_binData=00_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFILHCJcGB20CZpGpilOSitmViJRcpM8oPKGT8MxTchu0YJ50jmNDZGlQmuFwjnQE7D7SU+HE+t5YHGaWpiR5gjQ==",
+      "subType": "06"
+    }
+  },
+  "aws_binData=00_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
+      "subType": "06"
+    }
+  },
+  "aws_binData=00_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
+      "subType": "06"
+    }
+  },
+  "aws_binData=00_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
+      "subType": "06"
+    }
+  },
+  "aws_binData=00_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
+      "subType": "06"
+    }
+  },
+  "aws_binData=04_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFF5ZKQOiDD2XDDL+ibmvus4Be5EPli+/LjghkOay2VET4ITNOUy8W0Qd/J6xNmYHnpaZE7oWHYP87bbgrgZVGjRknofka9NKM2Ult4NzRk/U=",
+      "subType": "06"
+    }
+  },
+  "aws_binData=04_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFF7U/mU0LE5zDFMHv3L+JyYi5Rmp8tiX19tMfS2pkCK4FrACGG+VPC3wtef4hjsAudUr3HbXe09q7D+ksqOv0LOe2dDWMSD/sWQN6g4fo/sc=",
+      "subType": "06"
+    }
+  },
+  "aws_binData=04_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFF447dzBZjpE4ZCDGNwfCSz1qEh9njo8auyMYscOe3TwT0A2gPZzB/TH5D9C/8KVCbW3kOw7uU2sahUMTq9m3NgHeP/hpvoIjEbJHgCsZlq0=",
+      "subType": "06"
+    }
+  },
+  "aws_binData=04_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAF7Nd3HuUsVPbFsrCSl5ZhGlxoMxCMPrPBvLCK18vq9d946/y0O0IPARaXdQu6/k4eRLvehJ54DH57LmEg8AImINLQCfgsIxnIrDPcOjyDGN8=",
+      "subType": "06"
+    }
+  },
+  "aws_binData=04_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
+      "subType": "06"
+    }
+  },
+  "aws_binData=04_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
+      "subType": "06"
+    }
+  },
+  "aws_binData=04_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
+      "subType": "06"
+    }
+  },
+  "aws_binData=04_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
+      "subType": "06"
+    }
+  },
+  "aws_objectId_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHFp9aNdg3C/xIE7u9hQFQynm0qXF+JBY2vHOVmTvqi/jXHqMbsOtV5JjMLcznGp9S11zMsvqYDRx1oHkfkf+FXg==",
+      "subType": "06"
+    }
+  },
+  "aws_objectId_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHIJz2HVBSmOLHNHs8tmgYeRauKr0/xb1O7Z1V0Y98jfn9uKs44X12My55eu7h0TCGQPAITsefPjiHtm0alm6i7Q==",
+      "subType": "06"
+    }
+  },
+  "aws_objectId_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHAUTRQf9ldi0PoE6R0CZ838mZe00CtbtJ063+8rFXA01uvMSh3uV5z3dDdVzHiryoiHfnby5MsHR8CuySwgM11w==",
+      "subType": "06"
+    }
+  },
+  "aws_objectId_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHbdmjHzLRLStaZWMueSQ0IrZXqozPRJLONEfTfqETucJqCKXs+H6rEtXEeaEdAKncwcCnGt+1f/CiPi617tRuQg==",
+      "subType": "06"
+    }
+  },
+  "aws_objectId_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
+      "subType": "06"
+    }
+  },
+  "aws_objectId_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
+      "subType": "06"
+    }
+  },
+  "aws_objectId_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
+      "subType": "06"
+    }
+  },
+  "aws_objectId_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
+      "subType": "06"
+    }
+  },
+  "aws_bool_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAI4a0Lxoi4IqX4Ctwwu+NrJYHMYmBmjWhCkrvm3HL8Q1BKnyLa1my+J/xC6a0GeiCDp663heie5bSsvqfWG47u4w==",
+      "subType": "06"
+    }
+  },
+  "aws_bool_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIOOVylnoqlLfy1tCk7tjfyefwJPKy658wF/E4JzLKTOrho3dh+NZubYSI6zxYiIJaGZZYfisBoBBqir0rRf4/sw==",
+      "subType": "06"
+    }
+  },
+  "aws_bool_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIHE6hRFKc1AdB3n7JYvlhhT+VIoIAHpuX55APlarPXVNRAhE97LlI93ionR1O55z5jh5HRe2jRoCZHoXdzCBTkw==",
+      "subType": "06"
+    }
+  },
+  "aws_bool_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIpkFE8ZnPeQovaU0B8XtLs9zTgIKOAJzHPr7K9VCaP/Hm+zuh5Jx46LjGEhsneBsfy0gIuhmxwpWIG09ctX4IPQ==",
+      "subType": "06"
+    }
+  },
+  "aws_date_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJUK9HLH1SvBpTwuHC0SeJgoT4HPkyq8Afbm7D0G9tcSE998xJFlbMfcegsBVoddTmRFivnJdpKSs/hSMWGYMnMg==",
+      "subType": "06"
+    }
+  },
+  "aws_date_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJnDI2pHYqLLdTP4ZUOcTbPPUOMdJykRqdEXEth7nwoCWDTqLGVsPYU6FpAYSLtEnewiHyE4rH7i1urpK5jt9cvA==",
+      "subType": "06"
+    }
+  },
+  "aws_date_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJ3rrzosFvjMYrBosPb5XrBxRIE+CUTP/zwLdABMCAJc8MNPFPmcqkq98Z2aXy7TUe//zgj5nL0ti6ua3YfXHL7g==",
+      "subType": "06"
+    }
+  },
+  "aws_date_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJIZfkuHWYBK7cImV/L5RgRay9sAt44ZI74sCOQsmdVtWtYdNV3uwM2ZMlFvZxrdzBE8l58KO4qSA6SvUQFO7JSw==",
+      "subType": "06"
+    }
+  },
+  "aws_date_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
+      "subType": "06"
+    }
+  },
+  "aws_date_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
+      "subType": "06"
+    }
+  },
+  "aws_date_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
+      "subType": "06"
+    }
+  },
+  "aws_date_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
+      "subType": "06"
+    }
+  },
+  "aws_regex_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAALXX/Qlag3fjyF3hJR92a4Fz+mmH+o5FxDr9JrqFG8uZP/rfnBWZz6YxrpgY/J429YMe2Js4KAVlu4yLMOJ7hp9g==",
+      "subType": "06"
+    }
+  },
+  "aws_regex_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAALrtHi5hLJKAOPCLuvSs8VBBtteMI969fPgOAnxz5m6OewCAths3reZ4KNEpcLjfS7XtLxeXXX3lAAL2JLky11xQ==",
+      "subType": "06"
+    }
+  },
+  "aws_regex_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAALxQc7JlqldcvmVjNnjsBUJaDPWFkD/zwkaFBZ+XrUFI0Z10+19e34+dx65Q0ZcssqsTjUwn+zC5yWc4bqqtT/2g==",
+      "subType": "06"
+    }
+  },
+  "aws_regex_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAALvyPS8mwcwJsvjrxeip6CjwWn/IWlgPmRNFjiMEX0tivovzmGHMifnkzLWZS1yt54kFeVpENSrJvEK7f8igtslw==",
+      "subType": "06"
+    }
+  },
+  "aws_regex_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
+      "subType": "06"
+    }
+  },
+  "aws_regex_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
+      "subType": "06"
+    }
+  },
+  "aws_regex_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
+      "subType": "06"
+    }
+  },
+  "aws_regex_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
+      "subType": "06"
+    }
+  },
+  "aws_dbPointer_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMN6mx/DLgREK50PfmDJI6C13KwUw6H23xYaBRu9fAcynSbpMthECx+zYboikKBY/Wu6Chxqq0UQzWKLaoOi2UvO/e98h60AKKMOVEV0nQ3JY=",
+      "subType": "06"
+    }
+  },
+  "aws_dbPointer_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMIeQ7jKSWweEfW9VGTKXON9k8kxdKGBjAhQ+JKXqZPSaE9mNcq+vE9r+6UtWFjAcWdJXSU1xArGhq4CiAVXdJB0HWDyjpqvZFgULwVCNGZtk=",
+      "subType": "06"
+    }
+  },
+  "aws_dbPointer_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMDYOqSTox3jvhlXiLrm5dXud2C9WtHVZAmA68mj3KX/pgUhZedeNdTY6MCMM8nJkdzXOSjY1tu70Pd5m1jxbSMX/qcbWbN+fDgkfoosNtURI=",
+      "subType": "06"
+    }
+  },
+  "aws_dbPointer_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAM/+qYLyverSGzfbcib8E2EflWdlAFx5Fvmrh8PsGTgtVfM53svNjXHI+x+K4zStTCz/Y0T1n+MftCXuj+byVQHhBKETZSSlBAOj6FdzCAXEo=",
+      "subType": "06"
+    }
+  },
+  "aws_dbPointer_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
+      "subType": "06"
+    }
+  },
+  "aws_dbPointer_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
+      "subType": "06"
+    }
+  },
+  "aws_dbPointer_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
+      "subType": "06"
+    }
+  },
+  "aws_dbPointer_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
+      "subType": "06"
+    }
+  },
+  "aws_javascript_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAANj3NZKEWvKFrkMjWqWmMx1d9TcdaEwnpJbycFBoTXYAo7x1JZ+HPBNQxHBdj5YZZYEOWrwNwqpQw1+MTBqXKS2w==",
+      "subType": "06"
+    }
+  },
+  "aws_javascript_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAANZy9km12VQWBx4t3jxncyalnfWENa8HJGGki9F740iyCI61Srdykf8M9t58WCwObv8TB13D2RQsYYWHw+luh7XA==",
+      "subType": "06"
+    }
+  },
+  "aws_javascript_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAANvlebO3bnVpyP0V6u6SoWebg6XhG8UUlIQXSWUObcJciJqIn2WIwNg599n1snKblSaXRC6mVjlIL5HyihRNixqg==",
+      "subType": "06"
+    }
+  },
+  "aws_javascript_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAANFy+5ZamUs37q2nRfLi5rPojMPBAHmgJFPjZ8giD5GsKQ3tek29RKkNn/62TaFwhux2N0ucx1nHCB6jByfA4I9Q==",
+      "subType": "06"
+    }
+  },
+  "aws_symbol_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOmbgaL0TyliHhftno4j2oyZhorj51t67UbK9Ip5/MbxiVbzVje/Hjajv4XiyG8SS6igfA4GaIki0h9J2PlL/f6CFqIIgLFJZrQZuZULxxRrg=",
+      "subType": "06"
+    }
+  },
+  "aws_symbol_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOgBpVGel5Xp13ovNLABmB3maZdyRbPeJZGcGUhX5ezWnxfbNmaIBsmE9YxLpI1YjDL9/wD8ZDFBwfrVnfCNyIgt28GtckKLd7Wj0puyEMO+c=",
+      "subType": "06"
+    }
+  },
+  "aws_symbol_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAO5lTw80vOTH2T/WIXOx0GA1UGOavaM+srPfY9yCPHs/aDKw8GyAkJ2bqNxwubfAq16WntHiBNd+eMvmWxbaFHJJV0Brw1qXGnJqs7IqkDxSM=",
+      "subType": "06"
+    }
+  },
+  "aws_symbol_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOxZPsKOeaUdXrJ2hnQGPhOZNE2Ae+HXepVJwdxAjMi3tRN4bll0yGhJ/zgA66GXt+bbT655EYC2/DwQ+a3PsIYY1pcr0+484LqWN4e1IH8ZY=",
+      "subType": "06"
+    }
+  },
+  "aws_symbol_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
+      "subType": "06"
+    }
+  },
+  "aws_symbol_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
+      "subType": "06"
+    }
+  },
+  "aws_symbol_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
+      "subType": "06"
+    }
+  },
+  "aws_symbol_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
+      "subType": "06"
+    }
+  },
+  "aws_javascriptWithScope_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPwONE0XMSc3WwwvQ8veIos7mZ0SAPf5YoCxlISevUokmjMam/3TlycHNYUA5/sLguRgYk4fPc424K1Cfk+PkE7nRZ8W8HmeYnWjzpftzLWxk=",
+      "subType": "06"
+    }
+  },
+  "aws_javascriptWithScope_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPH1CyARio0BzZK5Wtdq7Ur1ZfQvbq34liDWYH09RRzFalXseeNMqtFwLecEIv+h0enjcoX1UCoAos+o/zItu0vvcGuZwlUaLUHrH4TWU3bTc=",
+      "subType": "06"
+    }
+  },
+  "aws_javascriptWithScope_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPf0/0/7vaVBJp9yRiPszjVaV2WtTFcD6e6GvWSJKoynwecUYG+3lo1XGCais0xRr1bhhZQX7rmWlCR7KGBV8SuJKXgapE8xOSgPsai7ZLh/k=",
+      "subType": "06"
+    }
+  },
+  "aws_javascriptWithScope_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPyObqjxlwSrJwtZvDdCO3Seqb8EqCjVe00ZMqsGb05def7P1jme9syqEeQwumVvFWU7bOf4Mz35F2zyirBLOg2odkQ8y/lPiBRILlfQE9Z5k=",
+      "subType": "06"
+    }
+  },
+  "aws_int_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQd1j1auS+gEtd/D7lcmQnDBDA9PHtMLKGUFRDLze67v5T50adJxTwE0ULldeQ2tcI83hd2JY6QOB09A+8tsFm4A==",
+      "subType": "06"
+    }
+  },
+  "aws_int_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQfHEMifL7q2JEnmskBQBpXEvvMrN5zSkyJgUio5H9f6soa1Ug4W3u+a38qnsF82WfD6U70ZuQuAtQEuOF3/flxA==",
+      "subType": "06"
+    }
+  },
+  "aws_int_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQq3p15T1lh54FnQrmIBzSDQag+ZYyy7UEVr+q6lbdSobMshNddz91eNJ7onqBsykHT3KLKk+OMAInjlvlou1ZcQ==",
+      "subType": "06"
+    }
+  },
+  "aws_int_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQdwr9KLGn+PhJ4Z2TtbvsJxCT2th0+7b7jLim3E9xeBOElTwAFLcjDoUe4nwb28qnochXfXRwoMLUMh2fkz29xA==",
+      "subType": "06"
+    }
+  },
+  "aws_int_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
+      "subType": "06"
+    }
+  },
+  "aws_int_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
+      "subType": "06"
+    }
+  },
+  "aws_int_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
+      "subType": "06"
+    }
+  },
+  "aws_int_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
+      "subType": "06"
+    }
+  },
+  "aws_timestamp_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAR2SF6EGtDiEqXErZ+f39gQmxx10IdjgIcbPfgGuTZsQvOl2X/JgMSLDcP/+MfTIUWUDFyZDki5jryzzs2P5ZdPw==",
+      "subType": "06"
+    }
+  },
+  "aws_timestamp_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAARhEp4wfPLAAtGFh+sqyZhqPdpXyDkiAQMARS19B7qxQt8GPODIlnNHvMwZJj5xnzLcrsPy1avHBvUSDvn9aIttA==",
+      "subType": "06"
+    }
+  },
+  "aws_timestamp_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAARNIvTgx6DG84/P302kj0scfDFiYJUeCaHum0M4TSFO9Zsm39JEilT7fJTIGLeU+S2C/YHQb2KTBrNNVtUPRRpVA==",
+      "subType": "06"
+    }
+  },
+  "aws_timestamp_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAARg+ojBP7gg72CWDdI/rUH4I792YV8ot77BPP59XkI/OOjJ1Leo58+4YJp8wn2TnmvHNz8+ms2YXE4RRSoQSuXNw==",
+      "subType": "06"
+    }
+  },
+  "aws_timestamp_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
+      "subType": "06"
+    }
+  },
+  "aws_timestamp_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
+      "subType": "06"
+    }
+  },
+  "aws_timestamp_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
+      "subType": "06"
+    }
+  },
+  "aws_timestamp_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
+      "subType": "06"
+    }
+  },
+  "aws_long_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAASH1yVYGceol+S4lm3V1Gh6H6Ri8PBJxNSPvIh+bnl/ikqX5qwjRfNWAwmZ/+h5CAZwfv6mRsp25tzfhZud8wC6Q==",
+      "subType": "06"
+    }
+  },
+  "aws_long_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAASj9m0kLKuq0xpUE1+Nmg+SON5y45KFnmEkBsUjLxSx9hwenzsuMmio3xSFTfMQdyIcfpukpYoEk88LMTZMUCjBA==",
+      "subType": "06"
+    }
+  },
+  "aws_long_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAASpbbkYL0ZGpWEPdxBHgVTRuGMPlGCXFAmTOrPLMDB1kjaf3/sp55m4NTzD3AvzOJIRhxCnnxTIVQFzKHUGefB5A==",
+      "subType": "06"
+    }
+  },
+  "aws_long_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAASXlj/hbWdnf36dhehcidkBXULzt2V+sKIc9vXm1XAzyFMFbvyopsTJVhgtbA8Y/CURmFL8PHpW9HSwUdBqhwtFA==",
+      "subType": "06"
+    }
+  },
+  "aws_long_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
+      "subType": "06"
+    }
+  },
+  "aws_long_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
+      "subType": "06"
+    }
+  },
+  "aws_long_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
+      "subType": "06"
+    }
+  },
+  "aws_long_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
+      "subType": "06"
+    }
+  },
+  "aws_decimal_rand_auto_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAATi4Q+JjQSEPCCttQ8vgVvEBrmHefkWwOmXbOGpdPjHY7t+IOPZNHa1rmPhC6UGe8w5/1A+PsJWIg/zmMu11eeJR/66Jyik8nUqvzfqr2C/yI=",
+      "subType": "06"
+    }
+  },
+  "aws_decimal_rand_auto_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAATEh457S8fhggOw4ke+aPCpVffRDAPJC4PtYSNRMH9ImGFvQOKsAY+BiGTCb4Uc5ZfTg+SYxgvMH8ck8dD9omEuUmpyEEgW+9DImBeqN7ekTE=",
+      "subType": "06"
+    }
+  },
+  "aws_decimal_rand_explicit_id": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAT3eIzDQ/7Qivpvlwf78lt+z4SY5Ze3IQAOYHsbz30WPktHqQ5ZtBo9YuajB4Gnj85BRKn4XQ+UHkUmkuO4C4soyX7Lm5r5zgckfTtS9diWfs=",
+      "subType": "06"
+    }
+  },
+  "aws_decimal_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAATPUeRRva271Ec2vd0GaieLBGoGkkiAxdWnPhJCCeZIi6xFT4DEGaMS/4378rlvtoyB9/wWPSiTbMLBX1hyeGcFPc2XQdEk0Fz+6Nh5iNIo40=",
+      "subType": "06"
+    }
+  },
+  "local_double_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAB8Tz4+b9g2mh3mTAaK7XAmhRvFWsjewYYRa9VnflspK+G6LVeYeJv7SL6dKPshPJep1btOabCGATGqIRMhHiNoA==",
+      "subType": "06"
+    }
+  },
+  "local_double_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAABVIsxrFDfJK6IePEjkI4I5WI1sDE1kZpaVvRAHeCV/KSEEMCD1pcYZEfUKbKgwK6d9bHM6r5rOH/Gjldqx3mysQ==",
+      "subType": "06"
+    }
+  },
+  "local_double_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAABoz1hSZBELRpiQgapKrLW0wLywVdglg/9sdSZVdDAIj8FSUzeSWrWa5ewvffQaPuKL4carJc/uPoVCT/fXk/ilg==",
+      "subType": "06"
+    }
+  },
+  "local_double_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAABkwbUPTlLaR2v1nX43mHRHhf7414ItktgvfRvuykNaoRfSep94xv9P52EaxAWlNhgeaQ29FMimJEqK0cki6dzhQ==",
+      "subType": "06"
+    }
+  },
+  "local_string_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAACim4NbrYeeSxsX87WISZqc1EpHO1nmPMeK4CXRTNpV5dgH76GdmthYCLMku6nHZdwrekb0+eTIZJWZ6LZmZCMAA==",
+      "subType": "06"
+    }
+  },
+  "local_string_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAACPXrmNzOD0r1xzDLYJrLBg+7KGFxtboye9LSAsT13/QWy27FjchA7fzJpRSKcGNeJ/R2GAIAOQnC2UKWD7+JrMA==",
+      "subType": "06"
+    }
+  },
+  "local_string_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAACQrel7aY52J4vOf3VDal8BaenE4V+vxD4kMFtHhwUXBCpG8bkqA1wGgSVAdzDY1ppCnWdoVhccow9zG4Qw0kmiA==",
+      "subType": "06"
+    }
+  },
+  "local_string_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAACVJj9PS5eftgnHzYglLJKn7tYdyx2zftiNc5skM3gc5yWFUl/dM+Ss8OG9+lUWnzcRulJyRHEixTbiT7HYCV3FQ==",
+      "subType": "06"
+    }
+  },
+  "local_string_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
+      "subType": "06"
+    }
+  },
+  "local_string_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
+      "subType": "06"
+    }
+  },
+  "local_string_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
+      "subType": "06"
+    }
+  },
+  "local_string_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
+      "subType": "06"
+    }
+  },
+  "local_object_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAADNZNKFBityuvkAEo+XNlansZ7+sbRH1OM5oyyCNvjinq5YlrEG84SeccPNt/iy2nd4A1bIivFOYkOrFHDvfYLYQ==",
+      "subType": "06"
+    }
+  },
+  "local_object_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAADUXzdVW4gWU5hR2vssRT1XXy9+B+0Olr6OMhQtocgR6oDsUVupyNM+rV/HU1ZY4eWXe5DK9Kd8J7E0kR8HJjpCQ==",
+      "subType": "06"
+    }
+  },
+  "local_object_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAADoIQn146Z1oDJTiTZlKs/VD/iSSdn4c5uCCstUyBb/J4dP2++MTh5MZCGbUT1stnvJWmdKQ2/s8aeq8Ay/fXABw==",
+      "subType": "06"
+    }
+  },
+  "local_object_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAADI1hSs1rxC2eYbFn0COrZAXW0wbv6oPN1so4x1qFYMnGiz7SsoXKnDVt13BfgLJgg9WZjmPtlDDh0J+rYjoiVOA==",
+      "subType": "06"
+    }
+  },
+  "local_array_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAEBotHS7xVtuhFIQqmmP9oyLWIQ522b5PUWy7EMe/s6KWIVWrf9BDx4Lq7Yyfgbct93SJljkAc735iU3l8Sc0Hosl6cvIsUA35ZQXyID23IRY=",
+      "subType": "06"
+    }
+  },
+  "local_array_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAE4spDbeiakyiP81ktbI9tVWhQcg+XNCdeMjLKGlTFyf5ePnIUVcLKXwog+TscgklD3SWftf6BfuhWVZ3pE/Y9sfx0sH6TapO5flX2nNqghqE=",
+      "subType": "06"
+    }
+  },
+  "local_array_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAEr765Sbtz47kJ3nWdJXjv6/gLOAr8GiWMVwRLfPK7mXZpaPyzq/SXNNAP1coESF7urbDdKas1FnSy9Ml9yqsWjo8wF5eA7+wKYxpZEfMk/tE=",
+      "subType": "06"
+    }
+  },
+  "local_array_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAEaVCgyG83KHiwUcAMkjc52qRCVDv8u+8vp0kmQEC7xAp4GwDkBWcC4OWiUTYVLJGhNM1hp9ZT83JP4+Y7MNLg0Km9M2DHrdfjGrC9crVgaQ8=",
+      "subType": "06"
+    }
+  },
+  "local_binData=00_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFmluxgy79DpYwmRE6/Q+DDP03j3cem+VyCn7hLw+UB4g6sGM5hOwziNZah/oLZH3HZFAgXGpeV1klLyuLAjSVVg==",
+      "subType": "06"
+    }
+  },
+  "local_binData=00_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFBFTCMPVUEXyjVwd8LrGzAktth6ZgifvdgNviOgTr4BSQ8z3KoSxI1bL6X9rFDmgmlzLtRorKZ0xDSChdXt/FeA==",
+      "subType": "06"
+    }
+  },
+  "local_binData=00_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFlyI6aiM9rPXMkUAzStMib/UQ9r23xL1xmkzkW53qr1+l49KN/xj+il9k5ninshTkIVeTVc0xZbFMJ6bs4KYZIg==",
+      "subType": "06"
+    }
+  },
+  "local_binData=00_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFaRAv0bOajzcJrO1WegwB4AqOTBxc+3aMCmbdJ/F+dE2WFMPPTYcWYrx3LKf+5bw+EYjqn7lG73tBrRidRsgbBA==",
+      "subType": "06"
+    }
+  },
+  "local_binData=00_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
+      "subType": "06"
+    }
+  },
+  "local_binData=00_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
+      "subType": "06"
+    }
+  },
+  "local_binData=00_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
+      "subType": "06"
+    }
+  },
+  "local_binData=00_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
+      "subType": "06"
+    }
+  },
+  "local_binData=04_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFvIAZP+AioH7+GEZ55OtYRBE3vNsQVW31dliI6RDtU6dpJl1JIamGko9e7f/Lro57oWevFaHWMXINeoOmP4lr77fBb0enJ+gY7H8AmLJ/K1Q=",
+      "subType": "06"
+    }
+  },
+  "local_binData=04_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAF7zLAV4/ppn1JnKS9wtzA2EPwSf/Y2IPpsi/Q0Y4aYKcESXqFzGIwuJqMGr/C6hfXAkteDXA1qYUnBn5R965QgIIcXbIBSfvg2C+R9Ij/4h4=",
+      "subType": "06"
+    }
+  },
+  "local_binData=04_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFag/bf/a+veosXeLqO34CtGPm1uDvTOE/03hXQuLS4CBKt45hneq6EcFtCQubI7ujaOcF0x2X87qIEn/A1QbIU5G/zMLWelc6RGiTooImsH8=",
+      "subType": "06"
+    }
+  },
+  "local_binData=04_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFUzU4CbDt4sKj7KrHT8xu5A+XheyPfSuKtpeHTZWN4geIF+LWPLy9ygDEA8ptoH6E8RfIfYV2gSisc/xYGQK7lwSRLoR7e5q4GiT7DTgiAWs=",
+      "subType": "06"
+    }
+  },
+  "local_binData=04_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
+      "subType": "06"
+    }
+  },
+  "local_binData=04_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
+      "subType": "06"
+    }
+  },
+  "local_binData=04_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
+      "subType": "06"
+    }
+  },
+  "local_binData=04_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
+      "subType": "06"
+    }
+  },
+  "local_objectId_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAHDa2Ada67WNGLMb+Yg0K4VLCzr45+K6matJXI3qiTWsCdSVUDlfLCUg2Ssn90oRo/U8vbqM6KN5dyaEqLRsGlvQ==",
+      "subType": "06"
+    }
+  },
+  "local_objectId_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAHT388kIHTBagjaX1w5KwJ7gB62f9qrLUkiJ1Gy5DTSTwxZMcKp+ULk+MptcqIVeySSDZLPj+9zV/OFTV+Vu3Tog==",
+      "subType": "06"
+    }
+  },
+  "local_objectId_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAHnX1GvDhhSjvE6nA5Kw+HqkgwUv7ZmRrPH/YJMrNT+091i8+IUg7BNMPfTUmO8KIBqQknOmXgvd6RtaORQ9yiDg==",
+      "subType": "06"
+    }
+  },
+  "local_objectId_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAHv1rJ2s2f6eIM2ZhRdumw4STNlESaqEXS5Se3FH8qLTMffhXcqk/y0axKu1RMZo0tI+5yWIXApWNpefBmzHdFzQ==",
+      "subType": "06"
+    }
+  },
+  "local_objectId_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
+      "subType": "06"
+    }
+  },
+  "local_objectId_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
+      "subType": "06"
+    }
+  },
+  "local_objectId_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
+      "subType": "06"
+    }
+  },
+  "local_objectId_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
+      "subType": "06"
+    }
+  },
+  "local_bool_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAId1cIgL4tpvba2HgBklz2oB09lNQpzzNf8j1rAAJxsQujuIBt3rHBaIpwkyDptjQoAr2Zu5aSPkIGXb/CtL4Ctw==",
+      "subType": "06"
+    }
+  },
+  "local_bool_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAIqLHhBKPafkg/H+WqagDlsIpXR4rwHd7IbXqNeho+EQGF5yDQLT8P0hqKLZuAZ5zrRuRIRD4c1hElIzR4FCrGfA==",
+      "subType": "06"
+    }
+  },
+  "local_bool_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAI9gYdaPD4TKWMDrZ37on0BITNEudMpc2j3nq55yTklbJYf1iDzdnkIkdLh7/3TebzzQ8ZKqxWjh7cTVrZOEwvFg==",
+      "subType": "06"
+    }
+  },
+  "local_bool_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAIx4UkD65GKY5qzonoz5KK7p0daTpGTdJEfbVW9xl8nizQAIZ9Zq1WHxQYQ4bwVSlHYm5bn4Zvzl+BF8fN1wqnTA==",
+      "subType": "06"
+    }
+  },
+  "local_date_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAJic2/y8cGgHp9y9AMDrk/gdCgHwRSfRyxkjNjuq/rUmthH73PDVI9SICvoW31RBv7M/GJZRB0D2TXuwDLiRQW4g==",
+      "subType": "06"
+    }
+  },
+  "local_date_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAJru9UaiHPR2TUDzmafC9xqZPXQ7hxsmLdw08JiXVAWs7oHdb7qPODVM5zyInV4qO8derjiBInEZDCbegsF3F5eQ==",
+      "subType": "06"
+    }
+  },
+  "local_date_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAJF2pgcon+hGl/E/Fnk9VwVyLYrhihn2+Ah1nqUJNHBbBsg/mfPANtkQPx4NTaPIp69evN3LR1gbbUlRZMl8K91w==",
+      "subType": "06"
+    }
+  },
+  "local_date_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAJs3AtKNjNTwmtbQ+1Q/anVF3YkaMTE4uqRrKpwIxCbUZAJ8/2MPl0QgIZGt/y7nA+/+MG4fBP1/BqctxfsbHY7w==",
+      "subType": "06"
+    }
+  },
+  "local_date_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
+      "subType": "06"
+    }
+  },
+  "local_date_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
+      "subType": "06"
+    }
+  },
+  "local_date_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
+      "subType": "06"
+    }
+  },
+  "local_date_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
+      "subType": "06"
+    }
+  },
+  "local_regex_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAL8wd+9CNuNtxhtaxMAmdZHcFmKyJNp3MRXsdBFt61U/DPd+E1FZp8SaYn/uCoqm/BvRTcK9mOxr2JUZzCggHEog==",
+      "subType": "06"
+    }
+  },
+  "local_regex_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAALzOZvEOH98tKq8qMjaGpom/g8NjO88HTslXAxeejDLg6F2sWLmYLCtPqxUeWaNcNHfOmAbU2mT3AZyHyc/IBmEA==",
+      "subType": "06"
+    }
+  },
+  "local_regex_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAALuQm3nFVQGh9+z+J95Z3gCAsO26havZS8iMl0q8BiuDye7Qh8x51XhhtYaLONe4CNv3B5uIVh4oZ6tEQgOur05w==",
+      "subType": "06"
+    }
+  },
+  "local_regex_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAALzKq7gWYP+iBn3jgMFxwwEZxDQVj+1D7XBOyLszGurZqI5ZUWgzAn9Xytz3sa/1igRkkcE8T7Wrgsc3pEkEkdFQ==",
+      "subType": "06"
+    }
+  },
+  "local_regex_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
+      "subType": "06"
+    }
+  },
+  "local_regex_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
+      "subType": "06"
+    }
+  },
+  "local_regex_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
+      "subType": "06"
+    }
+  },
+  "local_regex_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
+      "subType": "06"
+    }
+  },
+  "local_dbPointer_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAMU7StSbgLWdhCumyK/Q0IpmkkS16JKWg/Kd1LxO0SYe7n5FnSIAW3LQdfVQrxqcBPnEqSWkUcFrmvrkF/6VUpx5IZMiWqxmq+K+40/jAgM4M=",
+      "subType": "06"
+    }
+  },
+  "local_dbPointer_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAMwOLszcKqTPfnRaXdDKoIYt8PvTfL3/2R6HGjYTpJMkZeZtpj2jKrFVEikZ5pzjFrUky/Tkj2mt16QvfgtpN8FBWocSwME0HOJpHoOYv6Djs=",
+      "subType": "06"
+    }
+  },
+  "local_dbPointer_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAMpuYKT/IZNhOF7H1Fa35G4QyJSabGATy2qpXqU3TiOC/RrF70aAiOacb/bVTNN+Gmo4Q0dJ/5BqB+Nt6IxhLHra4WkBghVDUpJHry0vlgGrY=",
+      "subType": "06"
+    }
+  },
+  "local_dbPointer_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAMR93khbRIRfR8HfCSM4Or7OMz3Gi3nEhLIKvFidFUzNuh+oBDo82AOcZ46iwjYYawFhrqQRQscJdrulmKxvLODnBxqz/QI+G46lLrP6prjf4=",
+      "subType": "06"
+    }
+  },
+  "local_dbPointer_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
+      "subType": "06"
+    }
+  },
+  "local_dbPointer_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
+      "subType": "06"
+    }
+  },
+  "local_dbPointer_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
+      "subType": "06"
+    }
+  },
+  "local_dbPointer_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
+      "subType": "06"
+    }
+  },
+  "local_javascript_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAANh0QD2X7SVWkPNsJwf8i4FgCbOUXxfPuX13TDSPiPH9Ul7A9PZG79+QIC6ZPYy6JYFBhBx9xUWSiNkGVy5GyNQA==",
+      "subType": "06"
+    }
+  },
+  "local_javascript_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAN9cHQ1Ff1ZevAJGQimrravXmJlnoDdGgb+RBAdM7ccYfBoW23IuN7CKWaBHlId33VvvsObYuUGsLVMf/bWrnC0w==",
+      "subType": "06"
+    }
+  },
+  "local_javascript_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAN7k5VQxKmO4T6niXQn5IphjjCQYhqlkHLuZGai2TagZ76A4j0GKYi7WoxdnMUN8+oZdscIPioYLBCw4Tg5a0GSg==",
+      "subType": "06"
+    }
+  },
+  "local_javascript_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAANvNY/n4JpCxdAaGoaOe3bz0OtuXHpukeI9E4xQInBaEPYTUSbFP25bO/4/vkJOkMdJ34c8UQGT3mqY/67PJseOw==",
+      "subType": "06"
+    }
+  },
+  "local_symbol_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAOuFHrZ61BKgrTa4iKgP7fB9m7Jx4pvUflxfY5myatlWg4LYsgQGTrBLHhnhgQttopMhY1tWXCO1jvufkF7TRNl9pz/AMGFEwr3poov1fRYc0=",
+      "subType": "06"
+    }
+  },
+  "local_symbol_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAOoEzTN3YBPP29j1SGS5H+ITQGVRdqbn5VfDWLyD7sksQXhIHR5A0cNfCLIWj5+6OLHnWiRlifc5EK6FcWPdr2QUQJU8/RIhNpPt37YXuXeyw=",
+      "subType": "06"
+    }
+  },
+  "local_symbol_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAOzUmadmaYGdWRdjp+2OQNTVlxA+Q9sDCvn/GrzDReP7SZvtXoFKbJ/g62Bh1vEk22vOX4XjhlvZ6g7JzQT/uE/uiFpeWBuWSY1S21gNZt0+Q=",
+      "subType": "06"
+    }
+  },
+  "local_symbol_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAOnkp4IEucGLVy/co+sgfnOIuoT61AZwgBLKMlp7g7macnOAb976PYZPICdhn7rXPkD/InFXTKWAqEleX4JJjot8T8qpMAmrE+q4nRxRhHAew=",
+      "subType": "06"
+    }
+  },
+  "local_symbol_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
+      "subType": "06"
+    }
+  },
+  "local_symbol_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
+      "subType": "06"
+    }
+  },
+  "local_symbol_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
+      "subType": "06"
+    }
+  },
+  "local_symbol_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
+      "subType": "06"
+    }
+  },
+  "local_javascriptWithScope_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAPme4I/i63PkIWqkKUNQGRFCvnd5eNtp7mL6AtyLicnUZmfjaKp238iBBdanDkucUWJGtFsQ+UMM4sU4TSMRSOXrrghmGriq+xQskCR+9UqPI=",
+      "subType": "06"
+    }
+  },
+  "local_javascriptWithScope_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAP23gGxIoSjqc0Msdfzh0UtrI3o+JNrlOBRsO2vuzWf193Oha9aYZFcU9QQWrnoi0quUvozU8rhmT9gIGhyoGQ0cEOslx0DIQGv84moI4LVdY=",
+      "subType": "06"
+    }
+  },
+  "local_javascriptWithScope_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAPcnatj8W5ToAtJvciC3+TN94teSum/iZ1D7sSm2b08VuXIAvIhXVKZpMEOZ6EQdEOS6zwoLnbyUxcLvXbq7BGmFyNTh3bIAE44pLmTc5TlEQ=",
+      "subType": "06"
+    }
+  },
+  "local_javascriptWithScope_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAPC8QF6ejexLcTE02Dw3a+jZtuaq49VkVQShiKiYCAP8+afgVhPgrQMSpVb9oeaF5Ue8mYCajYJUBZMREHfPcw5LM7usB5ts1s1KBt7wpuBWk=",
+      "subType": "06"
+    }
+  },
+  "local_int_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAQw4iYyYh9DxJOjYYDdP9BZSP/P4DmXhAp7rQWdflTfLYrusUcghkJfz3DML6HW4wxibKgK4Ho7YdNO2l4oD56Mg==",
+      "subType": "06"
+    }
+  },
+  "local_int_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAQGB9RO3Dks5tVNVyy0Pb9eG6OgPh5Gdwdi8k3QJyRWVmV1F3tV2S11RQaP08K8B8H27YsndYSS2IlDjO3ovZkTg==",
+      "subType": "06"
+    }
+  },
+  "local_int_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAQ6VVTwaWkwSv3P5lcxaJ3P4Acin+54tTmMoKOuhCPmlbMaQsGYSsAm0g6O6RV4uAoG8fGnXF6pcjSO4sLDeL7TQ==",
+      "subType": "06"
+    }
+  },
+  "local_int_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAQZAYbSWBDGFLf8f7F5wcqFBwShmDnCMz/GLii8lyd856rNdN+QKVzWyaFB+Lk9F0cFAVm2ur6ghgjNu5Itb+c/w==",
+      "subType": "06"
+    }
+  },
+  "local_int_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
+      "subType": "06"
+    }
+  },
+  "local_int_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
+      "subType": "06"
+    }
+  },
+  "local_int_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
+      "subType": "06"
+    }
+  },
+  "local_int_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
+      "subType": "06"
+    }
+  },
+  "local_timestamp_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAARV/6QxKynRPZrqXaTaVq1csxDd6wneM4vB1KkD8WplfK+fYzNmc1ALcacQ6KO1It72qgNWAnotKqSQEc7dhXR1g==",
+      "subType": "06"
+    }
+  },
+  "local_timestamp_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAARQymQaAwxs6a8W9c8wzTVOWaHTNGYGQAE5ZQumG3CzoCcj8R4LKCg5jJs3HzuhkWdZc+OTI1W2NXVO9IwvCF5Hw==",
+      "subType": "06"
+    }
+  },
+  "local_timestamp_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAARkXXseUIqlzPzC3efPFgZbSh3X2wjCBhPdjfyPk4jM/33/ckVfNNfv1aK/kU/CwQr2RLdqA6ZSsB21zdmFhTdFQ==",
+      "subType": "06"
+    }
+  },
+  "local_timestamp_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAARYkjb2Z5pxQeygA2ncx3UjuSfXRpvY25Mpa2BRsuY5CiuLcw1815fpsSP0C2jc22SnhOCEsezh9qQO3kBp8nrQw==",
+      "subType": "06"
+    }
+  },
+  "local_timestamp_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
+      "subType": "06"
+    }
+  },
+  "local_timestamp_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
+      "subType": "06"
+    }
+  },
+  "local_timestamp_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
+      "subType": "06"
+    }
+  },
+  "local_timestamp_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
+      "subType": "06"
+    }
+  },
+  "local_long_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAASOB6f7mCqjrgoLgm2a56DODphJodt8PU55FEAatluuDo6EFx+tDJzledCDLw4PSi3Rvel4VZxfOUdMEfq6OsMrg==",
+      "subType": "06"
+    }
+  },
+  "local_long_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAAS1TSYREAfBBWbznd4ujXbD0QIOMBbZddGblarCUDQp1WzPzKhxTqMYbzTSoEuF4me/Z/cYHeDphhsYy/FBjveLQ==",
+      "subType": "06"
+    }
+  },
+  "local_long_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAASa8CsY5pLBzr+KADtbsYMv9UttuvA5KAfN21QcsnUz1oVaJvjkx086VaKdOEQXwTuuiLofT51ykmL2LfjSIBJLg==",
+      "subType": "06"
+    }
+  },
+  "local_long_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAASIzdA3MIo/nVbMvVflAuXKjR3Zstk3znoT+XC7+qggBywDED7YOpGUXzeZNLlppo7hmW7UNXhvday3kbsuyl/BA==",
+      "subType": "06"
+    }
+  },
+  "local_long_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
+      "subType": "06"
+    }
+  },
+  "local_long_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
+      "subType": "06"
+    }
+  },
+  "local_long_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
+      "subType": "06"
+    }
+  },
+  "local_long_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
+      "subType": "06"
+    }
+  },
+  "local_decimal_rand_auto_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAATKe0o3iwGB4O+14xv04bbVsya38bmC5/LVAE97VwAYSSkGmflUhibwBmdKJBPPM3gFrq1cQj8jstMOs6cR6jSkLBXuiJ5/+RccFBFSnh1dFI=",
+      "subType": "06"
+    }
+  },
+  "local_decimal_rand_auto_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAATaaGWPrKnMGhhUWKdgDLhpNv7aYZX5LVX5RFrfpm4tEl6RmlhHG3THbcyQ+wYjoIqgDGrMeVb0uCJXOnbAPsQs54naVaRlbqmwIyJ98mxTWM=",
+      "subType": "06"
+    }
+  },
+  "local_decimal_rand_explicit_id": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAATMViuwcfnpi36V7jgROF2jwUYbp2zLsgE557s82VvkpH7cy4JxMDeB+7rgjxnWquMdneQcRk5AsQmhs/38dYx+e+iLe2ipm6nxMKkgonLbcM=",
+      "subType": "06"
+    }
+  },
+  "local_decimal_rand_explicit_altname": {
+    "$binary": {
+      "base64": "AizggCwAAAAAAAAAAAAAAAATH8URkolS6J5wU8+GwLJPHsElfR4BOB+VR4FE/U4xmo2O591DN0smUaVf8C8ISiNtG1w2cS6x1yYEaBRm5aDdwiQftF+C4mKFkale6tUJThQ=",
+      "subType": "06"
+    }
+  }
+}

--- a/source/client-side-encryption/corpus/corpus-encrypted.json
+++ b/source/client-side-encryption/corpus/corpus-encrypted.json
@@ -4,49 +4,50 @@
   "altname_local": "local",
   "aws_double_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAABEOvVX2kOfuy/2K7qMnehmMNH3qkkMUr511WsqHvn11dWapX77AFS6wvZ38kuRUiWtT5WZ+HM40JyWRRk6JmLsQ==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAB+tzzg7dhiIS1kLRZv6h+45tKeFZTMkK80fx56lsOAsvc16+yxbn8Jt5y3X4mXXx74HFpZFfi5EVunkpFP1teaA==",
       "subType": "06"
     }
   },
   "aws_double_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAABWJP88eldRVwYwjHxYBkkMdJ/d3YoVEGhzD4BNd9+bgUtMNzEhx/6Lb2+T9MYqlI1Jjt2r4tfi8I40HKPuKmlag==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAABVcge8kBP9wgz+okbOOsumnVcnx7XQ7+N6XwhzOIb4tT9d1ww++gQIRNZUcpwWL35cfmelZ45SXaLhjL/zAiFTw==",
       "subType": "06"
     }
   },
   "aws_double_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAABSN1R51nW75Tj/mZ7rSB5F0Nu/JZbGYNbN3cyyW2sG0wcCdiT8s4EADteMFvwStYweddaWt8zr+9WBo/9xkgA7w==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAB+iLYgWW7naQ9LOXoLv/I0HT3EW+C8gNVaJ5OBgOUvi7rF05q842IXXXECKXuQgVGzik99q8a1NfyFD73lqZDCg==",
       "subType": "06"
     }
   },
   "aws_double_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAABaq0RAo+JTXZpC/3oBo3WvKouNmEPB1A3MN+32q2DgBGsQZxjKRal6e61GAMs13lCBUvAEbBbzFPRmssrL6+tCQ==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAB5b0/+aksLM28ogm+0pP8b9i2cHVxbHHpBYX4IiR1fJenL2eLoxsAUAp2B+B/hxT4U/uVwORdMy5vJMwpMf9RTw==",
       "subType": "06"
     }
   },
+  "aws_double_det_prohibited_id": { "$numberDouble": "1.234" },
   "aws_string_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAACM3OC43fPVHA+GHoW0k8u4g/gf9SIEgbUfPrClrCOuH2dOBU2Wf1inZJMaiIY9RTds4DBam8VA4sE2ojCOMPJjg==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAACDgz0f6F16di3iBp+bLoZK201Ck67y5DW7+5j8B8a5mIT/5l7poaHYfpLfdwY2GwDaWtvgoXLiqOWXKVc/GOkMA==",
       "subType": "06"
     }
   },
   "aws_string_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAACl10wcrH+chI8fT1HNdNSsner2kHSaxrfy8cQnuyp4oOoE/lKj18E8bWuPd6l2zbObxH8jMhjNZskD7450hfUPA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAACoKR2LFbroD5Cw34Ppw9pHmlps7FlNJKkm7zPYE1mVxFxhGpyMNKpKLaj5W4lX89eAqbUWPFxQ7P1ec4cBpJFLA==",
       "subType": "06"
     }
   },
   "aws_string_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAACpY4Xzg7dTcXBXXfZ6Q4JJ6lOccuTTLc+F76ztrg/5Klo4N3hoghBqzrBJwkVu0oPG5qXDu1qysSxaSAz+dIaOA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAC7rOwmG8P5W5Uzd1nOsNebdcYl0BG3UFp+kq62dv3NptKXHIefv+KSyVcXJcXnUq0ZQ/2coPt1Cj7kQxU4kUKxg==",
       "subType": "06"
     }
   },
   "aws_string_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAACkPg6mJExUvKEpNnMNEeI6dmssUwgt6/b0f+0keMxn3StieZ4CoKQnzj15CFmwl4+d/1v8KC5F+5IsISYt5mAgA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAC9L0FJn2DjOJw2bhVGwdW4WY4sALw5swqLc4IrzIroZYMpNEyepiPRpnxqGIXeAvXs18i+bD+XSl711/NxrTrWg==",
       "subType": "06"
     }
   },
@@ -76,73 +77,79 @@
   },
   "aws_object_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAADb1b5ZDZFX78poGH8Xvuh14FKjFyg+WdiKUvV/Vqbj6jgQfheoYzSJjjS1XLCDpc2/xtBqH9gR1lXph0gR2FQUg==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAADZdfqNQzuWd39VUlazCZqeo3yNBm09MtMx2Gh5o83T7wysV2ZvDTd9po/I1v5WygT1hVBv/dGZVweWVFRLt6rMQ==",
       "subType": "06"
     }
   },
   "aws_object_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAADc+SGkdBGLHCRZIbC0MqcDSlyV98c7my0ft3b6t+tTIIq1JJlxOsE5kK3VU4w+kFP+Q1DP3f5ItpgY5rESeduHA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAADt6tCsXvqm43r/lvm9jPCHAnAY++zvVyY9hPsmYCxng9vprj/TzVK/x4LuQzRiIf1t+cAm8fSnl1Q/YHyxkToLw==",
       "subType": "06"
     }
   },
   "aws_object_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAADazF+X3yF1cX/F83WXRQGxGT+NMETVOaLEYOZ8h5swxzMK6FOfeRn+fjffRLVIWLYD4j06VI6S6h8Mk4xmeqfUw==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAADZW42nSIMjBL/1ZwWzcaqypH/yBJJavuapsRVdjV/IsIAdsqF90lm/uXPgKGHmNIOi0B3Sx1r8AKLAX/za8CP9g==",
       "subType": "06"
     }
   },
   "aws_object_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAADlbzc4V938eJe/7n9OlXEsllDEMN8I01VWmmOzKw7oCqO+aCr0Hxe5MNQA4xHC9KKEL23rUMNHWIOjTKhTOzeSQ==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAADqlwedxMkzl8nMak5bai+mYXZg5sEu7SHaG/Dxo59COvRVk9qgl4SOFuv0Sk4eOqY5lxzDRNG91mUbEfIdtFpjg==",
       "subType": "06"
     }
   },
+  "aws_object_det_prohibited_id": { "x": { "$numberInt": "1" } },
   "aws_array_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAEnT8OVWD7ibHhq88xRDGZNfXtfsIUbPIB6GLpDPkQZq00HrwRGtgrq8pBC5ZnEbez1LFX1TYnY+BNw4wldArV+XiAWw23jBGp0d47IrQorUM=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAE/P006Jaq7ocRWVVV3vxXxWBPabXD1ISoS+SuTFgG+net+H83PaMaNj5CW8Kfyq1Jqns8063iK1kNjYGg98buVze0ptwH63O/z9VaMCNq7EY=",
       "subType": "06"
     }
   },
   "aws_array_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAEDxq5MZ5Pwu4pKMIJfeLA6PiGJle3YJ7kSsbNrTaqwV52CFB+zbxyuc1A2fis88rvycuLampc8PNwCahZdQ35eDpfe8VIpPEzkPhbJpCe3Zc=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAEKqcNEgUyIHCNnIbHH1HtFoJ55bmuINTshjdPZqDZl3PlFu6yXLySPeLjeWCPfieiYoQ0h/nAPu8+fAtNgUFOUOeR52+aVd1m7qJ5PpGYCVk=",
       "subType": "06"
     }
   },
   "aws_array_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAELOLzw4vLPQpMuVL9PRmqulkx04FfJEi/KO0N1/9KJtYIwqidt32Pc0P+5tBHxNZVE7aHygoLq3RCoofoQoQj6JDyNAfvxclWJbuRZJcsfb4=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAE8M27ZuYbhmd1u4IIvfitTe9flhHMwndcFPPPVxrAcWHKAZmfvvn/mdrfi2ZYSE1skKC7RManiFIxeqwfzEHmeJ1tfhbsKioP0vKX40PD1Hc=",
       "subType": "06"
     }
   },
   "aws_array_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAENBJ9GIHyZ6oDnH0lYexLSOUcXC2pj7aV9dzAO2J/ZcNPQcoxMLa79AFnEAZx8rr/cLge/c67mSvPRnCVRMxWNf5TiCmanty6pGfbe4RER10=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAEQT0BhcE+iZKzXCWWP4OKqDnv7SXbNdfojeSD0g1bMAFQ86i02MANEd4YmXh5UEmRZlftaUkncRzVt+x6rclOYTFsOMxlNehYzAKzIbIFQiw=",
       "subType": "06"
     }
   },
+  "aws_array_det_prohibited_id": [
+    { "$numberInt": "1" },
+    { "$numberInt": "2" },
+    { "$numberInt": "3" }
+  ],
   "aws_binData=00_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAF86rpuvp1dXgtd8CUfVhA18gym+2MmHJeVkL+F0kdHkSBiDVzkRZAHxeih5yQMjM4h9IUV5dUZGZqUPKBdUqKBg==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFP1VQsbfkpJfJuxmk5pJTAkT5o6dVEntEZFt+PLXmIt+RdIcfc43R4jlPXL1Dw66C3JHTQI9IV8InGH9dpYSHww==",
       "subType": "06"
     }
   },
   "aws_binData=00_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAF7as6ZrLq8CXpTw+2HhDa+gb8CcLnIuVMar5HkAlSS8MlvYCtghwEmiXThBahrfvCVyPUTiJ6vrPnSyuKBLYwgw==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFIg9yy//cWnoD3OD0llGnzHIWOsYTbYokwa7iHDeHVgAnD19glYnZD8teWvTEQ2RW9Mi0AkE/SspaC042ArmGGw==",
       "subType": "06"
     }
   },
   "aws_binData=00_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFBXSTm25j2KPeuhWguIg1JAww6IAtk5ezIzpCb1LBUOdHd3DcR62mV2caa7RrbeIJCLi0MH1mHXMilKux1uAfSw==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFmh05SHuFgCSP4sfYxS5K6kCgkgRX0R03ZredG59Llui5sPp19QwpMLLUSsTJiEuOtJkSNaZ2cCVxukS2K/mAXw==",
       "subType": "06"
     }
   },
   "aws_binData=00_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFILHCJcGB20CZpGpilOSitmViJRcpM8oPKGT8MxTchu0YJ50jmNDZGlQmuFwjnQE7D7SU+HE+t5YHGaWpiR5gjQ==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFkl2XKYNi3CiTROCbyAY9eNtmf1xS9eOc1sbcRVHQSYgNryphdnsDTaJLi8USOanIVZBzFn/qxndfjSMn/kB+0w==",
       "subType": "06"
     }
   },
@@ -172,25 +179,25 @@
   },
   "aws_binData=04_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFF5ZKQOiDD2XDDL+ibmvus4Be5EPli+/LjghkOay2VET4ITNOUy8W0Qd/J6xNmYHnpaZE7oWHYP87bbgrgZVGjRknofka9NKM2Ult4NzRk/U=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFK+UjO7BkaAZ/xf8C3ohSxPdxrw3mmb3ExtY4eyHQOAxBgo7S6BGsb/s7MnLfOtvWXGpLfGwwnfs59pY4MEvxJfRGOoMyRBk/jRQilD1Ro0g=",
       "subType": "06"
     }
   },
   "aws_binData=04_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFF7U/mU0LE5zDFMHv3L+JyYi5Rmp8tiX19tMfS2pkCK4FrACGG+VPC3wtef4hjsAudUr3HbXe09q7D+ksqOv0LOe2dDWMSD/sWQN6g4fo/sc=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFJ1aVAT473eINp08CCA8sZsPvdGWrSXkulFZuNqsP+mlpzc8LRFsgEyHztjnoA2OvcLqi0J4I7Fcc16Z+DlOHlctNJ5iLpy4EmaDI+BBs2TI=",
       "subType": "06"
     }
   },
   "aws_binData=04_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFF447dzBZjpE4ZCDGNwfCSz1qEh9njo8auyMYscOe3TwT0A2gPZzB/TH5D9C/8KVCbW3kOw7uU2sahUMTq9m3NgHeP/hpvoIjEbJHgCsZlq0=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAF0VSCm9XbBWvWwsU+hDDrqSCyWCYjojSxgiDaXLsLHWGURpFkiCbIJwCH8mkuQ/ZwAlJvCONJp6RXG7VoYHd4gP4Jp38k5Z/v39H/YFAh50w=",
       "subType": "06"
     }
   },
   "aws_binData=04_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAF7Nd3HuUsVPbFsrCSl5ZhGlxoMxCMPrPBvLCK18vq9d946/y0O0IPARaXdQu6/k4eRLvehJ54DH57LmEg8AImINLQCfgsIxnIrDPcOjyDGN8=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFSJ+DLDAjRXaLkliZjD9aDD+kJORp1LQZgVRn5t9HncgJRW6gXJ5FwWPHcZtYmgl4cqUwfkwT6DIPjOyP2duzR+nku6dbZoFjLLCDeOpOowE=",
       "subType": "06"
     }
   },
@@ -218,27 +225,29 @@
       "subType": "06"
     }
   },
+  "aws_undefined_rand_prohibited_id": { "$undefined": true },
+  "aws_undefined_det_prohibited_id": { "$undefined": true },
   "aws_objectId_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHFp9aNdg3C/xIE7u9hQFQynm0qXF+JBY2vHOVmTvqi/jXHqMbsOtV5JjMLcznGp9S11zMsvqYDRx1oHkfkf+FXg==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHmHyTV4N48P2bhlUNQff8Lzt0IkW4XfMOD0Q3Q6KPAPJLnGIFbeDjy26aRckr5xnXsj5vOp5ta8LF3GJFKiaYmA==",
       "subType": "06"
     }
   },
   "aws_objectId_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHIJz2HVBSmOLHNHs8tmgYeRauKr0/xb1O7Z1V0Y98jfn9uKs44X12My55eu7h0TCGQPAITsefPjiHtm0alm6i7Q==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHFVbk7c2S17uC+eV8CSkBeF7i3UML21XoA8TintZtOC8NtYJXk/SYqasyWtYiIemlwPGfFVyYBLlZTCmE22bRsw==",
       "subType": "06"
     }
   },
   "aws_objectId_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHAUTRQf9ldi0PoE6R0CZ838mZe00CtbtJ063+8rFXA01uvMSh3uV5z3dDdVzHiryoiHfnby5MsHR8CuySwgM11w==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHODeUPvRTFNAl9Q5QxBYRGO1vUEYtE2qhGAON+g7NhxZ8qRl67xGmETngdH56dzZ08gxYFwnU1loLB8JXEZsqKw==",
       "subType": "06"
     }
   },
   "aws_objectId_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHbdmjHzLRLStaZWMueSQ0IrZXqozPRJLONEfTfqETucJqCKXs+H6rEtXEeaEdAKncwcCnGt+1f/CiPi617tRuQg==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHIDhyxipvQleHrRcpty6VGHctD99kbc5mPCjKw05DyB2gC/1x+aO3P/nZSewTKLVoq+5o1dAqopK9xaCnvG3liQ==",
       "subType": "06"
     }
   },
@@ -268,49 +277,50 @@
   },
   "aws_bool_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAI4a0Lxoi4IqX4Ctwwu+NrJYHMYmBmjWhCkrvm3HL8Q1BKnyLa1my+J/xC6a0GeiCDp663heie5bSsvqfWG47u4w==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIBfsHwwtldopxCL1TnKNxbofwcOZre/T5c8EXjfvNSTaxx4y+sqmxXN4iBdIQUJKxDLvrh4Csodo+fjm6FVIqpw==",
       "subType": "06"
     }
   },
   "aws_bool_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIOOVylnoqlLfy1tCk7tjfyefwJPKy658wF/E4JzLKTOrho3dh+NZubYSI6zxYiIJaGZZYfisBoBBqir0rRf4/sw==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIz9N5F4roK/RFUnEdAgSHPuluANmo2y2Te8MUeH2U2MdJxsFzIDQMuo1/488jGaj0nGmHCZBLSP2zEZsXCmZwEQ==",
       "subType": "06"
     }
   },
   "aws_bool_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIHE6hRFKc1AdB3n7JYvlhhT+VIoIAHpuX55APlarPXVNRAhE97LlI93ionR1O55z5jh5HRe2jRoCZHoXdzCBTkw==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIGxsQ1l+LF+OyJKqDqxNyfHWK7N3u541jGen1auKFtjL2CpxZoi9YEVERKrqNI2ZpWHyBDTWQ9MqbdMiImfujtA==",
       "subType": "06"
     }
   },
   "aws_bool_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIpkFE8ZnPeQovaU0B8XtLs9zTgIKOAJzHPr7K9VCaP/Hm+zuh5Jx46LjGEhsneBsfy0gIuhmxwpWIG09ctX4IPQ==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIUJT+LYJyGyHU+fIIqH65ODZENeqv9cUChH39wBi7g7Mj37Tc9Yboe7lN9KX2d+nVzgrWUxh6P4xT+iWwqRdFuw==",
       "subType": "06"
     }
   },
+  "aws_bool_det_prohibited_id": true,
   "aws_date_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJUK9HLH1SvBpTwuHC0SeJgoT4HPkyq8Afbm7D0G9tcSE998xJFlbMfcegsBVoddTmRFivnJdpKSs/hSMWGYMnMg==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJtAEbKbbZHxYXZezMliN/EQkoLAnm56pkJSy5g8QuUwjP0iqKWRCIHDpoFs+bwDsLydtvLqrbZNPKydM4pom4iw==",
       "subType": "06"
     }
   },
   "aws_date_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJnDI2pHYqLLdTP4ZUOcTbPPUOMdJykRqdEXEth7nwoCWDTqLGVsPYU6FpAYSLtEnewiHyE4rH7i1urpK5jt9cvA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJkwp/a5KpS7oCHoQfsOUe7xKTiqnkrk+F3S9EfWoEQqVIK/V1A60a/+zC058elkaoUqhKkityXdBOJsYgrbBmZQ==",
       "subType": "06"
     }
   },
   "aws_date_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJ3rrzosFvjMYrBosPb5XrBxRIE+CUTP/zwLdABMCAJc8MNPFPmcqkq98Z2aXy7TUe//zgj5nL0ti6ua3YfXHL7g==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJaYuqsns8/54YUWOir9Al8AtETOH3jui4piLAeAZVKZJPjJjyUqLjUTFrpqAuAGxugJRk381UoZ/rOcXhkPc+Gw==",
       "subType": "06"
     }
   },
   "aws_date_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJIZfkuHWYBK7cImV/L5RgRay9sAt44ZI74sCOQsmdVtWtYdNV3uwM2ZMlFvZxrdzBE8l58KO4qSA6SvUQFO7JSw==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJfy4dyoYb+f4gdoin0mWBzsibZtvC76Q3rn3/mVjIaceAeIlp8b23l0g8cOiWHCI1lgu6CZhwpG/mMGVb/H77rQ==",
       "subType": "06"
     }
   },
@@ -338,27 +348,29 @@
       "subType": "06"
     }
   },
+  "aws_null_rand_prohibited_id": null,
+  "aws_null_det_prohibited_id": null,
   "aws_regex_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAALXX/Qlag3fjyF3hJR92a4Fz+mmH+o5FxDr9JrqFG8uZP/rfnBWZz6YxrpgY/J429YMe2Js4KAVlu4yLMOJ7hp9g==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAALgS/ZMc33aAMxHIv0vvVaIn+/ncU9COdEZVkWo5cVsRH8/EFVh/sSwa+QEwySX7mbg09pjP2tzsl/qcs2+WQMTQ==",
       "subType": "06"
     }
   },
   "aws_regex_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAALrtHi5hLJKAOPCLuvSs8VBBtteMI969fPgOAnxz5m6OewCAths3reZ4KNEpcLjfS7XtLxeXXX3lAAL2JLky11xQ==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAALB+NDPqEYXF31a2jvNnHkxh9NPxDdUFy40vRmvg2u+4QlQPwneb0TADNqsv2YFyQhvjjmwDLymhVifXrKe0nFUw==",
       "subType": "06"
     }
   },
   "aws_regex_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAALxQc7JlqldcvmVjNnjsBUJaDPWFkD/zwkaFBZ+XrUFI0Z10+19e34+dx65Q0ZcssqsTjUwn+zC5yWc4bqqtT/2g==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAALEw73E3R+BIMtIP0jOX3/7EkEWR1J2znIYX5POkGvUkvKKDqfL812qkozOn/vqTdBHvpfiDFA4vMMhR66kwK4OQ==",
       "subType": "06"
     }
   },
   "aws_regex_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAALvyPS8mwcwJsvjrxeip6CjwWn/IWlgPmRNFjiMEX0tivovzmGHMifnkzLWZS1yt54kFeVpENSrJvEK7f8igtslw==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAALBKI1zp2FS2ytWuy21/Y4rkAFxoHgoyaM2fDf7HDPtgBM/mz/Sl3b6eluZU6PtdQDLO53329lqP2d+2X/XLqiVg==",
       "subType": "06"
     }
   },
@@ -388,25 +400,25 @@
   },
   "aws_dbPointer_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMN6mx/DLgREK50PfmDJI6C13KwUw6H23xYaBRu9fAcynSbpMthECx+zYboikKBY/Wu6Chxqq0UQzWKLaoOi2UvO/e98h60AKKMOVEV0nQ3JY=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMa4fdZJyhSZGO1UnufS7/4r8CProCSqjQI854jffBQGxkNzzz49ENppk8B8nGiKUZgOZuuB6Vv/ROuFFLaJDh9yXKsN2U+LdyT4+Hk+lvghg=",
       "subType": "06"
     }
   },
   "aws_dbPointer_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMIeQ7jKSWweEfW9VGTKXON9k8kxdKGBjAhQ+JKXqZPSaE9mNcq+vE9r+6UtWFjAcWdJXSU1xArGhq4CiAVXdJB0HWDyjpqvZFgULwVCNGZtk=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMf1QJ5CTlYuPkLiBICFntXIfQ0Mv+xGfzMHQ7BowPDrUzCXuWyYyZ6K+Ao9FlrbaHsmbhFeKru5nw05jftvblxIb7HolPbtm2ot9trphMEwQ=",
       "subType": "06"
     }
   },
   "aws_dbPointer_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMDYOqSTox3jvhlXiLrm5dXud2C9WtHVZAmA68mj3KX/pgUhZedeNdTY6MCMM8nJkdzXOSjY1tu70Pd5m1jxbSMX/qcbWbN+fDgkfoosNtURI=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAM1dRfBBEpRdcJz4Y2hK0ySDTi6Us9KxotnEzbEdQvSVLaAorPKylWJvFyhkmKSJMo/dX362Ud+2TF8z2/GGsHcTfXLlVZXE5JxG7Cm9XWz6w=",
       "subType": "06"
     }
   },
   "aws_dbPointer_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAM/+qYLyverSGzfbcib8E2EflWdlAFx5Fvmrh8PsGTgtVfM53svNjXHI+x+K4zStTCz/Y0T1n+MftCXuj+byVQHhBKETZSSlBAOj6FdzCAXEo=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMQCd8Rx9un1mL6DrRiFTMnmVXwz4vGSfVkT5N7i+WbMgqk0unZbkRUakkA6yo6Z0VPNxylYhV/Kg6vgwdZGhOqWfTo7kf+Ri166dz1TA6n28=",
       "subType": "06"
     }
   },
@@ -436,49 +448,73 @@
   },
   "aws_javascript_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAANj3NZKEWvKFrkMjWqWmMx1d9TcdaEwnpJbycFBoTXYAo7x1JZ+HPBNQxHBdj5YZZYEOWrwNwqpQw1+MTBqXKS2w==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAN/56pexPdRR7pRdoUxYdMOfH2vgQUgN4DQWzOVYUJSmYsCLNo//Drz1foeZwLky7gCvm+QfHWpZ1CNXgIJQ6Lig==",
       "subType": "06"
     }
   },
   "aws_javascript_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAANZy9km12VQWBx4t3jxncyalnfWENa8HJGGki9F740iyCI61Srdykf8M9t58WCwObv8TB13D2RQsYYWHw+luh7XA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAANshTz5x++O98nq67UWUyyPdt1ZElk+YAWVdMd90ZW16LbUMPLaKAq6yQ6Bqz4DwTfyaWIQvBFNGed4oF7xAkDXQ==",
       "subType": "06"
     }
   },
   "aws_javascript_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAANvlebO3bnVpyP0V6u6SoWebg6XhG8UUlIQXSWUObcJciJqIn2WIwNg599n1snKblSaXRC6mVjlIL5HyihRNixqg==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAN/zbxp4DjbSOfZdrnYm7zr0GTuOrKA+m4ult7D/H4ZKxmUfRg31nWXMwXerAI44r14tdi7LF3ihvULP97HTRyVQ==",
       "subType": "06"
     }
   },
   "aws_javascript_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAANFy+5ZamUs37q2nRfLi5rPojMPBAHmgJFPjZ8giD5GsKQ3tek29RKkNn/62TaFwhux2N0ucx1nHCB6jByfA4I9Q==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAANkvNAKc+M/1Uu3KgPGLNuAzNmH7M7kDZ9XBOgkqsahDh3lCEwgpB0fX92ggdXQzskkJyp019HyTslwcd3NhHDQw==",
+      "subType": "06"
+    }
+  },
+  "aws_javascript_det_auto_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
+      "subType": "06"
+    }
+  },
+  "aws_javascript_det_auto_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
+      "subType": "06"
+    }
+  },
+  "aws_javascript_det_explicit_id": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
+      "subType": "06"
+    }
+  },
+  "aws_javascript_det_explicit_altname": {
+    "$binary": {
+      "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
       "subType": "06"
     }
   },
   "aws_symbol_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOmbgaL0TyliHhftno4j2oyZhorj51t67UbK9Ip5/MbxiVbzVje/Hjajv4XiyG8SS6igfA4GaIki0h9J2PlL/f6CFqIIgLFJZrQZuZULxxRrg=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOl3VbN4GcA2qHe7TWvJK+WwW1HhzC0fAClsgXx+nGGH+umDHXTOWuHQeLtc9AEex1Q5nrvRGhT6bHk/CWCwbwY62Fi2mxRWcNIYzRU5Czu0E=",
       "subType": "06"
     }
   },
   "aws_symbol_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOgBpVGel5Xp13ovNLABmB3maZdyRbPeJZGcGUhX5ezWnxfbNmaIBsmE9YxLpI1YjDL9/wD8ZDFBwfrVnfCNyIgt28GtckKLd7Wj0puyEMO+c=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOWdIipgoD5gD1rpaCcU7XJ1RPWk2nqyNdHpuz1IR3MPjdIiwDNVl8qm/vb7XCcgMU+gIqhfDUF18+8zvf8vV8AGGKtk+iKTxtLxAT2LzLpMA=",
       "subType": "06"
     }
   },
   "aws_symbol_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAO5lTw80vOTH2T/WIXOx0GA1UGOavaM+srPfY9yCPHs/aDKw8GyAkJ2bqNxwubfAq16WntHiBNd+eMvmWxbaFHJJV0Brw1qXGnJqs7IqkDxSM=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOfaprpg8TXtSj9UsuIK9Ikj+EhYXJveHxT+7k3ZR9J8RTkRua6lqfDkTVKnOjPIxEJAI1Nr7ziTd3bqJKaLVGAjA7lLDV6N9ZMSq0wNcY1ac=",
       "subType": "06"
     }
   },
   "aws_symbol_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOxZPsKOeaUdXrJ2hnQGPhOZNE2Ae+HXepVJwdxAjMi3tRN4bll0yGhJ/zgA66GXt+bbT655EYC2/DwQ+a3PsIYY1pcr0+484LqWN4e1IH8ZY=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOOamYmpKhNxC5JgL6/FJJNw+/4kgF2GyCcj/GUQMBXO/COxZkYIjKgbSbPJoZgo0IcDtwAr9wu8JzWShfCCG7etCVG5mf2vBDXgZBj71isjk=",
       "subType": "06"
     }
   },
@@ -508,49 +544,50 @@
   },
   "aws_javascriptWithScope_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPwONE0XMSc3WwwvQ8veIos7mZ0SAPf5YoCxlISevUokmjMam/3TlycHNYUA5/sLguRgYk4fPc424K1Cfk+PkE7nRZ8W8HmeYnWjzpftzLWxk=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPytI0/BZ9TU8DIhQcLPgnlb/0dSKyuKaRQQyBOey9scp+kwpiwG6q3uBekUgGdpKZyPbTBMDHnXFe8eWgJhCsj3B62b745J3hdRLb4mmrlUY=",
       "subType": "06"
     }
   },
   "aws_javascriptWithScope_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPH1CyARio0BzZK5Wtdq7Ur1ZfQvbq34liDWYH09RRzFalXseeNMqtFwLecEIv+h0enjcoX1UCoAos+o/zItu0vvcGuZwlUaLUHrH4TWU3bTc=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPrgKWv7hCBP2ONy5ZcVkPUBwYKqLAeR2LjlBDXgiLxbvllRaCvYPFa/zINokIrdvZ4hF7g1O4I73rwCHH/YoS4ZUcgh5ZTJKK/Jauf6wR+O8=",
       "subType": "06"
     }
   },
   "aws_javascriptWithScope_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPf0/0/7vaVBJp9yRiPszjVaV2WtTFcD6e6GvWSJKoynwecUYG+3lo1XGCais0xRr1bhhZQX7rmWlCR7KGBV8SuJKXgapE8xOSgPsai7ZLh/k=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPYxm1JIkOYxwYrLwPPG2f32hgLyOfgaHNfb9dcC8MEZtOuX7vslGGWxoToVMuM0OM6de07M18/+3zHz3hRxWOIqWUQxprUo1n3/+X42nb4Fk=",
       "subType": "06"
     }
   },
   "aws_javascriptWithScope_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPyObqjxlwSrJwtZvDdCO3Seqb8EqCjVe00ZMqsGb05def7P1jme9syqEeQwumVvFWU7bOf4Mz35F2zyirBLOg2odkQ8y/lPiBRILlfQE9Z5k=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPIX6N3w6qeyner1JE88dS7s2PFHYqiUtHy/vZb9cSMg5lulHOgGjrPWgKmy+ryfeE17PF/N5REOXjYPsuCYO3N58NEJIffXmM0qpGxwWEVUw=",
       "subType": "06"
     }
   },
+  "aws_javascriptWithScope_det_prohibited_id": { "$code": "x=1", "$scope": {} },
   "aws_int_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQd1j1auS+gEtd/D7lcmQnDBDA9PHtMLKGUFRDLze67v5T50adJxTwE0ULldeQ2tcI83hd2JY6QOB09A+8tsFm4A==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQopmZBvNnPODMN85EXZlFQuBKKXJ29m7ZrtoUeHR2qKy3nfg/A8MODB7Kj8hiUc6TV2Rv43I6KY21LArtuLz1Gw==",
       "subType": "06"
     }
   },
   "aws_int_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQfHEMifL7q2JEnmskBQBpXEvvMrN5zSkyJgUio5H9f6soa1Ug4W3u+a38qnsF82WfD6U70ZuQuAtQEuOF3/flxA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQi4HLad7H1ytZyzq9BinlDmExc3lEgLcrwyc+gWm7ucDn48y7TYMTOk0OgPLH6R4vizQzt0IYhzLAYkftQmy7kw==",
       "subType": "06"
     }
   },
   "aws_int_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQq3p15T1lh54FnQrmIBzSDQag+ZYyy7UEVr+q6lbdSobMshNddz91eNJ7onqBsykHT3KLKk+OMAInjlvlou1ZcQ==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQVZae6nJbkDJE/BzHkDY0hepq3dPQkLeA9ZPjuBeuJEgdk9NWlP2YahCvTDdDRxjpL4C8L7xBKeqcXTf0ZTMJOQ==",
       "subType": "06"
     }
   },
   "aws_int_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQdwr9KLGn+PhJ4Z2TtbvsJxCT2th0+7b7jLim3E9xeBOElTwAFLcjDoUe4nwb28qnochXfXRwoMLUMh2fkz29xA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQrTohlTTC2nXAzf1+r68OTReXyQ1GdhsnEMfvZeu6ZJ5GpYy3Oj2PlxqZunt+HzjpLj8otz5DnnPPaFIdMBXn/w==",
       "subType": "06"
     }
   },
@@ -580,25 +617,25 @@
   },
   "aws_timestamp_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAR2SF6EGtDiEqXErZ+f39gQmxx10IdjgIcbPfgGuTZsQvOl2X/JgMSLDcP/+MfTIUWUDFyZDki5jryzzs2P5ZdPw==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAR8I+VqSJGDA5CYPJfpAIYBv88KvttmS1sEGFA0qMOVrhh+L48iTJ+vsE+QxC/YqwHYw1dmlZDzEe6H4CYkT+/HA==",
       "subType": "06"
     }
   },
   "aws_timestamp_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAARhEp4wfPLAAtGFh+sqyZhqPdpXyDkiAQMARS19B7qxQt8GPODIlnNHvMwZJj5xnzLcrsPy1avHBvUSDvn9aIttA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAR0AOKtV8oExmokFG8kcPmH28SCSLXcUcqqToSINBrUmdYZ+98YTX5WhUEEphXci6f9q6wmXwQLiCMoggn0nfsHw==",
       "subType": "06"
     }
   },
   "aws_timestamp_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAARNIvTgx6DG84/P302kj0scfDFiYJUeCaHum0M4TSFO9Zsm39JEilT7fJTIGLeU+S2C/YHQb2KTBrNNVtUPRRpVA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAARKWngA51yFUTciOz/382fK5PpEf1mibArWlwNGmC3zwDCjF2aHeYzvj/2KXETb9Cl+qLo96EZw3FECQThg5Xxeg==",
       "subType": "06"
     }
   },
   "aws_timestamp_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAARg+ojBP7gg72CWDdI/rUH4I792YV8ot77BPP59XkI/OOjJ1Leo58+4YJp8wn2TnmvHNz8+ms2YXE4RRSoQSuXNw==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAARLgcgp3orTgRjtjKlJtCwmPv3V39BVLAgHOjnkAKl8QWz+wL3I6gjR4tGr157XnkjcsdlsX32QmdmelJLxkNhkw==",
       "subType": "06"
     }
   },
@@ -628,25 +665,25 @@
   },
   "aws_long_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAASH1yVYGceol+S4lm3V1Gh6H6Ri8PBJxNSPvIh+bnl/ikqX5qwjRfNWAwmZ/+h5CAZwfv6mRsp25tzfhZud8wC6Q==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAS5JGsTx47PgSzOsp5QDN5fn5X0Uitbm+oYklLBRhnt4sxWvilQQHIHSyPJ4csyDHHrHWSEscesIKOCyryS4vG7Q==",
       "subType": "06"
     }
   },
   "aws_long_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAASj9m0kLKuq0xpUE1+Nmg+SON5y45KFnmEkBsUjLxSx9hwenzsuMmio3xSFTfMQdyIcfpukpYoEk88LMTZMUCjBA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAASdy2WlNhcamInLdoNrQLyDGqtgQzIDDJ5YKpfw97RDRBEBiq5s5hnmoLNfF73+eNOyq9nkwOGxItJ/wwH7iuHkw==",
       "subType": "06"
     }
   },
   "aws_long_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAASpbbkYL0ZGpWEPdxBHgVTRuGMPlGCXFAmTOrPLMDB1kjaf3/sp55m4NTzD3AvzOJIRhxCnnxTIVQFzKHUGefB5A==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAASOOrX8Y6yFidAq8coVK8TDDnaHfwGA/3YeHsZSp24FrTNL3zHyBw+xV/Q99FUc3GQ9Vhh75gPOvT6zmiPI5Qo/A==",
       "subType": "06"
     }
   },
   "aws_long_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAASXlj/hbWdnf36dhehcidkBXULzt2V+sKIc9vXm1XAzyFMFbvyopsTJVhgtbA8Y/CURmFL8PHpW9HSwUdBqhwtFA==",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAShTFHXCpE4h5zcWdpc+bLL6DNUKf0p7PR2rrVptbYIW/7TjhRceIHUnGT/5N5MZWqckINPe36M5dkD3YkeeQLpg==",
       "subType": "06"
     }
   },
@@ -676,73 +713,79 @@
   },
   "aws_decimal_rand_auto_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAATi4Q+JjQSEPCCttQ8vgVvEBrmHefkWwOmXbOGpdPjHY7t+IOPZNHa1rmPhC6UGe8w5/1A+PsJWIg/zmMu11eeJR/66Jyik8nUqvzfqr2C/yI=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAATZR1EzFfj8Pdnvegjb82u0Ceg0pQP81dGJ3seCLBi5sBdyaqi18n3HMf6hzBz2Moi1QM5g9ODf2boF8tqrLmfehXpvg6hobEGoqz7OTcmYqY=",
       "subType": "06"
     }
   },
   "aws_decimal_rand_auto_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAATEh457S8fhggOw4ke+aPCpVffRDAPJC4PtYSNRMH9ImGFvQOKsAY+BiGTCb4Uc5ZfTg+SYxgvMH8ck8dD9omEuUmpyEEgW+9DImBeqN7ekTE=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAATbovMFEqztgtgaI9Yaz/ephY/8+slceNLFSQ8sZzx9Tu5LOsF3ENZsLJSRuugkMqmTct3KGLOIzLp7h5TnvJbylm5Ol9gH+zWd3NLwbz4p7s=",
       "subType": "06"
     }
   },
   "aws_decimal_rand_explicit_id": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAT3eIzDQ/7Qivpvlwf78lt+z4SY5Ze3IQAOYHsbz30WPktHqQ5ZtBo9YuajB4Gnj85BRKn4XQ+UHkUmkuO4C4soyX7Lm5r5zgckfTtS9diWfs=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAAT+kUc/E8bb2L5R41GNWETZyjjNyKc7ttu78trc3dTG5WV97qmklOCLwmxpu1Sxy5hP34q+CBv27PwkU2R6kGEAdgx14b/7ks6Dh+ttSGn7/c=",
       "subType": "06"
     }
   },
   "aws_decimal_rand_explicit_altname": {
     "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAATPUeRRva271Ec2vd0GaieLBGoGkkiAxdWnPhJCCeZIi6xFT4DEGaMS/4378rlvtoyB9/wWPSiTbMLBX1hyeGcFPc2XQdEk0Fz+6Nh5iNIo40=",
+      "base64": "AgFkgAAAAAAAAAAAAAAAAAATeYI3D5gwCKZbT7PNnyqqDv9kZjyM/ZAH+jQaJoMytZBqRAC8sR/sXWpfn1zvVQ0bjNlzCbjv07gbYp2rEDxGLMHeCnI1K5spYIp/z5OMmrQ=",
       "subType": "06"
     }
   },
+  "aws_decimal_det_prohibited_id": { "$numberDecimal": "1.234" },
+  "aws_minKey_rand_prohibited_id": { "$minKey": 1 },
+  "aws_minKey_det_prohibited_id": { "$minKey": 1 },
+  "aws_maxKey_rand_prohibited_id": { "$maxKey": 1 },
+  "aws_maxKey_det_prohibited_id": { "$maxKey": 1 },
   "local_double_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAB8Tz4+b9g2mh3mTAaK7XAmhRvFWsjewYYRa9VnflspK+G6LVeYeJv7SL6dKPshPJep1btOabCGATGqIRMhHiNoA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAABmvr0W8b4lcFbnXapyzbEJu7y4G8U1otHjvPRV3/fiz6kMVuBbgjxIXRK949oJUIpocbc4ZnMLBkZfpMQVqTgbA==",
       "subType": "06"
     }
   },
   "local_double_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAABVIsxrFDfJK6IePEjkI4I5WI1sDE1kZpaVvRAHeCV/KSEEMCD1pcYZEfUKbKgwK6d9bHM6r5rOH/Gjldqx3mysQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAB99dGDJ8TVK0kqYsBKtfLeSU4MssJ6+ZDHVeNq34/el4eEk9hQBWpjBL/YWRh6ER3uXhgtxzfZ1X/XSvfFa7yBQ==",
       "subType": "06"
     }
   },
   "local_double_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAABoz1hSZBELRpiQgapKrLW0wLywVdglg/9sdSZVdDAIj8FSUzeSWrWa5ewvffQaPuKL4carJc/uPoVCT/fXk/ilg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAABbgp4kP4Ff3AwfrEDGZqZESka9GQMuW3q8Cq4trgEZAZsvJy+y4zM0GV1P4rRDbDVWMPV8UwNB7PIUVuvn6tWgg==",
       "subType": "06"
     }
   },
   "local_double_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAABkwbUPTlLaR2v1nX43mHRHhf7414ItktgvfRvuykNaoRfSep94xv9P52EaxAWlNhgeaQ29FMimJEqK0cki6dzhQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAABsqOrgsXH981wjzuVKOGtBWLp5vy/m1Ol6ZaFulkNfCd3f5TDkwySIAUvGFu563w0EP6VW3jo7nXEpJHGwKpKsw==",
       "subType": "06"
     }
   },
+  "local_double_det_prohibited_id": { "$numberDouble": "1.234" },
   "local_string_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAACim4NbrYeeSxsX87WISZqc1EpHO1nmPMeK4CXRTNpV5dgH76GdmthYCLMku6nHZdwrekb0+eTIZJWZ6LZmZCMAA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAACTKx6vmGR/zmEFI4Px41cIMLwA8u1Jx0ccrAtdM22lyoTuNf686a39yuhpwuU8nJTtIz/Hg7pMtwoZpnKS7pEfA==",
       "subType": "06"
     }
   },
   "local_string_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAACPXrmNzOD0r1xzDLYJrLBg+7KGFxtboye9LSAsT13/QWy27FjchA7fzJpRSKcGNeJ/R2GAIAOQnC2UKWD7+JrMA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAACCVHp9AdklelnsZ3st41ssDo3teGLMan04EFG2tOLwLU4rza2zHmeVvU2FS8HcVXKSj2rkt1ybqUK5dm/ERAOsA==",
       "subType": "06"
     }
   },
   "local_string_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAACQrel7aY52J4vOf3VDal8BaenE4V+vxD4kMFtHhwUXBCpG8bkqA1wGgSVAdzDY1ppCnWdoVhccow9zG4Qw0kmiA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAC0t2t3agUqYNaF+rgJAse2cC5KXvJQkpLUfCFhtBmog4xg9V1+jD2hPXfG3juU1bR1l+obDRQAHHeZjJMj83+wg==",
       "subType": "06"
     }
   },
   "local_string_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAACVJj9PS5eftgnHzYglLJKn7tYdyx2zftiNc5skM3gc5yWFUl/dM+Ss8OG9+lUWnzcRulJyRHEixTbiT7HYCV3FQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAACVGsEtPAu0mvY38RUREvxH5z9uUGV147riVYeex+ZNw7cCy3GVwOXmwb57DOYXKBC0ZYtLmMw82nHGW7CwgEYeg==",
       "subType": "06"
     }
   },
@@ -772,73 +815,79 @@
   },
   "local_object_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAADNZNKFBityuvkAEo+XNlansZ7+sbRH1OM5oyyCNvjinq5YlrEG84SeccPNt/iy2nd4A1bIivFOYkOrFHDvfYLYQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAADudbNGKCfYi3BygueSE/rh5cwsueMKeny2lqqd0RinXaKN/QnEZZ8qiXTBOr5lDneOoO2qaLZ5WAhxXsvmLU3Mw==",
       "subType": "06"
     }
   },
   "local_object_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAADUXzdVW4gWU5hR2vssRT1XXy9+B+0Olr6OMhQtocgR6oDsUVupyNM+rV/HU1ZY4eWXe5DK9Kd8J7E0kR8HJjpCQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAADycKraFaktvZ1xKq97S1tLEGtV67zVZQxf3dm+FFFuZBzO4lpAh5WSJneisKiWlec3H4pWhfWnHAE6JQU+SLVYg==",
       "subType": "06"
     }
   },
   "local_object_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAADoIQn146Z1oDJTiTZlKs/VD/iSSdn4c5uCCstUyBb/J4dP2++MTh5MZCGbUT1stnvJWmdKQ2/s8aeq8Ay/fXABw==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAADpM5puNAXDa2im0l6dfiwYATwjKqChHOl4wJB2wRy3ql9XXR78c85qqcpfhY673wBrMlzO82sibQyll7K9f/F+g==",
       "subType": "06"
     }
   },
   "local_object_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAADI1hSs1rxC2eYbFn0COrZAXW0wbv6oPN1so4x1qFYMnGiz7SsoXKnDVt13BfgLJgg9WZjmPtlDDh0J+rYjoiVOA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAADU41hRGpBQdMLy/v5U8TztoIKctPmkwPul99JkPva5tmWSN5MYolOQGkg5eEXHWg1OzC4ZRj/TU+DEJU3M3OYrA==",
       "subType": "06"
     }
   },
+  "local_object_det_prohibited_id": { "x": { "$numberInt": "1" } },
   "local_array_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAEBotHS7xVtuhFIQqmmP9oyLWIQ522b5PUWy7EMe/s6KWIVWrf9BDx4Lq7Yyfgbct93SJljkAc735iU3l8Sc0Hosl6cvIsUA35ZQXyID23IRY=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAEA+IJjnU1TZJqUfpR/CWy5gc+ANmK99KaJ+ucpgtyZ7OD1eua3/2Ol9lmQ60NanhM1Qilsbh81G7yU0gLQPETLA5WwGEMtRXLSsiQGqtcxgQ=",
       "subType": "06"
     }
   },
   "local_array_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAE4spDbeiakyiP81ktbI9tVWhQcg+XNCdeMjLKGlTFyf5ePnIUVcLKXwog+TscgklD3SWftf6BfuhWVZ3pE/Y9sfx0sH6TapO5flX2nNqghqE=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAEDizByeeu0+4zo9Zb1TJzSbYADx4yBf8wtYl0F9/363THqng/zNP1Svkwc1tP5iqdkpCpBV5Fdc4msi3v2jPPqTA5W4z/JsnRyK5wHNqi6/s=",
       "subType": "06"
     }
   },
   "local_array_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAEr765Sbtz47kJ3nWdJXjv6/gLOAr8GiWMVwRLfPK7mXZpaPyzq/SXNNAP1coESF7urbDdKas1FnSy9Ml9yqsWjo8wF5eA7+wKYxpZEfMk/tE=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAEiVslbcKQ9o9J5uKGPsU1mCEjipIlRbEAvRi9i2nNV3debxMcxzxWFglaJxTyzNPOOq699cewfLnAA4sh3HDfuQBe4DJKfdFjxsl53/Tj29g=",
       "subType": "06"
     }
   },
   "local_array_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAEaVCgyG83KHiwUcAMkjc52qRCVDv8u+8vp0kmQEC7xAp4GwDkBWcC4OWiUTYVLJGhNM1hp9ZT83JP4+Y7MNLg0Km9M2DHrdfjGrC9crVgaQ8=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAEgMMzSizfZVuWXpLbEBllZW1PCT8WjRoEi4Lq2tsGUbXqkhCGx3ttyAHTkvIoIjCuGFOt4cn2c/1gM/lRlZ3HFpIH8q6/uckZA1Wx3DeCWKA=",
       "subType": "06"
     }
   },
+  "local_array_det_prohibited_id": [
+    { "$numberInt": "1" },
+    { "$numberInt": "2" },
+    { "$numberInt": "3" }
+  ],
   "local_binData=00_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFmluxgy79DpYwmRE6/Q+DDP03j3cem+VyCn7hLw+UB4g6sGM5hOwziNZah/oLZH3HZFAgXGpeV1klLyuLAjSVVg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFhkAEDOE/dXfJ1kXeW9+8Wh5HeyFOlaChdCv8sZHmnmnK1WXVLWxq73GwcwQSCLM0lPAcPvGFNFR7S2R2cCkkLA==",
       "subType": "06"
     }
   },
   "local_binData=00_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFBFTCMPVUEXyjVwd8LrGzAktth6ZgifvdgNviOgTr4BSQ8z3KoSxI1bL6X9rFDmgmlzLtRorKZ0xDSChdXt/FeA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFLQpyxs5+OpSi24GOuv2eSzasDyQXbTRKi1hgKZmZTXVR3asRJo2r31/GkpmU4a+Wcr0Gsfy0A/qIDihQpXpv0w==",
       "subType": "06"
     }
   },
   "local_binData=00_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFlyI6aiM9rPXMkUAzStMib/UQ9r23xL1xmkzkW53qr1+l49KN/xj+il9k5ninshTkIVeTVc0xZbFMJ6bs4KYZIg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFOW6kHS4tlXfonm7/6MWY3p+7e24GxrLGSfYgDyTsZ20tnE5HCOmu9UwcbWY3kKiHA5bwVW6rmKVQwVrlZRSpgw==",
       "subType": "06"
     }
   },
   "local_binData=00_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFaRAv0bOajzcJrO1WegwB4AqOTBxc+3aMCmbdJ/F+dE2WFMPPTYcWYrx3LKf+5bw+EYjqn7lG73tBrRidRsgbBA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFyMyzBU/QrKEMwsLdRMzUnGcGM7AKpOsbaLCvd57VUQAxruRy+turzhRV4lygU0CQDM3Fc24hpF+0EXYgXfGOQg==",
       "subType": "06"
     }
   },
@@ -868,25 +917,25 @@
   },
   "local_binData=04_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFvIAZP+AioH7+GEZ55OtYRBE3vNsQVW31dliI6RDtU6dpJl1JIamGko9e7f/Lro57oWevFaHWMXINeoOmP4lr77fBb0enJ+gY7H8AmLJ/K1Q=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFINmvibUNjhJJc44opxWMqjXzKxzYZor7VbZ3Edx+f8wQ0iHAwMeLGMTMBK1YWbnd52CPxGChoL+g6ZNqG0kM6zQhnnR5pmWINxvJvf5OdbA=",
       "subType": "06"
     }
   },
   "local_binData=04_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAF7zLAV4/ppn1JnKS9wtzA2EPwSf/Y2IPpsi/Q0Y4aYKcESXqFzGIwuJqMGr/C6hfXAkteDXA1qYUnBn5R965QgIIcXbIBSfvg2C+R9Ij/4h4=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAF1BVFZay3E2uddcBcvq2vAhPOQPocuKJyP9bDs8TaRkM9REUmxrVPDwrAeCMMDNvaeyjLZEagJJjMUEKbUB2JKCdUIxFx8uIRfXtmZIsIC7o=",
       "subType": "06"
     }
   },
   "local_binData=04_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFag/bf/a+veosXeLqO34CtGPm1uDvTOE/03hXQuLS4CBKt45hneq6EcFtCQubI7ujaOcF0x2X87qIEn/A1QbIU5G/zMLWelc6RGiTooImsH8=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFvGF57yU4rdsN5WD7NKxPFPu93PAfsJSHXusgsI8WUWFLx5JZKVVVmlbtgi+EYBoLwO3W/MYsYaBzH1jxTSIhWsPDWi4BMKXpVhVVWFTb/zU=",
       "subType": "06"
     }
   },
   "local_binData=04_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFUzU4CbDt4sKj7KrHT8xu5A+XheyPfSuKtpeHTZWN4geIF+LWPLy9ygDEA8ptoH6E8RfIfYV2gSisc/xYGQK7lwSRLoR7e5q4GiT7DTgiAWs=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAFxoY1RO9WKAJZkv4Q14GWwZZMSTswhA0PFJLTqsgBivwJHdneD4B5drmBPclxSDuBpWRBXfUJibWwdKg5RvL7qAoGXphKrSBbK8GIhDkyD4A=",
       "subType": "06"
     }
   },
@@ -914,27 +963,29 @@
       "subType": "06"
     }
   },
+  "local_undefined_rand_prohibited_id": { "$undefined": true },
+  "local_undefined_det_prohibited_id": { "$undefined": true },
   "local_objectId_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAHDa2Ada67WNGLMb+Yg0K4VLCzr45+K6matJXI3qiTWsCdSVUDlfLCUg2Ssn90oRo/U8vbqM6KN5dyaEqLRsGlvQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAH97Ui/rLmEF4MqHgchzLfsK3EXJHGaER3NsjV52CYsJjhhvhpHlLCav5iDKRyKjaaKzU3yFNmDOY5fF6VtnXQHw==",
       "subType": "06"
     }
   },
   "local_objectId_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAHT388kIHTBagjaX1w5KwJ7gB62f9qrLUkiJ1Gy5DTSTwxZMcKp+ULk+MptcqIVeySSDZLPj+9zV/OFTV+Vu3Tog==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAHOrYvleXpCX3IIZIv4p+4PSex4AYpzgyg73B8XjJtceLkth9e68yyVnuiLRiTaF4VGdOCHDU9rvDTUAGso0iQmQ==",
       "subType": "06"
     }
   },
   "local_objectId_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAHnX1GvDhhSjvE6nA5Kw+HqkgwUv7ZmRrPH/YJMrNT+091i8+IUg7BNMPfTUmO8KIBqQknOmXgvd6RtaORQ9yiDg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAHv4eDycUMEJAFYs6o1A52NDRXb9jMtgK9b8BA8WXYSC048KCRp6PvhIis60I4UfX0h0btEIfQaA+GQ3MnjYpPrQ==",
       "subType": "06"
     }
   },
   "local_objectId_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAHv1rJ2s2f6eIM2ZhRdumw4STNlESaqEXS5Se3FH8qLTMffhXcqk/y0axKu1RMZo0tI+5yWIXApWNpefBmzHdFzQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAHgkRKWeeNfMh2xDtSyrLYGJx2PFz0yXaVCpQZbBRqoae7zYNRqWC3NG7OsJ5kc/thqD79+OR8hPxnVyG+DGFq8w==",
       "subType": "06"
     }
   },
@@ -964,49 +1015,50 @@
   },
   "local_bool_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAId1cIgL4tpvba2HgBklz2oB09lNQpzzNf8j1rAAJxsQujuIBt3rHBaIpwkyDptjQoAr2Zu5aSPkIGXb/CtL4Ctw==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAIFk1Obh42QWEFgTh29A/3Ez5/jg8DbhnI18KsAj20TB74m/wE2gp5DWnCpvGBoMY5ozyQLJXUFyFFbPQdqvTDaQ==",
       "subType": "06"
     }
   },
   "local_bool_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAIqLHhBKPafkg/H+WqagDlsIpXR4rwHd7IbXqNeho+EQGF5yDQLT8P0hqKLZuAZ5zrRuRIRD4c1hElIzR4FCrGfA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAIDKEGJYD1/NbXSH6XvdgH/yVopabDitj98D/X6bt0PrYViJa2mfSyj2RvAA5COlIqBINyVcp27oncQy+bzyyVLg==",
       "subType": "06"
     }
   },
   "local_bool_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAI9gYdaPD4TKWMDrZ37on0BITNEudMpc2j3nq55yTklbJYf1iDzdnkIkdLh7/3TebzzQ8ZKqxWjh7cTVrZOEwvFg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAIPolPWoxyjTPClLHG21oWVnOWfI/MpEiZ+E98xzJzFLZw+pcFTizDpXXIJC1rq5HasqypPk2fKaoDGMT85f7n0Q==",
       "subType": "06"
     }
   },
   "local_bool_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAIx4UkD65GKY5qzonoz5KK7p0daTpGTdJEfbVW9xl8nizQAIZ9Zq1WHxQYQ4bwVSlHYm5bn4Zvzl+BF8fN1wqnTA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAIgSV+ue2UeUjqPDRaqGvCdUe525/bfRHuKO4310gsh2vjkBhU1DQlPBZbi9QWyxpY/p1laTP79bIiOQ47f0A0qA==",
       "subType": "06"
     }
   },
+  "local_bool_det_prohibited_id": true,
   "local_date_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAJic2/y8cGgHp9y9AMDrk/gdCgHwRSfRyxkjNjuq/rUmthH73PDVI9SICvoW31RBv7M/GJZRB0D2TXuwDLiRQW4g==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAJYruWq79Ry5UCXZBLu46kY4mG94oZH+MMgzoTEi22ZQfgBV+W39mZuOVBqdYOnB9Oiw51FDUpjL3LAdoL3TYP4A==",
       "subType": "06"
     }
   },
   "local_date_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAJru9UaiHPR2TUDzmafC9xqZPXQ7hxsmLdw08JiXVAWs7oHdb7qPODVM5zyInV4qO8derjiBInEZDCbegsF3F5eQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAJBv0oMbcjdsmRmvjEALX/JqeB7F7IGtDHpNLRYjZQJwvZdjz0WUHjjfXbasCNOLzAca+cIDyWiF7DJZxa0VVYGQ==",
       "subType": "06"
     }
   },
   "local_date_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAJF2pgcon+hGl/E/Fnk9VwVyLYrhihn2+Ah1nqUJNHBbBsg/mfPANtkQPx4NTaPIp69evN3LR1gbbUlRZMl8K91w==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAJsUPpcAlLrhweEoj5NKXnkIUcENVQmvMCNitMVADkXNiBSFxpHiNtwSuvyBgQSiKgQeB5vK9unpBeXBA2tvqn3Q==",
       "subType": "06"
     }
   },
   "local_date_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAJs3AtKNjNTwmtbQ+1Q/anVF3YkaMTE4uqRrKpwIxCbUZAJ8/2MPl0QgIZGt/y7nA+/+MG4fBP1/BqctxfsbHY7w==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAJLqk8gH+wcWJHMlW5lW2K7lzSS32K75PlFEoehIGBIQLbWx0SoEifcXYhe08rf2ZPY9JoIAyyeV8D4aJaeJRfww==",
       "subType": "06"
     }
   },
@@ -1034,27 +1086,29 @@
       "subType": "06"
     }
   },
+  "local_null_rand_prohibited_id": null,
+  "local_null_det_prohibited_id": null,
   "local_regex_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAL8wd+9CNuNtxhtaxMAmdZHcFmKyJNp3MRXsdBFt61U/DPd+E1FZp8SaYn/uCoqm/BvRTcK9mOxr2JUZzCggHEog==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAALSNaki59phgFtPQ8Hsg15EAozEWcPQUkogqwx9oEaMVyBHX3CbTVMBxKRLJxnazl6foG5wCC0gzaRlKkE34r/Ng==",
       "subType": "06"
     }
   },
   "local_regex_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAALzOZvEOH98tKq8qMjaGpom/g8NjO88HTslXAxeejDLg6F2sWLmYLCtPqxUeWaNcNHfOmAbU2mT3AZyHyc/IBmEA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAALDGRh0/inBXP6UIHYKTczT73y2l79vui1pdxvMJfG0w1IHYlQivcNNN6GtR4pzsjBJMi53mzpSfCDVhTTlr21iA==",
       "subType": "06"
     }
   },
   "local_regex_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAALuQm3nFVQGh9+z+J95Z3gCAsO26havZS8iMl0q8BiuDye7Qh8x51XhhtYaLONe4CNv3B5uIVh4oZ6tEQgOur05w==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAALQFDojn1lEboUzgIzfIgKnF7l0/i7cVN0IIDkvsCkjjKNEH5xxccS51VBgrGky2sHwDdwWzE9WmW4+aTFfuT1BA==",
       "subType": "06"
     }
   },
   "local_regex_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAALzKq7gWYP+iBn3jgMFxwwEZxDQVj+1D7XBOyLszGurZqI5ZUWgzAn9Xytz3sa/1igRkkcE8T7Wrgsc3pEkEkdFQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAALxgoelr9Rt/n1D7o/2PErZGu5q9wZg7SuNFSSV0bclCisXx0jCCcOlUr3MoqleJLamQ9DT7/Kqkn0DBJgEGA8kw==",
       "subType": "06"
     }
   },
@@ -1084,25 +1138,25 @@
   },
   "local_dbPointer_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAMU7StSbgLWdhCumyK/Q0IpmkkS16JKWg/Kd1LxO0SYe7n5FnSIAW3LQdfVQrxqcBPnEqSWkUcFrmvrkF/6VUpx5IZMiWqxmq+K+40/jAgM4M=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAMXZyQVKL4GDdVG/FsbkRLOqA74BGvD1gbveAeePzalhG68xM5avdLO8+xA4hfMHb3C0ODymimUESLWHReh8zhZwXQQCdaElXWZGUzUwAM6PM=",
       "subType": "06"
     }
   },
   "local_dbPointer_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAMwOLszcKqTPfnRaXdDKoIYt8PvTfL3/2R6HGjYTpJMkZeZtpj2jKrFVEikZ5pzjFrUky/Tkj2mt16QvfgtpN8FBWocSwME0HOJpHoOYv6Djs=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAMeepzb1RxqM/ruTrasvfRVfIDUHTG19P54vydPxsa5h/gnV6C/YTz0a3fBeOF89zWj3ppR9te4OHTLxYx+QI+qakfd6BVtJq+uIhMskNo9zY=",
       "subType": "06"
     }
   },
   "local_dbPointer_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAMpuYKT/IZNhOF7H1Fa35G4QyJSabGATy2qpXqU3TiOC/RrF70aAiOacb/bVTNN+Gmo4Q0dJ/5BqB+Nt6IxhLHra4WkBghVDUpJHry0vlgGrY=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAMu6vZt44pVcOIp3ebmg+3vjvcXzQqIkLJu/J9lgqg7vlJmODIpuCzMSExNVS/HJvtjNyOWUsv+X+nIWEvc8PvN4tA+B1YPhsuj0/++HSExcE=",
       "subType": "06"
     }
   },
   "local_dbPointer_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAMR93khbRIRfR8HfCSM4Or7OMz3Gi3nEhLIKvFidFUzNuh+oBDo82AOcZ46iwjYYawFhrqQRQscJdrulmKxvLODnBxqz/QI+G46lLrP6prjf4=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAM1wu9kpWtPgbQtPOy81L6q0BzZ+z2OTVbzL5XgWjUvs4nKbwmipvTA3V2y2qYCofJewAaypjvPVD4Ub9Cqe2bqhFF3Ro0n5jT/Kgmn5bWqKo=",
       "subType": "06"
     }
   },
@@ -1132,49 +1186,73 @@
   },
   "local_javascript_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAANh0QD2X7SVWkPNsJwf8i4FgCbOUXxfPuX13TDSPiPH9Ul7A9PZG79+QIC6ZPYy6JYFBhBx9xUWSiNkGVy5GyNQA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAANObKIAo1Z9Rhvyi67fx1FUMyP+H+IAWIM+phCne/mi8gXyE5KI+UjRoMUqwEWIf4hF7x1PLLBLOnv9vjYOxhOPw==",
       "subType": "06"
     }
   },
   "local_javascript_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAN9cHQ1Ff1ZevAJGQimrravXmJlnoDdGgb+RBAdM7ccYfBoW23IuN7CKWaBHlId33VvvsObYuUGsLVMf/bWrnC0w==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAANFuImM+TZ7t7fcNuASVPI7lTG76j1wtZWbiL/2vbJLSXH6vQscZeTAvkjcaTY35XA/BvXZG2JJj7jEmC82RyTAg==",
       "subType": "06"
     }
   },
   "local_javascript_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAN7k5VQxKmO4T6niXQn5IphjjCQYhqlkHLuZGai2TagZ76A4j0GKYi7WoxdnMUN8+oZdscIPioYLBCw4Tg5a0GSg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAANFOKgXsXaOrdDoLQkmWtiZJ75sA1uU+3iMH+bbxmRdR7GTluYxqek9ssYQQeW1XaLDCSHbrk+fvZ4YYBav4Tdjw==",
       "subType": "06"
     }
   },
   "local_javascript_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAANvNY/n4JpCxdAaGoaOe3bz0OtuXHpukeI9E4xQInBaEPYTUSbFP25bO/4/vkJOkMdJ34c8UQGT3mqY/67PJseOw==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAANyc/K8k5iP42mNC991m7D2WKSZ6io3F7ryh6XLJ0MO4BSg8GebHjrs48sGfFqIesOKjsyuOlEBHOCIVQI5wpNTg==",
+      "subType": "06"
+    }
+  },
+  "local_javascript_det_auto_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
+      "subType": "06"
+    }
+  },
+  "local_javascript_det_auto_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
+      "subType": "06"
+    }
+  },
+  "local_javascript_det_explicit_id": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
+      "subType": "06"
+    }
+  },
+  "local_javascript_det_explicit_altname": {
+    "$binary": {
+      "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
       "subType": "06"
     }
   },
   "local_symbol_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAOuFHrZ61BKgrTa4iKgP7fB9m7Jx4pvUflxfY5myatlWg4LYsgQGTrBLHhnhgQttopMhY1tWXCO1jvufkF7TRNl9pz/AMGFEwr3poov1fRYc0=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAOxMUOVXQrSgvyzgD+xBAn3p3xxzQf8olvi+QqsL50loXdt3rL16liFJzo19m4Aw9usFMVtdxKxoka+/94Jdl24Uh9yHh4lNy3DfGi0esX8WA=",
       "subType": "06"
     }
   },
   "local_symbol_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAOoEzTN3YBPP29j1SGS5H+ITQGVRdqbn5VfDWLyD7sksQXhIHR5A0cNfCLIWj5+6OLHnWiRlifc5EK6FcWPdr2QUQJU8/RIhNpPt37YXuXeyw=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAOcggAd1JJ3ekPqd3CevAu26+UKTt2GZdNKSSZSRou2GzVtiV8/d0lj8saTMz3DZ+mLXZV5K/9d+zhRQ2qJtwFCTjwZ3w6smhUhKBFIVxHg4g=",
       "subType": "06"
     }
   },
   "local_symbol_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAOzUmadmaYGdWRdjp+2OQNTVlxA+Q9sDCvn/GrzDReP7SZvtXoFKbJ/g62Bh1vEk22vOX4XjhlvZ6g7JzQT/uE/uiFpeWBuWSY1S21gNZt0+Q=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAOKRw3xdSzSGV0bAXIYpBFPW8cxgOX0MTC+xSj5HhiC2nwN9wZ1YuXX6h3Cd0LOzYfVuby4Q+6foPr/3eHkYe1ArcUO8IDKyCeKleGzBtDn6E=",
       "subType": "06"
     }
   },
   "local_symbol_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAOnkp4IEucGLVy/co+sgfnOIuoT61AZwgBLKMlp7g7macnOAb976PYZPICdhn7rXPkD/InFXTKWAqEleX4JJjot8T8qpMAmrE+q4nRxRhHAew=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAOmNF4cGG3PT9vqHfAcYwGFbtZWAjifbLGUtXmrVTJ41T/QR9ptSCfh+FamP2ySKTV1y4bfdcbV830mS3GnFghl47l7E2+33UdbTbrQAAn5GM=",
       "subType": "06"
     }
   },
@@ -1204,49 +1282,53 @@
   },
   "local_javascriptWithScope_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAPme4I/i63PkIWqkKUNQGRFCvnd5eNtp7mL6AtyLicnUZmfjaKp238iBBdanDkucUWJGtFsQ+UMM4sU4TSMRSOXrrghmGriq+xQskCR+9UqPI=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAPWs+QOHRP/BI/FsVpKSvTf9S2w3CSl6oWuw5T2657iaEvtfYqa4YyhDIQ0STqXDynN0tFx8jr+NRmcr4n6x/KjDylx4qf9tBHd2g3bivZ25E=",
       "subType": "06"
     }
   },
   "local_javascriptWithScope_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAP23gGxIoSjqc0Msdfzh0UtrI3o+JNrlOBRsO2vuzWf193Oha9aYZFcU9QQWrnoi0quUvozU8rhmT9gIGhyoGQ0cEOslx0DIQGv84moI4LVdY=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAP4mweXl2pP+8ccFfktCbGdb6zBnGT8R2n9VtMDxkkuMuXHzJ8vPrR3axj++fIzS/FnEZoIJ0MqSGsgdeqlp1sEbysNejy1kNSLt63qowIw5k=",
       "subType": "06"
     }
   },
   "local_javascriptWithScope_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAPcnatj8W5ToAtJvciC3+TN94teSum/iZ1D7sSm2b08VuXIAvIhXVKZpMEOZ6EQdEOS6zwoLnbyUxcLvXbq7BGmFyNTh3bIAE44pLmTc5TlEQ=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAPF34OOm/uBjhGsSKdML3a01DY1gaH8fdqW1cM7HwGVX1M9iqW1K7hnC3IJcOfHb1Yb7XCihHm2B+I0VSD9xvo/Lj8wF7soB1OMtf6JyLtHfA=",
       "subType": "06"
     }
   },
   "local_javascriptWithScope_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAPC8QF6ejexLcTE02Dw3a+jZtuaq49VkVQShiKiYCAP8+afgVhPgrQMSpVb9oeaF5Ue8mYCajYJUBZMREHfPcw5LM7usB5ts1s1KBt7wpuBWk=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAPI+bEoEcC8lN9/rH9fTafKHyEAeD8lszfhCpckCru/TeSDgqyU8FgBmnp/wnnWfB88wDBtZa5gGMOgY9q2ldGeKqrUOwlxurXCULqvax/HfQ=",
       "subType": "06"
     }
   },
+  "local_javascriptWithScope_det_prohibited_id": {
+    "$code": "x=1",
+    "$scope": {}
+  },
   "local_int_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAQw4iYyYh9DxJOjYYDdP9BZSP/P4DmXhAp7rQWdflTfLYrusUcghkJfz3DML6HW4wxibKgK4Ho7YdNO2l4oD56Mg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAQwWkdDxTo6h2+Cpl3zFyNUOhhA/xzQSTLq92iuEPqwQyKOWGURrHyrb3Uxs0a9VTa4pboufpCRVy56JLxnLVcgQ==",
       "subType": "06"
     }
   },
   "local_int_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAQGB9RO3Dks5tVNVyy0Pb9eG6OgPh5Gdwdi8k3QJyRWVmV1F3tV2S11RQaP08K8B8H27YsndYSS2IlDjO3ovZkTg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAQOmGXBr/HqmCmXQf2VA6TS8kBbeZ/zJQ/nL2PXIbPM+UwkI0sMBmrHy1dE5aG7LczlEWKg3ZBwDPya1SxLz3NUw==",
       "subType": "06"
     }
   },
   "local_int_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAQ6VVTwaWkwSv3P5lcxaJ3P4Acin+54tTmMoKOuhCPmlbMaQsGYSsAm0g6O6RV4uAoG8fGnXF6pcjSO4sLDeL7TQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAQ8ZKIibm9Gl0+rkZ+M53d8ibsPtZchp+N3LRHEJWCqPTf6lnc/BffUzFFEyaR7O7qPiFxfI9ayCXhZrQIpT4c8g==",
       "subType": "06"
     }
   },
   "local_int_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAQZAYbSWBDGFLf8f7F5wcqFBwShmDnCMz/GLii8lyd856rNdN+QKVzWyaFB+Lk9F0cFAVm2ur6ghgjNu5Itb+c/w==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAQh+1sCiOVVL5H/rwqdSV5yjQEqF77DLKkegtU3bhBDrRgA0fJx0dtZopZcgCJmBRoEaEx8S5w5KKDRwVNXYdUHQ==",
       "subType": "06"
     }
   },
@@ -1276,25 +1358,25 @@
   },
   "local_timestamp_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAARV/6QxKynRPZrqXaTaVq1csxDd6wneM4vB1KkD8WplfK+fYzNmc1ALcacQ6KO1It72qgNWAnotKqSQEc7dhXR1g==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAARKYzCdugZj3kBper+3mKsYTMoC/6qLUQw5bzqKiiBBqHgVBGLgDAG56inGd4YhGqVZd2zmoa7IoJu74F2w25olg==",
       "subType": "06"
     }
   },
   "local_timestamp_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAARQymQaAwxs6a8W9c8wzTVOWaHTNGYGQAE5ZQumG3CzoCcj8R4LKCg5jJs3HzuhkWdZc+OTI1W2NXVO9IwvCF5Hw==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAARYkH+9O04GQuqgdAXDtXEjxCNTRDPy6p8DojIvxsXRPqS4QimJstIN5uaLlwvZQ5+DuW0Bijlc99ULziuCK+/gA==",
       "subType": "06"
     }
   },
   "local_timestamp_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAARkXXseUIqlzPzC3efPFgZbSh3X2wjCBhPdjfyPk4jM/33/ckVfNNfv1aK/kU/CwQr2RLdqA6ZSsB21zdmFhTdFQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAARNzl20yUsog4zoKPh0/dHvbI0OyTFBpm1N3qwz08i7DaZeNOPguP9tZeOkeQ9gZH/cXD83M94OeB+P/LFTj89Aw==",
       "subType": "06"
     }
   },
   "local_timestamp_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAARYkjb2Z5pxQeygA2ncx3UjuSfXRpvY25Mpa2BRsuY5CiuLcw1815fpsSP0C2jc22SnhOCEsezh9qQO3kBp8nrQw==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAARtvx46e9auVI0U5pCfWj0LTmFJAvwZ+HbiTbZL23cpQuMaTNKjBKdZq/yafpOSSVKhEzI9+Uj2X8/jWTvq7udRA==",
       "subType": "06"
     }
   },
@@ -1324,25 +1406,25 @@
   },
   "local_long_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAASOB6f7mCqjrgoLgm2a56DODphJodt8PU55FEAatluuDo6EFx+tDJzledCDLw4PSi3Rvel4VZxfOUdMEfq6OsMrg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAASSVa42/WyOA2SGX2m2KcqMEkWN/l5+qv+jl9arofcVfeX6qkeuqM+DC/9ziJkvsF/7s9DI2QhbjJNEbj2mJDkKQ==",
       "subType": "06"
     }
   },
   "local_long_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAS1TSYREAfBBWbznd4ujXbD0QIOMBbZddGblarCUDQp1WzPzKhxTqMYbzTSoEuF4me/Z/cYHeDphhsYy/FBjveLQ==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAASzL1dK2FMTMLYxP6axCHiV3ikwlA3u5zKGF3+wM/sxyprl3mjcCi1NwkFyQH9YA/pQ9H+ClXEIfC98TX89QHqmA==",
       "subType": "06"
     }
   },
   "local_long_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAASa8CsY5pLBzr+KADtbsYMv9UttuvA5KAfN21QcsnUz1oVaJvjkx086VaKdOEQXwTuuiLofT51ykmL2LfjSIBJLg==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAASncR/wRkX/HLn2+18GNj3pN8Br3ajnPhTk4VhZbgiZgyEmKquaPN24u7NQd5vL7pg3eKcYNAVxFcMr9rm091kDg==",
       "subType": "06"
     }
   },
   "local_long_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAASIzdA3MIo/nVbMvVflAuXKjR3Zstk3znoT+XC7+qggBywDED7YOpGUXzeZNLlppo7hmW7UNXhvday3kbsuyl/BA==",
+      "base64": "AizggCwAAAAAAAAAAAAAAAASeLVwHdT8yHoBg5atURT7oucAM+YjxD6HqfYfNVg4A05uUCf2VnxUWlWNHObYJDi/CbI5gYnR5aryPFDzD1vCyA==",
       "subType": "06"
     }
   },
@@ -1372,26 +1454,31 @@
   },
   "local_decimal_rand_auto_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAATKe0o3iwGB4O+14xv04bbVsya38bmC5/LVAE97VwAYSSkGmflUhibwBmdKJBPPM3gFrq1cQj8jstMOs6cR6jSkLBXuiJ5/+RccFBFSnh1dFI=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAATPNuEyaZJ3SKQjzlvozpriBP2jdReFbxMzwv9NwtwkRAtSQSDF5Y6mAiCKFGOZ8BhlDCzGlpbZ6XMDB0rsIfJsONN4IQB8Au0gnBZ+zboS+0=",
       "subType": "06"
     }
   },
   "local_decimal_rand_auto_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAATaaGWPrKnMGhhUWKdgDLhpNv7aYZX5LVX5RFrfpm4tEl6RmlhHG3THbcyQ+wYjoIqgDGrMeVb0uCJXOnbAPsQs54naVaRlbqmwIyJ98mxTWM=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAT5XsdplzQbvijs7dpEbfWuPI05KWKUokLSklR6aN+a7OhUg1HCxAc5yQeWNknHnNK9D/u1eibg8gJA2L+0oIIyyTKImx2ri+UuNpSnjEu6Tw=",
       "subType": "06"
     }
   },
   "local_decimal_rand_explicit_id": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAATMViuwcfnpi36V7jgROF2jwUYbp2zLsgE557s82VvkpH7cy4JxMDeB+7rgjxnWquMdneQcRk5AsQmhs/38dYx+e+iLe2ipm6nxMKkgonLbcM=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAAT1vTTReF5uCVaAUMDY2Iipa347xnAXMcg7Kq3lLlPSy+5yOsqWSEnNMwBoazMujDjaZxJrPPfoR2p9eP5emxoR3JAu5sG34ulBeZ63SMoJ0A=",
       "subType": "06"
     }
   },
   "local_decimal_rand_explicit_altname": {
     "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAATH8URkolS6J5wU8+GwLJPHsElfR4BOB+VR4FE/U4xmo2O591DN0smUaVf8C8ISiNtG1w2cS6x1yYEaBRm5aDdwiQftF+C4mKFkale6tUJThQ=",
+      "base64": "AizggCwAAAAAAAAAAAAAAAATdODPCn1O+HwzTCDIYtBNj/GhYcZCOfZ7ZlufjyNHcVxW8+H7FQnNlRJLHAYsUgaaTNaQr/muzQ7eTKUh0y63KGtOxsf+lfDoP5L1lrV/L14=",
       "subType": "06"
     }
-  }
+  },
+  "local_decimal_det_prohibited_id": { "$numberDecimal": "1.234" },
+  "local_minKey_rand_prohibited_id": { "$minKey": 1 },
+  "local_minKey_det_prohibited_id": { "$minKey": 1 },
+  "local_maxKey_rand_prohibited_id": { "$maxKey": 1 },
+  "local_maxKey_det_prohibited_id": { "$maxKey": 1 }
 }

--- a/source/client-side-encryption/corpus/corpus-encrypted.json
+++ b/source/client-side-encryption/corpus/corpus-encrypted.json
@@ -3,1482 +3,3883 @@
   "altname_aws": "aws",
   "altname_local": "local",
   "aws_double_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAB+tzzg7dhiIS1kLRZv6h+45tKeFZTMkK80fx56lsOAsvc16+yxbn8Jt5y3X4mXXx74HFpZFfi5EVunkpFP1teaA==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "double",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAABM9KQ+Ph2lxyYUIV+Tu7gkrFndur280S5r43432bT+Q0WKKGSlu7s4anRPCvpwSyC7zP2VOD9ggBp29OvXsjm6A==",
+        "subType": "06"
+      }
     }
   },
   "aws_double_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAABVcge8kBP9wgz+okbOOsumnVcnx7XQ7+N6XwhzOIb4tT9d1ww++gQIRNZUcpwWL35cfmelZ45SXaLhjL/zAiFTw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "double",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAABuTwGICHwa66WMwfQIFFMZH58Ye9b8K9FAIxN/2RnXrkzLXDrksNcNkH3Y7iuQH6n1V6cjS36ZYGS+u9KsDpI+w==",
+        "subType": "06"
+      }
     }
   },
   "aws_double_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAB+iLYgWW7naQ9LOXoLv/I0HT3EW+C8gNVaJ5OBgOUvi7rF05q842IXXXECKXuQgVGzik99q8a1NfyFD73lqZDCg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "double",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAB/Zdjv6Dfng3Aw+QDz+nuJ8jbkA5nI5o8E+e92Z64zfN2mDDhK0G1p5Rwzyo1X3NhPkoFltvV/4m2xsLw7RII1Q==",
+        "subType": "06"
+      }
     }
   },
   "aws_double_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAB5b0/+aksLM28ogm+0pP8b9i2cHVxbHHpBYX4IiR1fJenL2eLoxsAUAp2B+B/hxT4U/uVwORdMy5vJMwpMf9RTw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "double",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAB18NK1o+bcG9Wv1sHxkx7tXDIQvms+f7XTmHXxKzP5A1w5YFV9IlGvCyUVp7Pi5CdkuihdJe7e+PC0/yyLm+n3w==",
+        "subType": "06"
+      }
     }
   },
-  "aws_double_det_prohibited_id": { "$numberDouble": "1.234" },
+  "aws_double_det_explicit_id": {
+    "kms": "aws",
+    "type": "double",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "aws_double_det_explicit_altname": {
+    "kms": "aws",
+    "type": "double",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$numberDouble": "1.234" }
+  },
   "aws_string_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAACDgz0f6F16di3iBp+bLoZK201Ck67y5DW7+5j8B8a5mIT/5l7poaHYfpLfdwY2GwDaWtvgoXLiqOWXKVc/GOkMA==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "string",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAACzBNVII5cLYFwM07v+HMX5bV2L/iHfaKCJVdtJFrQg4jeZnf+AmQsfhZI+SRK2C1Ek2hbkPGPkZt427HDd4WvKA==",
+        "subType": "06"
+      }
     }
   },
   "aws_string_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAACoKR2LFbroD5Cw34Ppw9pHmlps7FlNJKkm7zPYE1mVxFxhGpyMNKpKLaj5W4lX89eAqbUWPFxQ7P1ec4cBpJFLA==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "string",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAACJ9qe1DlGDBYVTA6yd8CYcTkhfMb+4n7lurpeqJRRlPYcqXwX4QySCvvnIpFl3NHPYDrmgqLH9kIZicQksj+D2Q==",
+        "subType": "06"
+      }
     }
   },
   "aws_string_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAC7rOwmG8P5W5Uzd1nOsNebdcYl0BG3UFp+kq62dv3NptKXHIefv+KSyVcXJcXnUq0ZQ/2coPt1Cj7kQxU4kUKxg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "string",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAACWm26/1yQgZ6fMhA+UlbobgsAjJHd5F2vEI/FHP4vJqpM8Ma4g78h92Rbp43SFPb9tE7HSM4Mj3yXi8r+7UflLA==",
+        "subType": "06"
+      }
     }
   },
   "aws_string_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAC9L0FJn2DjOJw2bhVGwdW4WY4sALw5swqLc4IrzIroZYMpNEyepiPRpnxqGIXeAvXs18i+bD+XSl711/NxrTrWg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "string",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAACfke1HM5JDTT3Z321UZkbz+TlEQUicJFs1n6MKibqAu18Y8ppJR3QUk6eW9UlnrB/h6OuVhlXy7wtjmp9MYaiNQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_string_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "string",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
+        "subType": "06"
+      }
     }
   },
   "aws_string_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "string",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
+        "subType": "06"
+      }
     }
   },
   "aws_string_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "string",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
+        "subType": "06"
+      }
     }
   },
   "aws_string_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "string",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAACyvOW8NcqRkZYzujivwVmYptJkic27PWr3Nq3Yv5Njz8cJdoyesVaQan6mn+U3wdfGEH8zbUUISdCx5qgvXEpvw==",
+        "subType": "06"
+      }
     }
   },
   "aws_object_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAADZdfqNQzuWd39VUlazCZqeo3yNBm09MtMx2Gh5o83T7wysV2ZvDTd9po/I1v5WygT1hVBv/dGZVweWVFRLt6rMQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "object",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAADaOjzZVFlYsze97Qfc5EdL6YT466g5B6oa63udRq9fyNqqcmJKle8S0zYJaFewif9ZmLF3+qku5dkhR/k6BdnRA==",
+        "subType": "06"
+      }
     }
   },
   "aws_object_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAADt6tCsXvqm43r/lvm9jPCHAnAY++zvVyY9hPsmYCxng9vprj/TzVK/x4LuQzRiIf1t+cAm8fSnl1Q/YHyxkToLw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "object",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAD2RC9j6QX7F9FMcxukP9BjtNbLD5XNx/a6z8LdP3imaFbnDPRgIneHedGNsRKrxBWrL3nF0H/t5HO8GiXKIF7eA==",
+        "subType": "06"
+      }
     }
   },
   "aws_object_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAADZW42nSIMjBL/1ZwWzcaqypH/yBJJavuapsRVdjV/IsIAdsqF90lm/uXPgKGHmNIOi0B3Sx1r8AKLAX/za8CP9g==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "object",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAADJs1QAlG8QpvqYT9ULHckMiP69LnzQGpMiab5sPipyp9sKfoaAQ7XLc7rbmNLYq1KZrY+x0eBRR6F+T582fxk6g==",
+        "subType": "06"
+      }
     }
   },
   "aws_object_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAADqlwedxMkzl8nMak5bai+mYXZg5sEu7SHaG/Dxo59COvRVk9qgl4SOFuv0Sk4eOqY5lxzDRNG91mUbEfIdtFpjg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "object",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAADBi9Fs9M/fBjpBxVD5TyLVgHaDBw0/RK/VnSk+dJM4IOlaoAVS90RZDrMnlN7uXC+/WlkF5J1trzJeD+sceRGDg==",
+        "subType": "06"
+      }
     }
   },
-  "aws_object_det_prohibited_id": { "x": { "$numberInt": "1" } },
+  "aws_object_det_explicit_id": {
+    "kms": "aws",
+    "type": "object",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "aws_object_det_explicit_altname": {
+    "kms": "aws",
+    "type": "object",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "x": { "$numberInt": "1" } }
+  },
   "aws_array_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAE/P006Jaq7ocRWVVV3vxXxWBPabXD1ISoS+SuTFgG+net+H83PaMaNj5CW8Kfyq1Jqns8063iK1kNjYGg98buVze0ptwH63O/z9VaMCNq7EY=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "array",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAEy/fJNHfPwqBGOMVItTR7rns9Z0DfK3RJvmV4SlRhepKBTkdmIgHZU0qs/k3KN9jP/wR+k/Lo8/tq9KOgP0GJ1McgSCJASIM3WWIOwA1wxQM=",
+        "subType": "06"
+      }
     }
   },
   "aws_array_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAEKqcNEgUyIHCNnIbHH1HtFoJ55bmuINTshjdPZqDZl3PlFu6yXLySPeLjeWCPfieiYoQ0h/nAPu8+fAtNgUFOUOeR52+aVd1m7qJ5PpGYCVk=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "array",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAEF42U+xszi+UXDy+3RcYm9luxI0ukgctr5FjiH6IX9Fyyf9qmpTZWE0mwSo6vnwOisiPKMeHW0hBuDfcwt2rYzm1CZ32gnviL2KfN45TYGTA=",
+        "subType": "06"
+      }
     }
   },
   "aws_array_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAE8M27ZuYbhmd1u4IIvfitTe9flhHMwndcFPPPVxrAcWHKAZmfvvn/mdrfi2ZYSE1skKC7RManiFIxeqwfzEHmeJ1tfhbsKioP0vKX40PD1Hc=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "array",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAEC30eVwzJFKCcRsWbRcGbyryBlD7N6u2HC3Y86wvHCLsXoe3La4oYlGtw6obFIVRNojaPhhBs9+Ap9qqsiw6CSdIfmSeuMhzIK7njE5WjZfs=",
+        "subType": "06"
+      }
     }
   },
   "aws_array_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAEQT0BhcE+iZKzXCWWP4OKqDnv7SXbNdfojeSD0g1bMAFQ86i02MANEd4YmXh5UEmRZlftaUkncRzVt+x6rclOYTFsOMxlNehYzAKzIbIFQiw=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "array",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAEv5AvBT1T+3zBPpjbSVoBYf/y1po2GLO9OP7xEPIY51avEuLS/6hseW0FG69eZvUSUE3e3QkNWaTOSurpxV9OeqG5rEd70ytihtd2dUJAxgc=",
+        "subType": "06"
+      }
     }
   },
-  "aws_array_det_prohibited_id": [
-    { "$numberInt": "1" },
-    { "$numberInt": "2" },
-    { "$numberInt": "3" }
-  ],
+  "aws_array_det_explicit_id": {
+    "kms": "aws",
+    "type": "array",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "aws_array_det_explicit_altname": {
+    "kms": "aws",
+    "type": "array",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
   "aws_binData=00_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFP1VQsbfkpJfJuxmk5pJTAkT5o6dVEntEZFt+PLXmIt+RdIcfc43R4jlPXL1Dw66C3JHTQI9IV8InGH9dpYSHww==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAF8m3RO6o3Ta146kYRH+nbs1zYLIr6wwC24IkzH/rESKvx0uk1ZwE4fDyzlLxB4A/WDx5+/lFAI+uX5HSlEtwbIA==",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=00_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFIg9yy//cWnoD3OD0llGnzHIWOsYTbYokwa7iHDeHVgAnD19glYnZD8teWvTEQ2RW9Mi0AkE/SspaC042ArmGGw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAFTl2T/YpJr2emOgXYmgAdCDYjRJ1MUuq813oLdCiLr3oLKARkerXfJ1KTC1JhxrXo/aCEyO3l6pqguNHUOCHWyg==",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=00_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFmh05SHuFgCSP4sfYxS5K6kCgkgRX0R03ZredG59Llui5sPp19QwpMLLUSsTJiEuOtJkSNaZ2cCVxukS2K/mAXw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAF4Tz+jvfUFFwZt8cETyKz5YKaecwjgFnoPTAtT0mnhiNHBBZawlURx+XtnwYb665v+rhkhhSNDwBBJCTRHjw7+A==",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=00_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFkl2XKYNi3CiTROCbyAY9eNtmf1xS9eOc1sbcRVHQSYgNryphdnsDTaJLi8USOanIVZBzFn/qxndfjSMn/kB+0w==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAFWGVbXBuY1J+vA2XblUlt76l5tG+dmOdtVbOLBOqo92J0eYSyQK7GXNO7J+oT/CBclXbKjNH7A6+bhM4VL/rPww==",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=00_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=00_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=00_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=00_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAF6SJGmfD3hLVc4tLPm4v2zFuHoRxUDLumBR8Q0AlKK2nQPyvuHEPVBD3vQdDi+Q7PwFxmovJsHccr59VnzvpJeg==",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=04_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFK+UjO7BkaAZ/xf8C3ohSxPdxrw3mmb3ExtY4eyHQOAxBgo7S6BGsb/s7MnLfOtvWXGpLfGwwnfs59pY4MEvxJfRGOoMyRBk/jRQilD1Ro0g=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAF3UMEodyb/mOrq42kiUmwovZ4W3cV+dWwG9o4EjB+JURGQHIuNV5XWSawmB98zTcInuHiOcNXnx53dAn/ps5k5qz2yJJYlsvW384CIs5caUM=",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=04_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFJ1aVAT473eINp08CCA8sZsPvdGWrSXkulFZuNqsP+mlpzc8LRFsgEyHztjnoA2OvcLqi0J4I7Fcc16Z+DlOHlctNJ5iLpy4EmaDI+BBs2TI=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAF2fC02kILOGiZ9MJCP5x9/d2HLe0NmC5tKJTX62H13lB8SQ5ybB0uuj1j1QOQ47TaWM2yQmdFqTnjZCMPj2lPXafMuhGoaKPIwdWuVctgMJg=",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=04_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAF0VSCm9XbBWvWwsU+hDDrqSCyWCYjojSxgiDaXLsLHWGURpFkiCbIJwCH8mkuQ/ZwAlJvCONJp6RXG7VoYHd4gP4Jp38k5Z/v39H/YFAh50w=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAFm6vGuZjwv4S//926v+VcLKjoFmKhbxbDJNff04C4FrejbFDg4pu3iFczzycIY7/sb3daSA+s1T+PjSZA2qaL+U9KySczs2CjDmkfjesP3+Q=",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=04_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAFSJ+DLDAjRXaLkliZjD9aDD+kJORp1LQZgVRn5t9HncgJRW6gXJ5FwWPHcZtYmgl4cqUwfkwT6DIPjOyP2duzR+nku6dbZoFjLLCDeOpOowE=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAFACA7n9/qXUhElNJ9xwkxrYRIsXE7L0szvPM3nQTWAthya56bmlbwNhu0q3t0iDTtB16PnUXDSPfBCxDRAssu5teVyuC6zxnYyDebSr2vtNw=",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=04_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=04_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=04_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
+        "subType": "06"
+      }
     }
   },
   "aws_binData=04_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAFlg7ceq9w/JMhHcNzQks6UrKYAffpUyeWuBIpcuLoB7YbFO61Dphseh77pzZbk3OvmveUq6EtCP2pmsq7hA+QV4hkv6BTn4m6wnXw6ss/qfE=",
+        "subType": "06"
+      }
     }
   },
-  "aws_undefined_rand_prohibited_id": { "$undefined": true },
-  "aws_undefined_det_prohibited_id": { "$undefined": true },
+  "aws_undefined_rand_explicit_id": {
+    "kms": "aws",
+    "type": "undefined",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "aws_undefined_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "undefined",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "aws_undefined_det_explicit_id": {
+    "kms": "aws",
+    "type": "undefined",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "aws_undefined_det_explicit_altname": {
+    "kms": "aws",
+    "type": "undefined",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
   "aws_objectId_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHmHyTV4N48P2bhlUNQff8Lzt0IkW4XfMOD0Q3Q6KPAPJLnGIFbeDjy26aRckr5xnXsj5vOp5ta8LF3GJFKiaYmA==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAHP8N915eT7Su/Omjfq+F3mE3vPvoHOUxn3xKAnCBqoEWE/e1vNaOqMm1OMlHMjBZILyBUzmfICBL8CnkUp++DoA==",
+        "subType": "06"
+      }
     }
   },
   "aws_objectId_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHFVbk7c2S17uC+eV8CSkBeF7i3UML21XoA8TintZtOC8NtYJXk/SYqasyWtYiIemlwPGfFVyYBLlZTCmE22bRsw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAHyO+eA5U78vyqI8sROaHgqH4GFakqyVj2+Hyv5luhm3wmXXPrHOSZD+h0Du9hM8JbhlF3ej638P7XfXKjQlbLkQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_objectId_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHODeUPvRTFNAl9Q5QxBYRGO1vUEYtE2qhGAON+g7NhxZ8qRl67xGmETngdH56dzZ08gxYFwnU1loLB8JXEZsqKw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAH3KE2hePkTeRW07y0w9lCOG9XIG7fas3iYnfNCoje0l4/hdMDnlcEL++YsY5PBMQAgYbO84AUSSapI3tomHXiWQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_objectId_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAHIDhyxipvQleHrRcpty6VGHctD99kbc5mPCjKw05DyB2gC/1x+aO3P/nZSewTKLVoq+5o1dAqopK9xaCnvG3liQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAHTe1RfuhXabZF8Wz1y4tYCLuZpZitM6vLw1GA3RmbK9ZQlKTVF60RSwuwsUGjW5Oo1jotku2sOa8me8bW1sJMJQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_objectId_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_objectId_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_objectId_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_objectId_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAHTMY2l+gY8glm4HeSsGfCSfOsTVTzYU8qnQV8iqEFHrO5SBJac59gv3N/jukMwAnt0j6vIIQrROkVetU24YY7sQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_bool_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIBfsHwwtldopxCL1TnKNxbofwcOZre/T5c8EXjfvNSTaxx4y+sqmxXN4iBdIQUJKxDLvrh4Csodo+fjm6FVIqpw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "bool",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAIFChdnaWPUHNxV2dS9+pbAGLt/6jimEUBaeqD6aQWGel8LIc1TrxrYiPJI0hDYSn6DdTaSmbPvXUgBo4OsxShDg==",
+        "subType": "06"
+      }
     }
   },
   "aws_bool_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIz9N5F4roK/RFUnEdAgSHPuluANmo2y2Te8MUeH2U2MdJxsFzIDQMuo1/488jGaj0nGmHCZBLSP2zEZsXCmZwEQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "bool",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAIuLQZEQPSrxPA7wgfL2uYTKkbfT1pFaKyaVXO5tmEgI1yI3mh4RU/s+GkualAbsKzOX58WQQEb+chel0iGztm2g==",
+        "subType": "06"
+      }
     }
   },
   "aws_bool_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIGxsQ1l+LF+OyJKqDqxNyfHWK7N3u541jGen1auKFtjL2CpxZoi9YEVERKrqNI2ZpWHyBDTWQ9MqbdMiImfujtA==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "bool",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAI4BdWl5Fy6F+O5HRQpBMbFwsMQsmKUBod/1uON7U55BFRl8YSR+N0cAvTg8+o506HSkl5g32zCzOCYNNb3I2YVw==",
+        "subType": "06"
+      }
     }
   },
   "aws_bool_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAIUJT+LYJyGyHU+fIIqH65ODZENeqv9cUChH39wBi7g7Mj37Tc9Yboe7lN9KX2d+nVzgrWUxh6P4xT+iWwqRdFuw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "bool",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAI9DlS7LsjiMMEEkwpnyW5k6OzuOaoU8eo6W3N9zGcAUTTLyi74dcalDfEtNNcCsfIKWIWUtrXvWRTwbB0RmQ/hQ==",
+        "subType": "06"
+      }
     }
   },
-  "aws_bool_det_prohibited_id": true,
+  "aws_bool_det_explicit_id": {
+    "kms": "aws",
+    "type": "bool",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": true
+  },
+  "aws_bool_det_explicit_altname": {
+    "kms": "aws",
+    "type": "bool",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": true
+  },
   "aws_date_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJtAEbKbbZHxYXZezMliN/EQkoLAnm56pkJSy5g8QuUwjP0iqKWRCIHDpoFs+bwDsLydtvLqrbZNPKydM4pom4iw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "date",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAJ75dvvtGwKAdilQ6H9Y8Wqs4ujgZNy+ud8J3tcEqqzqYZXAtkx3amJDeA0DAxK+NG0sCL6abPEDdzZExK+MXEtA==",
+        "subType": "06"
+      }
     }
   },
   "aws_date_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJkwp/a5KpS7oCHoQfsOUe7xKTiqnkrk+F3S9EfWoEQqVIK/V1A60a/+zC058elkaoUqhKkityXdBOJsYgrbBmZQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "date",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAJqeu6xm1HwROT4hkGcygdpFfzoNY3tN5seNkblma+VAfU11tmWEsjMFpo/qemvhDSfZe4EBIo3vPhXndI0E7Xpw==",
+        "subType": "06"
+      }
     }
   },
   "aws_date_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJaYuqsns8/54YUWOir9Al8AtETOH3jui4piLAeAZVKZJPjJjyUqLjUTFrpqAuAGxugJRk381UoZ/rOcXhkPc+Gw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "date",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAJZZzvegIiR7vruFUPLsJ0vSfRm7cOMaOmyROhNLaEwkP7Hiyoia3BRqQgph2SO5YyVaeEpw31G6JTEQVREG73Vw==",
+        "subType": "06"
+      }
     }
   },
   "aws_date_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAJfy4dyoYb+f4gdoin0mWBzsibZtvC76Q3rn3/mVjIaceAeIlp8b23l0g8cOiWHCI1lgu6CZhwpG/mMGVb/H77rQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "date",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAJDefrwMnJcaAYuv+Sdyoc3Didd+qTXRxmVdffKA4ReCEqtO4k34tyZu9aFf5nyfbRO9YTxuYfipJP5vUNCXZd7Q==",
+        "subType": "06"
+      }
     }
   },
   "aws_date_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "date",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_date_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "date",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_date_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "date",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_date_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "date",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAJEEpQNsiqMWPqD4lhMkiOJHGE8FxOeYrKPiiAp/bZTrLKyCSS0ZL1WT9H3cGzxWPm5veihCjKqWhjatC/pjtzbQ==",
+        "subType": "06"
+      }
     }
   },
-  "aws_null_rand_prohibited_id": null,
-  "aws_null_det_prohibited_id": null,
+  "aws_null_rand_explicit_id": {
+    "kms": "aws",
+    "type": "null",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": null
+  },
+  "aws_null_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "null",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": null
+  },
+  "aws_null_det_explicit_id": {
+    "kms": "aws",
+    "type": "null",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": null
+  },
+  "aws_null_det_explicit_altname": {
+    "kms": "aws",
+    "type": "null",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": null
+  },
   "aws_regex_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAALgS/ZMc33aAMxHIv0vvVaIn+/ncU9COdEZVkWo5cVsRH8/EFVh/sSwa+QEwySX7mbg09pjP2tzsl/qcs2+WQMTQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "regex",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAALmcJ0ASBRfBW7MqzBE1za075A49g5+VwVoacl48hZ2W0h4BxHHHFBx4eACl4C8aRBIL4Mn3Ubsq7aXte/Ag6bSw==",
+        "subType": "06"
+      }
     }
   },
   "aws_regex_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAALB+NDPqEYXF31a2jvNnHkxh9NPxDdUFy40vRmvg2u+4QlQPwneb0TADNqsv2YFyQhvjjmwDLymhVifXrKe0nFUw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "regex",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAALD0CNFde6Q51yLR2IHrx31e11WDMsMCjIC6iVFYpvk4Pbm693ZrrRnz3Mr7/WDKN709d6jFHcOs9kwC4UK2/j8A==",
+        "subType": "06"
+      }
     }
   },
   "aws_regex_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAALEw73E3R+BIMtIP0jOX3/7EkEWR1J2znIYX5POkGvUkvKKDqfL812qkozOn/vqTdBHvpfiDFA4vMMhR66kwK4OQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "regex",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAALZRyrRvK/Scvt4konbrlh9yzTnFTK6hbcXXKjY+70tgflcsEQD5XoqMK4S1h3eHqfMjBG6UMGXOcbyhAP4uxX2g==",
+        "subType": "06"
+      }
     }
   },
   "aws_regex_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAALBKI1zp2FS2ytWuy21/Y4rkAFxoHgoyaM2fDf7HDPtgBM/mz/Sl3b6eluZU6PtdQDLO53329lqP2d+2X/XLqiVg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "regex",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAALX5k/jsyLGfP2O41QSkdl5KPZsFawxAIusmSWCNfqWK/+E3I2bKNQYahhGOYHCHL2fIRaLtpDx/qX0tkmOUE3sw==",
+        "subType": "06"
+      }
     }
   },
   "aws_regex_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "regex",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_regex_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "regex",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_regex_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "regex",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_regex_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "regex",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAALpwNlokiTCUtTa2Kx9NVGvXR/aKPGhR5iaCT7nHEk4BOiZ9Kr4cRHdPCeZ7A+gjG4cKoT62sm3Fj1FwSOl8J8aQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_dbPointer_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMa4fdZJyhSZGO1UnufS7/4r8CProCSqjQI854jffBQGxkNzzz49ENppk8B8nGiKUZgOZuuB6Vv/ROuFFLaJDh9yXKsN2U+LdyT4+Hk+lvghg=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAMW052wCrlOFtY7pN68m70hQeOy0RBJv9lydsfMVBt9mvEG5mQwKcWvPgRVxnSMzIjiUITB9FI37srW55capTlYmkUlFft0cAuTiH2amTlxDk=",
+        "subType": "06"
+      }
     }
   },
   "aws_dbPointer_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMf1QJ5CTlYuPkLiBICFntXIfQ0Mv+xGfzMHQ7BowPDrUzCXuWyYyZ6K+Ao9FlrbaHsmbhFeKru5nw05jftvblxIb7HolPbtm2ot9trphMEwQ=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAMd0MuePxXNQgZTHuxFwsSOQZycsUPVpJkmEQ6wDpANFiHyxHka5Pi959D9BOMeohgUFK8j1FVIaM1/5fwfO04aN3WD5JRiifijw0Ha7bTHbI=",
+        "subType": "06"
+      }
     }
   },
   "aws_dbPointer_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAM1dRfBBEpRdcJz4Y2hK0ySDTi6Us9KxotnEzbEdQvSVLaAorPKylWJvFyhkmKSJMo/dX362Ud+2TF8z2/GGsHcTfXLlVZXE5JxG7Cm9XWz6w=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAMkPGaCmxUOgRX+pBQK60JcgN97ys6C+/57TqH8g5P6JPhcBFvf+GEQtriJn2FlycjkqmHOC8UD5VAS2nKcl9zWfV0GX1Mh/hp1kcuWli5duE=",
+        "subType": "06"
+      }
     }
   },
   "aws_dbPointer_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAMQCd8Rx9un1mL6DrRiFTMnmVXwz4vGSfVkT5N7i+WbMgqk0unZbkRUakkA6yo6Z0VPNxylYhV/Kg6vgwdZGhOqWfTo7kf+Ri166dz1TA6n28=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAMvRBTLUW/qDQPN4NygPj2CXzO8SiRzeziUsSYQ9chNNDtayj1bvNreyl0n0pn3P+dzIGsCb7M0jjTn0ne4rx1/v5eZjAIDNgWLO9VCMkZyLI=",
+        "subType": "06"
+      }
     }
   },
   "aws_dbPointer_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
+        "subType": "06"
+      }
     }
   },
   "aws_dbPointer_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
+        "subType": "06"
+      }
     }
   },
   "aws_dbPointer_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
+        "subType": "06"
+      }
     }
   },
   "aws_dbPointer_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAMp4QxbaEOij66L+RtaMekrDSm6QbfJBTQ8lQFhxfq9n7SVuQ9Zwdy14Ja8tyI3cGgQzQ/73rHUJ3CKA4+OYr63skYUkkkdlHxUrIMd5j5woc=",
+        "subType": "06"
+      }
     }
   },
   "aws_javascript_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAN/56pexPdRR7pRdoUxYdMOfH2vgQUgN4DQWzOVYUJSmYsCLNo//Drz1foeZwLky7gCvm+QfHWpZ1CNXgIJQ6Lig==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAN86TgtxahHKHXYmG0jmL2XdAuYNN2w+2WCShxjqAP6ik6W5AS9d6yO76WjwlMZLUHypxeP+CZzsSmtNZ2JUAQzA==",
+        "subType": "06"
+      }
     }
   },
   "aws_javascript_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAANshTz5x++O98nq67UWUyyPdt1ZElk+YAWVdMd90ZW16LbUMPLaKAq6yQ6Bqz4DwTfyaWIQvBFNGed4oF7xAkDXQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAANNamQV+MqLffCyhkpZAwm2tBjqWTem3KabZRdO1TEf4kLdRWEIRlgpAeKtTCp0tnamrmn2W1WHbmoqP72oH+VPg==",
+        "subType": "06"
+      }
     }
   },
   "aws_javascript_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAN/zbxp4DjbSOfZdrnYm7zr0GTuOrKA+m4ult7D/H4ZKxmUfRg31nWXMwXerAI44r14tdi7LF3ihvULP97HTRyVQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAANau2doBC3YsO/2ia6WRRnE2f+Rmc7gnHcgfNTI2ECc+A43T6XrblanS71VU1ALj2YpQcsMxZxZqF1LhFIjsR59A==",
+        "subType": "06"
+      }
     }
   },
   "aws_javascript_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAANkvNAKc+M/1Uu3KgPGLNuAzNmH7M7kDZ9XBOgkqsahDh3lCEwgpB0fX92ggdXQzskkJyp019HyTslwcd3NhHDQw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAANer+MzNwtC6PNYB7ZKSkPmTkLKCn63UREjVCJGoC3B/VbqXyfw2LseTurgy13P5YFihU6W3sXWBhBoXaVlWbu/w==",
+        "subType": "06"
+      }
     }
   },
   "aws_javascript_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
+        "subType": "06"
+      }
     }
   },
   "aws_javascript_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
+        "subType": "06"
+      }
     }
   },
   "aws_javascript_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
+        "subType": "06"
+      }
     }
   },
   "aws_javascript_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAANE39aEGiuUZ1WyakVEBgkGzLp5whkIjJ4uiaFLXniRszJL70FRkcf+aFXlA5Y4So9/ODKF76qbSsH4Jk6L+3mog==",
+        "subType": "06"
+      }
     }
   },
   "aws_symbol_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOl3VbN4GcA2qHe7TWvJK+WwW1HhzC0fAClsgXx+nGGH+umDHXTOWuHQeLtc9AEex1Q5nrvRGhT6bHk/CWCwbwY62Fi2mxRWcNIYzRU5Czu0E=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAO081G5pd5uaM59sbLM9GzlbAQd1gf8xUkTBANFp32513nwX4vaxKv/n2FUqDRXZHR9I8sUCfFnIvzib+DmwCsi6pvHlmWvj/uF5tPwTKwvzE=",
+        "subType": "06"
+      }
     }
   },
   "aws_symbol_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOWdIipgoD5gD1rpaCcU7XJ1RPWk2nqyNdHpuz1IR3MPjdIiwDNVl8qm/vb7XCcgMU+gIqhfDUF18+8zvf8vV8AGGKtk+iKTxtLxAT2LzLpMA=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAOBgYSKENQdres1WVEII4CNWi1pgMG3B0/4WGR963oA7H6i4mQJSz86hkDpdxloa5MawrTxUxQAywuNx7MebHpcVyQhNr3hSL85TEFmhpwy9A=",
+        "subType": "06"
+      }
     }
   },
   "aws_symbol_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOfaprpg8TXtSj9UsuIK9Ikj+EhYXJveHxT+7k3ZR9J8RTkRua6lqfDkTVKnOjPIxEJAI1Nr7ziTd3bqJKaLVGAjA7lLDV6N9ZMSq0wNcY1ac=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAOL2DMIZdyCLv8SNdpN80ysZsvHvPypI2GXgCseZHZ7qfx/o0ZB/CkHB9rIblYBVhk22o0w1v1RoFeNWx6MN9UYln2pqsIlVtH9T8QNYvXy6c=",
+        "subType": "06"
+      }
     }
   },
   "aws_symbol_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAOOamYmpKhNxC5JgL6/FJJNw+/4kgF2GyCcj/GUQMBXO/COxZkYIjKgbSbPJoZgo0IcDtwAr9wu8JzWShfCCG7etCVG5mf2vBDXgZBj71isjk=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAO340DwVT1akGK9yHWMsTPudF/OPuPQgM1bAXn8aTh/YMjVgmFNVTYQcPEURUsTx5xbnTZIKHVKl/T74V1aodZj6vTAxZ2vlIMTei1cub62e4=",
+        "subType": "06"
+      }
     }
   },
   "aws_symbol_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
+        "subType": "06"
+      }
     }
   },
   "aws_symbol_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
+        "subType": "06"
+      }
     }
   },
   "aws_symbol_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
+        "subType": "06"
+      }
     }
   },
   "aws_symbol_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAO5IHripygBGEsVK8RFWZ1rIIVUap8KVDuqOspZpERaj+5ZEfqIcyrP/WK9KdvwOfdOWXfP/mOwuImYgNdbaQe+ejkYe4W0Y0uneCuw88k95Q=",
+        "subType": "06"
+      }
     }
   },
   "aws_javascriptWithScope_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPytI0/BZ9TU8DIhQcLPgnlb/0dSKyuKaRQQyBOey9scp+kwpiwG6q3uBekUgGdpKZyPbTBMDHnXFe8eWgJhCsj3B62b745J3hdRLb4mmrlUY=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAP69SvXsAvn0LF4nElJYrdF6VmsTDvY77eXZjaiYHIGnfhwoSKvNLTCOx+b3ckaRWmknVXBB1DZry4CKryue+7fcZnEaSzVhuGLuxdV+Ri7IY=",
+        "subType": "06"
+      }
     }
   },
   "aws_javascriptWithScope_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPrgKWv7hCBP2ONy5ZcVkPUBwYKqLAeR2LjlBDXgiLxbvllRaCvYPFa/zINokIrdvZ4hF7g1O4I73rwCHH/YoS4ZUcgh5ZTJKK/Jauf6wR+O8=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAPOQvifQVJkPC75eTS0qzDlFI3HeIwZrDUGFZDBdj4UYerCmAKi6Q7zVYIS1HLMn0EzlpruF/oJQd/lo7sqFPbgU34ETx2FDhCdNDtNFa46jM=",
+        "subType": "06"
+      }
     }
   },
   "aws_javascriptWithScope_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPYxm1JIkOYxwYrLwPPG2f32hgLyOfgaHNfb9dcC8MEZtOuX7vslGGWxoToVMuM0OM6de07M18/+3zHz3hRxWOIqWUQxprUo1n3/+X42nb4Fk=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAPSxYhqGoAQbVaa2FQBVS0bOSQRNzB6AwwVc57XQ5Ex/gVVH3IgGUknU3bTnHJ0XBfnyX4OtgcFjdMlK/nWsE6GAMpi0JaSTZ0Sp0++vN7ONc=",
+        "subType": "06"
+      }
     }
   },
   "aws_javascriptWithScope_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAPIX6N3w6qeyner1JE88dS7s2PFHYqiUtHy/vZb9cSMg5lulHOgGjrPWgKmy+ryfeE17PF/N5REOXjYPsuCYO3N58NEJIffXmM0qpGxwWEVUw=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAPGt2Fb6GWECUob1Brlm8WTq0qG54G3JfszPCUTCcFXVVgV7w/5ouIq+vjfpO1PI87m0D2dbOd9CLETunzIRXxt8lb6MGdu9yAU5uyrFL72GY=",
+        "subType": "06"
+      }
     }
   },
-  "aws_javascriptWithScope_det_prohibited_id": { "$code": "x=1", "$scope": {} },
+  "aws_javascriptWithScope_det_explicit_id": {
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "aws_javascriptWithScope_det_explicit_altname": {
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
   "aws_int_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQopmZBvNnPODMN85EXZlFQuBKKXJ29m7ZrtoUeHR2qKy3nfg/A8MODB7Kj8hiUc6TV2Rv43I6KY21LArtuLz1Gw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "int",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAQ5ifmQEj5SdBnZjU2GjeThpdzE29neG3X7R5xsfgJy8t+rSgTgiRmW2AXQUBW5dCtGOmK35+wwHbNiyzaxmENlw==",
+        "subType": "06"
+      }
     }
   },
   "aws_int_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQi4HLad7H1ytZyzq9BinlDmExc3lEgLcrwyc+gWm7ucDn48y7TYMTOk0OgPLH6R4vizQzt0IYhzLAYkftQmy7kw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "int",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAQ2ou+zeux1HIxGQulsSyEk3iiUiWIbyvhwjI3KqJ3FWFN3+hcHqag3FZLncI4AkSHMrbq5ieINH8sWXm6FxNkpg==",
+        "subType": "06"
+      }
     }
   },
   "aws_int_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQVZae6nJbkDJE/BzHkDY0hepq3dPQkLeA9ZPjuBeuJEgdk9NWlP2YahCvTDdDRxjpL4C8L7xBKeqcXTf0ZTMJOQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "int",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAQJ0t0VwzhsQAc3yEXtPn9u4fowktaIo223HCHPmw31HBueCCxRv31DctxT34h9TJfxgTnsbDqYBc2aLGkd8CZ+A==",
+        "subType": "06"
+      }
     }
   },
   "aws_int_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAQrTohlTTC2nXAzf1+r68OTReXyQ1GdhsnEMfvZeu6ZJ5GpYy3Oj2PlxqZunt+HzjpLj8otz5DnnPPaFIdMBXn/w==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "int",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAQ2SjglOOysLuS91o2vLMnjeJTr49rYmlFoIte42Ll0/nOoxXye761ZVvmAt83dett31xKGSNx587ftugjaD7/JA==",
+        "subType": "06"
+      }
     }
   },
   "aws_int_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "int",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
+        "subType": "06"
+      }
     }
   },
   "aws_int_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "int",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
+        "subType": "06"
+      }
     }
   },
   "aws_int_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "int",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
+        "subType": "06"
+      }
     }
   },
   "aws_int_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "int",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAAQCXo6ieWvfoqkG+rP7J2BV013AVf/oNMmmGWe44VEHahF+qZHzW5I/F2qIA+xgKkk172pFq0iTSOpe+K2WHMKFw==",
+        "subType": "06"
+      }
     }
   },
   "aws_timestamp_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAR8I+VqSJGDA5CYPJfpAIYBv88KvttmS1sEGFA0qMOVrhh+L48iTJ+vsE+QxC/YqwHYw1dmlZDzEe6H4CYkT+/HA==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAARWPzfH69LvKa2NEU7/y1DppIqKddDV++q0lBVYLw5sGFV92HQqmU9umIuYzS2RwbDUl07jJgEuZrTKudA/zt9fQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_timestamp_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAR0AOKtV8oExmokFG8kcPmH28SCSLXcUcqqToSINBrUmdYZ+98YTX5WhUEEphXci6f9q6wmXwQLiCMoggn0nfsHw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAR9+ga1okTPrVHA8PIwXA/mZnuBxDklnmP4zTJrCBcBeP3YAF0Gy8j/jMxoJ7fPxYBI18RSgeX+U3C/h98Lod0Kg==",
+        "subType": "06"
+      }
     }
   },
   "aws_timestamp_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAARKWngA51yFUTciOz/382fK5PpEf1mibArWlwNGmC3zwDCjF2aHeYzvj/2KXETb9Cl+qLo96EZw3FECQThg5Xxeg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAARjgkPfqEcB5WPiL4w1js1aJOMWYPX9aPzwBllMupIgTM42QF0YipLwTiV0p9v2VKMWNrcwT8Kqbo2fSokK7P47w==",
+        "subType": "06"
+      }
     }
   },
   "aws_timestamp_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAARLgcgp3orTgRjtjKlJtCwmPv3V39BVLAgHOjnkAKl8QWz+wL3I6gjR4tGr157XnkjcsdlsX32QmdmelJLxkNhkw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAARJv2bQpNO8g49/54CO0dLJLqXB7a/aD5S7wdK9NLUczpPDEczlvzrq+JkzG2Z0e/Am9Ig3Eo8MRZAB89YcP6GmA==",
+        "subType": "06"
+      }
     }
   },
   "aws_timestamp_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_timestamp_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_timestamp_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_timestamp_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAARG7kGfx0ky+d4Hl/fRBu8oUR1Mph26Dkv3J7fxGYanpzOFMiHIfVO0uwYMvsfzG54y0DDNlS3FmmS13DzepbzGQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_long_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAS5JGsTx47PgSzOsp5QDN5fn5X0Uitbm+oYklLBRhnt4sxWvilQQHIHSyPJ4csyDHHrHWSEscesIKOCyryS4vG7Q==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "long",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAASwG1qjbpOKcpUTqnc0XEzBpYBJ2k/gMPBamjC7MmHO83q9a+Sm7yD8VkEgO6OT+nkSPy9OEDtb0a7mSAQ6fLnVg==",
+        "subType": "06"
+      }
     }
   },
   "aws_long_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAASdy2WlNhcamInLdoNrQLyDGqtgQzIDDJ5YKpfw97RDRBEBiq5s5hnmoLNfF73+eNOyq9nkwOGxItJ/wwH7iuHkw==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "long",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAASC6kOcWG/m5UkuOhGB+GScx5NZ1W/T6Wf7AnfVR3d/X4Kh2WkvoaNeQvTvkriEMenedrrg/l4/jSZaimT9cXkWw==",
+        "subType": "06"
+      }
     }
   },
   "aws_long_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAASOOrX8Y6yFidAq8coVK8TDDnaHfwGA/3YeHsZSp24FrTNL3zHyBw+xV/Q99FUc3GQ9Vhh75gPOvT6zmiPI5Qo/A==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "long",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAS65Wul+droFDlHzFvT45z5YsF3sLOnINTl6wxfKqtLvVXGxQXxNN4lcB7aXUcIiHIkBrz4k1tZ0JFYU5KBFTOzg==",
+        "subType": "06"
+      }
     }
   },
   "aws_long_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAShTFHXCpE4h5zcWdpc+bLL6DNUKf0p7PR2rrVptbYIW/7TjhRceIHUnGT/5N5MZWqckINPe36M5dkD3YkeeQLpg==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "long",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAASBPkGN8oUyrZOaceIiCOXEjbUJKNbYCbSqRnFc5lc748hq5woFZ90/KiV8lTSXuhapaIpql6Y4raDG2tKrbZ3ng==",
+        "subType": "06"
+      }
     }
   },
   "aws_long_det_auto_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "long",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_long_det_auto_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "long",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_long_det_explicit_id": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "long",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_long_det_explicit_altname": {
-    "$binary": {
-      "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
-      "subType": "06"
+    "kms": "aws",
+    "type": "long",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AQFkgAAAAAAAAAAAAAAAAAASC7O/8JeB4WTqQFPuMpFRsAuonPS3yu7IAPZeRPIr03CmM6HNndYIKMoFM13eELNZTdJSgg9u9ItGqRw+/XMHzQ==",
+        "subType": "06"
+      }
     }
   },
   "aws_decimal_rand_auto_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAATZR1EzFfj8Pdnvegjb82u0Ceg0pQP81dGJ3seCLBi5sBdyaqi18n3HMf6hzBz2Moi1QM5g9ODf2boF8tqrLmfehXpvg6hobEGoqz7OTcmYqY=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAAT35zzIC8GurAOyhqVqIvFWvluaUKcoDDmpleGam/NYheoPxevTvrrAofddZP52N1ZsDoXuteFqfert6uZAnoIWBRu61PAp6THxVaJeDvMeWg=",
+        "subType": "06"
+      }
     }
   },
   "aws_decimal_rand_auto_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAATbovMFEqztgtgaI9Yaz/ephY/8+slceNLFSQ8sZzx9Tu5LOsF3ENZsLJSRuugkMqmTct3KGLOIzLp7h5TnvJbylm5Ol9gH+zWd3NLwbz4p7s=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAATfsUt6tZFzx22djX/3rHfJ0W4Bby41nnOk1C+HcguddJSnPpAtDCNJM/Bz1x9gUl5Z1RlndwSJBqGjDA2c3E506DDc4KRTPWOdHuCVWVCm5A=",
+        "subType": "06"
+      }
     }
   },
   "aws_decimal_rand_explicit_id": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAAT+kUc/E8bb2L5R41GNWETZyjjNyKc7ttu78trc3dTG5WV97qmklOCLwmxpu1Sxy5hP34q+CBv27PwkU2R6kGEAdgx14b/7ks6Dh+ttSGn7/c=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAATK70LztIpICEdZxi2bL6RuI0nS+6N55qHMG+FsLMl2T7TH3kJ5FBbPjp1eizgKUGegydAqx/FhGos87YPhk1EjRuOYZF2WBx2e+NFm7pIRBw=",
+        "subType": "06"
+      }
     }
   },
   "aws_decimal_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AgFkgAAAAAAAAAAAAAAAAAATeYI3D5gwCKZbT7PNnyqqDv9kZjyM/ZAH+jQaJoMytZBqRAC8sR/sXWpfn1zvVQ0bjNlzCbjv07gbYp2rEDxGLMHeCnI1K5spYIp/z5OMmrQ=",
-      "subType": "06"
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AgFkgAAAAAAAAAAAAAAAAAATd8JrIW1qL2oprQt3tuxC5LxLdPjUQpRstn6qAr4O7TAbpZ5U1xZRDz2YUDswg4E/+1MHZBP+ynxnAVmTKbsw4ohMEJ+lp0z9880qdwzEk2c=",
+        "subType": "06"
+      }
     }
   },
-  "aws_decimal_det_prohibited_id": { "$numberDecimal": "1.234" },
-  "aws_minKey_rand_prohibited_id": { "$minKey": 1 },
-  "aws_minKey_det_prohibited_id": { "$minKey": 1 },
-  "aws_maxKey_rand_prohibited_id": { "$maxKey": 1 },
-  "aws_maxKey_det_prohibited_id": { "$maxKey": 1 },
+  "aws_decimal_det_explicit_id": {
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "aws_decimal_det_explicit_altname": {
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "aws_minKey_rand_explicit_id": {
+    "kms": "aws",
+    "type": "minKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "aws_minKey_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "minKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "aws_minKey_det_explicit_id": {
+    "kms": "aws",
+    "type": "minKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "aws_minKey_det_explicit_altname": {
+    "kms": "aws",
+    "type": "minKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "aws_maxKey_rand_explicit_id": {
+    "kms": "aws",
+    "type": "maxKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "aws_maxKey_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "maxKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "aws_maxKey_det_explicit_id": {
+    "kms": "aws",
+    "type": "maxKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "aws_maxKey_det_explicit_altname": {
+    "kms": "aws",
+    "type": "maxKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
   "local_double_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAABmvr0W8b4lcFbnXapyzbEJu7y4G8U1otHjvPRV3/fiz6kMVuBbgjxIXRK949oJUIpocbc4ZnMLBkZfpMQVqTgbA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "double",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAABpxf0dH2kwuH5jGscq3DBh7auWgktkBki93W1oziD3d7PsnSKYYMSHq3Zps3lPre4YZNW/V1ISmBpWPFEkPMUBQ==",
+        "subType": "06"
+      }
     }
   },
   "local_double_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAB99dGDJ8TVK0kqYsBKtfLeSU4MssJ6+ZDHVeNq34/el4eEk9hQBWpjBL/YWRh6ER3uXhgtxzfZ1X/XSvfFa7yBQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "double",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAABMFDxremanpOxa3rrfwKhaARPK3ZlTz3DvYQyaUmMV9FB/4VcfqKu37XohpM1h/1RHAyd+anyw9BOeUsYERoSgQ==",
+        "subType": "06"
+      }
     }
   },
   "local_double_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAABbgp4kP4Ff3AwfrEDGZqZESka9GQMuW3q8Cq4trgEZAZsvJy+y4zM0GV1P4rRDbDVWMPV8UwNB7PIUVuvn6tWgg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "double",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAABjrGlz6ES7ztFT0+0YiR1cZLwKkx+VQy97l/ecYw2fHLm3TBVGYitZnvNPlLSjBVlNtOOIFdpiSLSZIP1XDWkXA==",
+        "subType": "06"
+      }
     }
   },
   "local_double_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAABsqOrgsXH981wjzuVKOGtBWLp5vy/m1Ol6ZaFulkNfCd3f5TDkwySIAUvGFu563w0EP6VW3jo7nXEpJHGwKpKsw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "double",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAABBCDb+uibtyhl08pfo18oPVgPnN6L5mdXCSd5Fm/JRdvfkeUdm9QcGqBZ9zMDDRGCYkmuU3wMW75KuVzgU0c5Xg==",
+        "subType": "06"
+      }
     }
   },
-  "local_double_det_prohibited_id": { "$numberDouble": "1.234" },
+  "local_double_det_explicit_id": {
+    "kms": "local",
+    "type": "double",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "local_double_det_explicit_altname": {
+    "kms": "local",
+    "type": "double",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$numberDouble": "1.234" }
+  },
   "local_string_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAACTKx6vmGR/zmEFI4Px41cIMLwA8u1Jx0ccrAtdM22lyoTuNf686a39yuhpwuU8nJTtIz/Hg7pMtwoZpnKS7pEfA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "string",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAACqbpU0oVWx3ADcCSwcHlZ4TqmUF9CamE1Qyysuv/AGAu0xynnmsdvcELPfdQ+ILBxr7Q0pc86Dvt02VEUPJK8jA==",
+        "subType": "06"
+      }
     }
   },
   "local_string_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAACCVHp9AdklelnsZ3st41ssDo3teGLMan04EFG2tOLwLU4rza2zHmeVvU2FS8HcVXKSj2rkt1ybqUK5dm/ERAOsA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "string",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAACV29lwOT/sR230gO3/drs0Ekzdreh+NFSq7YYEJpNxBodXUKGkTSlOueNtaFKFEbNZDAffA7oCIK1KgIGw1s9Gw==",
+        "subType": "06"
+      }
     }
   },
   "local_string_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAC0t2t3agUqYNaF+rgJAse2cC5KXvJQkpLUfCFhtBmog4xg9V1+jD2hPXfG3juU1bR1l+obDRQAHHeZjJMj83+wg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "string",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAC/2dQqh5d7gRQh8iozRH0kPj6JGb7w9KV99GMIovtgbpdKRNE4yxzzvp5HbB18ljhfQInO2b19nOsngk5VaFU9A==",
+        "subType": "06"
+      }
     }
   },
   "local_string_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAACVGsEtPAu0mvY38RUREvxH5z9uUGV147riVYeex+ZNw7cCy3GVwOXmwb57DOYXKBC0ZYtLmMw82nHGW7CwgEYeg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "string",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAACLoH3INuOkVNBtYGajoGJC425iKWD2gOcvJB33aqZJnGHHDs1qJR/vQa+BsGYXxsgHk7tf6aSFGetVDhF/rA4Hw==",
+        "subType": "06"
+      }
     }
   },
   "local_string_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "string",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
+        "subType": "06"
+      }
     }
   },
   "local_string_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "string",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
+        "subType": "06"
+      }
     }
   },
   "local_string_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "string",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
+        "subType": "06"
+      }
     }
   },
   "local_string_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "string",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAACW0cZMYWOY3eoqQQkSdBtS9iHC4CSQA27dy6XJGcmTV8EDuhGNnPmbx0EKFTDb0PCSyCjMyuE4nsgmNYgjTaSuw==",
+        "subType": "06"
+      }
     }
   },
   "local_object_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAADudbNGKCfYi3BygueSE/rh5cwsueMKeny2lqqd0RinXaKN/QnEZZ8qiXTBOr5lDneOoO2qaLZ5WAhxXsvmLU3Mw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "object",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAD/U+rwhAyAcKDgrC0nrsS+Y9OPTS9r5cQ16v0W408bxov9hfhmHKir+1a/I+k1zDtovHS2dbOTVNbT/8qcXe38A==",
+        "subType": "06"
+      }
     }
   },
   "local_object_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAADycKraFaktvZ1xKq97S1tLEGtV67zVZQxf3dm+FFFuZBzO4lpAh5WSJneisKiWlec3H4pWhfWnHAE6JQU+SLVYg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "object",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAADHXXTideAZyfJaom5A4nqiqnMu3FOhkYjraRcFLEDvFwiFqHpUVy9VA9avFZlZiLhfzSZSaOMp7XMPKCD4k3x2A==",
+        "subType": "06"
+      }
     }
   },
   "local_object_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAADpM5puNAXDa2im0l6dfiwYATwjKqChHOl4wJB2wRy3ql9XXR78c85qqcpfhY673wBrMlzO82sibQyll7K9f/F+g==",
-      "subType": "06"
+    "kms": "local",
+    "type": "object",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAADLDVHmYlw0+6H9e0inEN9JZmSqTzyjptuYWzf4sw1n4U8jnsn3kCLFuzGfZ569PFhpnczHMQACepm9uuPXH1ZWg==",
+        "subType": "06"
+      }
     }
   },
   "local_object_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAADU41hRGpBQdMLy/v5U8TztoIKctPmkwPul99JkPva5tmWSN5MYolOQGkg5eEXHWg1OzC4ZRj/TU+DEJU3M3OYrA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "object",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAADDr5EIehPlUvBVcx/xM81aiBhqkDxspPPwiVQ9y5ONfj9gugVFWtL3tcpd3iA0GuiDiuFILEwZLyTanw0PdkQdQ==",
+        "subType": "06"
+      }
     }
   },
-  "local_object_det_prohibited_id": { "x": { "$numberInt": "1" } },
+  "local_object_det_explicit_id": {
+    "kms": "local",
+    "type": "object",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "local_object_det_explicit_altname": {
+    "kms": "local",
+    "type": "object",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "x": { "$numberInt": "1" } }
+  },
   "local_array_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAEA+IJjnU1TZJqUfpR/CWy5gc+ANmK99KaJ+ucpgtyZ7OD1eua3/2Ol9lmQ60NanhM1Qilsbh81G7yU0gLQPETLA5WwGEMtRXLSsiQGqtcxgQ=",
-      "subType": "06"
+    "kms": "local",
+    "type": "array",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAESlkE5CjB6JwyMLLeT8Aq50IGasOOo408iCrCGFJYyWkThbU+PgZ+64fbCMmDT2oFNb5LelYcFE9h8zh/18LjB6e4qcGmFurROmk7d8MCxuc=",
+        "subType": "06"
+      }
     }
   },
   "local_array_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAEDizByeeu0+4zo9Zb1TJzSbYADx4yBf8wtYl0F9/363THqng/zNP1Svkwc1tP5iqdkpCpBV5Fdc4msi3v2jPPqTA5W4z/JsnRyK5wHNqi6/s=",
-      "subType": "06"
+    "kms": "local",
+    "type": "array",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAEobPBA2aOQRQ79ALz50+7fZ+Q0y8MHGgfKzsQEU2jjLbF3gbwPROj43dIkPRRg8zTQC/ZkFsBg3gvFzeYgZ6jUFDbUqpw9XJqsKuE8/hMiMw=",
+        "subType": "06"
+      }
     }
   },
   "local_array_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAEiVslbcKQ9o9J5uKGPsU1mCEjipIlRbEAvRi9i2nNV3debxMcxzxWFglaJxTyzNPOOq699cewfLnAA4sh3HDfuQBe4DJKfdFjxsl53/Tj29g=",
-      "subType": "06"
+    "kms": "local",
+    "type": "array",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAEfJxgBDOdaIhOycZ7jNTE2GVkufolw6ZFrcGYd4GiB18bqcm0t9rfv91d6f8/XtzLhbz8uXCCKmf7gXVjYhe46qIx9IDY7uCZ3wfpfUpAdfM=",
+        "subType": "06"
+      }
     }
   },
   "local_array_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAEgMMzSizfZVuWXpLbEBllZW1PCT8WjRoEi4Lq2tsGUbXqkhCGx3ttyAHTkvIoIjCuGFOt4cn2c/1gM/lRlZ3HFpIH8q6/uckZA1Wx3DeCWKA=",
-      "subType": "06"
+    "kms": "local",
+    "type": "array",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAEs48WcCjcpb4iWOzM8HfUOhYjuYSMdOwwa88FEWYllJWLlignGanTFv2V5r3zea9CeYe0FnD8jCaHDksPi4AD6I0JydvEfX1mIRYkybXpEmk=",
+        "subType": "06"
+      }
     }
   },
-  "local_array_det_prohibited_id": [
-    { "$numberInt": "1" },
-    { "$numberInt": "2" },
-    { "$numberInt": "3" }
-  ],
+  "local_array_det_explicit_id": {
+    "kms": "local",
+    "type": "array",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "local_array_det_explicit_altname": {
+    "kms": "local",
+    "type": "array",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
   "local_binData=00_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFhkAEDOE/dXfJ1kXeW9+8Wh5HeyFOlaChdCv8sZHmnmnK1WXVLWxq73GwcwQSCLM0lPAcPvGFNFR7S2R2cCkkLA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAFn5ZXXXuOO3B2q+6qno4XnUREiwtGQbmplipZOxQm+KeeUcqdrutmcyBim7cIMpPodz91ku2CLtULnIe1OVpW6w==",
+        "subType": "06"
+      }
     }
   },
   "local_binData=00_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFLQpyxs5+OpSi24GOuv2eSzasDyQXbTRKi1hgKZmZTXVR3asRJo2r31/GkpmU4a+Wcr0Gsfy0A/qIDihQpXpv0w==",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAF5/NXmL5cGaPHtWmD1FGD3lN67H67M8bEry4wXxm/shNdpWie3zkTHz3WsTrBxc217mhHdIiBy79EQqoOvHsB1w==",
+        "subType": "06"
+      }
     }
   },
   "local_binData=00_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFOW6kHS4tlXfonm7/6MWY3p+7e24GxrLGSfYgDyTsZ20tnE5HCOmu9UwcbWY3kKiHA5bwVW6rmKVQwVrlZRSpgw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAFs2xgSWuEVUCUH/NLwvT921FEDsf3RIGRQ7YD9ISOAwlhnUYJ0J7cGW+XwAUQOKfuEF+rI2KZfaSB777lv31MbQ==",
+        "subType": "06"
+      }
     }
   },
   "local_binData=00_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFyMyzBU/QrKEMwsLdRMzUnGcGM7AKpOsbaLCvd57VUQAxruRy+turzhRV4lygU0CQDM3Fc24hpF+0EXYgXfGOQg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAFFogLA4S10ifHkKzR0RJtsSDGjg+8qs+w3Ek1ZuDslsKHofqmtg/ss7TgiBSNiSSz5dB9I8FVTiaJS4hkxkzrgA==",
+        "subType": "06"
+      }
     }
   },
   "local_binData=00_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
+        "subType": "06"
+      }
     }
   },
   "local_binData=00_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
+        "subType": "06"
+      }
     }
   },
   "local_binData=00_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
+        "subType": "06"
+      }
     }
   },
   "local_binData=00_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAF1ofBnK9+ERP29P/i14GQ/y3muic6tNKY532zCkzQkJSktYCOeXS8DdY1DdaOP/asZWzPTdgwby6/iZcAxJU+xQ==",
+        "subType": "06"
+      }
     }
   },
   "local_binData=04_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFINmvibUNjhJJc44opxWMqjXzKxzYZor7VbZ3Edx+f8wQ0iHAwMeLGMTMBK1YWbnd52CPxGChoL+g6ZNqG0kM6zQhnnR5pmWINxvJvf5OdbA=",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAFtoGxUxAQpuUA4aHBQEfFnk3Bz0eW7sEQS3lrTaSqRHu9OzP5wlfXti59h2Z9lI4S3ha2/yWKrgKRfLC8qpznTKv4bOHiIEcnYDAF9BDu5Po=",
+        "subType": "06"
+      }
     }
   },
   "local_binData=04_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAF1BVFZay3E2uddcBcvq2vAhPOQPocuKJyP9bDs8TaRkM9REUmxrVPDwrAeCMMDNvaeyjLZEagJJjMUEKbUB2JKCdUIxFx8uIRfXtmZIsIC7o=",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAF02SrdbVudIcEQ6wulj0s4QFWZgow76A657LEClyYuzDUABEfcOsYuBAzR2R59QipMmeuRN9WNqElt9mMTEJbDc0P9EYxwI3W83MoDSoJMc0=",
+        "subType": "06"
+      }
     }
   },
   "local_binData=04_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFvGF57yU4rdsN5WD7NKxPFPu93PAfsJSHXusgsI8WUWFLx5JZKVVVmlbtgi+EYBoLwO3W/MYsYaBzH1jxTSIhWsPDWi4BMKXpVhVVWFTb/zU=",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAFBx3Zd6yTygz1kdUUGpwq2ZjQvFEUdAuvb8tXy0V3S4NYmJP0PbCaviocbG7pYHz1FAnTU0Foou94At+VrvKGXvLC2Hbx8GuJ3uCrSgV+h6A=",
+        "subType": "06"
+      }
     }
   },
   "local_binData=04_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAFxoY1RO9WKAJZkv4Q14GWwZZMSTswhA0PFJLTqsgBivwJHdneD4B5drmBPclxSDuBpWRBXfUJibWwdKg5RvL7qAoGXphKrSBbK8GIhDkyD4A=",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAFWOU/76wkmSzUBTn8g1MwRjw9ZZrjfrXo9FbUjsZOS+qYYvljE0G7N9m2Qxfw0K/GPuu7C7Fy6hPVniZfwkYA5z8279guvKGTMwOyQQW+FoA=",
+        "subType": "06"
+      }
     }
   },
   "local_binData=04_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
+        "subType": "06"
+      }
     }
   },
   "local_binData=04_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
+        "subType": "06"
+      }
     }
   },
   "local_binData=04_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
+        "subType": "06"
+      }
     }
   },
   "local_binData=04_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
-      "subType": "06"
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAFwO3hsD8ee/uwgUiHWem8fGe54LsTJWqgbRCacIe6sxrsyLT6EsVIqg4Sn7Ou+FC3WJbFld5kx8euLe/MHa8FGYjxD97z5j+rUx5tt3T6YbA=",
+        "subType": "06"
+      }
     }
   },
-  "local_undefined_rand_prohibited_id": { "$undefined": true },
-  "local_undefined_det_prohibited_id": { "$undefined": true },
+  "local_undefined_rand_explicit_id": {
+    "kms": "local",
+    "type": "undefined",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "local_undefined_rand_explicit_altname": {
+    "kms": "local",
+    "type": "undefined",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "local_undefined_det_explicit_id": {
+    "kms": "local",
+    "type": "undefined",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "local_undefined_det_explicit_altname": {
+    "kms": "local",
+    "type": "undefined",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
   "local_objectId_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAH97Ui/rLmEF4MqHgchzLfsK3EXJHGaER3NsjV52CYsJjhhvhpHlLCav5iDKRyKjaaKzU3yFNmDOY5fF6VtnXQHw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAHQm4irnEGjZz4x14cmwxFVbHcEO3Ui38t3SWUv311r3RfpNYimW1s+F7Gh21MHp1OYpwUyYEWtonvqSOlX2pLUA==",
+        "subType": "06"
+      }
     }
   },
   "local_objectId_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAHOrYvleXpCX3IIZIv4p+4PSex4AYpzgyg73B8XjJtceLkth9e68yyVnuiLRiTaF4VGdOCHDU9rvDTUAGso0iQmQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAHryvKYWNbiQIjVIYwCo3B7g8VFX7zZuVcP+mg9WGqkmab1bqrCZLKqdugRP6RSS1LFwChEPuBmKwoAjuXAQtrNA==",
+        "subType": "06"
+      }
     }
   },
   "local_objectId_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAHv4eDycUMEJAFYs6o1A52NDRXb9jMtgK9b8BA8WXYSC048KCRp6PvhIis60I4UfX0h0btEIfQaA+GQ3MnjYpPrQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAHisoR/6XrF82uheTYGa5OKModDJFAshuR+iPn9O3ol4ObHMEV6aRuC17PfZpepfKVaAXpOo9oq9lEHWygfUwrWQ==",
+        "subType": "06"
+      }
     }
   },
   "local_objectId_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAHgkRKWeeNfMh2xDtSyrLYGJx2PFz0yXaVCpQZbBRqoae7zYNRqWC3NG7OsJ5kc/thqD79+OR8hPxnVyG+DGFq8w==",
-      "subType": "06"
+    "kms": "local",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAHhZlTUmp3pzuHeXf6XPu2xLRhi+yjlnsC2FVWWmDrapwB9TnUH+vyWvBI3srJ/hBGwKVDYArXmE8AvnsWEDip3Q==",
+        "subType": "06"
+      }
     }
   },
   "local_objectId_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "objectId",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
+        "subType": "06"
+      }
     }
   },
   "local_objectId_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "objectId",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
+        "subType": "06"
+      }
     }
   },
   "local_objectId_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "objectId",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
+        "subType": "06"
+      }
     }
   },
   "local_objectId_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "objectId",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAH4ElF4AvQ+kkGfhadgKNy3GcYrDZPN6RpzaMYIhcCGDvC9W+cIS9dH1aJbPU7vTPmEZnnynPTDWjw3rAj2+9mOA==",
+        "subType": "06"
+      }
     }
   },
   "local_bool_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAIFk1Obh42QWEFgTh29A/3Ez5/jg8DbhnI18KsAj20TB74m/wE2gp5DWnCpvGBoMY5ozyQLJXUFyFFbPQdqvTDaQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "bool",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAI34El5nnjdcnUAlFoOsMDqf9qaHCn7QXks+PljhCmpV5uqG1OkwcTY7wWLP9/p+HSVtIzih8gOVAj55z9tMKmtA==",
+        "subType": "06"
+      }
     }
   },
   "local_bool_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAIDKEGJYD1/NbXSH6XvdgH/yVopabDitj98D/X6bt0PrYViJa2mfSyj2RvAA5COlIqBINyVcp27oncQy+bzyyVLg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "bool",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAI79Ubrk9OQqg+JtV9LCFxyVROOQPJndF7RJRU7u+ShabL0L5+GTBGmwIplWdsXEmJTB9OOOjsN1PJrET+ACouNA==",
+        "subType": "06"
+      }
     }
   },
   "local_bool_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAIPolPWoxyjTPClLHG21oWVnOWfI/MpEiZ+E98xzJzFLZw+pcFTizDpXXIJC1rq5HasqypPk2fKaoDGMT85f7n0Q==",
-      "subType": "06"
+    "kms": "local",
+    "type": "bool",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAIwBZskAechNTpurTkRUIKT/+yjEkoB1fKIgBUu6TWcLGeFn0v9ZcEOfgV7p9NTLg+UyUIEqrU455VTv/RzKs3tw==",
+        "subType": "06"
+      }
     }
   },
   "local_bool_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAIgSV+ue2UeUjqPDRaqGvCdUe525/bfRHuKO4310gsh2vjkBhU1DQlPBZbi9QWyxpY/p1laTP79bIiOQ47f0A0qA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "bool",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAIW9B9Nj28roR0uFjkxPPQENiCR6pDHHgVR6Gtyk3wjNIxo1EDrdZxKBw+UTAzBQp4oyFovqsdtSBtc/n82jUYZA==",
+        "subType": "06"
+      }
     }
   },
-  "local_bool_det_prohibited_id": true,
+  "local_bool_det_explicit_id": {
+    "kms": "local",
+    "type": "bool",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": true
+  },
+  "local_bool_det_explicit_altname": {
+    "kms": "local",
+    "type": "bool",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": true
+  },
   "local_date_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAJYruWq79Ry5UCXZBLu46kY4mG94oZH+MMgzoTEi22ZQfgBV+W39mZuOVBqdYOnB9Oiw51FDUpjL3LAdoL3TYP4A==",
-      "subType": "06"
+    "kms": "local",
+    "type": "date",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAJQ3dkifKtM2IjkMT5eLSd0swNHg/NalSWbjHYR875zTecD2NlkgSDc3jBhqPRO1XeD4Lj1U6gWnOP39PJWRXtkg==",
+        "subType": "06"
+      }
     }
   },
   "local_date_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAJBv0oMbcjdsmRmvjEALX/JqeB7F7IGtDHpNLRYjZQJwvZdjz0WUHjjfXbasCNOLzAca+cIDyWiF7DJZxa0VVYGQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "date",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAJeaJs1Z1GcwjZxe5xmkwQfyn+NuBd4nmMEqhMh/fgst5L7dPLQ32BPU5PNaYS++zgUTgOBheY4hrnJinac8F68w==",
+        "subType": "06"
+      }
     }
   },
   "local_date_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAJsUPpcAlLrhweEoj5NKXnkIUcENVQmvMCNitMVADkXNiBSFxpHiNtwSuvyBgQSiKgQeB5vK9unpBeXBA2tvqn3Q==",
-      "subType": "06"
+    "kms": "local",
+    "type": "date",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAJ7JQmfFgTFWII7Asnrx6gVeVurB2SGYY06VU6B+9JWOLt5seh9+Z5dyoVLsufoBYXBoi1dS8m0fczclzvIvQQkg==",
+        "subType": "06"
+      }
     }
   },
   "local_date_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAJLqk8gH+wcWJHMlW5lW2K7lzSS32K75PlFEoehIGBIQLbWx0SoEifcXYhe08rf2ZPY9JoIAyyeV8D4aJaeJRfww==",
-      "subType": "06"
+    "kms": "local",
+    "type": "date",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAJrzbONyc3wYG0Gal78JrcLyibW07et5QSj6+MX6iXoOGUSDKXDwE45fs2HiPn78LeuGSpS2u3MNsbtJ/KgefisA==",
+        "subType": "06"
+      }
     }
   },
   "local_date_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
-      "subType": "06"
+    "kms": "local",
+    "type": "date",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
+        "subType": "06"
+      }
     }
   },
   "local_date_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
-      "subType": "06"
+    "kms": "local",
+    "type": "date",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
+        "subType": "06"
+      }
     }
   },
   "local_date_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
-      "subType": "06"
+    "kms": "local",
+    "type": "date",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
+        "subType": "06"
+      }
     }
   },
   "local_date_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
-      "subType": "06"
+    "kms": "local",
+    "type": "date",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAJ1GMYQTruoKr6fv9XCbcVkx/3yivymPSMEkPCRDYxQv45w4TqBKMDfpRd1TOLOv1qvcb+gjH+z5IfVBMp2IpG/Q==",
+        "subType": "06"
+      }
     }
   },
-  "local_null_rand_prohibited_id": null,
-  "local_null_det_prohibited_id": null,
+  "local_null_rand_explicit_id": {
+    "kms": "local",
+    "type": "null",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": null
+  },
+  "local_null_rand_explicit_altname": {
+    "kms": "local",
+    "type": "null",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": null
+  },
+  "local_null_det_explicit_id": {
+    "kms": "local",
+    "type": "null",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": null
+  },
+  "local_null_det_explicit_altname": {
+    "kms": "local",
+    "type": "null",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": null
+  },
   "local_regex_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAALSNaki59phgFtPQ8Hsg15EAozEWcPQUkogqwx9oEaMVyBHX3CbTVMBxKRLJxnazl6foG5wCC0gzaRlKkE34r/Ng==",
-      "subType": "06"
+    "kms": "local",
+    "type": "regex",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAL0XcUsRWJx34hSHulNOpA4np7Y0VySEbOSCjTzr6KQw0s2Rj0ZM6rryu3NgcwyrWyJI2cic0LUwu+p4RRQf0VTg==",
+        "subType": "06"
+      }
     }
   },
   "local_regex_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAALDGRh0/inBXP6UIHYKTczT73y2l79vui1pdxvMJfG0w1IHYlQivcNNN6GtR4pzsjBJMi53mzpSfCDVhTTlr21iA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "regex",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAL/JrV5oXWu3cH8XPwrO1ail2KMtKaYqbb8uTlQczuA+sCfkHfLD/5iWsViBHQOkhrmIM9WSM1k+PRT0ZZ3wHooA==",
+        "subType": "06"
+      }
     }
   },
   "local_regex_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAALQFDojn1lEboUzgIzfIgKnF7l0/i7cVN0IIDkvsCkjjKNEH5xxccS51VBgrGky2sHwDdwWzE9WmW4+aTFfuT1BA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "regex",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAALkFgnqGJ0gZCCeuoSQBfcVt3lPJbSc7pTfacm/eqsgoujzVegPEeXU3/BFrYlhUPLlD1lMOo1Z/8KPExNzMcJ/A==",
+        "subType": "06"
+      }
     }
   },
   "local_regex_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAALxgoelr9Rt/n1D7o/2PErZGu5q9wZg7SuNFSSV0bclCisXx0jCCcOlUr3MoqleJLamQ9DT7/Kqkn0DBJgEGA8kw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "regex",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAALgHKZXQh9WUJEpoKNGUMb1pJAFB9FM7KnsPDv+sMAGWYrVFLbFj1TUzGvu45prMpM/fCZPqoXxpmHNHdqrPC25w==",
+        "subType": "06"
+      }
     }
   },
   "local_regex_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "regex",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
+        "subType": "06"
+      }
     }
   },
   "local_regex_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "regex",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
+        "subType": "06"
+      }
     }
   },
   "local_regex_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "regex",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
+        "subType": "06"
+      }
     }
   },
   "local_regex_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "regex",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAALiZbL5nFIZl7cSLH5E3wK3jJeAeFc7hLHNITtLAu+o10raEs5i/UCihMHmkf8KHZxghs056pfm5BjPzlL9x7IHQ==",
+        "subType": "06"
+      }
     }
   },
   "local_dbPointer_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAMXZyQVKL4GDdVG/FsbkRLOqA74BGvD1gbveAeePzalhG68xM5avdLO8+xA4hfMHb3C0ODymimUESLWHReh8zhZwXQQCdaElXWZGUzUwAM6PM=",
-      "subType": "06"
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAMJKTB742RLYr4+SmlpSSms6b9njnKpc6JjFAgcLVcoC3hz/Z4GtWeqkhMh7FEkf0G47rc1SyZ+H4Ge59P7In9FysEUVPHFhUIXIAlO2AohCc=",
+        "subType": "06"
+      }
     }
   },
   "local_dbPointer_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAMeepzb1RxqM/ruTrasvfRVfIDUHTG19P54vydPxsa5h/gnV6C/YTz0a3fBeOF89zWj3ppR9te4OHTLxYx+QI+qakfd6BVtJq+uIhMskNo9zY=",
-      "subType": "06"
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAMhwSwGQbtZIwd8Ont612lbv/S7hLaNRBbg59Xo12+Ce937EszeEWsiIbCAZt6bNEcfd5rQd11cDZKTLwffPoHULz9m1m0r+t5VLQhSfxSdWg=",
+        "subType": "06"
+      }
     }
   },
   "local_dbPointer_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAMu6vZt44pVcOIp3ebmg+3vjvcXzQqIkLJu/J9lgqg7vlJmODIpuCzMSExNVS/HJvtjNyOWUsv+X+nIWEvc8PvN4tA+B1YPhsuj0/++HSExcE=",
-      "subType": "06"
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAMma7LFb2k/3SGzsqHJQZznBb4R1L73R1+CmirOikq/nrUbKw9/2Gzu+5RwB3fTxgMxT5Y6qq/Yzu/uwwMnGzQy8y1Kig9elZF0FJ2KctOYFY=",
+        "subType": "06"
+      }
     }
   },
   "local_dbPointer_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAM1wu9kpWtPgbQtPOy81L6q0BzZ+z2OTVbzL5XgWjUvs4nKbwmipvTA3V2y2qYCofJewAaypjvPVD4Ub9Cqe2bqhFF3Ro0n5jT/Kgmn5bWqKo=",
-      "subType": "06"
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAMyBidAGkMIeEdUoZ5seIpdYOtT7QtCcIf2iIr5ZwmtVeVFkfR7OvxXfQRw48RhpH3r3Td9tPHS0xIC/CEOeqsQTswkRQBb5hK5uAsaEIrUHE=",
+        "subType": "06"
+      }
     }
   },
   "local_dbPointer_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
-      "subType": "06"
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
+        "subType": "06"
+      }
     }
   },
   "local_dbPointer_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
-      "subType": "06"
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
+        "subType": "06"
+      }
     }
   },
   "local_dbPointer_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
-      "subType": "06"
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
+        "subType": "06"
+      }
     }
   },
   "local_dbPointer_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
-      "subType": "06"
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAMQWace2C1w3yqtmo/rgz3YtIDnx1Ia/oDsoHnnMZlEy5RoK3uosi1hvNAZCSg3Sen0H7MH3XVhGGMCL4cS69uJ0ENSvh+K6fiZzAXCKUPfvM=",
+        "subType": "06"
+      }
     }
   },
   "local_javascript_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAANObKIAo1Z9Rhvyi67fx1FUMyP+H+IAWIM+phCne/mi8gXyE5KI+UjRoMUqwEWIf4hF7x1PLLBLOnv9vjYOxhOPw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAN/XaPef1i0CN2Aend3vfvx5VgA5sRj5N+fC8BavQfObKp/SC9KdeufbtmiC6zjpGSGdL17m91WTe1+XuMgLhVzA==",
+        "subType": "06"
+      }
     }
   },
   "local_javascript_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAANFuImM+TZ7t7fcNuASVPI7lTG76j1wtZWbiL/2vbJLSXH6vQscZeTAvkjcaTY35XA/BvXZG2JJj7jEmC82RyTAg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAANT3TkKsorXHOo6aOokKfqcgZLaGGpHto9PdnSfFJoIS0IL9l8VXadhI4TiyF42vB1b/kMjgS4lRZOrVHcmgDrSg==",
+        "subType": "06"
+      }
     }
   },
   "local_javascript_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAANFOKgXsXaOrdDoLQkmWtiZJ75sA1uU+3iMH+bbxmRdR7GTluYxqek9ssYQQeW1XaLDCSHbrk+fvZ4YYBav4Tdjw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAANF3b6JkvqOBxs2HKgheTR+JcbfS9/EcwcdyYm4e03H1qKWJl4H42ANI+TTmEAjnjXkz7lTGb8oeM+0hiWqRU6Wg==",
+        "subType": "06"
+      }
     }
   },
   "local_javascript_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAANyc/K8k5iP42mNC991m7D2WKSZ6io3F7ryh6XLJ0MO4BSg8GebHjrs48sGfFqIesOKjsyuOlEBHOCIVQI5wpNTg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAANtMqYOAV4OHkuBbyitfZk574r8/Un+aiE3Lvpjnd6ttmpjE9XkTjaX5ccBqmoXOSStbr4MaV6ZZu4syvddVmFVg==",
+        "subType": "06"
+      }
     }
   },
   "local_javascript_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascript",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
+        "subType": "06"
+      }
     }
   },
   "local_javascript_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascript",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
+        "subType": "06"
+      }
     }
   },
   "local_javascript_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascript",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
+        "subType": "06"
+      }
     }
   },
   "local_javascript_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascript",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAANmQsg9E/BzGJVNVhSNyunS/TH0332oVFdPS6gjX0Cp/JC0YhB97DLz3N4e/q8ECaz7tTdQt9JacNUgxo+YCULUA==",
+        "subType": "06"
+      }
     }
   },
   "local_symbol_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAOxMUOVXQrSgvyzgD+xBAn3p3xxzQf8olvi+QqsL50loXdt3rL16liFJzo19m4Aw9usFMVtdxKxoka+/94Jdl24Uh9yHh4lNy3DfGi0esX8WA=",
-      "subType": "06"
+    "kms": "local",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAOnWy64MORT57EveXcYL+oepWFrL9uQQOgMWKRnyM1eKlVuE8Q62ga6mdkuhDnKyzVoeSgkyBND8Xb8AkQXZooBjXX3tGK6hOuUZjh7m/USp0=",
+        "subType": "06"
+      }
     }
   },
   "local_symbol_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAOcggAd1JJ3ekPqd3CevAu26+UKTt2GZdNKSSZSRou2GzVtiV8/d0lj8saTMz3DZ+mLXZV5K/9d+zhRQ2qJtwFCTjwZ3w6smhUhKBFIVxHg4g=",
-      "subType": "06"
+    "kms": "local",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAOhJA2x97EXAtGPp1mS+0T3XxZYAYRoiKb3zGQPXCQ6D40p2BnkflcgWZmNAXUhK72HoBtGIFqX2JyMhCk4BvyRPTbZ8FG3dFgF7vKD2l1z+k=",
+        "subType": "06"
+      }
     }
   },
   "local_symbol_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAOKRw3xdSzSGV0bAXIYpBFPW8cxgOX0MTC+xSj5HhiC2nwN9wZ1YuXX6h3Cd0LOzYfVuby4Q+6foPr/3eHkYe1ArcUO8IDKyCeKleGzBtDn6E=",
-      "subType": "06"
+    "kms": "local",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAO5mnmocUuA7WedoN1fcnhd4odu98pTQJzdunI2Zc20WbUUF7T4VnLT+8L4xIQBUwm0UiJgExzIx3i61cU7Fj6iaWgll/ljfljzuzZtp4AdGI=",
+        "subType": "06"
+      }
     }
   },
   "local_symbol_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAOmNF4cGG3PT9vqHfAcYwGFbtZWAjifbLGUtXmrVTJ41T/QR9ptSCfh+FamP2ySKTV1y4bfdcbV830mS3GnFghl47l7E2+33UdbTbrQAAn5GM=",
-      "subType": "06"
+    "kms": "local",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAOU4uwDJUoJVa16SkhGEDV9hRHHorUwCIBkUrycbsk8FwD3dnBmIgQ0MhCL6e+AUr927a+95voDlFy/wQa4v27tRp14/+xVosoHg3MyW6ZL34=",
+        "subType": "06"
+      }
     }
   },
   "local_symbol_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
-      "subType": "06"
+    "kms": "local",
+    "type": "symbol",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
+        "subType": "06"
+      }
     }
   },
   "local_symbol_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
-      "subType": "06"
+    "kms": "local",
+    "type": "symbol",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
+        "subType": "06"
+      }
     }
   },
   "local_symbol_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
-      "subType": "06"
+    "kms": "local",
+    "type": "symbol",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
+        "subType": "06"
+      }
     }
   },
   "local_symbol_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
-      "subType": "06"
+    "kms": "local",
+    "type": "symbol",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAOsg5cs6VpZWoTOFg4ztZmpj8kSTeCArVcI1Zz2pOnmMqNv/vcKQGhKSBbfniMripr7iuiYtlgkHGsdO2FqUp6Jb8NEWm5uWqdNU21zR9SRkE=",
+        "subType": "06"
+      }
     }
   },
   "local_javascriptWithScope_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAPWs+QOHRP/BI/FsVpKSvTf9S2w3CSl6oWuw5T2657iaEvtfYqa4YyhDIQ0STqXDynN0tFx8jr+NRmcr4n6x/KjDylx4qf9tBHd2g3bivZ25E=",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAPv/J8sjTxNfaE2PpAc9otlfoj66cOxWXCR7Wn6q34RhTKCw3GtIeDipR9hDtMQF/sjkEgQ1iD3BtkPpvuYj9PmPRDOyP24/ZQn765wSqwrtA=",
+        "subType": "06"
+      }
     }
   },
   "local_javascriptWithScope_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAP4mweXl2pP+8ccFfktCbGdb6zBnGT8R2n9VtMDxkkuMuXHzJ8vPrR3axj++fIzS/FnEZoIJ0MqSGsgdeqlp1sEbysNejy1kNSLt63qowIw5k=",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAPh1W8C34N7mijqV3ytSgEu+bSJ4+Z7Y+RypMkAraJIAffJ2uQwz16eRPQaWoq/Sy5PoHreLQPvBdfCOBeVYWAIUoEIMQGkTuzpSHH+dLgVjw=",
+        "subType": "06"
+      }
     }
   },
   "local_javascriptWithScope_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAPF34OOm/uBjhGsSKdML3a01DY1gaH8fdqW1cM7HwGVX1M9iqW1K7hnC3IJcOfHb1Yb7XCihHm2B+I0VSD9xvo/Lj8wF7soB1OMtf6JyLtHfA=",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAP3P/IrhaWHxY8ys92lcECgA4sZYAMUFldYtwO6OG91dJAJrZmtFgrxUn6xFMdqjBbo/RCwPTSNeIEIZkCNvLz2ciyFawd/ud1HLAADoKjvmY=",
+        "subType": "06"
+      }
     }
   },
   "local_javascriptWithScope_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAPI+bEoEcC8lN9/rH9fTafKHyEAeD8lszfhCpckCru/TeSDgqyU8FgBmnp/wnnWfB88wDBtZa5gGMOgY9q2ldGeKqrUOwlxurXCULqvax/HfQ=",
-      "subType": "06"
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAPRCcDfA7aKF/XexIjkQEURNj5v9qnDrvZoa2ANAh/97gJiXiBtRu1jNMBK8S+/Qv4FPBZvVcBm74VaeyvyyADEh3XsfuUdhKK1A83xl1QhdA=",
+        "subType": "06"
+      }
     }
   },
-  "local_javascriptWithScope_det_prohibited_id": {
-    "$code": "x=1",
-    "$scope": {}
+  "local_javascriptWithScope_det_explicit_id": {
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "local_javascriptWithScope_det_explicit_altname": {
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$code": "x=1", "$scope": {} }
   },
   "local_int_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAQwWkdDxTo6h2+Cpl3zFyNUOhhA/xzQSTLq92iuEPqwQyKOWGURrHyrb3Uxs0a9VTa4pboufpCRVy56JLxnLVcgQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "int",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAQ/d1SIvX7YSZhLUDs+iV4hOBoq+dGvQoePn7Y82rSloyUZKxh1lN1NZ+s25lSuXjO9JkujrsFMDbq64qpiIItLw==",
+        "subType": "06"
+      }
     }
   },
   "local_int_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAQOmGXBr/HqmCmXQf2VA6TS8kBbeZ/zJQ/nL2PXIbPM+UwkI0sMBmrHy1dE5aG7LczlEWKg3ZBwDPya1SxLz3NUw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "int",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAQFq9rlcprrlqujbiNxkIS4jC9Wx8PMn3B2t03sbhdq3a5VQElffWwzWLnx2mVb/T+gSZ+yJ0u3coidTYuY01hnw==",
+        "subType": "06"
+      }
     }
   },
   "local_int_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAQ8ZKIibm9Gl0+rkZ+M53d8ibsPtZchp+N3LRHEJWCqPTf6lnc/BffUzFFEyaR7O7qPiFxfI9ayCXhZrQIpT4c8g==",
-      "subType": "06"
+    "kms": "local",
+    "type": "int",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAQoesHJaYZvHfmt5+QJ5xJ2XIn+OS9VIcciXHovm5zgnQ1lvliL5US0/+gybpgA2yBEwoVoznqulo9To5Ct+FqsA==",
+        "subType": "06"
+      }
     }
   },
   "local_int_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAQh+1sCiOVVL5H/rwqdSV5yjQEqF77DLKkegtU3bhBDrRgA0fJx0dtZopZcgCJmBRoEaEx8S5w5KKDRwVNXYdUHQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "int",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAQ3vFG7Y+fzI2amwTELnVTDeSrQjV9HdDNar8JYye35GiDql8S5a0NhuO0G4KaQqgINm8FxUKk2XZZJm7sFnyr7w==",
+        "subType": "06"
+      }
     }
   },
   "local_int_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
-      "subType": "06"
+    "kms": "local",
+    "type": "int",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
+        "subType": "06"
+      }
     }
   },
   "local_int_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
-      "subType": "06"
+    "kms": "local",
+    "type": "int",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
+        "subType": "06"
+      }
     }
   },
   "local_int_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
-      "subType": "06"
+    "kms": "local",
+    "type": "int",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
+        "subType": "06"
+      }
     }
   },
   "local_int_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
-      "subType": "06"
+    "kms": "local",
+    "type": "int",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAQIxWjLBromNUgiOoeoZ4RUJUYIfhfOmab0sa4qYlS9bgYI41FU6BtzaOevR16O9i+uACbiHL0X6FMXKjOmiRAug==",
+        "subType": "06"
+      }
     }
   },
   "local_timestamp_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAARKYzCdugZj3kBper+3mKsYTMoC/6qLUQw5bzqKiiBBqHgVBGLgDAG56inGd4YhGqVZd2zmoa7IoJu74F2w25olg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAARtyNBcKsCKCl6GgghZIesdEW8C0X3PUsHjXFoyLWrj4Lq8bdbHpDfCr3oGmhDhfz/dv7BGmAMiBZ2M2j9ceFjug==",
+        "subType": "06"
+      }
     }
   },
   "local_timestamp_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAARYkH+9O04GQuqgdAXDtXEjxCNTRDPy6p8DojIvxsXRPqS4QimJstIN5uaLlwvZQ5+DuW0Bijlc99ULziuCK+/gA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAARfvSMHjty/IRcRhNj4GftRkuWV5S0277pynjc/kYxb/anPp18QiIzJBcjkHsdLbD0oazgEcvif4K1xu/Tmmu1fw==",
+        "subType": "06"
+      }
     }
   },
   "local_timestamp_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAARNzl20yUsog4zoKPh0/dHvbI0OyTFBpm1N3qwz08i7DaZeNOPguP9tZeOkeQ9gZH/cXD83M94OeB+P/LFTj89Aw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAR4TORdIQYJnRkwuZZ/HVWN/bsGtFaabr3BD2X2WWvyljm/m4NYSceNF7sQNCmMDOS94cJYM3QTzZMTURkktPtiw==",
+        "subType": "06"
+      }
     }
   },
   "local_timestamp_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAARtvx46e9auVI0U5pCfWj0LTmFJAvwZ+HbiTbZL23cpQuMaTNKjBKdZq/yafpOSSVKhEzI9+Uj2X8/jWTvq7udRA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAARu8HD50qL2oRTufBcI3xwV5f+h4VTA468iJmZc69gCoiKoYgifx8QY4AMeEHHyaTyyPeKiQOcMSInGxHu+m0zdQ==",
+        "subType": "06"
+      }
     }
   },
   "local_timestamp_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
+        "subType": "06"
+      }
     }
   },
   "local_timestamp_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
+        "subType": "06"
+      }
     }
   },
   "local_timestamp_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
+        "subType": "06"
+      }
     }
   },
   "local_timestamp_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAAR6uMylGytMq8QDr5Yz3w9HlW2MkGt6yIgUKcXYSaXru8eer+EkLv66/vy5rHqTfV0+8ryoi+d+PWO5U6b3Ng5Gg==",
+        "subType": "06"
+      }
     }
   },
   "local_long_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAASSVa42/WyOA2SGX2m2KcqMEkWN/l5+qv+jl9arofcVfeX6qkeuqM+DC/9ziJkvsF/7s9DI2QhbjJNEbj2mJDkKQ==",
-      "subType": "06"
+    "kms": "local",
+    "type": "long",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAASPjFk0xYdFTm/xjzmZSDVDrPJ3I4AmjngivHmXzV0bZlGsVpokn77LfZYIxgflHZxHZx9V37BAr5jypIa7p7ILA==",
+        "subType": "06"
+      }
     }
   },
   "local_long_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAASzL1dK2FMTMLYxP6axCHiV3ikwlA3u5zKGF3+wM/sxyprl3mjcCi1NwkFyQH9YA/pQ9H+ClXEIfC98TX89QHqmA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "long",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAASpG7LZ2J/xhrzPL0G+UD1JS0ZWmszl4qST8kRBqv1Dv2lBHdr8ECTT1e4JEL7Yt+RtQj5FsULaFe6zwrVJp7BAw==",
+        "subType": "06"
+      }
     }
   },
   "local_long_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAASncR/wRkX/HLn2+18GNj3pN8Br3ajnPhTk4VhZbgiZgyEmKquaPN24u7NQd5vL7pg3eKcYNAVxFcMr9rm091kDg==",
-      "subType": "06"
+    "kms": "local",
+    "type": "long",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAASrGAhHEQaqZwgKYnRsE9Ru+F2PcHKQFWNXHbFpMdq/M6ljVNOFwPzKnsKZ2H6fEKKJ01tUWxoXYqfRvSJmpKFig==",
+        "subType": "06"
+      }
     }
   },
   "local_long_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAASeLVwHdT8yHoBg5atURT7oucAM+YjxD6HqfYfNVg4A05uUCf2VnxUWlWNHObYJDi/CbI5gYnR5aryPFDzD1vCyA==",
-      "subType": "06"
+    "kms": "local",
+    "type": "long",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAASa+Kf5IVTM45r7KROzEjqmWFCfBC9YHmwbB/RtJeSdIDtgbAu2FDmZJMjE9d7jP8L88OmYmCAUvW38s79Dx39Ug==",
+        "subType": "06"
+      }
     }
   },
   "local_long_det_auto_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "long",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
+        "subType": "06"
+      }
     }
   },
   "local_long_det_auto_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "long",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
+        "subType": "06"
+      }
     }
   },
   "local_long_det_explicit_id": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "long",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
+        "subType": "06"
+      }
     }
   },
   "local_long_det_explicit_altname": {
-    "$binary": {
-      "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
-      "subType": "06"
+    "kms": "local",
+    "type": "long",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "ASzggCwAAAAAAAAAAAAAAAASQk372m/hW3WX82/GH+ikPv3QUwK7Hh/RBpAguiNxMdNhkgA/y2gznVNm17t6djyub7+d5zN4P5PLS/EOm2kjtw==",
+        "subType": "06"
+      }
     }
   },
   "local_decimal_rand_auto_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAATPNuEyaZJ3SKQjzlvozpriBP2jdReFbxMzwv9NwtwkRAtSQSDF5Y6mAiCKFGOZ8BhlDCzGlpbZ6XMDB0rsIfJsONN4IQB8Au0gnBZ+zboS+0=",
-      "subType": "06"
+    "kms": "local",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAATPbY/MTWO3rkQXLEJFGbxhqQy4Y2MXLOqmg6nuT1gW3W2dLSHnpKh5IUFNN1aFYcj3rWQtGTu7+GhnbYTJcfTKxIYH4wlVEq9YegT5ajX3P4=",
+        "subType": "06"
+      }
     }
   },
   "local_decimal_rand_auto_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAT5XsdplzQbvijs7dpEbfWuPI05KWKUokLSklR6aN+a7OhUg1HCxAc5yQeWNknHnNK9D/u1eibg8gJA2L+0oIIyyTKImx2ri+UuNpSnjEu6Tw=",
-      "subType": "06"
+    "kms": "local",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAATFBEzBoTTyohXQHhDjdtBCIpeKLYFIGDeGZV1koVia2nJMz52P5bgWzxGXqsV/k6nR/aNbcJ45MTlEXohosZkWTm3OqtMS66DFhKBB/46z9w=",
+        "subType": "06"
+      }
     }
   },
   "local_decimal_rand_explicit_id": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAAT1vTTReF5uCVaAUMDY2Iipa347xnAXMcg7Kq3lLlPSy+5yOsqWSEnNMwBoazMujDjaZxJrPPfoR2p9eP5emxoR3JAu5sG34ulBeZ63SMoJ0A=",
-      "subType": "06"
+    "kms": "local",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAAToKGWGzs4nOJftADnIAAfa9gjIJcETFqIHul+gryaAUDHchaYa5HsMfviYrSQ9dGwOE4v0pRPLDHP1sNvvNyF7uIHk2oNBlN5MRlpX7xImIw=",
+        "subType": "06"
+      }
     }
   },
   "local_decimal_rand_explicit_altname": {
-    "$binary": {
-      "base64": "AizggCwAAAAAAAAAAAAAAAATdODPCn1O+HwzTCDIYtBNj/GhYcZCOfZ7ZlufjyNHcVxW8+H7FQnNlRJLHAYsUgaaTNaQr/muzQ7eTKUh0y63KGtOxsf+lfDoP5L1lrV/L14=",
-      "subType": "06"
+    "kms": "local",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": {
+        "base64": "AizggCwAAAAAAAAAAAAAAAATGD4QwAwXPQ80/ck23fWifFCEFqyfMm7kPDCRzWesbtjWRj578P0la51GC3jK/b8FhvhFIFkcwAyChNLd9NY/BsFymdOe0h74mz25dY+JlJU=",
+        "subType": "06"
+      }
     }
   },
-  "local_decimal_det_prohibited_id": { "$numberDecimal": "1.234" },
-  "local_minKey_rand_prohibited_id": { "$minKey": 1 },
-  "local_minKey_det_prohibited_id": { "$minKey": 1 },
-  "local_maxKey_rand_prohibited_id": { "$maxKey": 1 },
-  "local_maxKey_det_prohibited_id": { "$maxKey": 1 }
+  "local_decimal_det_explicit_id": {
+    "kms": "local",
+    "type": "decimal",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "local_decimal_det_explicit_altname": {
+    "kms": "local",
+    "type": "decimal",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "local_minKey_rand_explicit_id": {
+    "kms": "local",
+    "type": "minKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "local_minKey_rand_explicit_altname": {
+    "kms": "local",
+    "type": "minKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "local_minKey_det_explicit_id": {
+    "kms": "local",
+    "type": "minKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "local_minKey_det_explicit_altname": {
+    "kms": "local",
+    "type": "minKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "local_maxKey_rand_explicit_id": {
+    "kms": "local",
+    "type": "maxKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "local_maxKey_rand_explicit_altname": {
+    "kms": "local",
+    "type": "maxKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "local_maxKey_det_explicit_id": {
+    "kms": "local",
+    "type": "maxKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "local_maxKey_det_explicit_altname": {
+    "kms": "local",
+    "type": "maxKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  }
 }

--- a/source/client-side-encryption/corpus/corpus-key-aws.json
+++ b/source/client-side-encryption/corpus/corpus-key-aws.json
@@ -1,0 +1,33 @@
+{
+    "status": {
+        "$numberInt": "1"
+    }, 
+    "_id": {
+        "$binary": {
+            "base64": "AWSAAAAAAAAAAAAAAAAAAA==", 
+            "subType": "04"
+        }
+    }, 
+    "masterKey": {
+        "region": "us-east-1", 
+        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0", 
+        "provider": "aws"
+    }, 
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1557827033449"
+        }
+    }, 
+    "keyMaterial": {
+        "$binary": {
+            "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO", 
+            "subType": "00"
+        }
+    }, 
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1557827033449"
+        }
+    },
+    "keyAltNames": ["aws"]
+}

--- a/source/client-side-encryption/corpus/corpus-key-local.json
+++ b/source/client-side-encryption/corpus/corpus-key-local.json
@@ -1,0 +1,31 @@
+{
+    "status": {
+        "$numberInt": "1"
+    }, 
+    "_id": {
+        "$binary": {
+            "base64": "LOCALAAAAAAAAAAAAAAAAA==", 
+            "subType": "04"
+        }
+    }, 
+    "masterKey": {
+        "provider": "local"
+    }, 
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1557827033449"
+        }
+    }, 
+    "keyMaterial": {
+        "$binary": {
+            "base64": "Ce9HSz/HKKGkIt4uyy+jDuKGA+rLC2cycykMo6vc8jXxqa1UVDYHWq1r+vZKbnnSRBfB981akzRKZCFpC05CTyFqDhXv6OnMjpG97OZEREGIsHEYiJkBW0jJJvfLLgeLsEpBzsro9FztGGXASxyxFRZFhXvHxyiLOKrdWfs7X1O/iK3pEoHMx6uSNSfUOgbebLfIqW7TO++iQS5g1xovXA==", 
+            "subType": "00"
+        }
+    }, 
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1557827033449"
+        }
+    },
+    "keyAltNames": [ "local" ]
+}

--- a/source/client-side-encryption/corpus/corpus-schema.json
+++ b/source/client-side-encryption/corpus/corpus-schema.json
@@ -1,701 +1,2507 @@
 {
   "bsonType": "object",
   "properties": {
-    "aws_double_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_double_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "double"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "double"
+        }
       }
     },
-    "aws_double_rand_explicit": { "bsonType": "binData" },
-    "aws_string_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_double_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "double"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "string"
+        }
       }
     },
-    "aws_string_rand_explicit": { "bsonType": "binData" },
-    "aws_string_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_double_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_double_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_double_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_double_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_string_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "string"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "string"
+        }
       }
     },
-    "aws_string_det_explicit": { "bsonType": "binData" },
-    "aws_object_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_string_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "string"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "object"
+        }
       }
     },
-    "aws_object_rand_explicit": { "bsonType": "binData" },
-    "aws_array_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_string_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_string_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_string_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "string"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "array"
+        }
       }
     },
-    "aws_array_rand_explicit": { "bsonType": "binData" },
-    "aws_binData=00_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_string_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "string"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "binData"
+        }
       }
     },
-    "aws_binData=00_rand_explicit": { "bsonType": "binData" },
-    "aws_binData=00_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_string_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_string_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_object_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "object"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "binData"
+        }
       }
     },
-    "aws_binData=00_det_explicit": { "bsonType": "binData" },
-    "aws_binData=04_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_object_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "object"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "binData"
+        }
       }
     },
-    "aws_binData=04_rand_explicit": { "bsonType": "binData" },
-    "aws_binData=04_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_object_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_object_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_object_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_object_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_array_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "array"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "binData"
+        }
       }
     },
-    "aws_binData=04_det_explicit": { "bsonType": "binData" },
-    "aws_objectId_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_array_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "array"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "objectId"
+        }
       }
     },
-    "aws_objectId_rand_explicit": { "bsonType": "binData" },
-    "aws_objectId_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_array_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_array_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_array_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_array_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_binData=00_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "binData"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "objectId"
+        }
       }
     },
-    "aws_objectId_det_explicit": { "bsonType": "binData" },
-    "aws_bool_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_binData=00_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "binData"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "bool"
+        }
       }
     },
-    "aws_bool_rand_explicit": { "bsonType": "binData" },
-    "aws_date_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_binData=00_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_binData=00_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_binData=00_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "binData"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "date"
+        }
       }
     },
-    "aws_date_rand_explicit": { "bsonType": "binData" },
-    "aws_date_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_binData=00_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "binData"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "date"
+        }
       }
     },
-    "aws_date_det_explicit": { "bsonType": "binData" },
-    "aws_regex_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_binData=00_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_binData=00_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_binData=04_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "binData"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "regex"
+        }
       }
     },
-    "aws_regex_rand_explicit": { "bsonType": "binData" },
-    "aws_regex_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_binData=04_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "binData"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "regex"
+        }
       }
     },
-    "aws_regex_det_explicit": { "bsonType": "binData" },
-    "aws_dbPointer_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_binData=04_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_binData=04_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_binData=04_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "binData"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "dbPointer"
+        }
       }
     },
-    "aws_dbPointer_rand_explicit": { "bsonType": "binData" },
-    "aws_dbPointer_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_binData=04_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "binData"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "dbPointer"
+        }
       }
     },
-    "aws_dbPointer_det_explicit": { "bsonType": "binData" },
-    "aws_javascript_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_binData=04_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_binData=04_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_undefined_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_undefined_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_undefined_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_undefined_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_objectId_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "objectId"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "javascript"
+        }
       }
     },
-    "aws_javascript_rand_explicit": { "bsonType": "binData" },
-    "aws_symbol_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_objectId_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "objectId"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "symbol"
+        }
       }
     },
-    "aws_symbol_rand_explicit": { "bsonType": "binData" },
-    "aws_symbol_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_objectId_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_objectId_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_objectId_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "objectId"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "symbol"
+        }
       }
     },
-    "aws_symbol_det_explicit": { "bsonType": "binData" },
-    "aws_javascriptWithScope_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_objectId_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "objectId"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "javascriptWithScope"
+        }
       }
     },
-    "aws_javascriptWithScope_rand_explicit": { "bsonType": "binData" },
-    "aws_int_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_objectId_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_objectId_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_bool_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "bool"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "int"
+        }
       }
     },
-    "aws_int_rand_explicit": { "bsonType": "binData" },
-    "aws_int_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_bool_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "bool"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "int"
+        }
       }
     },
-    "aws_int_det_explicit": { "bsonType": "binData" },
-    "aws_timestamp_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_bool_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_bool_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_bool_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_bool_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_date_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "date"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "timestamp"
+        }
       }
     },
-    "aws_timestamp_rand_explicit": { "bsonType": "binData" },
-    "aws_timestamp_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_date_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "date"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "timestamp"
+        }
       }
     },
-    "aws_timestamp_det_explicit": { "bsonType": "binData" },
-    "aws_long_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_date_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_date_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_date_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "date"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "long"
+        }
       }
     },
-    "aws_long_rand_explicit": { "bsonType": "binData" },
-    "aws_long_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_date_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "date"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "long"
+        }
       }
     },
-    "aws_long_det_explicit": { "bsonType": "binData" },
-    "aws_decimal_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_date_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_date_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_null_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_null_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_null_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_null_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_regex_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "regex"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "decimal"
+        }
       }
     },
-    "aws_decimal_rand_explicit": { "bsonType": "binData" },
-    "local_double_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_regex_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "regex"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "double"
+        }
       }
     },
-    "local_double_rand_explicit": { "bsonType": "binData" },
-    "local_string_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_regex_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_regex_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_regex_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "regex"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "string"
+        }
       }
     },
-    "local_string_rand_explicit": { "bsonType": "binData" },
-    "local_string_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_regex_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "regex"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "string"
+        }
       }
     },
-    "local_string_det_explicit": { "bsonType": "binData" },
-    "local_object_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_regex_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_regex_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_dbPointer_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "dbPointer"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "object"
+        }
       }
     },
-    "local_object_rand_explicit": { "bsonType": "binData" },
-    "local_array_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_dbPointer_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "dbPointer"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "array"
+        }
       }
     },
-    "local_array_rand_explicit": { "bsonType": "binData" },
-    "local_binData=00_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_dbPointer_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_dbPointer_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_dbPointer_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "dbPointer"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "binData"
+        }
       }
     },
-    "local_binData=00_rand_explicit": { "bsonType": "binData" },
-    "local_binData=00_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_dbPointer_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "dbPointer"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "binData"
+        }
       }
     },
-    "local_binData=00_det_explicit": { "bsonType": "binData" },
-    "local_binData=04_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_dbPointer_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_dbPointer_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_javascript_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "javascript"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "binData"
+        }
       }
     },
-    "local_binData=04_rand_explicit": { "bsonType": "binData" },
-    "local_binData=04_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_javascript_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "javascript"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "binData"
+        }
       }
     },
-    "local_binData=04_det_explicit": { "bsonType": "binData" },
-    "local_objectId_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_javascript_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_javascript_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_javascript_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_javascript_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_symbol_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "symbol"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "objectId"
+        }
       }
     },
-    "local_objectId_rand_explicit": { "bsonType": "binData" },
-    "local_objectId_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_symbol_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "symbol"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "objectId"
+        }
       }
     },
-    "local_objectId_det_explicit": { "bsonType": "binData" },
-    "local_bool_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_symbol_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_symbol_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_symbol_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "symbol"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "bool"
+        }
       }
     },
-    "local_bool_rand_explicit": { "bsonType": "binData" },
-    "local_date_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_symbol_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "symbol"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "date"
+        }
       }
     },
-    "local_date_rand_explicit": { "bsonType": "binData" },
-    "local_date_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_symbol_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_symbol_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_javascriptWithScope_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "javascriptWithScope"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "date"
+        }
       }
     },
-    "local_date_det_explicit": { "bsonType": "binData" },
-    "local_regex_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_javascriptWithScope_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "javascriptWithScope"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "regex"
+        }
       }
     },
-    "local_regex_rand_explicit": { "bsonType": "binData" },
-    "local_regex_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_javascriptWithScope_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_javascriptWithScope_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_javascriptWithScope_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_javascriptWithScope_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_int_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "int"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "regex"
+        }
       }
     },
-    "local_regex_det_explicit": { "bsonType": "binData" },
-    "local_dbPointer_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_int_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "int"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "dbPointer"
+        }
       }
     },
-    "local_dbPointer_rand_explicit": { "bsonType": "binData" },
-    "local_dbPointer_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_int_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_int_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_int_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "int"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "dbPointer"
+        }
       }
     },
-    "local_dbPointer_det_explicit": { "bsonType": "binData" },
-    "local_javascript_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_int_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "int"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "javascript"
+        }
       }
     },
-    "local_javascript_rand_explicit": { "bsonType": "binData" },
-    "local_symbol_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_int_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_int_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_timestamp_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "timestamp"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "symbol"
+        }
       }
     },
-    "local_symbol_rand_explicit": { "bsonType": "binData" },
-    "local_symbol_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_timestamp_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "timestamp"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "symbol"
+        }
       }
     },
-    "local_symbol_det_explicit": { "bsonType": "binData" },
-    "local_javascriptWithScope_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_timestamp_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_timestamp_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_timestamp_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "timestamp"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "javascriptWithScope"
+        }
       }
     },
-    "local_javascriptWithScope_rand_explicit": { "bsonType": "binData" },
-    "local_int_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_timestamp_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "timestamp"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "int"
+        }
       }
     },
-    "local_int_rand_explicit": { "bsonType": "binData" },
-    "local_int_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_timestamp_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_timestamp_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_long_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "long"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "int"
+        }
       }
     },
-    "local_int_det_explicit": { "bsonType": "binData" },
-    "local_timestamp_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_long_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "long"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "timestamp"
+        }
       }
     },
-    "local_timestamp_rand_explicit": { "bsonType": "binData" },
-    "local_timestamp_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_long_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_long_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_long_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "long"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "timestamp"
+        }
       }
     },
-    "local_timestamp_det_explicit": { "bsonType": "binData" },
-    "local_long_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_long_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "long"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "long"
+        }
       }
     },
-    "local_long_rand_explicit": { "bsonType": "binData" },
-    "local_long_det_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_long_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_long_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_decimal_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "AWSAAAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "decimal"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-        "bsonType": "long"
+        }
       }
     },
-    "local_long_det_explicit": { "bsonType": "binData" },
-    "local_decimal_rand_auto": {
-      "encrypt": {
-        "keyId": [
-          {
-            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+    "aws_decimal_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_aws",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "decimal"
           }
-        ],
-        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
-        "bsonType": "decimal"
+        }
       }
     },
-    "local_decimal_rand_explicit": { "bsonType": "binData" }
+    "aws_decimal_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_decimal_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_decimal_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_decimal_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_minKey_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_minKey_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_minKey_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_minKey_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_maxKey_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_maxKey_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_maxKey_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "aws_maxKey_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_double_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "double"
+          }
+        }
+      }
+    },
+    "local_double_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "double"
+          }
+        }
+      }
+    },
+    "local_double_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_double_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_double_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_double_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_string_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "string"
+          }
+        }
+      }
+    },
+    "local_string_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "string"
+          }
+        }
+      }
+    },
+    "local_string_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_string_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_string_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "string"
+          }
+        }
+      }
+    },
+    "local_string_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "string"
+          }
+        }
+      }
+    },
+    "local_string_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_string_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_object_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "object"
+          }
+        }
+      }
+    },
+    "local_object_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "object"
+          }
+        }
+      }
+    },
+    "local_object_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_object_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_object_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_object_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_array_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "array"
+          }
+        }
+      }
+    },
+    "local_array_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "array"
+          }
+        }
+      }
+    },
+    "local_array_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_array_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_array_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_array_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_binData=00_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "binData"
+          }
+        }
+      }
+    },
+    "local_binData=00_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "binData"
+          }
+        }
+      }
+    },
+    "local_binData=00_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_binData=00_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_binData=00_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "binData"
+          }
+        }
+      }
+    },
+    "local_binData=00_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "binData"
+          }
+        }
+      }
+    },
+    "local_binData=00_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_binData=00_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_binData=04_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "binData"
+          }
+        }
+      }
+    },
+    "local_binData=04_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "binData"
+          }
+        }
+      }
+    },
+    "local_binData=04_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_binData=04_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_binData=04_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "binData"
+          }
+        }
+      }
+    },
+    "local_binData=04_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "binData"
+          }
+        }
+      }
+    },
+    "local_binData=04_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_binData=04_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_undefined_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_undefined_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_undefined_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_undefined_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_objectId_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "objectId"
+          }
+        }
+      }
+    },
+    "local_objectId_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "objectId"
+          }
+        }
+      }
+    },
+    "local_objectId_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_objectId_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_objectId_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "objectId"
+          }
+        }
+      }
+    },
+    "local_objectId_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "objectId"
+          }
+        }
+      }
+    },
+    "local_objectId_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_objectId_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_bool_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "bool"
+          }
+        }
+      }
+    },
+    "local_bool_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "bool"
+          }
+        }
+      }
+    },
+    "local_bool_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_bool_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_bool_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_bool_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_date_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "date"
+          }
+        }
+      }
+    },
+    "local_date_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "date"
+          }
+        }
+      }
+    },
+    "local_date_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_date_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_date_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "date"
+          }
+        }
+      }
+    },
+    "local_date_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "date"
+          }
+        }
+      }
+    },
+    "local_date_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_date_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_null_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_null_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_null_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_null_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_regex_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "regex"
+          }
+        }
+      }
+    },
+    "local_regex_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "regex"
+          }
+        }
+      }
+    },
+    "local_regex_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_regex_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_regex_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "regex"
+          }
+        }
+      }
+    },
+    "local_regex_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "regex"
+          }
+        }
+      }
+    },
+    "local_regex_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_regex_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_dbPointer_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "dbPointer"
+          }
+        }
+      }
+    },
+    "local_dbPointer_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "dbPointer"
+          }
+        }
+      }
+    },
+    "local_dbPointer_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_dbPointer_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_dbPointer_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "dbPointer"
+          }
+        }
+      }
+    },
+    "local_dbPointer_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "dbPointer"
+          }
+        }
+      }
+    },
+    "local_dbPointer_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_dbPointer_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_javascript_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "javascript"
+          }
+        }
+      }
+    },
+    "local_javascript_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "javascript"
+          }
+        }
+      }
+    },
+    "local_javascript_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_javascript_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_javascript_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_javascript_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_symbol_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "symbol"
+          }
+        }
+      }
+    },
+    "local_symbol_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "symbol"
+          }
+        }
+      }
+    },
+    "local_symbol_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_symbol_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_symbol_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "symbol"
+          }
+        }
+      }
+    },
+    "local_symbol_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "symbol"
+          }
+        }
+      }
+    },
+    "local_symbol_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_symbol_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_javascriptWithScope_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "javascriptWithScope"
+          }
+        }
+      }
+    },
+    "local_javascriptWithScope_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "javascriptWithScope"
+          }
+        }
+      }
+    },
+    "local_javascriptWithScope_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_javascriptWithScope_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_javascriptWithScope_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_javascriptWithScope_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_int_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "int"
+          }
+        }
+      }
+    },
+    "local_int_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "int"
+          }
+        }
+      }
+    },
+    "local_int_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_int_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_int_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "int"
+          }
+        }
+      }
+    },
+    "local_int_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "int"
+          }
+        }
+      }
+    },
+    "local_int_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_int_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_timestamp_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "timestamp"
+          }
+        }
+      }
+    },
+    "local_timestamp_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "timestamp"
+          }
+        }
+      }
+    },
+    "local_timestamp_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_timestamp_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_timestamp_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "timestamp"
+          }
+        }
+      }
+    },
+    "local_timestamp_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "timestamp"
+          }
+        }
+      }
+    },
+    "local_timestamp_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_timestamp_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_long_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "long"
+          }
+        }
+      }
+    },
+    "local_long_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "long"
+          }
+        }
+      }
+    },
+    "local_long_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_long_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_long_det_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "long"
+          }
+        }
+      }
+    },
+    "local_long_det_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+            "bsonType": "long"
+          }
+        }
+      }
+    },
+    "local_long_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_long_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_decimal_rand_auto_id": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": [
+              {
+                "$binary": {
+                  "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+                  "subType": "04"
+                }
+              }
+            ],
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "decimal"
+          }
+        }
+      }
+    },
+    "local_decimal_rand_auto_altname": {
+      "bsonType": "object",
+      "properties": {
+        "value": {
+          "encrypt": {
+            "keyId": "/altname_local",
+            "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+            "bsonType": "decimal"
+          }
+        }
+      }
+    },
+    "local_decimal_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_decimal_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_decimal_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_decimal_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_minKey_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_minKey_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_minKey_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_minKey_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_maxKey_rand_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_maxKey_rand_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_maxKey_det_explicit_id": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    },
+    "local_maxKey_det_explicit_altname": {
+      "bsonType": "object",
+      "properties": { "value": { "bsonType": "binData" } }
+    }
   }
 }

--- a/source/client-side-encryption/corpus/corpus-schema.json
+++ b/source/client-side-encryption/corpus/corpus-schema.json
@@ -1,0 +1,701 @@
+{
+  "bsonType": "object",
+  "properties": {
+    "aws_double_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "double"
+      }
+    },
+    "aws_double_rand_explicit": { "bsonType": "binData" },
+    "aws_string_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "string"
+      }
+    },
+    "aws_string_rand_explicit": { "bsonType": "binData" },
+    "aws_string_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "string"
+      }
+    },
+    "aws_string_det_explicit": { "bsonType": "binData" },
+    "aws_object_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "object"
+      }
+    },
+    "aws_object_rand_explicit": { "bsonType": "binData" },
+    "aws_array_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "array"
+      }
+    },
+    "aws_array_rand_explicit": { "bsonType": "binData" },
+    "aws_binData=00_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "binData"
+      }
+    },
+    "aws_binData=00_rand_explicit": { "bsonType": "binData" },
+    "aws_binData=00_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "binData"
+      }
+    },
+    "aws_binData=00_det_explicit": { "bsonType": "binData" },
+    "aws_binData=04_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "binData"
+      }
+    },
+    "aws_binData=04_rand_explicit": { "bsonType": "binData" },
+    "aws_binData=04_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "binData"
+      }
+    },
+    "aws_binData=04_det_explicit": { "bsonType": "binData" },
+    "aws_objectId_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "objectId"
+      }
+    },
+    "aws_objectId_rand_explicit": { "bsonType": "binData" },
+    "aws_objectId_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "objectId"
+      }
+    },
+    "aws_objectId_det_explicit": { "bsonType": "binData" },
+    "aws_bool_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "bool"
+      }
+    },
+    "aws_bool_rand_explicit": { "bsonType": "binData" },
+    "aws_date_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "date"
+      }
+    },
+    "aws_date_rand_explicit": { "bsonType": "binData" },
+    "aws_date_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "date"
+      }
+    },
+    "aws_date_det_explicit": { "bsonType": "binData" },
+    "aws_regex_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "regex"
+      }
+    },
+    "aws_regex_rand_explicit": { "bsonType": "binData" },
+    "aws_regex_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "regex"
+      }
+    },
+    "aws_regex_det_explicit": { "bsonType": "binData" },
+    "aws_dbPointer_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "dbPointer"
+      }
+    },
+    "aws_dbPointer_rand_explicit": { "bsonType": "binData" },
+    "aws_dbPointer_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "dbPointer"
+      }
+    },
+    "aws_dbPointer_det_explicit": { "bsonType": "binData" },
+    "aws_javascript_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "javascript"
+      }
+    },
+    "aws_javascript_rand_explicit": { "bsonType": "binData" },
+    "aws_symbol_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "symbol"
+      }
+    },
+    "aws_symbol_rand_explicit": { "bsonType": "binData" },
+    "aws_symbol_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "symbol"
+      }
+    },
+    "aws_symbol_det_explicit": { "bsonType": "binData" },
+    "aws_javascriptWithScope_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "javascriptWithScope"
+      }
+    },
+    "aws_javascriptWithScope_rand_explicit": { "bsonType": "binData" },
+    "aws_int_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "int"
+      }
+    },
+    "aws_int_rand_explicit": { "bsonType": "binData" },
+    "aws_int_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "int"
+      }
+    },
+    "aws_int_det_explicit": { "bsonType": "binData" },
+    "aws_timestamp_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "timestamp"
+      }
+    },
+    "aws_timestamp_rand_explicit": { "bsonType": "binData" },
+    "aws_timestamp_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "timestamp"
+      }
+    },
+    "aws_timestamp_det_explicit": { "bsonType": "binData" },
+    "aws_long_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "long"
+      }
+    },
+    "aws_long_rand_explicit": { "bsonType": "binData" },
+    "aws_long_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "long"
+      }
+    },
+    "aws_long_det_explicit": { "bsonType": "binData" },
+    "aws_decimal_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "decimal"
+      }
+    },
+    "aws_decimal_rand_explicit": { "bsonType": "binData" },
+    "local_double_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "double"
+      }
+    },
+    "local_double_rand_explicit": { "bsonType": "binData" },
+    "local_string_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "string"
+      }
+    },
+    "local_string_rand_explicit": { "bsonType": "binData" },
+    "local_string_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "string"
+      }
+    },
+    "local_string_det_explicit": { "bsonType": "binData" },
+    "local_object_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "object"
+      }
+    },
+    "local_object_rand_explicit": { "bsonType": "binData" },
+    "local_array_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "array"
+      }
+    },
+    "local_array_rand_explicit": { "bsonType": "binData" },
+    "local_binData=00_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "binData"
+      }
+    },
+    "local_binData=00_rand_explicit": { "bsonType": "binData" },
+    "local_binData=00_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "binData"
+      }
+    },
+    "local_binData=00_det_explicit": { "bsonType": "binData" },
+    "local_binData=04_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "binData"
+      }
+    },
+    "local_binData=04_rand_explicit": { "bsonType": "binData" },
+    "local_binData=04_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "binData"
+      }
+    },
+    "local_binData=04_det_explicit": { "bsonType": "binData" },
+    "local_objectId_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "objectId"
+      }
+    },
+    "local_objectId_rand_explicit": { "bsonType": "binData" },
+    "local_objectId_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "objectId"
+      }
+    },
+    "local_objectId_det_explicit": { "bsonType": "binData" },
+    "local_bool_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "bool"
+      }
+    },
+    "local_bool_rand_explicit": { "bsonType": "binData" },
+    "local_date_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "date"
+      }
+    },
+    "local_date_rand_explicit": { "bsonType": "binData" },
+    "local_date_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "date"
+      }
+    },
+    "local_date_det_explicit": { "bsonType": "binData" },
+    "local_regex_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "regex"
+      }
+    },
+    "local_regex_rand_explicit": { "bsonType": "binData" },
+    "local_regex_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "regex"
+      }
+    },
+    "local_regex_det_explicit": { "bsonType": "binData" },
+    "local_dbPointer_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "dbPointer"
+      }
+    },
+    "local_dbPointer_rand_explicit": { "bsonType": "binData" },
+    "local_dbPointer_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "dbPointer"
+      }
+    },
+    "local_dbPointer_det_explicit": { "bsonType": "binData" },
+    "local_javascript_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "javascript"
+      }
+    },
+    "local_javascript_rand_explicit": { "bsonType": "binData" },
+    "local_symbol_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "symbol"
+      }
+    },
+    "local_symbol_rand_explicit": { "bsonType": "binData" },
+    "local_symbol_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "symbol"
+      }
+    },
+    "local_symbol_det_explicit": { "bsonType": "binData" },
+    "local_javascriptWithScope_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "javascriptWithScope"
+      }
+    },
+    "local_javascriptWithScope_rand_explicit": { "bsonType": "binData" },
+    "local_int_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "int"
+      }
+    },
+    "local_int_rand_explicit": { "bsonType": "binData" },
+    "local_int_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "int"
+      }
+    },
+    "local_int_det_explicit": { "bsonType": "binData" },
+    "local_timestamp_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "timestamp"
+      }
+    },
+    "local_timestamp_rand_explicit": { "bsonType": "binData" },
+    "local_timestamp_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "timestamp"
+      }
+    },
+    "local_timestamp_det_explicit": { "bsonType": "binData" },
+    "local_long_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "long"
+      }
+    },
+    "local_long_rand_explicit": { "bsonType": "binData" },
+    "local_long_det_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+        "bsonType": "long"
+      }
+    },
+    "local_long_det_explicit": { "bsonType": "binData" },
+    "local_decimal_rand_auto": {
+      "encrypt": {
+        "keyId": [
+          {
+            "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" }
+          }
+        ],
+        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random",
+        "bsonType": "decimal"
+      }
+    },
+    "local_decimal_rand_explicit": { "bsonType": "binData" }
+  }
+}

--- a/source/client-side-encryption/corpus/corpus.json
+++ b/source/client-side-encryption/corpus/corpus.json
@@ -1,0 +1,467 @@
+{
+  "_id": "client_side_encryption_corpus",
+  "altname_aws": "aws",
+  "altname_local": "local",
+  "aws_double_rand_auto_id": { "$numberDouble": "1.234" },
+  "aws_double_rand_auto_altname": { "$numberDouble": "1.234" },
+  "aws_double_rand_explicit_id": { "$numberDouble": "1.234" },
+  "aws_double_rand_explicit_altname": { "$numberDouble": "1.234" },
+  "aws_string_rand_auto_id": "mongodb",
+  "aws_string_rand_auto_altname": "mongodb",
+  "aws_string_rand_explicit_id": "mongodb",
+  "aws_string_rand_explicit_altname": "mongodb",
+  "aws_string_det_auto_id": "mongodb",
+  "aws_string_det_auto_altname": "mongodb",
+  "aws_string_det_explicit_id": "mongodb",
+  "aws_string_det_explicit_altname": "mongodb",
+  "aws_object_rand_auto_id": { "x": { "$numberInt": "1" } },
+  "aws_object_rand_auto_altname": { "x": { "$numberInt": "1" } },
+  "aws_object_rand_explicit_id": { "x": { "$numberInt": "1" } },
+  "aws_object_rand_explicit_altname": { "x": { "$numberInt": "1" } },
+  "aws_array_rand_auto_id": [
+    { "$numberInt": "3" },
+    { "$numberInt": "2" },
+    { "$numberInt": "1" }
+  ],
+  "aws_array_rand_auto_altname": [
+    { "$numberInt": "3" },
+    { "$numberInt": "2" },
+    { "$numberInt": "1" }
+  ],
+  "aws_array_rand_explicit_id": [
+    { "$numberInt": "3" },
+    { "$numberInt": "2" },
+    { "$numberInt": "1" }
+  ],
+  "aws_array_rand_explicit_altname": [
+    { "$numberInt": "3" },
+    { "$numberInt": "2" },
+    { "$numberInt": "1" }
+  ],
+  "aws_binData=00_rand_auto_id": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "aws_binData=00_rand_auto_altname": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "aws_binData=00_rand_explicit_id": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "aws_binData=00_rand_explicit_altname": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "aws_binData=00_det_auto_id": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "aws_binData=00_det_auto_altname": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "aws_binData=00_det_explicit_id": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "aws_binData=00_det_explicit_altname": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "aws_binData=04_rand_auto_id": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "aws_binData=04_rand_auto_altname": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "aws_binData=04_rand_explicit_id": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "aws_binData=04_rand_explicit_altname": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "aws_binData=04_det_auto_id": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "aws_binData=04_det_auto_altname": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "aws_binData=04_det_explicit_id": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "aws_binData=04_det_explicit_altname": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "aws_objectId_rand_auto_id": { "$oid": "01234567890abcdef0123456" },
+  "aws_objectId_rand_auto_altname": { "$oid": "01234567890abcdef0123456" },
+  "aws_objectId_rand_explicit_id": { "$oid": "01234567890abcdef0123456" },
+  "aws_objectId_rand_explicit_altname": { "$oid": "01234567890abcdef0123456" },
+  "aws_objectId_det_auto_id": { "$oid": "01234567890abcdef0123456" },
+  "aws_objectId_det_auto_altname": { "$oid": "01234567890abcdef0123456" },
+  "aws_objectId_det_explicit_id": { "$oid": "01234567890abcdef0123456" },
+  "aws_objectId_det_explicit_altname": { "$oid": "01234567890abcdef0123456" },
+  "aws_bool_rand_auto_id": true,
+  "aws_bool_rand_auto_altname": true,
+  "aws_bool_rand_explicit_id": true,
+  "aws_bool_rand_explicit_altname": true,
+  "aws_date_rand_auto_id": { "$date": { "$numberLong": "12345" } },
+  "aws_date_rand_auto_altname": { "$date": { "$numberLong": "12345" } },
+  "aws_date_rand_explicit_id": { "$date": { "$numberLong": "12345" } },
+  "aws_date_rand_explicit_altname": { "$date": { "$numberLong": "12345" } },
+  "aws_date_det_auto_id": { "$date": { "$numberLong": "12345" } },
+  "aws_date_det_auto_altname": { "$date": { "$numberLong": "12345" } },
+  "aws_date_det_explicit_id": { "$date": { "$numberLong": "12345" } },
+  "aws_date_det_explicit_altname": { "$date": { "$numberLong": "12345" } },
+  "aws_regex_rand_auto_id": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "aws_regex_rand_auto_altname": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "aws_regex_rand_explicit_id": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "aws_regex_rand_explicit_altname": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "aws_regex_det_auto_id": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "aws_regex_det_auto_altname": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "aws_regex_det_explicit_id": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "aws_regex_det_explicit_altname": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "aws_dbPointer_rand_auto_id": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "aws_dbPointer_rand_auto_altname": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "aws_dbPointer_rand_explicit_id": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "aws_dbPointer_rand_explicit_altname": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "aws_dbPointer_det_auto_id": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "aws_dbPointer_det_auto_altname": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "aws_dbPointer_det_explicit_id": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "aws_dbPointer_det_explicit_altname": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "aws_javascript_rand_auto_id": { "$code": "x=1" },
+  "aws_javascript_rand_auto_altname": { "$code": "x=1" },
+  "aws_javascript_rand_explicit_id": { "$code": "x=1" },
+  "aws_javascript_rand_explicit_altname": { "$code": "x=1" },
+  "aws_symbol_rand_auto_id": { "$symbol": "mongodb-symbol" },
+  "aws_symbol_rand_auto_altname": { "$symbol": "mongodb-symbol" },
+  "aws_symbol_rand_explicit_id": { "$symbol": "mongodb-symbol" },
+  "aws_symbol_rand_explicit_altname": { "$symbol": "mongodb-symbol" },
+  "aws_symbol_det_auto_id": { "$symbol": "mongodb-symbol" },
+  "aws_symbol_det_auto_altname": { "$symbol": "mongodb-symbol" },
+  "aws_symbol_det_explicit_id": { "$symbol": "mongodb-symbol" },
+  "aws_symbol_det_explicit_altname": { "$symbol": "mongodb-symbol" },
+  "aws_javascriptWithScope_rand_auto_id": { "$code": "x=1", "$scope": {} },
+  "aws_javascriptWithScope_rand_auto_altname": { "$code": "x=1", "$scope": {} },
+  "aws_javascriptWithScope_rand_explicit_id": { "$code": "x=1", "$scope": {} },
+  "aws_javascriptWithScope_rand_explicit_altname": {
+    "$code": "x=1",
+    "$scope": {}
+  },
+  "aws_int_rand_auto_id": { "$numberInt": "123" },
+  "aws_int_rand_auto_altname": { "$numberInt": "123" },
+  "aws_int_rand_explicit_id": { "$numberInt": "123" },
+  "aws_int_rand_explicit_altname": { "$numberInt": "123" },
+  "aws_int_det_auto_id": { "$numberInt": "123" },
+  "aws_int_det_auto_altname": { "$numberInt": "123" },
+  "aws_int_det_explicit_id": { "$numberInt": "123" },
+  "aws_int_det_explicit_altname": { "$numberInt": "123" },
+  "aws_timestamp_rand_auto_id": { "$timestamp": { "t": 0, "i": 12345 } },
+  "aws_timestamp_rand_auto_altname": { "$timestamp": { "t": 0, "i": 12345 } },
+  "aws_timestamp_rand_explicit_id": { "$timestamp": { "t": 0, "i": 12345 } },
+  "aws_timestamp_rand_explicit_altname": {
+    "$timestamp": { "t": 0, "i": 12345 }
+  },
+  "aws_timestamp_det_auto_id": { "$timestamp": { "t": 0, "i": 12345 } },
+  "aws_timestamp_det_auto_altname": { "$timestamp": { "t": 0, "i": 12345 } },
+  "aws_timestamp_det_explicit_id": { "$timestamp": { "t": 0, "i": 12345 } },
+  "aws_timestamp_det_explicit_altname": {
+    "$timestamp": { "t": 0, "i": 12345 }
+  },
+  "aws_long_rand_auto_id": { "$numberLong": "456" },
+  "aws_long_rand_auto_altname": { "$numberLong": "456" },
+  "aws_long_rand_explicit_id": { "$numberLong": "456" },
+  "aws_long_rand_explicit_altname": { "$numberLong": "456" },
+  "aws_long_det_auto_id": { "$numberLong": "456" },
+  "aws_long_det_auto_altname": { "$numberLong": "456" },
+  "aws_long_det_explicit_id": { "$numberLong": "456" },
+  "aws_long_det_explicit_altname": { "$numberLong": "456" },
+  "aws_decimal_rand_auto_id": { "$numberDecimal": "1.234" },
+  "aws_decimal_rand_auto_altname": { "$numberDecimal": "1.234" },
+  "aws_decimal_rand_explicit_id": { "$numberDecimal": "1.234" },
+  "aws_decimal_rand_explicit_altname": { "$numberDecimal": "1.234" },
+  "local_double_rand_auto_id": { "$numberDouble": "1.234" },
+  "local_double_rand_auto_altname": { "$numberDouble": "1.234" },
+  "local_double_rand_explicit_id": { "$numberDouble": "1.234" },
+  "local_double_rand_explicit_altname": { "$numberDouble": "1.234" },
+  "local_string_rand_auto_id": "mongodb",
+  "local_string_rand_auto_altname": "mongodb",
+  "local_string_rand_explicit_id": "mongodb",
+  "local_string_rand_explicit_altname": "mongodb",
+  "local_string_det_auto_id": "mongodb",
+  "local_string_det_auto_altname": "mongodb",
+  "local_string_det_explicit_id": "mongodb",
+  "local_string_det_explicit_altname": "mongodb",
+  "local_object_rand_auto_id": { "x": { "$numberInt": "1" } },
+  "local_object_rand_auto_altname": { "x": { "$numberInt": "1" } },
+  "local_object_rand_explicit_id": { "x": { "$numberInt": "1" } },
+  "local_object_rand_explicit_altname": { "x": { "$numberInt": "1" } },
+  "local_array_rand_auto_id": [
+    { "$numberInt": "3" },
+    { "$numberInt": "2" },
+    { "$numberInt": "1" }
+  ],
+  "local_array_rand_auto_altname": [
+    { "$numberInt": "3" },
+    { "$numberInt": "2" },
+    { "$numberInt": "1" }
+  ],
+  "local_array_rand_explicit_id": [
+    { "$numberInt": "3" },
+    { "$numberInt": "2" },
+    { "$numberInt": "1" }
+  ],
+  "local_array_rand_explicit_altname": [
+    { "$numberInt": "3" },
+    { "$numberInt": "2" },
+    { "$numberInt": "1" }
+  ],
+  "local_binData=00_rand_auto_id": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "local_binData=00_rand_auto_altname": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "local_binData=00_rand_explicit_id": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "local_binData=00_rand_explicit_altname": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "local_binData=00_det_auto_id": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "local_binData=00_det_auto_altname": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "local_binData=00_det_explicit_id": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "local_binData=00_det_explicit_altname": {
+    "$binary": { "base64": "AQIDBA==", "subType": "00" }
+  },
+  "local_binData=04_rand_auto_id": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "local_binData=04_rand_auto_altname": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "local_binData=04_rand_explicit_id": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "local_binData=04_rand_explicit_altname": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "local_binData=04_det_auto_id": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "local_binData=04_det_auto_altname": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "local_binData=04_det_explicit_id": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "local_binData=04_det_explicit_altname": {
+    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+  },
+  "local_objectId_rand_auto_id": { "$oid": "01234567890abcdef0123456" },
+  "local_objectId_rand_auto_altname": { "$oid": "01234567890abcdef0123456" },
+  "local_objectId_rand_explicit_id": { "$oid": "01234567890abcdef0123456" },
+  "local_objectId_rand_explicit_altname": {
+    "$oid": "01234567890abcdef0123456"
+  },
+  "local_objectId_det_auto_id": { "$oid": "01234567890abcdef0123456" },
+  "local_objectId_det_auto_altname": { "$oid": "01234567890abcdef0123456" },
+  "local_objectId_det_explicit_id": { "$oid": "01234567890abcdef0123456" },
+  "local_objectId_det_explicit_altname": { "$oid": "01234567890abcdef0123456" },
+  "local_bool_rand_auto_id": true,
+  "local_bool_rand_auto_altname": true,
+  "local_bool_rand_explicit_id": true,
+  "local_bool_rand_explicit_altname": true,
+  "local_date_rand_auto_id": { "$date": { "$numberLong": "12345" } },
+  "local_date_rand_auto_altname": { "$date": { "$numberLong": "12345" } },
+  "local_date_rand_explicit_id": { "$date": { "$numberLong": "12345" } },
+  "local_date_rand_explicit_altname": { "$date": { "$numberLong": "12345" } },
+  "local_date_det_auto_id": { "$date": { "$numberLong": "12345" } },
+  "local_date_det_auto_altname": { "$date": { "$numberLong": "12345" } },
+  "local_date_det_explicit_id": { "$date": { "$numberLong": "12345" } },
+  "local_date_det_explicit_altname": { "$date": { "$numberLong": "12345" } },
+  "local_regex_rand_auto_id": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "local_regex_rand_auto_altname": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "local_regex_rand_explicit_id": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "local_regex_rand_explicit_altname": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "local_regex_det_auto_id": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "local_regex_det_auto_altname": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "local_regex_det_explicit_id": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "local_regex_det_explicit_altname": {
+    "$regularExpression": { "pattern": ".*", "options": "" }
+  },
+  "local_dbPointer_rand_auto_id": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "local_dbPointer_rand_auto_altname": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "local_dbPointer_rand_explicit_id": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "local_dbPointer_rand_explicit_altname": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "local_dbPointer_det_auto_id": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "local_dbPointer_det_auto_altname": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "local_dbPointer_det_explicit_id": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "local_dbPointer_det_explicit_altname": {
+    "$dbPointer": {
+      "$ref": "db.example",
+      "$id": { "$oid": "01234567890abcdef0123456" }
+    }
+  },
+  "local_javascript_rand_auto_id": { "$code": "x=1" },
+  "local_javascript_rand_auto_altname": { "$code": "x=1" },
+  "local_javascript_rand_explicit_id": { "$code": "x=1" },
+  "local_javascript_rand_explicit_altname": { "$code": "x=1" },
+  "local_symbol_rand_auto_id": { "$symbol": "mongodb-symbol" },
+  "local_symbol_rand_auto_altname": { "$symbol": "mongodb-symbol" },
+  "local_symbol_rand_explicit_id": { "$symbol": "mongodb-symbol" },
+  "local_symbol_rand_explicit_altname": { "$symbol": "mongodb-symbol" },
+  "local_symbol_det_auto_id": { "$symbol": "mongodb-symbol" },
+  "local_symbol_det_auto_altname": { "$symbol": "mongodb-symbol" },
+  "local_symbol_det_explicit_id": { "$symbol": "mongodb-symbol" },
+  "local_symbol_det_explicit_altname": { "$symbol": "mongodb-symbol" },
+  "local_javascriptWithScope_rand_auto_id": { "$code": "x=1", "$scope": {} },
+  "local_javascriptWithScope_rand_auto_altname": {
+    "$code": "x=1",
+    "$scope": {}
+  },
+  "local_javascriptWithScope_rand_explicit_id": {
+    "$code": "x=1",
+    "$scope": {}
+  },
+  "local_javascriptWithScope_rand_explicit_altname": {
+    "$code": "x=1",
+    "$scope": {}
+  },
+  "local_int_rand_auto_id": { "$numberInt": "123" },
+  "local_int_rand_auto_altname": { "$numberInt": "123" },
+  "local_int_rand_explicit_id": { "$numberInt": "123" },
+  "local_int_rand_explicit_altname": { "$numberInt": "123" },
+  "local_int_det_auto_id": { "$numberInt": "123" },
+  "local_int_det_auto_altname": { "$numberInt": "123" },
+  "local_int_det_explicit_id": { "$numberInt": "123" },
+  "local_int_det_explicit_altname": { "$numberInt": "123" },
+  "local_timestamp_rand_auto_id": { "$timestamp": { "t": 0, "i": 12345 } },
+  "local_timestamp_rand_auto_altname": { "$timestamp": { "t": 0, "i": 12345 } },
+  "local_timestamp_rand_explicit_id": { "$timestamp": { "t": 0, "i": 12345 } },
+  "local_timestamp_rand_explicit_altname": {
+    "$timestamp": { "t": 0, "i": 12345 }
+  },
+  "local_timestamp_det_auto_id": { "$timestamp": { "t": 0, "i": 12345 } },
+  "local_timestamp_det_auto_altname": { "$timestamp": { "t": 0, "i": 12345 } },
+  "local_timestamp_det_explicit_id": { "$timestamp": { "t": 0, "i": 12345 } },
+  "local_timestamp_det_explicit_altname": {
+    "$timestamp": { "t": 0, "i": 12345 }
+  },
+  "local_long_rand_auto_id": { "$numberLong": "456" },
+  "local_long_rand_auto_altname": { "$numberLong": "456" },
+  "local_long_rand_explicit_id": { "$numberLong": "456" },
+  "local_long_rand_explicit_altname": { "$numberLong": "456" },
+  "local_long_det_auto_id": { "$numberLong": "456" },
+  "local_long_det_auto_altname": { "$numberLong": "456" },
+  "local_long_det_explicit_id": { "$numberLong": "456" },
+  "local_long_det_explicit_altname": { "$numberLong": "456" },
+  "local_decimal_rand_auto_id": { "$numberDecimal": "1.234" },
+  "local_decimal_rand_auto_altname": { "$numberDecimal": "1.234" },
+  "local_decimal_rand_explicit_id": { "$numberDecimal": "1.234" },
+  "local_decimal_rand_explicit_altname": { "$numberDecimal": "1.234" }
+}

--- a/source/client-side-encryption/corpus/corpus.json
+++ b/source/client-side-encryption/corpus/corpus.json
@@ -1,476 +1,299 @@
-{
-  "_id": "client_side_encryption_corpus",
-  "altname_aws": "aws",
-  "altname_local": "local",
-  "aws_double_rand_auto_id": { "$numberDouble": 1.234 },
-  "aws_double_rand_auto_altname": { "$numberDouble": 1.234 },
-  "aws_double_rand_explicit_id": { "$numberDouble": 1.234 },
-  "aws_double_rand_explicit_altname": { "$numberDouble": 1.234 },
-  "aws_double_det_prohibited_id": { "$numberDouble": 1.234 },
-  "aws_string_rand_auto_id": "mongodb",
-  "aws_string_rand_auto_altname": "mongodb",
-  "aws_string_rand_explicit_id": "mongodb",
-  "aws_string_rand_explicit_altname": "mongodb",
-  "aws_string_det_auto_id": "mongodb",
-  "aws_string_det_auto_altname": "mongodb",
-  "aws_string_det_explicit_id": "mongodb",
-  "aws_string_det_explicit_altname": "mongodb",
-  "aws_object_rand_auto_id": { "x": { "$numberInt": 1 } },
-  "aws_object_rand_auto_altname": { "x": { "$numberInt": 1 } },
-  "aws_object_rand_explicit_id": { "x": { "$numberInt": 1 } },
-  "aws_object_rand_explicit_altname": { "x": { "$numberInt": 1 } },
-  "aws_object_det_prohibited_id": { "x": { "$numberInt": 1 } },
-  "aws_array_rand_auto_id": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "aws_array_rand_auto_altname": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "aws_array_rand_explicit_id": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "aws_array_rand_explicit_altname": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "aws_array_det_prohibited_id": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "aws_binData=00_rand_auto_id": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "aws_binData=00_rand_auto_altname": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "aws_binData=00_rand_explicit_id": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "aws_binData=00_rand_explicit_altname": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "aws_binData=00_det_auto_id": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "aws_binData=00_det_auto_altname": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "aws_binData=00_det_explicit_id": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "aws_binData=00_det_explicit_altname": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "aws_binData=04_rand_auto_id": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "aws_binData=04_rand_auto_altname": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "aws_binData=04_rand_explicit_id": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "aws_binData=04_rand_explicit_altname": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "aws_binData=04_det_auto_id": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "aws_binData=04_det_auto_altname": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "aws_binData=04_det_explicit_id": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "aws_binData=04_det_explicit_altname": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "aws_undefined_rand_prohibited_id": { "$undefined": true },
-  "aws_undefined_det_prohibited_id": { "$undefined": true },
-  "aws_objectId_rand_auto_id": { "$oid": "01234567890abcdef0123456" },
-  "aws_objectId_rand_auto_altname": { "$oid": "01234567890abcdef0123456" },
-  "aws_objectId_rand_explicit_id": { "$oid": "01234567890abcdef0123456" },
-  "aws_objectId_rand_explicit_altname": { "$oid": "01234567890abcdef0123456" },
-  "aws_objectId_det_auto_id": { "$oid": "01234567890abcdef0123456" },
-  "aws_objectId_det_auto_altname": { "$oid": "01234567890abcdef0123456" },
-  "aws_objectId_det_explicit_id": { "$oid": "01234567890abcdef0123456" },
-  "aws_objectId_det_explicit_altname": { "$oid": "01234567890abcdef0123456" },
-  "aws_bool_rand_auto_id": true,
-  "aws_bool_rand_auto_altname": true,
-  "aws_bool_rand_explicit_id": true,
-  "aws_bool_rand_explicit_altname": true,
-  "aws_bool_det_prohibited_id": true,
-  "aws_date_rand_auto_id": { "$date": { "$numberLong": "12345" } },
-  "aws_date_rand_auto_altname": { "$date": { "$numberLong": "12345" } },
-  "aws_date_rand_explicit_id": { "$date": { "$numberLong": "12345" } },
-  "aws_date_rand_explicit_altname": { "$date": { "$numberLong": "12345" } },
-  "aws_date_det_auto_id": { "$date": { "$numberLong": "12345" } },
-  "aws_date_det_auto_altname": { "$date": { "$numberLong": "12345" } },
-  "aws_date_det_explicit_id": { "$date": { "$numberLong": "12345" } },
-  "aws_date_det_explicit_altname": { "$date": { "$numberLong": "12345" } },
-  "aws_null_rand_prohibited_id": null,
-  "aws_null_det_prohibited_id": null,
-  "aws_regex_rand_auto_id": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "aws_regex_rand_auto_altname": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "aws_regex_rand_explicit_id": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "aws_regex_rand_explicit_altname": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "aws_regex_det_auto_id": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "aws_regex_det_auto_altname": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "aws_regex_det_explicit_id": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "aws_regex_det_explicit_altname": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "aws_dbPointer_rand_auto_id": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "aws_dbPointer_rand_auto_altname": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "aws_dbPointer_rand_explicit_id": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "aws_dbPointer_rand_explicit_altname": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "aws_dbPointer_det_auto_id": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "aws_dbPointer_det_auto_altname": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "aws_dbPointer_det_explicit_id": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "aws_dbPointer_det_explicit_altname": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "aws_javascript_rand_auto_id": { "$code": "x=1" },
-  "aws_javascript_rand_auto_altname": { "$code": "x=1" },
-  "aws_javascript_rand_explicit_id": { "$code": "x=1" },
-  "aws_javascript_rand_explicit_altname": { "$code": "x=1" },
-  "aws_javascript_det_prohibited_id": { "$code": "x=1" },
-  "aws_symbol_rand_auto_id": { "$symbol": "mongodb-symbol" },
-  "aws_symbol_rand_auto_altname": { "$symbol": "mongodb-symbol" },
-  "aws_symbol_rand_explicit_id": { "$symbol": "mongodb-symbol" },
-  "aws_symbol_rand_explicit_altname": { "$symbol": "mongodb-symbol" },
-  "aws_symbol_det_auto_id": { "$symbol": "mongodb-symbol" },
-  "aws_symbol_det_auto_altname": { "$symbol": "mongodb-symbol" },
-  "aws_symbol_det_explicit_id": { "$symbol": "mongodb-symbol" },
-  "aws_symbol_det_explicit_altname": { "$symbol": "mongodb-symbol" },
-  "aws_javascriptWithScope_rand_auto_id": { "$code": "x=1", "$scope": {} },
-  "aws_javascriptWithScope_rand_auto_altname": { "$code": "x=1", "$scope": {} },
-  "aws_javascriptWithScope_rand_explicit_id": { "$code": "x=1", "$scope": {} },
-  "aws_javascriptWithScope_rand_explicit_altname": {
-    "$code": "x=1",
-    "$scope": {}
-  },
-  "aws_javascriptWithScope_det_prohibited_id": { "$code": "x=1", "$scope": {} },
-  "aws_int_rand_auto_id": { "$numberInt": "123" },
-  "aws_int_rand_auto_altname": { "$numberInt": "123" },
-  "aws_int_rand_explicit_id": { "$numberInt": "123" },
-  "aws_int_rand_explicit_altname": { "$numberInt": "123" },
-  "aws_int_det_auto_id": { "$numberInt": "123" },
-  "aws_int_det_auto_altname": { "$numberInt": "123" },
-  "aws_int_det_explicit_id": { "$numberInt": "123" },
-  "aws_int_det_explicit_altname": { "$numberInt": "123" },
-  "aws_timestamp_rand_auto_id": { "$timestamp": { "t": 0, "i": 12345 } },
-  "aws_timestamp_rand_auto_altname": { "$timestamp": { "t": 0, "i": 12345 } },
-  "aws_timestamp_rand_explicit_id": { "$timestamp": { "t": 0, "i": 12345 } },
-  "aws_timestamp_rand_explicit_altname": {
-    "$timestamp": { "t": 0, "i": 12345 }
-  },
-  "aws_timestamp_det_auto_id": { "$timestamp": { "t": 0, "i": 12345 } },
-  "aws_timestamp_det_auto_altname": { "$timestamp": { "t": 0, "i": 12345 } },
-  "aws_timestamp_det_explicit_id": { "$timestamp": { "t": 0, "i": 12345 } },
-  "aws_timestamp_det_explicit_altname": {
-    "$timestamp": { "t": 0, "i": 12345 }
-  },
-  "aws_long_rand_auto_id": { "$numberLong": "456" },
-  "aws_long_rand_auto_altname": { "$numberLong": "456" },
-  "aws_long_rand_explicit_id": { "$numberLong": "456" },
-  "aws_long_rand_explicit_altname": { "$numberLong": "456" },
-  "aws_long_det_auto_id": { "$numberLong": "456" },
-  "aws_long_det_auto_altname": { "$numberLong": "456" },
-  "aws_long_det_explicit_id": { "$numberLong": "456" },
-  "aws_long_det_explicit_altname": { "$numberLong": "456" },
-  "aws_decimal_rand_auto_id": { "$numberDecimal": "1.234" },
-  "aws_decimal_rand_auto_altname": { "$numberDecimal": "1.234" },
-  "aws_decimal_rand_explicit_id": { "$numberDecimal": "1.234" },
-  "aws_decimal_rand_explicit_altname": { "$numberDecimal": "1.234" },
-  "aws_decimal_det_prohibited_id": { "$numberDecimal": "1.234" },
-  "aws_minKey_rand_prohibited_id": { "$minKey": 1 },
-  "aws_minKey_det_prohibited_id": { "$minKey": 1 },
-  "aws_maxKey_rand_prohibited_id": { "$maxKey": 1 },
-  "aws_maxKey_det_prohibited_id": { "$maxKey": 1 },
-  "local_double_rand_auto_id": { "$numberDouble": 1.234 },
-  "local_double_rand_auto_altname": { "$numberDouble": 1.234 },
-  "local_double_rand_explicit_id": { "$numberDouble": 1.234 },
-  "local_double_rand_explicit_altname": { "$numberDouble": 1.234 },
-  "local_double_det_prohibited_id": { "$numberDouble": 1.234 },
-  "local_string_rand_auto_id": "mongodb",
-  "local_string_rand_auto_altname": "mongodb",
-  "local_string_rand_explicit_id": "mongodb",
-  "local_string_rand_explicit_altname": "mongodb",
-  "local_string_det_auto_id": "mongodb",
-  "local_string_det_auto_altname": "mongodb",
-  "local_string_det_explicit_id": "mongodb",
-  "local_string_det_explicit_altname": "mongodb",
-  "local_object_rand_auto_id": { "x": { "$numberInt": 1 } },
-  "local_object_rand_auto_altname": { "x": { "$numberInt": 1 } },
-  "local_object_rand_explicit_id": { "x": { "$numberInt": 1 } },
-  "local_object_rand_explicit_altname": { "x": { "$numberInt": 1 } },
-  "local_object_det_prohibited_id": { "x": { "$numberInt": 1 } },
-  "local_array_rand_auto_id": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "local_array_rand_auto_altname": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "local_array_rand_explicit_id": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "local_array_rand_explicit_altname": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "local_array_det_prohibited_id": [
-    { "$numberInt": 1 },
-    { "$numberInt": 2 },
-    { "$numberInt": 3 }
-  ],
-  "local_binData=00_rand_auto_id": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "local_binData=00_rand_auto_altname": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "local_binData=00_rand_explicit_id": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "local_binData=00_rand_explicit_altname": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "local_binData=00_det_auto_id": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "local_binData=00_det_auto_altname": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "local_binData=00_det_explicit_id": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "local_binData=00_det_explicit_altname": {
-    "$binary": { "base64": "AQIDBA==", "subType": "00" }
-  },
-  "local_binData=04_rand_auto_id": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "local_binData=04_rand_auto_altname": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "local_binData=04_rand_explicit_id": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "local_binData=04_rand_explicit_altname": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "local_binData=04_det_auto_id": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "local_binData=04_det_auto_altname": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "local_binData=04_det_explicit_id": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "local_binData=04_det_explicit_altname": {
-    "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
-  },
-  "local_undefined_rand_prohibited_id": { "$undefined": true },
-  "local_undefined_det_prohibited_id": { "$undefined": true },
-  "local_objectId_rand_auto_id": { "$oid": "01234567890abcdef0123456" },
-  "local_objectId_rand_auto_altname": { "$oid": "01234567890abcdef0123456" },
-  "local_objectId_rand_explicit_id": { "$oid": "01234567890abcdef0123456" },
-  "local_objectId_rand_explicit_altname": {
-    "$oid": "01234567890abcdef0123456"
-  },
-  "local_objectId_det_auto_id": { "$oid": "01234567890abcdef0123456" },
-  "local_objectId_det_auto_altname": { "$oid": "01234567890abcdef0123456" },
-  "local_objectId_det_explicit_id": { "$oid": "01234567890abcdef0123456" },
-  "local_objectId_det_explicit_altname": { "$oid": "01234567890abcdef0123456" },
-  "local_bool_rand_auto_id": true,
-  "local_bool_rand_auto_altname": true,
-  "local_bool_rand_explicit_id": true,
-  "local_bool_rand_explicit_altname": true,
-  "local_bool_det_prohibited_id": true,
-  "local_date_rand_auto_id": { "$date": { "$numberLong": "12345" } },
-  "local_date_rand_auto_altname": { "$date": { "$numberLong": "12345" } },
-  "local_date_rand_explicit_id": { "$date": { "$numberLong": "12345" } },
-  "local_date_rand_explicit_altname": { "$date": { "$numberLong": "12345" } },
-  "local_date_det_auto_id": { "$date": { "$numberLong": "12345" } },
-  "local_date_det_auto_altname": { "$date": { "$numberLong": "12345" } },
-  "local_date_det_explicit_id": { "$date": { "$numberLong": "12345" } },
-  "local_date_det_explicit_altname": { "$date": { "$numberLong": "12345" } },
-  "local_null_rand_prohibited_id": null,
-  "local_null_det_prohibited_id": null,
-  "local_regex_rand_auto_id": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "local_regex_rand_auto_altname": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "local_regex_rand_explicit_id": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "local_regex_rand_explicit_altname": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "local_regex_det_auto_id": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "local_regex_det_auto_altname": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "local_regex_det_explicit_id": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "local_regex_det_explicit_altname": {
-    "$regularExpression": { "pattern": ".*", "options": "" }
-  },
-  "local_dbPointer_rand_auto_id": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "local_dbPointer_rand_auto_altname": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "local_dbPointer_rand_explicit_id": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "local_dbPointer_rand_explicit_altname": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "local_dbPointer_det_auto_id": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "local_dbPointer_det_auto_altname": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "local_dbPointer_det_explicit_id": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "local_dbPointer_det_explicit_altname": {
-    "$ref": "db.example",
-    "$id": { "$oid": "01234567890abcdef0123456" }
-  },
-  "local_javascript_rand_auto_id": { "$code": "x=1" },
-  "local_javascript_rand_auto_altname": { "$code": "x=1" },
-  "local_javascript_rand_explicit_id": { "$code": "x=1" },
-  "local_javascript_rand_explicit_altname": { "$code": "x=1" },
-  "local_javascript_det_prohibited_id": { "$code": "x=1" },
-  "local_symbol_rand_auto_id": { "$symbol": "mongodb-symbol" },
-  "local_symbol_rand_auto_altname": { "$symbol": "mongodb-symbol" },
-  "local_symbol_rand_explicit_id": { "$symbol": "mongodb-symbol" },
-  "local_symbol_rand_explicit_altname": { "$symbol": "mongodb-symbol" },
-  "local_symbol_det_auto_id": { "$symbol": "mongodb-symbol" },
-  "local_symbol_det_auto_altname": { "$symbol": "mongodb-symbol" },
-  "local_symbol_det_explicit_id": { "$symbol": "mongodb-symbol" },
-  "local_symbol_det_explicit_altname": { "$symbol": "mongodb-symbol" },
-  "local_javascriptWithScope_rand_auto_id": { "$code": "x=1", "$scope": {} },
-  "local_javascriptWithScope_rand_auto_altname": {
-    "$code": "x=1",
-    "$scope": {}
-  },
-  "local_javascriptWithScope_rand_explicit_id": {
-    "$code": "x=1",
-    "$scope": {}
-  },
-  "local_javascriptWithScope_rand_explicit_altname": {
-    "$code": "x=1",
-    "$scope": {}
-  },
-  "local_javascriptWithScope_det_prohibited_id": {
-    "$code": "x=1",
-    "$scope": {}
-  },
-  "local_int_rand_auto_id": { "$numberInt": "123" },
-  "local_int_rand_auto_altname": { "$numberInt": "123" },
-  "local_int_rand_explicit_id": { "$numberInt": "123" },
-  "local_int_rand_explicit_altname": { "$numberInt": "123" },
-  "local_int_det_auto_id": { "$numberInt": "123" },
-  "local_int_det_auto_altname": { "$numberInt": "123" },
-  "local_int_det_explicit_id": { "$numberInt": "123" },
-  "local_int_det_explicit_altname": { "$numberInt": "123" },
-  "local_timestamp_rand_auto_id": { "$timestamp": { "t": 0, "i": 12345 } },
-  "local_timestamp_rand_auto_altname": { "$timestamp": { "t": 0, "i": 12345 } },
-  "local_timestamp_rand_explicit_id": { "$timestamp": { "t": 0, "i": 12345 } },
-  "local_timestamp_rand_explicit_altname": {
-    "$timestamp": { "t": 0, "i": 12345 }
-  },
-  "local_timestamp_det_auto_id": { "$timestamp": { "t": 0, "i": 12345 } },
-  "local_timestamp_det_auto_altname": { "$timestamp": { "t": 0, "i": 12345 } },
-  "local_timestamp_det_explicit_id": { "$timestamp": { "t": 0, "i": 12345 } },
-  "local_timestamp_det_explicit_altname": {
-    "$timestamp": { "t": 0, "i": 12345 }
-  },
-  "local_long_rand_auto_id": { "$numberLong": "456" },
-  "local_long_rand_auto_altname": { "$numberLong": "456" },
-  "local_long_rand_explicit_id": { "$numberLong": "456" },
-  "local_long_rand_explicit_altname": { "$numberLong": "456" },
-  "local_long_det_auto_id": { "$numberLong": "456" },
-  "local_long_det_auto_altname": { "$numberLong": "456" },
-  "local_long_det_explicit_id": { "$numberLong": "456" },
-  "local_long_det_explicit_altname": { "$numberLong": "456" },
-  "local_decimal_rand_auto_id": { "$numberDecimal": "1.234" },
-  "local_decimal_rand_auto_altname": { "$numberDecimal": "1.234" },
-  "local_decimal_rand_explicit_id": { "$numberDecimal": "1.234" },
-  "local_decimal_rand_explicit_altname": { "$numberDecimal": "1.234" },
-  "local_decimal_det_prohibited_id": { "$numberDecimal": "1.234" },
-  "local_minKey_rand_prohibited_id": { "$minKey": 1 },
-  "local_minKey_det_prohibited_id": { "$minKey": 1 },
-  "local_maxKey_rand_prohibited_id": { "$maxKey": 1 },
-  "local_maxKey_det_prohibited_id": { "$maxKey": 1 }
-}
+{ "_id": "client_side_encryption_corpus" ,
+  "altname_aws": "aws" ,
+  "altname_local": "local" ,
+  "aws_double_rand_auto_id" : { "kms": "aws", "type": "double", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value": { "$numberDouble" : "1.234" } },
+  "aws_double_rand_auto_altname" : { "kms": "aws", "type": "double", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value": { "$numberDouble" : "1.234" } },
+  "aws_double_rand_explicit_id" : { "kms": "aws", "type": "double", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value": { "$numberDouble" : "1.234" } },
+  "aws_double_rand_explicit_altname" : { "kms": "aws", "type": "double", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value": { "$numberDouble" : "1.234" } },
+  "aws_double_det_explicit_id" : { "kms": "aws", "type": "double", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": { "$numberDouble" : "1.234" } },
+  "aws_double_det_explicit_altname" : { "kms": "aws", "type": "double", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": { "$numberDouble" : "1.234" } },
+  "aws_string_rand_auto_id" : { "kms": "aws", "type": "string", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  "mongodb"  },
+  "aws_string_rand_auto_altname" : { "kms": "aws", "type": "string", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
+  "aws_string_rand_explicit_id" : { "kms": "aws", "type": "string", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  "mongodb"  },
+  "aws_string_rand_explicit_altname" : { "kms": "aws", "type": "string", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
+  "aws_string_det_auto_id" : { "kms": "aws", "type": "string", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  "mongodb"  },
+  "aws_string_det_auto_altname" : { "kms": "aws", "type": "string", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
+  "aws_string_det_explicit_id" : { "kms": "aws", "type": "string", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  "mongodb"  },
+  "aws_string_det_explicit_altname" : { "kms": "aws", "type": "string", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
+  "aws_object_rand_auto_id" : { "kms": "aws", "type": "object", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
+  "aws_object_rand_auto_altname" : { "kms": "aws", "type": "object", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
+  "aws_object_rand_explicit_id" : { "kms": "aws", "type": "object", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
+  "aws_object_rand_explicit_altname" : { "kms": "aws", "type": "object", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
+  "aws_object_det_explicit_id" : { "kms": "aws", "type": "object", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "x" : { "$numberInt": "1" } }  },
+  "aws_object_det_explicit_altname" : { "kms": "aws", "type": "object", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "x" : { "$numberInt": "1" } }  },
+  "aws_array_rand_auto_id" : { "kms": "aws", "type": "array", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "aws_array_rand_auto_altname" : { "kms": "aws", "type": "array", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "aws_array_rand_explicit_id" : { "kms": "aws", "type": "array", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "aws_array_rand_explicit_altname" : { "kms": "aws", "type": "array", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "aws_array_det_explicit_id" : { "kms": "aws", "type": "array", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "aws_array_det_explicit_altname" : { "kms": "aws", "type": "array", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "aws_binData=00_rand_auto_id" : { "kms": "aws", "type": "binData=00", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "aws_binData=00_rand_auto_altname" : { "kms": "aws", "type": "binData=00", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "aws_binData=00_rand_explicit_id" : { "kms": "aws", "type": "binData=00", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "aws_binData=00_rand_explicit_altname" : { "kms": "aws", "type": "binData=00", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "aws_binData=00_det_auto_id" : { "kms": "aws", "type": "binData=00", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "aws_binData=00_det_auto_altname" : { "kms": "aws", "type": "binData=00", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "aws_binData=00_det_explicit_id" : { "kms": "aws", "type": "binData=00", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "aws_binData=00_det_explicit_altname" : { "kms": "aws", "type": "binData=00", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "aws_binData=04_rand_auto_id" : { "kms": "aws", "type": "binData=04", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "aws_binData=04_rand_auto_altname" : { "kms": "aws", "type": "binData=04", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "aws_binData=04_rand_explicit_id" : { "kms": "aws", "type": "binData=04", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "aws_binData=04_rand_explicit_altname" : { "kms": "aws", "type": "binData=04", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "aws_binData=04_det_auto_id" : { "kms": "aws", "type": "binData=04", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "aws_binData=04_det_auto_altname" : { "kms": "aws", "type": "binData=04", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "aws_binData=04_det_explicit_id" : { "kms": "aws", "type": "binData=04", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "aws_binData=04_det_explicit_altname" : { "kms": "aws", "type": "binData=04", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "aws_undefined_rand_explicit_id" : { "kms": "aws", "type": "undefined", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value":  {"$undefined": true}  },
+  "aws_undefined_rand_explicit_altname" : { "kms": "aws", "type": "undefined", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value":  {"$undefined": true}  },
+  "aws_undefined_det_explicit_id" : { "kms": "aws", "type": "undefined", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  {"$undefined": true}  },
+  "aws_undefined_det_explicit_altname" : { "kms": "aws", "type": "undefined", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  {"$undefined": true}  },
+  "aws_objectId_rand_auto_id" : { "kms": "aws", "type": "objectId", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "aws_objectId_rand_auto_altname" : { "kms": "aws", "type": "objectId", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "aws_objectId_rand_explicit_id" : { "kms": "aws", "type": "objectId", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "aws_objectId_rand_explicit_altname" : { "kms": "aws", "type": "objectId", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "aws_objectId_det_auto_id" : { "kms": "aws", "type": "objectId", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "aws_objectId_det_auto_altname" : { "kms": "aws", "type": "objectId", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "aws_objectId_det_explicit_id" : { "kms": "aws", "type": "objectId", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "aws_objectId_det_explicit_altname" : { "kms": "aws", "type": "objectId", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "aws_bool_rand_auto_id" : { "kms": "aws", "type": "bool", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  true  },
+  "aws_bool_rand_auto_altname" : { "kms": "aws", "type": "bool", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  true  },
+  "aws_bool_rand_explicit_id" : { "kms": "aws", "type": "bool", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  true  },
+  "aws_bool_rand_explicit_altname" : { "kms": "aws", "type": "bool", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  true  },
+  "aws_bool_det_explicit_id" : { "kms": "aws", "type": "bool", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  true  },
+  "aws_bool_det_explicit_altname" : { "kms": "aws", "type": "bool", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  true  },
+  "aws_date_rand_auto_id" : { "kms": "aws", "type": "date", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "aws_date_rand_auto_altname" : { "kms": "aws", "type": "date", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "aws_date_rand_explicit_id" : { "kms": "aws", "type": "date", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "aws_date_rand_explicit_altname" : { "kms": "aws", "type": "date", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "aws_date_det_auto_id" : { "kms": "aws", "type": "date", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "aws_date_det_auto_altname" : { "kms": "aws", "type": "date", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "aws_date_det_explicit_id" : { "kms": "aws", "type": "date", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "aws_date_det_explicit_altname" : { "kms": "aws", "type": "date", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "aws_null_rand_explicit_id" : { "kms": "aws", "type": "null", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": null },
+  "aws_null_rand_explicit_altname" : { "kms": "aws", "type": "null", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": null },
+  "aws_null_det_explicit_id" : { "kms": "aws", "type": "null", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": null },
+  "aws_null_det_explicit_altname" : { "kms": "aws", "type": "null", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": null },
+  "aws_regex_rand_auto_id" : { "kms": "aws", "type": "regex", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "aws_regex_rand_auto_altname" : { "kms": "aws", "type": "regex", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "aws_regex_rand_explicit_id" : { "kms": "aws", "type": "regex", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "aws_regex_rand_explicit_altname" : { "kms": "aws", "type": "regex", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "aws_regex_det_auto_id" : { "kms": "aws", "type": "regex", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "aws_regex_det_auto_altname" : { "kms": "aws", "type": "regex", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "aws_regex_det_explicit_id" : { "kms": "aws", "type": "regex", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "aws_regex_det_explicit_altname" : { "kms": "aws", "type": "regex", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "aws_dbPointer_rand_auto_id" : { "kms": "aws", "type": "dbPointer", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "aws_dbPointer_rand_auto_altname" : { "kms": "aws", "type": "dbPointer", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "aws_dbPointer_rand_explicit_id" : { "kms": "aws", "type": "dbPointer", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "aws_dbPointer_rand_explicit_altname" : { "kms": "aws", "type": "dbPointer", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "aws_dbPointer_det_auto_id" : { "kms": "aws", "type": "dbPointer", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "aws_dbPointer_det_auto_altname" : { "kms": "aws", "type": "dbPointer", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "aws_dbPointer_det_explicit_id" : { "kms": "aws", "type": "dbPointer", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "aws_dbPointer_det_explicit_altname" : { "kms": "aws", "type": "dbPointer", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "aws_javascript_rand_auto_id" : { "kms": "aws", "type": "javascript", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
+  "aws_javascript_rand_auto_altname" : { "kms": "aws", "type": "javascript", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
+  "aws_javascript_rand_explicit_id" : { "kms": "aws", "type": "javascript", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
+  "aws_javascript_rand_explicit_altname" : { "kms": "aws", "type": "javascript", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
+  "aws_javascript_det_auto_id" : { "kms": "aws", "type": "javascript", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
+  "aws_javascript_det_auto_altname" : { "kms": "aws", "type": "javascript", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
+  "aws_javascript_det_explicit_id" : { "kms": "aws", "type": "javascript", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
+  "aws_javascript_det_explicit_altname" : { "kms": "aws", "type": "javascript", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
+  "aws_symbol_rand_auto_id" : { "kms": "aws", "type": "symbol", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "aws_symbol_rand_auto_altname" : { "kms": "aws", "type": "symbol", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "aws_symbol_rand_explicit_id" : { "kms": "aws", "type": "symbol", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "aws_symbol_rand_explicit_altname" : { "kms": "aws", "type": "symbol", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "aws_symbol_det_auto_id" : { "kms": "aws", "type": "symbol", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "aws_symbol_det_auto_altname" : { "kms": "aws", "type": "symbol", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "aws_symbol_det_explicit_id" : { "kms": "aws", "type": "symbol", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "aws_symbol_det_explicit_altname" : { "kms": "aws", "type": "symbol", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "aws_javascriptWithScope_rand_auto_id" : { "kms": "aws", "type": "javascriptWithScope", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
+  "aws_javascriptWithScope_rand_auto_altname" : { "kms": "aws", "type": "javascriptWithScope", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
+  "aws_javascriptWithScope_rand_explicit_id" : { "kms": "aws", "type": "javascriptWithScope", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
+  "aws_javascriptWithScope_rand_explicit_altname" : { "kms": "aws", "type": "javascriptWithScope", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
+  "aws_javascriptWithScope_det_explicit_id" : { "kms": "aws", "type": "javascriptWithScope", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "$code": "x=1", "$scope": {} }  },
+  "aws_javascriptWithScope_det_explicit_altname" : { "kms": "aws", "type": "javascriptWithScope", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "$code": "x=1", "$scope": {} }  },
+  "aws_int_rand_auto_id" : { "kms": "aws", "type": "int", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "aws_int_rand_auto_altname" : { "kms": "aws", "type": "int", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "aws_int_rand_explicit_id" : { "kms": "aws", "type": "int", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "aws_int_rand_explicit_altname" : { "kms": "aws", "type": "int", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "aws_int_det_auto_id" : { "kms": "aws", "type": "int", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "aws_int_det_auto_altname" : { "kms": "aws", "type": "int", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "aws_int_det_explicit_id" : { "kms": "aws", "type": "int", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "aws_int_det_explicit_altname" : { "kms": "aws", "type": "int", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "aws_timestamp_rand_auto_id" : { "kms": "aws", "type": "timestamp", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "aws_timestamp_rand_auto_altname" : { "kms": "aws", "type": "timestamp", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "aws_timestamp_rand_explicit_id" : { "kms": "aws", "type": "timestamp", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "aws_timestamp_rand_explicit_altname" : { "kms": "aws", "type": "timestamp", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "aws_timestamp_det_auto_id" : { "kms": "aws", "type": "timestamp", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "aws_timestamp_det_auto_altname" : { "kms": "aws", "type": "timestamp", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "aws_timestamp_det_explicit_id" : { "kms": "aws", "type": "timestamp", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "aws_timestamp_det_explicit_altname" : { "kms": "aws", "type": "timestamp", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "aws_long_rand_auto_id" : { "kms": "aws", "type": "long", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "aws_long_rand_auto_altname" : { "kms": "aws", "type": "long", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "aws_long_rand_explicit_id" : { "kms": "aws", "type": "long", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "aws_long_rand_explicit_altname" : { "kms": "aws", "type": "long", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "aws_long_det_auto_id" : { "kms": "aws", "type": "long", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "aws_long_det_auto_altname" : { "kms": "aws", "type": "long", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "aws_long_det_explicit_id" : { "kms": "aws", "type": "long", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "aws_long_det_explicit_altname" : { "kms": "aws", "type": "long", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "aws_decimal_rand_auto_id" : { "kms": "aws", "type": "decimal", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
+  "aws_decimal_rand_auto_altname" : { "kms": "aws", "type": "decimal", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
+  "aws_decimal_rand_explicit_id" : { "kms": "aws", "type": "decimal", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
+  "aws_decimal_rand_explicit_altname" : { "kms": "aws", "type": "decimal", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
+  "aws_decimal_det_explicit_id" : { "kms": "aws", "type": "decimal", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "$numberDecimal": "1.234" }  },
+  "aws_decimal_det_explicit_altname" : { "kms": "aws", "type": "decimal", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "$numberDecimal": "1.234" }  },
+  "aws_minKey_rand_explicit_id" : { "kms": "aws", "type": "minKey", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$minKey": 1} },
+  "aws_minKey_rand_explicit_altname" : { "kms": "aws", "type": "minKey", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$minKey": 1} },
+  "aws_minKey_det_explicit_id" : { "kms": "aws", "type": "minKey", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$minKey": 1} },
+  "aws_minKey_det_explicit_altname" : { "kms": "aws", "type": "minKey", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$minKey": 1} },
+  "aws_maxKey_rand_explicit_id" : { "kms": "aws", "type": "maxKey", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$maxKey": 1} },
+  "aws_maxKey_rand_explicit_altname" : { "kms": "aws", "type": "maxKey", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$maxKey": 1} },
+  "aws_maxKey_det_explicit_id" : { "kms": "aws", "type": "maxKey", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$maxKey": 1} },
+  "aws_maxKey_det_explicit_altname" : { "kms": "aws", "type": "maxKey", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$maxKey": 1} },
+  "local_double_rand_auto_id" : { "kms": "local", "type": "double", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value": { "$numberDouble" : "1.234" } },
+  "local_double_rand_auto_altname" : { "kms": "local", "type": "double", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value": { "$numberDouble" : "1.234" } },
+  "local_double_rand_explicit_id" : { "kms": "local", "type": "double", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value": { "$numberDouble" : "1.234" } },
+  "local_double_rand_explicit_altname" : { "kms": "local", "type": "double", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value": { "$numberDouble" : "1.234" } },
+  "local_double_det_explicit_id" : { "kms": "local", "type": "double", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": { "$numberDouble" : "1.234" } },
+  "local_double_det_explicit_altname" : { "kms": "local", "type": "double", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": { "$numberDouble" : "1.234" } },
+  "local_string_rand_auto_id" : { "kms": "local", "type": "string", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  "mongodb"  },
+  "local_string_rand_auto_altname" : { "kms": "local", "type": "string", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
+  "local_string_rand_explicit_id" : { "kms": "local", "type": "string", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  "mongodb"  },
+  "local_string_rand_explicit_altname" : { "kms": "local", "type": "string", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
+  "local_string_det_auto_id" : { "kms": "local", "type": "string", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  "mongodb"  },
+  "local_string_det_auto_altname" : { "kms": "local", "type": "string", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
+  "local_string_det_explicit_id" : { "kms": "local", "type": "string", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  "mongodb"  },
+  "local_string_det_explicit_altname" : { "kms": "local", "type": "string", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
+  "local_object_rand_auto_id" : { "kms": "local", "type": "object", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
+  "local_object_rand_auto_altname" : { "kms": "local", "type": "object", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
+  "local_object_rand_explicit_id" : { "kms": "local", "type": "object", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
+  "local_object_rand_explicit_altname" : { "kms": "local", "type": "object", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
+  "local_object_det_explicit_id" : { "kms": "local", "type": "object", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "x" : { "$numberInt": "1" } }  },
+  "local_object_det_explicit_altname" : { "kms": "local", "type": "object", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "x" : { "$numberInt": "1" } }  },
+  "local_array_rand_auto_id" : { "kms": "local", "type": "array", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "local_array_rand_auto_altname" : { "kms": "local", "type": "array", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "local_array_rand_explicit_id" : { "kms": "local", "type": "array", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "local_array_rand_explicit_altname" : { "kms": "local", "type": "array", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "local_array_det_explicit_id" : { "kms": "local", "type": "array", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "local_array_det_explicit_altname" : { "kms": "local", "type": "array", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
+  "local_binData=00_rand_auto_id" : { "kms": "local", "type": "binData=00", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "local_binData=00_rand_auto_altname" : { "kms": "local", "type": "binData=00", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "local_binData=00_rand_explicit_id" : { "kms": "local", "type": "binData=00", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "local_binData=00_rand_explicit_altname" : { "kms": "local", "type": "binData=00", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "local_binData=00_det_auto_id" : { "kms": "local", "type": "binData=00", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "local_binData=00_det_auto_altname" : { "kms": "local", "type": "binData=00", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "local_binData=00_det_explicit_id" : { "kms": "local", "type": "binData=00", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "local_binData=00_det_explicit_altname" : { "kms": "local", "type": "binData=00", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
+  "local_binData=04_rand_auto_id" : { "kms": "local", "type": "binData=04", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "local_binData=04_rand_auto_altname" : { "kms": "local", "type": "binData=04", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "local_binData=04_rand_explicit_id" : { "kms": "local", "type": "binData=04", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "local_binData=04_rand_explicit_altname" : { "kms": "local", "type": "binData=04", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "local_binData=04_det_auto_id" : { "kms": "local", "type": "binData=04", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "local_binData=04_det_auto_altname" : { "kms": "local", "type": "binData=04", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "local_binData=04_det_explicit_id" : { "kms": "local", "type": "binData=04", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "local_binData=04_det_explicit_altname" : { "kms": "local", "type": "binData=04", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
+  "local_undefined_rand_explicit_id" : { "kms": "local", "type": "undefined", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value":  {"$undefined": true}  },
+  "local_undefined_rand_explicit_altname" : { "kms": "local", "type": "undefined", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value":  {"$undefined": true}  },
+  "local_undefined_det_explicit_id" : { "kms": "local", "type": "undefined", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  {"$undefined": true}  },
+  "local_undefined_det_explicit_altname" : { "kms": "local", "type": "undefined", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  {"$undefined": true}  },
+  "local_objectId_rand_auto_id" : { "kms": "local", "type": "objectId", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "local_objectId_rand_auto_altname" : { "kms": "local", "type": "objectId", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "local_objectId_rand_explicit_id" : { "kms": "local", "type": "objectId", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "local_objectId_rand_explicit_altname" : { "kms": "local", "type": "objectId", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "local_objectId_det_auto_id" : { "kms": "local", "type": "objectId", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "local_objectId_det_auto_altname" : { "kms": "local", "type": "objectId", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "local_objectId_det_explicit_id" : { "kms": "local", "type": "objectId", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "local_objectId_det_explicit_altname" : { "kms": "local", "type": "objectId", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
+  "local_bool_rand_auto_id" : { "kms": "local", "type": "bool", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  true  },
+  "local_bool_rand_auto_altname" : { "kms": "local", "type": "bool", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  true  },
+  "local_bool_rand_explicit_id" : { "kms": "local", "type": "bool", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  true  },
+  "local_bool_rand_explicit_altname" : { "kms": "local", "type": "bool", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  true  },
+  "local_bool_det_explicit_id" : { "kms": "local", "type": "bool", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  true  },
+  "local_bool_det_explicit_altname" : { "kms": "local", "type": "bool", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  true  },
+  "local_date_rand_auto_id" : { "kms": "local", "type": "date", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "local_date_rand_auto_altname" : { "kms": "local", "type": "date", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "local_date_rand_explicit_id" : { "kms": "local", "type": "date", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "local_date_rand_explicit_altname" : { "kms": "local", "type": "date", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "local_date_det_auto_id" : { "kms": "local", "type": "date", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "local_date_det_auto_altname" : { "kms": "local", "type": "date", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "local_date_det_explicit_id" : { "kms": "local", "type": "date", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "local_date_det_explicit_altname" : { "kms": "local", "type": "date", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
+  "local_null_rand_explicit_id" : { "kms": "local", "type": "null", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": null },
+  "local_null_rand_explicit_altname" : { "kms": "local", "type": "null", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": null },
+  "local_null_det_explicit_id" : { "kms": "local", "type": "null", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": null },
+  "local_null_det_explicit_altname" : { "kms": "local", "type": "null", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": null },
+  "local_regex_rand_auto_id" : { "kms": "local", "type": "regex", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "local_regex_rand_auto_altname" : { "kms": "local", "type": "regex", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "local_regex_rand_explicit_id" : { "kms": "local", "type": "regex", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "local_regex_rand_explicit_altname" : { "kms": "local", "type": "regex", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "local_regex_det_auto_id" : { "kms": "local", "type": "regex", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "local_regex_det_auto_altname" : { "kms": "local", "type": "regex", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "local_regex_det_explicit_id" : { "kms": "local", "type": "regex", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "local_regex_det_explicit_altname" : { "kms": "local", "type": "regex", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
+  "local_dbPointer_rand_auto_id" : { "kms": "local", "type": "dbPointer", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "local_dbPointer_rand_auto_altname" : { "kms": "local", "type": "dbPointer", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "local_dbPointer_rand_explicit_id" : { "kms": "local", "type": "dbPointer", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "local_dbPointer_rand_explicit_altname" : { "kms": "local", "type": "dbPointer", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "local_dbPointer_det_auto_id" : { "kms": "local", "type": "dbPointer", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "local_dbPointer_det_auto_altname" : { "kms": "local", "type": "dbPointer", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "local_dbPointer_det_explicit_id" : { "kms": "local", "type": "dbPointer", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "local_dbPointer_det_explicit_altname" : { "kms": "local", "type": "dbPointer", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
+  "local_javascript_rand_auto_id" : { "kms": "local", "type": "javascript", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
+  "local_javascript_rand_auto_altname" : { "kms": "local", "type": "javascript", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
+  "local_javascript_rand_explicit_id" : { "kms": "local", "type": "javascript", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
+  "local_javascript_rand_explicit_altname" : { "kms": "local", "type": "javascript", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
+  "local_javascript_det_auto_id" : { "kms": "local", "type": "javascript", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
+  "local_javascript_det_auto_altname" : { "kms": "local", "type": "javascript", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
+  "local_javascript_det_explicit_id" : { "kms": "local", "type": "javascript", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
+  "local_javascript_det_explicit_altname" : { "kms": "local", "type": "javascript", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
+  "local_symbol_rand_auto_id" : { "kms": "local", "type": "symbol", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "local_symbol_rand_auto_altname" : { "kms": "local", "type": "symbol", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "local_symbol_rand_explicit_id" : { "kms": "local", "type": "symbol", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "local_symbol_rand_explicit_altname" : { "kms": "local", "type": "symbol", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "local_symbol_det_auto_id" : { "kms": "local", "type": "symbol", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "local_symbol_det_auto_altname" : { "kms": "local", "type": "symbol", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "local_symbol_det_explicit_id" : { "kms": "local", "type": "symbol", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "local_symbol_det_explicit_altname" : { "kms": "local", "type": "symbol", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
+  "local_javascriptWithScope_rand_auto_id" : { "kms": "local", "type": "javascriptWithScope", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
+  "local_javascriptWithScope_rand_auto_altname" : { "kms": "local", "type": "javascriptWithScope", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
+  "local_javascriptWithScope_rand_explicit_id" : { "kms": "local", "type": "javascriptWithScope", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
+  "local_javascriptWithScope_rand_explicit_altname" : { "kms": "local", "type": "javascriptWithScope", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
+  "local_javascriptWithScope_det_explicit_id" : { "kms": "local", "type": "javascriptWithScope", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "$code": "x=1", "$scope": {} }  },
+  "local_javascriptWithScope_det_explicit_altname" : { "kms": "local", "type": "javascriptWithScope", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "$code": "x=1", "$scope": {} }  },
+  "local_int_rand_auto_id" : { "kms": "local", "type": "int", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "local_int_rand_auto_altname" : { "kms": "local", "type": "int", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "local_int_rand_explicit_id" : { "kms": "local", "type": "int", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "local_int_rand_explicit_altname" : { "kms": "local", "type": "int", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "local_int_det_auto_id" : { "kms": "local", "type": "int", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "local_int_det_auto_altname" : { "kms": "local", "type": "int", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "local_int_det_explicit_id" : { "kms": "local", "type": "int", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "local_int_det_explicit_altname" : { "kms": "local", "type": "int", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
+  "local_timestamp_rand_auto_id" : { "kms": "local", "type": "timestamp", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "local_timestamp_rand_auto_altname" : { "kms": "local", "type": "timestamp", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "local_timestamp_rand_explicit_id" : { "kms": "local", "type": "timestamp", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "local_timestamp_rand_explicit_altname" : { "kms": "local", "type": "timestamp", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "local_timestamp_det_auto_id" : { "kms": "local", "type": "timestamp", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "local_timestamp_det_auto_altname" : { "kms": "local", "type": "timestamp", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "local_timestamp_det_explicit_id" : { "kms": "local", "type": "timestamp", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "local_timestamp_det_explicit_altname" : { "kms": "local", "type": "timestamp", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
+  "local_long_rand_auto_id" : { "kms": "local", "type": "long", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "local_long_rand_auto_altname" : { "kms": "local", "type": "long", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "local_long_rand_explicit_id" : { "kms": "local", "type": "long", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "local_long_rand_explicit_altname" : { "kms": "local", "type": "long", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "local_long_det_auto_id" : { "kms": "local", "type": "long", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "local_long_det_auto_altname" : { "kms": "local", "type": "long", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "local_long_det_explicit_id" : { "kms": "local", "type": "long", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "local_long_det_explicit_altname" : { "kms": "local", "type": "long", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
+  "local_decimal_rand_auto_id" : { "kms": "local", "type": "decimal", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
+  "local_decimal_rand_auto_altname" : { "kms": "local", "type": "decimal", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
+  "local_decimal_rand_explicit_id" : { "kms": "local", "type": "decimal", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
+  "local_decimal_rand_explicit_altname" : { "kms": "local", "type": "decimal", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
+  "local_decimal_det_explicit_id" : { "kms": "local", "type": "decimal", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "$numberDecimal": "1.234" }  },
+  "local_decimal_det_explicit_altname" : { "kms": "local", "type": "decimal", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "$numberDecimal": "1.234" }  },
+  "local_minKey_rand_explicit_id" : { "kms": "local", "type": "minKey", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$minKey": 1} },
+  "local_minKey_rand_explicit_altname" : { "kms": "local", "type": "minKey", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$minKey": 1} },
+  "local_minKey_det_explicit_id" : { "kms": "local", "type": "minKey", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$minKey": 1} },
+  "local_minKey_det_explicit_altname" : { "kms": "local", "type": "minKey", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$minKey": 1} },
+  "local_maxKey_rand_explicit_id" : { "kms": "local", "type": "maxKey", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$maxKey": 1} },
+  "local_maxKey_rand_explicit_altname" : { "kms": "local", "type": "maxKey", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$maxKey": 1} },
+  "local_maxKey_det_explicit_id" : { "kms": "local", "type": "maxKey", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$maxKey": 1} },
+  "local_maxKey_det_explicit_altname" : { "kms": "local", "type": "maxKey", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$maxKey": 1} }}

--- a/source/client-side-encryption/corpus/corpus.json
+++ b/source/client-side-encryption/corpus/corpus.json
@@ -2,10 +2,11 @@
   "_id": "client_side_encryption_corpus",
   "altname_aws": "aws",
   "altname_local": "local",
-  "aws_double_rand_auto_id": { "$numberDouble": "1.234" },
-  "aws_double_rand_auto_altname": { "$numberDouble": "1.234" },
-  "aws_double_rand_explicit_id": { "$numberDouble": "1.234" },
-  "aws_double_rand_explicit_altname": { "$numberDouble": "1.234" },
+  "aws_double_rand_auto_id": { "$numberDouble": 1.234 },
+  "aws_double_rand_auto_altname": { "$numberDouble": 1.234 },
+  "aws_double_rand_explicit_id": { "$numberDouble": 1.234 },
+  "aws_double_rand_explicit_altname": { "$numberDouble": 1.234 },
+  "aws_double_det_prohibited_id": { "$numberDouble": 1.234 },
   "aws_string_rand_auto_id": "mongodb",
   "aws_string_rand_auto_altname": "mongodb",
   "aws_string_rand_explicit_id": "mongodb",
@@ -14,29 +15,35 @@
   "aws_string_det_auto_altname": "mongodb",
   "aws_string_det_explicit_id": "mongodb",
   "aws_string_det_explicit_altname": "mongodb",
-  "aws_object_rand_auto_id": { "x": { "$numberInt": "1" } },
-  "aws_object_rand_auto_altname": { "x": { "$numberInt": "1" } },
-  "aws_object_rand_explicit_id": { "x": { "$numberInt": "1" } },
-  "aws_object_rand_explicit_altname": { "x": { "$numberInt": "1" } },
+  "aws_object_rand_auto_id": { "x": { "$numberInt": 1 } },
+  "aws_object_rand_auto_altname": { "x": { "$numberInt": 1 } },
+  "aws_object_rand_explicit_id": { "x": { "$numberInt": 1 } },
+  "aws_object_rand_explicit_altname": { "x": { "$numberInt": 1 } },
+  "aws_object_det_prohibited_id": { "x": { "$numberInt": 1 } },
   "aws_array_rand_auto_id": [
-    { "$numberInt": "3" },
-    { "$numberInt": "2" },
-    { "$numberInt": "1" }
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
   ],
   "aws_array_rand_auto_altname": [
-    { "$numberInt": "3" },
-    { "$numberInt": "2" },
-    { "$numberInt": "1" }
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
   ],
   "aws_array_rand_explicit_id": [
-    { "$numberInt": "3" },
-    { "$numberInt": "2" },
-    { "$numberInt": "1" }
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
   ],
   "aws_array_rand_explicit_altname": [
-    { "$numberInt": "3" },
-    { "$numberInt": "2" },
-    { "$numberInt": "1" }
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
+  ],
+  "aws_array_det_prohibited_id": [
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
   ],
   "aws_binData=00_rand_auto_id": {
     "$binary": { "base64": "AQIDBA==", "subType": "00" }
@@ -86,6 +93,8 @@
   "aws_binData=04_det_explicit_altname": {
     "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
   },
+  "aws_undefined_rand_prohibited_id": { "$undefined": true },
+  "aws_undefined_det_prohibited_id": { "$undefined": true },
   "aws_objectId_rand_auto_id": { "$oid": "01234567890abcdef0123456" },
   "aws_objectId_rand_auto_altname": { "$oid": "01234567890abcdef0123456" },
   "aws_objectId_rand_explicit_id": { "$oid": "01234567890abcdef0123456" },
@@ -98,6 +107,7 @@
   "aws_bool_rand_auto_altname": true,
   "aws_bool_rand_explicit_id": true,
   "aws_bool_rand_explicit_altname": true,
+  "aws_bool_det_prohibited_id": true,
   "aws_date_rand_auto_id": { "$date": { "$numberLong": "12345" } },
   "aws_date_rand_auto_altname": { "$date": { "$numberLong": "12345" } },
   "aws_date_rand_explicit_id": { "$date": { "$numberLong": "12345" } },
@@ -106,6 +116,8 @@
   "aws_date_det_auto_altname": { "$date": { "$numberLong": "12345" } },
   "aws_date_det_explicit_id": { "$date": { "$numberLong": "12345" } },
   "aws_date_det_explicit_altname": { "$date": { "$numberLong": "12345" } },
+  "aws_null_rand_prohibited_id": null,
+  "aws_null_det_prohibited_id": null,
   "aws_regex_rand_auto_id": {
     "$regularExpression": { "pattern": ".*", "options": "" }
   },
@@ -131,57 +143,42 @@
     "$regularExpression": { "pattern": ".*", "options": "" }
   },
   "aws_dbPointer_rand_auto_id": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "aws_dbPointer_rand_auto_altname": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "aws_dbPointer_rand_explicit_id": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "aws_dbPointer_rand_explicit_altname": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "aws_dbPointer_det_auto_id": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "aws_dbPointer_det_auto_altname": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "aws_dbPointer_det_explicit_id": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "aws_dbPointer_det_explicit_altname": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "aws_javascript_rand_auto_id": { "$code": "x=1" },
   "aws_javascript_rand_auto_altname": { "$code": "x=1" },
   "aws_javascript_rand_explicit_id": { "$code": "x=1" },
   "aws_javascript_rand_explicit_altname": { "$code": "x=1" },
+  "aws_javascript_det_prohibited_id": { "$code": "x=1" },
   "aws_symbol_rand_auto_id": { "$symbol": "mongodb-symbol" },
   "aws_symbol_rand_auto_altname": { "$symbol": "mongodb-symbol" },
   "aws_symbol_rand_explicit_id": { "$symbol": "mongodb-symbol" },
@@ -197,6 +194,7 @@
     "$code": "x=1",
     "$scope": {}
   },
+  "aws_javascriptWithScope_det_prohibited_id": { "$code": "x=1", "$scope": {} },
   "aws_int_rand_auto_id": { "$numberInt": "123" },
   "aws_int_rand_auto_altname": { "$numberInt": "123" },
   "aws_int_rand_explicit_id": { "$numberInt": "123" },
@@ -229,10 +227,16 @@
   "aws_decimal_rand_auto_altname": { "$numberDecimal": "1.234" },
   "aws_decimal_rand_explicit_id": { "$numberDecimal": "1.234" },
   "aws_decimal_rand_explicit_altname": { "$numberDecimal": "1.234" },
-  "local_double_rand_auto_id": { "$numberDouble": "1.234" },
-  "local_double_rand_auto_altname": { "$numberDouble": "1.234" },
-  "local_double_rand_explicit_id": { "$numberDouble": "1.234" },
-  "local_double_rand_explicit_altname": { "$numberDouble": "1.234" },
+  "aws_decimal_det_prohibited_id": { "$numberDecimal": "1.234" },
+  "aws_minKey_rand_prohibited_id": { "$minKey": 1 },
+  "aws_minKey_det_prohibited_id": { "$minKey": 1 },
+  "aws_maxKey_rand_prohibited_id": { "$maxKey": 1 },
+  "aws_maxKey_det_prohibited_id": { "$maxKey": 1 },
+  "local_double_rand_auto_id": { "$numberDouble": 1.234 },
+  "local_double_rand_auto_altname": { "$numberDouble": 1.234 },
+  "local_double_rand_explicit_id": { "$numberDouble": 1.234 },
+  "local_double_rand_explicit_altname": { "$numberDouble": 1.234 },
+  "local_double_det_prohibited_id": { "$numberDouble": 1.234 },
   "local_string_rand_auto_id": "mongodb",
   "local_string_rand_auto_altname": "mongodb",
   "local_string_rand_explicit_id": "mongodb",
@@ -241,29 +245,35 @@
   "local_string_det_auto_altname": "mongodb",
   "local_string_det_explicit_id": "mongodb",
   "local_string_det_explicit_altname": "mongodb",
-  "local_object_rand_auto_id": { "x": { "$numberInt": "1" } },
-  "local_object_rand_auto_altname": { "x": { "$numberInt": "1" } },
-  "local_object_rand_explicit_id": { "x": { "$numberInt": "1" } },
-  "local_object_rand_explicit_altname": { "x": { "$numberInt": "1" } },
+  "local_object_rand_auto_id": { "x": { "$numberInt": 1 } },
+  "local_object_rand_auto_altname": { "x": { "$numberInt": 1 } },
+  "local_object_rand_explicit_id": { "x": { "$numberInt": 1 } },
+  "local_object_rand_explicit_altname": { "x": { "$numberInt": 1 } },
+  "local_object_det_prohibited_id": { "x": { "$numberInt": 1 } },
   "local_array_rand_auto_id": [
-    { "$numberInt": "3" },
-    { "$numberInt": "2" },
-    { "$numberInt": "1" }
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
   ],
   "local_array_rand_auto_altname": [
-    { "$numberInt": "3" },
-    { "$numberInt": "2" },
-    { "$numberInt": "1" }
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
   ],
   "local_array_rand_explicit_id": [
-    { "$numberInt": "3" },
-    { "$numberInt": "2" },
-    { "$numberInt": "1" }
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
   ],
   "local_array_rand_explicit_altname": [
-    { "$numberInt": "3" },
-    { "$numberInt": "2" },
-    { "$numberInt": "1" }
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
+  ],
+  "local_array_det_prohibited_id": [
+    { "$numberInt": 1 },
+    { "$numberInt": 2 },
+    { "$numberInt": 3 }
   ],
   "local_binData=00_rand_auto_id": {
     "$binary": { "base64": "AQIDBA==", "subType": "00" }
@@ -313,6 +323,8 @@
   "local_binData=04_det_explicit_altname": {
     "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
   },
+  "local_undefined_rand_prohibited_id": { "$undefined": true },
+  "local_undefined_det_prohibited_id": { "$undefined": true },
   "local_objectId_rand_auto_id": { "$oid": "01234567890abcdef0123456" },
   "local_objectId_rand_auto_altname": { "$oid": "01234567890abcdef0123456" },
   "local_objectId_rand_explicit_id": { "$oid": "01234567890abcdef0123456" },
@@ -327,6 +339,7 @@
   "local_bool_rand_auto_altname": true,
   "local_bool_rand_explicit_id": true,
   "local_bool_rand_explicit_altname": true,
+  "local_bool_det_prohibited_id": true,
   "local_date_rand_auto_id": { "$date": { "$numberLong": "12345" } },
   "local_date_rand_auto_altname": { "$date": { "$numberLong": "12345" } },
   "local_date_rand_explicit_id": { "$date": { "$numberLong": "12345" } },
@@ -335,6 +348,8 @@
   "local_date_det_auto_altname": { "$date": { "$numberLong": "12345" } },
   "local_date_det_explicit_id": { "$date": { "$numberLong": "12345" } },
   "local_date_det_explicit_altname": { "$date": { "$numberLong": "12345" } },
+  "local_null_rand_prohibited_id": null,
+  "local_null_det_prohibited_id": null,
   "local_regex_rand_auto_id": {
     "$regularExpression": { "pattern": ".*", "options": "" }
   },
@@ -360,57 +375,42 @@
     "$regularExpression": { "pattern": ".*", "options": "" }
   },
   "local_dbPointer_rand_auto_id": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "local_dbPointer_rand_auto_altname": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "local_dbPointer_rand_explicit_id": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "local_dbPointer_rand_explicit_altname": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "local_dbPointer_det_auto_id": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "local_dbPointer_det_auto_altname": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "local_dbPointer_det_explicit_id": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "local_dbPointer_det_explicit_altname": {
-    "$dbPointer": {
-      "$ref": "db.example",
-      "$id": { "$oid": "01234567890abcdef0123456" }
-    }
+    "$ref": "db.example",
+    "$id": { "$oid": "01234567890abcdef0123456" }
   },
   "local_javascript_rand_auto_id": { "$code": "x=1" },
   "local_javascript_rand_auto_altname": { "$code": "x=1" },
   "local_javascript_rand_explicit_id": { "$code": "x=1" },
   "local_javascript_rand_explicit_altname": { "$code": "x=1" },
+  "local_javascript_det_prohibited_id": { "$code": "x=1" },
   "local_symbol_rand_auto_id": { "$symbol": "mongodb-symbol" },
   "local_symbol_rand_auto_altname": { "$symbol": "mongodb-symbol" },
   "local_symbol_rand_explicit_id": { "$symbol": "mongodb-symbol" },
@@ -429,6 +429,10 @@
     "$scope": {}
   },
   "local_javascriptWithScope_rand_explicit_altname": {
+    "$code": "x=1",
+    "$scope": {}
+  },
+  "local_javascriptWithScope_det_prohibited_id": {
     "$code": "x=1",
     "$scope": {}
   },
@@ -463,5 +467,10 @@
   "local_decimal_rand_auto_id": { "$numberDecimal": "1.234" },
   "local_decimal_rand_auto_altname": { "$numberDecimal": "1.234" },
   "local_decimal_rand_explicit_id": { "$numberDecimal": "1.234" },
-  "local_decimal_rand_explicit_altname": { "$numberDecimal": "1.234" }
+  "local_decimal_rand_explicit_altname": { "$numberDecimal": "1.234" },
+  "local_decimal_det_prohibited_id": { "$numberDecimal": "1.234" },
+  "local_minKey_rand_prohibited_id": { "$minKey": 1 },
+  "local_minKey_det_prohibited_id": { "$minKey": 1 },
+  "local_maxKey_rand_prohibited_id": { "$maxKey": 1 },
+  "local_maxKey_det_prohibited_id": { "$maxKey": 1 }
 }

--- a/source/client-side-encryption/corpus/corpus.json
+++ b/source/client-side-encryption/corpus/corpus.json
@@ -1,299 +1,2829 @@
-{ "_id": "client_side_encryption_corpus" ,
-  "altname_aws": "aws" ,
-  "altname_local": "local" ,
-  "aws_double_rand_auto_id" : { "kms": "aws", "type": "double", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value": { "$numberDouble" : "1.234" } },
-  "aws_double_rand_auto_altname" : { "kms": "aws", "type": "double", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value": { "$numberDouble" : "1.234" } },
-  "aws_double_rand_explicit_id" : { "kms": "aws", "type": "double", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value": { "$numberDouble" : "1.234" } },
-  "aws_double_rand_explicit_altname" : { "kms": "aws", "type": "double", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value": { "$numberDouble" : "1.234" } },
-  "aws_double_det_explicit_id" : { "kms": "aws", "type": "double", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": { "$numberDouble" : "1.234" } },
-  "aws_double_det_explicit_altname" : { "kms": "aws", "type": "double", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": { "$numberDouble" : "1.234" } },
-  "aws_string_rand_auto_id" : { "kms": "aws", "type": "string", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  "mongodb"  },
-  "aws_string_rand_auto_altname" : { "kms": "aws", "type": "string", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
-  "aws_string_rand_explicit_id" : { "kms": "aws", "type": "string", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  "mongodb"  },
-  "aws_string_rand_explicit_altname" : { "kms": "aws", "type": "string", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
-  "aws_string_det_auto_id" : { "kms": "aws", "type": "string", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  "mongodb"  },
-  "aws_string_det_auto_altname" : { "kms": "aws", "type": "string", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
-  "aws_string_det_explicit_id" : { "kms": "aws", "type": "string", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  "mongodb"  },
-  "aws_string_det_explicit_altname" : { "kms": "aws", "type": "string", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
-  "aws_object_rand_auto_id" : { "kms": "aws", "type": "object", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
-  "aws_object_rand_auto_altname" : { "kms": "aws", "type": "object", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
-  "aws_object_rand_explicit_id" : { "kms": "aws", "type": "object", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
-  "aws_object_rand_explicit_altname" : { "kms": "aws", "type": "object", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
-  "aws_object_det_explicit_id" : { "kms": "aws", "type": "object", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "x" : { "$numberInt": "1" } }  },
-  "aws_object_det_explicit_altname" : { "kms": "aws", "type": "object", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "x" : { "$numberInt": "1" } }  },
-  "aws_array_rand_auto_id" : { "kms": "aws", "type": "array", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "aws_array_rand_auto_altname" : { "kms": "aws", "type": "array", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "aws_array_rand_explicit_id" : { "kms": "aws", "type": "array", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "aws_array_rand_explicit_altname" : { "kms": "aws", "type": "array", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "aws_array_det_explicit_id" : { "kms": "aws", "type": "array", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "aws_array_det_explicit_altname" : { "kms": "aws", "type": "array", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "aws_binData=00_rand_auto_id" : { "kms": "aws", "type": "binData=00", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "aws_binData=00_rand_auto_altname" : { "kms": "aws", "type": "binData=00", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "aws_binData=00_rand_explicit_id" : { "kms": "aws", "type": "binData=00", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "aws_binData=00_rand_explicit_altname" : { "kms": "aws", "type": "binData=00", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "aws_binData=00_det_auto_id" : { "kms": "aws", "type": "binData=00", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "aws_binData=00_det_auto_altname" : { "kms": "aws", "type": "binData=00", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "aws_binData=00_det_explicit_id" : { "kms": "aws", "type": "binData=00", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "aws_binData=00_det_explicit_altname" : { "kms": "aws", "type": "binData=00", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "aws_binData=04_rand_auto_id" : { "kms": "aws", "type": "binData=04", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "aws_binData=04_rand_auto_altname" : { "kms": "aws", "type": "binData=04", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "aws_binData=04_rand_explicit_id" : { "kms": "aws", "type": "binData=04", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "aws_binData=04_rand_explicit_altname" : { "kms": "aws", "type": "binData=04", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "aws_binData=04_det_auto_id" : { "kms": "aws", "type": "binData=04", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "aws_binData=04_det_auto_altname" : { "kms": "aws", "type": "binData=04", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "aws_binData=04_det_explicit_id" : { "kms": "aws", "type": "binData=04", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "aws_binData=04_det_explicit_altname" : { "kms": "aws", "type": "binData=04", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "aws_undefined_rand_explicit_id" : { "kms": "aws", "type": "undefined", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value":  {"$undefined": true}  },
-  "aws_undefined_rand_explicit_altname" : { "kms": "aws", "type": "undefined", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value":  {"$undefined": true}  },
-  "aws_undefined_det_explicit_id" : { "kms": "aws", "type": "undefined", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  {"$undefined": true}  },
-  "aws_undefined_det_explicit_altname" : { "kms": "aws", "type": "undefined", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  {"$undefined": true}  },
-  "aws_objectId_rand_auto_id" : { "kms": "aws", "type": "objectId", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "aws_objectId_rand_auto_altname" : { "kms": "aws", "type": "objectId", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "aws_objectId_rand_explicit_id" : { "kms": "aws", "type": "objectId", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "aws_objectId_rand_explicit_altname" : { "kms": "aws", "type": "objectId", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "aws_objectId_det_auto_id" : { "kms": "aws", "type": "objectId", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "aws_objectId_det_auto_altname" : { "kms": "aws", "type": "objectId", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "aws_objectId_det_explicit_id" : { "kms": "aws", "type": "objectId", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "aws_objectId_det_explicit_altname" : { "kms": "aws", "type": "objectId", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "aws_bool_rand_auto_id" : { "kms": "aws", "type": "bool", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  true  },
-  "aws_bool_rand_auto_altname" : { "kms": "aws", "type": "bool", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  true  },
-  "aws_bool_rand_explicit_id" : { "kms": "aws", "type": "bool", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  true  },
-  "aws_bool_rand_explicit_altname" : { "kms": "aws", "type": "bool", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  true  },
-  "aws_bool_det_explicit_id" : { "kms": "aws", "type": "bool", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  true  },
-  "aws_bool_det_explicit_altname" : { "kms": "aws", "type": "bool", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  true  },
-  "aws_date_rand_auto_id" : { "kms": "aws", "type": "date", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "aws_date_rand_auto_altname" : { "kms": "aws", "type": "date", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "aws_date_rand_explicit_id" : { "kms": "aws", "type": "date", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "aws_date_rand_explicit_altname" : { "kms": "aws", "type": "date", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "aws_date_det_auto_id" : { "kms": "aws", "type": "date", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "aws_date_det_auto_altname" : { "kms": "aws", "type": "date", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "aws_date_det_explicit_id" : { "kms": "aws", "type": "date", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "aws_date_det_explicit_altname" : { "kms": "aws", "type": "date", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "aws_null_rand_explicit_id" : { "kms": "aws", "type": "null", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": null },
-  "aws_null_rand_explicit_altname" : { "kms": "aws", "type": "null", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": null },
-  "aws_null_det_explicit_id" : { "kms": "aws", "type": "null", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": null },
-  "aws_null_det_explicit_altname" : { "kms": "aws", "type": "null", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": null },
-  "aws_regex_rand_auto_id" : { "kms": "aws", "type": "regex", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "aws_regex_rand_auto_altname" : { "kms": "aws", "type": "regex", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "aws_regex_rand_explicit_id" : { "kms": "aws", "type": "regex", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "aws_regex_rand_explicit_altname" : { "kms": "aws", "type": "regex", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "aws_regex_det_auto_id" : { "kms": "aws", "type": "regex", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "aws_regex_det_auto_altname" : { "kms": "aws", "type": "regex", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "aws_regex_det_explicit_id" : { "kms": "aws", "type": "regex", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "aws_regex_det_explicit_altname" : { "kms": "aws", "type": "regex", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "aws_dbPointer_rand_auto_id" : { "kms": "aws", "type": "dbPointer", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "aws_dbPointer_rand_auto_altname" : { "kms": "aws", "type": "dbPointer", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "aws_dbPointer_rand_explicit_id" : { "kms": "aws", "type": "dbPointer", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "aws_dbPointer_rand_explicit_altname" : { "kms": "aws", "type": "dbPointer", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "aws_dbPointer_det_auto_id" : { "kms": "aws", "type": "dbPointer", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "aws_dbPointer_det_auto_altname" : { "kms": "aws", "type": "dbPointer", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "aws_dbPointer_det_explicit_id" : { "kms": "aws", "type": "dbPointer", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "aws_dbPointer_det_explicit_altname" : { "kms": "aws", "type": "dbPointer", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "aws_javascript_rand_auto_id" : { "kms": "aws", "type": "javascript", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
-  "aws_javascript_rand_auto_altname" : { "kms": "aws", "type": "javascript", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
-  "aws_javascript_rand_explicit_id" : { "kms": "aws", "type": "javascript", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
-  "aws_javascript_rand_explicit_altname" : { "kms": "aws", "type": "javascript", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
-  "aws_javascript_det_auto_id" : { "kms": "aws", "type": "javascript", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
-  "aws_javascript_det_auto_altname" : { "kms": "aws", "type": "javascript", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
-  "aws_javascript_det_explicit_id" : { "kms": "aws", "type": "javascript", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
-  "aws_javascript_det_explicit_altname" : { "kms": "aws", "type": "javascript", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
-  "aws_symbol_rand_auto_id" : { "kms": "aws", "type": "symbol", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "aws_symbol_rand_auto_altname" : { "kms": "aws", "type": "symbol", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "aws_symbol_rand_explicit_id" : { "kms": "aws", "type": "symbol", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "aws_symbol_rand_explicit_altname" : { "kms": "aws", "type": "symbol", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "aws_symbol_det_auto_id" : { "kms": "aws", "type": "symbol", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "aws_symbol_det_auto_altname" : { "kms": "aws", "type": "symbol", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "aws_symbol_det_explicit_id" : { "kms": "aws", "type": "symbol", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "aws_symbol_det_explicit_altname" : { "kms": "aws", "type": "symbol", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "aws_javascriptWithScope_rand_auto_id" : { "kms": "aws", "type": "javascriptWithScope", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
-  "aws_javascriptWithScope_rand_auto_altname" : { "kms": "aws", "type": "javascriptWithScope", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
-  "aws_javascriptWithScope_rand_explicit_id" : { "kms": "aws", "type": "javascriptWithScope", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
-  "aws_javascriptWithScope_rand_explicit_altname" : { "kms": "aws", "type": "javascriptWithScope", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
-  "aws_javascriptWithScope_det_explicit_id" : { "kms": "aws", "type": "javascriptWithScope", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "$code": "x=1", "$scope": {} }  },
-  "aws_javascriptWithScope_det_explicit_altname" : { "kms": "aws", "type": "javascriptWithScope", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "$code": "x=1", "$scope": {} }  },
-  "aws_int_rand_auto_id" : { "kms": "aws", "type": "int", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "aws_int_rand_auto_altname" : { "kms": "aws", "type": "int", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "aws_int_rand_explicit_id" : { "kms": "aws", "type": "int", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "aws_int_rand_explicit_altname" : { "kms": "aws", "type": "int", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "aws_int_det_auto_id" : { "kms": "aws", "type": "int", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "aws_int_det_auto_altname" : { "kms": "aws", "type": "int", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "aws_int_det_explicit_id" : { "kms": "aws", "type": "int", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "aws_int_det_explicit_altname" : { "kms": "aws", "type": "int", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "aws_timestamp_rand_auto_id" : { "kms": "aws", "type": "timestamp", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "aws_timestamp_rand_auto_altname" : { "kms": "aws", "type": "timestamp", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "aws_timestamp_rand_explicit_id" : { "kms": "aws", "type": "timestamp", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "aws_timestamp_rand_explicit_altname" : { "kms": "aws", "type": "timestamp", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "aws_timestamp_det_auto_id" : { "kms": "aws", "type": "timestamp", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "aws_timestamp_det_auto_altname" : { "kms": "aws", "type": "timestamp", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "aws_timestamp_det_explicit_id" : { "kms": "aws", "type": "timestamp", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "aws_timestamp_det_explicit_altname" : { "kms": "aws", "type": "timestamp", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "aws_long_rand_auto_id" : { "kms": "aws", "type": "long", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "aws_long_rand_auto_altname" : { "kms": "aws", "type": "long", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "aws_long_rand_explicit_id" : { "kms": "aws", "type": "long", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "aws_long_rand_explicit_altname" : { "kms": "aws", "type": "long", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "aws_long_det_auto_id" : { "kms": "aws", "type": "long", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "aws_long_det_auto_altname" : { "kms": "aws", "type": "long", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "aws_long_det_explicit_id" : { "kms": "aws", "type": "long", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "aws_long_det_explicit_altname" : { "kms": "aws", "type": "long", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "aws_decimal_rand_auto_id" : { "kms": "aws", "type": "decimal", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
-  "aws_decimal_rand_auto_altname" : { "kms": "aws", "type": "decimal", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
-  "aws_decimal_rand_explicit_id" : { "kms": "aws", "type": "decimal", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
-  "aws_decimal_rand_explicit_altname" : { "kms": "aws", "type": "decimal", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
-  "aws_decimal_det_explicit_id" : { "kms": "aws", "type": "decimal", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "$numberDecimal": "1.234" }  },
-  "aws_decimal_det_explicit_altname" : { "kms": "aws", "type": "decimal", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "$numberDecimal": "1.234" }  },
-  "aws_minKey_rand_explicit_id" : { "kms": "aws", "type": "minKey", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$minKey": 1} },
-  "aws_minKey_rand_explicit_altname" : { "kms": "aws", "type": "minKey", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$minKey": 1} },
-  "aws_minKey_det_explicit_id" : { "kms": "aws", "type": "minKey", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$minKey": 1} },
-  "aws_minKey_det_explicit_altname" : { "kms": "aws", "type": "minKey", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$minKey": 1} },
-  "aws_maxKey_rand_explicit_id" : { "kms": "aws", "type": "maxKey", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$maxKey": 1} },
-  "aws_maxKey_rand_explicit_altname" : { "kms": "aws", "type": "maxKey", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$maxKey": 1} },
-  "aws_maxKey_det_explicit_id" : { "kms": "aws", "type": "maxKey", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$maxKey": 1} },
-  "aws_maxKey_det_explicit_altname" : { "kms": "aws", "type": "maxKey", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$maxKey": 1} },
-  "local_double_rand_auto_id" : { "kms": "local", "type": "double", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value": { "$numberDouble" : "1.234" } },
-  "local_double_rand_auto_altname" : { "kms": "local", "type": "double", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value": { "$numberDouble" : "1.234" } },
-  "local_double_rand_explicit_id" : { "kms": "local", "type": "double", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value": { "$numberDouble" : "1.234" } },
-  "local_double_rand_explicit_altname" : { "kms": "local", "type": "double", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value": { "$numberDouble" : "1.234" } },
-  "local_double_det_explicit_id" : { "kms": "local", "type": "double", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": { "$numberDouble" : "1.234" } },
-  "local_double_det_explicit_altname" : { "kms": "local", "type": "double", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": { "$numberDouble" : "1.234" } },
-  "local_string_rand_auto_id" : { "kms": "local", "type": "string", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  "mongodb"  },
-  "local_string_rand_auto_altname" : { "kms": "local", "type": "string", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
-  "local_string_rand_explicit_id" : { "kms": "local", "type": "string", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  "mongodb"  },
-  "local_string_rand_explicit_altname" : { "kms": "local", "type": "string", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
-  "local_string_det_auto_id" : { "kms": "local", "type": "string", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  "mongodb"  },
-  "local_string_det_auto_altname" : { "kms": "local", "type": "string", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
-  "local_string_det_explicit_id" : { "kms": "local", "type": "string", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  "mongodb"  },
-  "local_string_det_explicit_altname" : { "kms": "local", "type": "string", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  "mongodb"  },
-  "local_object_rand_auto_id" : { "kms": "local", "type": "object", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
-  "local_object_rand_auto_altname" : { "kms": "local", "type": "object", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
-  "local_object_rand_explicit_id" : { "kms": "local", "type": "object", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
-  "local_object_rand_explicit_altname" : { "kms": "local", "type": "object", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "x" : { "$numberInt": "1" } }  },
-  "local_object_det_explicit_id" : { "kms": "local", "type": "object", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "x" : { "$numberInt": "1" } }  },
-  "local_object_det_explicit_altname" : { "kms": "local", "type": "object", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "x" : { "$numberInt": "1" } }  },
-  "local_array_rand_auto_id" : { "kms": "local", "type": "array", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "local_array_rand_auto_altname" : { "kms": "local", "type": "array", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "local_array_rand_explicit_id" : { "kms": "local", "type": "array", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "local_array_rand_explicit_altname" : { "kms": "local", "type": "array", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "local_array_det_explicit_id" : { "kms": "local", "type": "array", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "local_array_det_explicit_altname" : { "kms": "local", "type": "array", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  [ { "$numberInt": "1" }, { "$numberInt": "2" }, { "$numberInt": "3" } ]  },
-  "local_binData=00_rand_auto_id" : { "kms": "local", "type": "binData=00", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "local_binData=00_rand_auto_altname" : { "kms": "local", "type": "binData=00", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "local_binData=00_rand_explicit_id" : { "kms": "local", "type": "binData=00", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "local_binData=00_rand_explicit_altname" : { "kms": "local", "type": "binData=00", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "local_binData=00_det_auto_id" : { "kms": "local", "type": "binData=00", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "local_binData=00_det_auto_altname" : { "kms": "local", "type": "binData=00", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "local_binData=00_det_explicit_id" : { "kms": "local", "type": "binData=00", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "local_binData=00_det_explicit_altname" : { "kms": "local", "type": "binData=00", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AQIDBA==", "subType": "00" } }  },
-  "local_binData=04_rand_auto_id" : { "kms": "local", "type": "binData=04", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "local_binData=04_rand_auto_altname" : { "kms": "local", "type": "binData=04", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "local_binData=04_rand_explicit_id" : { "kms": "local", "type": "binData=04", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "local_binData=04_rand_explicit_altname" : { "kms": "local", "type": "binData=04", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "local_binData=04_det_auto_id" : { "kms": "local", "type": "binData=04", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "local_binData=04_det_auto_altname" : { "kms": "local", "type": "binData=04", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "local_binData=04_det_explicit_id" : { "kms": "local", "type": "binData=04", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "local_binData=04_det_explicit_altname" : { "kms": "local", "type": "binData=04", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } } },
-  "local_undefined_rand_explicit_id" : { "kms": "local", "type": "undefined", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value":  {"$undefined": true}  },
-  "local_undefined_rand_explicit_altname" : { "kms": "local", "type": "undefined", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value":  {"$undefined": true}  },
-  "local_undefined_det_explicit_id" : { "kms": "local", "type": "undefined", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  {"$undefined": true}  },
-  "local_undefined_det_explicit_altname" : { "kms": "local", "type": "undefined", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  {"$undefined": true}  },
-  "local_objectId_rand_auto_id" : { "kms": "local", "type": "objectId", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "local_objectId_rand_auto_altname" : { "kms": "local", "type": "objectId", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "local_objectId_rand_explicit_id" : { "kms": "local", "type": "objectId", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "local_objectId_rand_explicit_altname" : { "kms": "local", "type": "objectId", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "local_objectId_det_auto_id" : { "kms": "local", "type": "objectId", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "local_objectId_det_auto_altname" : { "kms": "local", "type": "objectId", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "local_objectId_det_explicit_id" : { "kms": "local", "type": "objectId", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "local_objectId_det_explicit_altname" : { "kms": "local", "type": "objectId", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$oid": "01234567890abcdef0123456" }  },
-  "local_bool_rand_auto_id" : { "kms": "local", "type": "bool", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  true  },
-  "local_bool_rand_auto_altname" : { "kms": "local", "type": "bool", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  true  },
-  "local_bool_rand_explicit_id" : { "kms": "local", "type": "bool", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  true  },
-  "local_bool_rand_explicit_altname" : { "kms": "local", "type": "bool", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  true  },
-  "local_bool_det_explicit_id" : { "kms": "local", "type": "bool", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  true  },
-  "local_bool_det_explicit_altname" : { "kms": "local", "type": "bool", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  true  },
-  "local_date_rand_auto_id" : { "kms": "local", "type": "date", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "local_date_rand_auto_altname" : { "kms": "local", "type": "date", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "local_date_rand_explicit_id" : { "kms": "local", "type": "date", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "local_date_rand_explicit_altname" : { "kms": "local", "type": "date", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "local_date_det_auto_id" : { "kms": "local", "type": "date", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "local_date_det_auto_altname" : { "kms": "local", "type": "date", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "local_date_det_explicit_id" : { "kms": "local", "type": "date", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "local_date_det_explicit_altname" : { "kms": "local", "type": "date", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$date": { "$numberLong": "12345" } }  },
-  "local_null_rand_explicit_id" : { "kms": "local", "type": "null", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": null },
-  "local_null_rand_explicit_altname" : { "kms": "local", "type": "null", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": null },
-  "local_null_det_explicit_id" : { "kms": "local", "type": "null", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": null },
-  "local_null_det_explicit_altname" : { "kms": "local", "type": "null", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": null },
-  "local_regex_rand_auto_id" : { "kms": "local", "type": "regex", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "local_regex_rand_auto_altname" : { "kms": "local", "type": "regex", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "local_regex_rand_explicit_id" : { "kms": "local", "type": "regex", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "local_regex_rand_explicit_altname" : { "kms": "local", "type": "regex", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "local_regex_det_auto_id" : { "kms": "local", "type": "regex", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "local_regex_det_auto_altname" : { "kms": "local", "type": "regex", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "local_regex_det_explicit_id" : { "kms": "local", "type": "regex", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "local_regex_det_explicit_altname" : { "kms": "local", "type": "regex", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$regularExpression": { "pattern": ".*", "options": "" } }  },
-  "local_dbPointer_rand_auto_id" : { "kms": "local", "type": "dbPointer", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "local_dbPointer_rand_auto_altname" : { "kms": "local", "type": "dbPointer", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "local_dbPointer_rand_explicit_id" : { "kms": "local", "type": "dbPointer", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "local_dbPointer_rand_explicit_altname" : { "kms": "local", "type": "dbPointer", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "local_dbPointer_det_auto_id" : { "kms": "local", "type": "dbPointer", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "local_dbPointer_det_auto_altname" : { "kms": "local", "type": "dbPointer", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "local_dbPointer_det_explicit_id" : { "kms": "local", "type": "dbPointer", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "local_dbPointer_det_explicit_altname" : { "kms": "local", "type": "dbPointer", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$dbPointer": { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } }  },
-  "local_javascript_rand_auto_id" : { "kms": "local", "type": "javascript", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
-  "local_javascript_rand_auto_altname" : { "kms": "local", "type": "javascript", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
-  "local_javascript_rand_explicit_id" : { "kms": "local", "type": "javascript", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
-  "local_javascript_rand_explicit_altname" : { "kms": "local", "type": "javascript", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
-  "local_javascript_det_auto_id" : { "kms": "local", "type": "javascript", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
-  "local_javascript_det_auto_altname" : { "kms": "local", "type": "javascript", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
-  "local_javascript_det_explicit_id" : { "kms": "local", "type": "javascript", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1" }  },
-  "local_javascript_det_explicit_altname" : { "kms": "local", "type": "javascript", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1" }  },
-  "local_symbol_rand_auto_id" : { "kms": "local", "type": "symbol", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "local_symbol_rand_auto_altname" : { "kms": "local", "type": "symbol", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "local_symbol_rand_explicit_id" : { "kms": "local", "type": "symbol", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "local_symbol_rand_explicit_altname" : { "kms": "local", "type": "symbol", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "local_symbol_det_auto_id" : { "kms": "local", "type": "symbol", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "local_symbol_det_auto_altname" : { "kms": "local", "type": "symbol", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "local_symbol_det_explicit_id" : { "kms": "local", "type": "symbol", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "local_symbol_det_explicit_altname" : { "kms": "local", "type": "symbol", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$symbol": "mongodb-symbol" }  },
-  "local_javascriptWithScope_rand_auto_id" : { "kms": "local", "type": "javascriptWithScope", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
-  "local_javascriptWithScope_rand_auto_altname" : { "kms": "local", "type": "javascriptWithScope", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
-  "local_javascriptWithScope_rand_explicit_id" : { "kms": "local", "type": "javascriptWithScope", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
-  "local_javascriptWithScope_rand_explicit_altname" : { "kms": "local", "type": "javascriptWithScope", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$code": "x=1", "$scope": {} }  },
-  "local_javascriptWithScope_det_explicit_id" : { "kms": "local", "type": "javascriptWithScope", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "$code": "x=1", "$scope": {} }  },
-  "local_javascriptWithScope_det_explicit_altname" : { "kms": "local", "type": "javascriptWithScope", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "$code": "x=1", "$scope": {} }  },
-  "local_int_rand_auto_id" : { "kms": "local", "type": "int", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "local_int_rand_auto_altname" : { "kms": "local", "type": "int", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "local_int_rand_explicit_id" : { "kms": "local", "type": "int", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "local_int_rand_explicit_altname" : { "kms": "local", "type": "int", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "local_int_det_auto_id" : { "kms": "local", "type": "int", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "local_int_det_auto_altname" : { "kms": "local", "type": "int", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "local_int_det_explicit_id" : { "kms": "local", "type": "int", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "local_int_det_explicit_altname" : { "kms": "local", "type": "int", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberInt": "123" }  },
-  "local_timestamp_rand_auto_id" : { "kms": "local", "type": "timestamp", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "local_timestamp_rand_auto_altname" : { "kms": "local", "type": "timestamp", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "local_timestamp_rand_explicit_id" : { "kms": "local", "type": "timestamp", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "local_timestamp_rand_explicit_altname" : { "kms": "local", "type": "timestamp", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "local_timestamp_det_auto_id" : { "kms": "local", "type": "timestamp", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "local_timestamp_det_auto_altname" : { "kms": "local", "type": "timestamp", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "local_timestamp_det_explicit_id" : { "kms": "local", "type": "timestamp", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "local_timestamp_det_explicit_altname" : { "kms": "local", "type": "timestamp", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$timestamp": { "t": 0, "i": 12345 } }  },
-  "local_long_rand_auto_id" : { "kms": "local", "type": "long", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "local_long_rand_auto_altname" : { "kms": "local", "type": "long", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "local_long_rand_explicit_id" : { "kms": "local", "type": "long", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "local_long_rand_explicit_altname" : { "kms": "local", "type": "long", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "local_long_det_auto_id" : { "kms": "local", "type": "long", "algo": "det", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "local_long_det_auto_altname" : { "kms": "local", "type": "long", "algo": "det", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "local_long_det_explicit_id" : { "kms": "local", "type": "long", "algo": "det", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "local_long_det_explicit_altname" : { "kms": "local", "type": "long", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberLong": "456" }  },
-  "local_decimal_rand_auto_id" : { "kms": "local", "type": "decimal", "algo": "rand", "method": "auto", "identifier": "id", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
-  "local_decimal_rand_auto_altname" : { "kms": "local", "type": "decimal", "algo": "rand", "method": "auto", "identifier": "altname", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
-  "local_decimal_rand_explicit_id" : { "kms": "local", "type": "decimal", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
-  "local_decimal_rand_explicit_altname" : { "kms": "local", "type": "decimal", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": true, "value":  { "$numberDecimal": "1.234" }  },
-  "local_decimal_det_explicit_id" : { "kms": "local", "type": "decimal", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value":  { "$numberDecimal": "1.234" }  },
-  "local_decimal_det_explicit_altname" : { "kms": "local", "type": "decimal", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value":  { "$numberDecimal": "1.234" }  },
-  "local_minKey_rand_explicit_id" : { "kms": "local", "type": "minKey", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$minKey": 1} },
-  "local_minKey_rand_explicit_altname" : { "kms": "local", "type": "minKey", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$minKey": 1} },
-  "local_minKey_det_explicit_id" : { "kms": "local", "type": "minKey", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$minKey": 1} },
-  "local_minKey_det_explicit_altname" : { "kms": "local", "type": "minKey", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$minKey": 1} },
-  "local_maxKey_rand_explicit_id" : { "kms": "local", "type": "maxKey", "algo": "rand", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$maxKey": 1} },
-  "local_maxKey_rand_explicit_altname" : { "kms": "local", "type": "maxKey", "algo": "rand", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$maxKey": 1} },
-  "local_maxKey_det_explicit_id" : { "kms": "local", "type": "maxKey", "algo": "det", "method": "explicit", "identifier": "id", "allowed": false, "value": {"$maxKey": 1} },
-  "local_maxKey_det_explicit_altname" : { "kms": "local", "type": "maxKey", "algo": "det", "method": "explicit", "identifier": "altname", "allowed": false, "value": {"$maxKey": 1} }}
+{
+  "_id": "client_side_encryption_corpus",
+  "altname_aws": "aws",
+  "altname_local": "local",
+  "aws_double_rand_auto_id": {
+    "kms": "aws",
+    "type": "double",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "aws_double_rand_auto_altname": {
+    "kms": "aws",
+    "type": "double",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "aws_double_rand_explicit_id": {
+    "kms": "aws",
+    "type": "double",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "aws_double_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "double",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "aws_double_det_explicit_id": {
+    "kms": "aws",
+    "type": "double",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "aws_double_det_explicit_altname": {
+    "kms": "aws",
+    "type": "double",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "aws_string_rand_auto_id": {
+    "kms": "aws",
+    "type": "string",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "aws_string_rand_auto_altname": {
+    "kms": "aws",
+    "type": "string",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "aws_string_rand_explicit_id": {
+    "kms": "aws",
+    "type": "string",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "aws_string_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "string",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "aws_string_det_auto_id": {
+    "kms": "aws",
+    "type": "string",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "aws_string_det_auto_altname": {
+    "kms": "aws",
+    "type": "string",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "aws_string_det_explicit_id": {
+    "kms": "aws",
+    "type": "string",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "aws_string_det_explicit_altname": {
+    "kms": "aws",
+    "type": "string",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "aws_object_rand_auto_id": {
+    "kms": "aws",
+    "type": "object",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "aws_object_rand_auto_altname": {
+    "kms": "aws",
+    "type": "object",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "aws_object_rand_explicit_id": {
+    "kms": "aws",
+    "type": "object",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "aws_object_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "object",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "aws_object_det_explicit_id": {
+    "kms": "aws",
+    "type": "object",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "aws_object_det_explicit_altname": {
+    "kms": "aws",
+    "type": "object",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "aws_array_rand_auto_id": {
+    "kms": "aws",
+    "type": "array",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "aws_array_rand_auto_altname": {
+    "kms": "aws",
+    "type": "array",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "aws_array_rand_explicit_id": {
+    "kms": "aws",
+    "type": "array",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "aws_array_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "array",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "aws_array_det_explicit_id": {
+    "kms": "aws",
+    "type": "array",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "aws_array_det_explicit_altname": {
+    "kms": "aws",
+    "type": "array",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "aws_binData=00_rand_auto_id": {
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "aws_binData=00_rand_auto_altname": {
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "aws_binData=00_rand_explicit_id": {
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "aws_binData=00_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "aws_binData=00_det_auto_id": {
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "aws_binData=00_det_auto_altname": {
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "aws_binData=00_det_explicit_id": {
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "aws_binData=00_det_explicit_altname": {
+    "kms": "aws",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "aws_binData=04_rand_auto_id": {
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "aws_binData=04_rand_auto_altname": {
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "aws_binData=04_rand_explicit_id": {
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "aws_binData=04_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "aws_binData=04_det_auto_id": {
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "aws_binData=04_det_auto_altname": {
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "aws_binData=04_det_explicit_id": {
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "aws_binData=04_det_explicit_altname": {
+    "kms": "aws",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "aws_undefined_rand_explicit_id": {
+    "kms": "aws",
+    "type": "undefined",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "aws_undefined_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "undefined",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "aws_undefined_det_explicit_id": {
+    "kms": "aws",
+    "type": "undefined",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "aws_undefined_det_explicit_altname": {
+    "kms": "aws",
+    "type": "undefined",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "aws_objectId_rand_auto_id": {
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "aws_objectId_rand_auto_altname": {
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "aws_objectId_rand_explicit_id": {
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "aws_objectId_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "aws_objectId_det_auto_id": {
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "aws_objectId_det_auto_altname": {
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "aws_objectId_det_explicit_id": {
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "aws_objectId_det_explicit_altname": {
+    "kms": "aws",
+    "type": "objectId",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "aws_bool_rand_auto_id": {
+    "kms": "aws",
+    "type": "bool",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": true
+  },
+  "aws_bool_rand_auto_altname": {
+    "kms": "aws",
+    "type": "bool",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": true
+  },
+  "aws_bool_rand_explicit_id": {
+    "kms": "aws",
+    "type": "bool",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": true
+  },
+  "aws_bool_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "bool",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": true
+  },
+  "aws_bool_det_explicit_id": {
+    "kms": "aws",
+    "type": "bool",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": true
+  },
+  "aws_bool_det_explicit_altname": {
+    "kms": "aws",
+    "type": "bool",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": true
+  },
+  "aws_date_rand_auto_id": {
+    "kms": "aws",
+    "type": "date",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "aws_date_rand_auto_altname": {
+    "kms": "aws",
+    "type": "date",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "aws_date_rand_explicit_id": {
+    "kms": "aws",
+    "type": "date",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "aws_date_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "date",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "aws_date_det_auto_id": {
+    "kms": "aws",
+    "type": "date",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "aws_date_det_auto_altname": {
+    "kms": "aws",
+    "type": "date",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "aws_date_det_explicit_id": {
+    "kms": "aws",
+    "type": "date",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "aws_date_det_explicit_altname": {
+    "kms": "aws",
+    "type": "date",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "aws_null_rand_explicit_id": {
+    "kms": "aws",
+    "type": "null",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": null
+  },
+  "aws_null_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "null",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": null
+  },
+  "aws_null_det_explicit_id": {
+    "kms": "aws",
+    "type": "null",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": null
+  },
+  "aws_null_det_explicit_altname": {
+    "kms": "aws",
+    "type": "null",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": null
+  },
+  "aws_regex_rand_auto_id": {
+    "kms": "aws",
+    "type": "regex",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "aws_regex_rand_auto_altname": {
+    "kms": "aws",
+    "type": "regex",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "aws_regex_rand_explicit_id": {
+    "kms": "aws",
+    "type": "regex",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "aws_regex_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "regex",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "aws_regex_det_auto_id": {
+    "kms": "aws",
+    "type": "regex",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "aws_regex_det_auto_altname": {
+    "kms": "aws",
+    "type": "regex",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "aws_regex_det_explicit_id": {
+    "kms": "aws",
+    "type": "regex",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "aws_regex_det_explicit_altname": {
+    "kms": "aws",
+    "type": "regex",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "aws_dbPointer_rand_auto_id": {
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "aws_dbPointer_rand_auto_altname": {
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "aws_dbPointer_rand_explicit_id": {
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "aws_dbPointer_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "aws_dbPointer_det_auto_id": {
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "aws_dbPointer_det_auto_altname": {
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "aws_dbPointer_det_explicit_id": {
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "aws_dbPointer_det_explicit_altname": {
+    "kms": "aws",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "aws_javascript_rand_auto_id": {
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "aws_javascript_rand_auto_altname": {
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "aws_javascript_rand_explicit_id": {
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "aws_javascript_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "aws_javascript_det_auto_id": {
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "aws_javascript_det_auto_altname": {
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "aws_javascript_det_explicit_id": {
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "aws_javascript_det_explicit_altname": {
+    "kms": "aws",
+    "type": "javascript",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "aws_symbol_rand_auto_id": {
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "aws_symbol_rand_auto_altname": {
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "aws_symbol_rand_explicit_id": {
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "aws_symbol_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "aws_symbol_det_auto_id": {
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "aws_symbol_det_auto_altname": {
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "aws_symbol_det_explicit_id": {
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "aws_symbol_det_explicit_altname": {
+    "kms": "aws",
+    "type": "symbol",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "aws_javascriptWithScope_rand_auto_id": {
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "aws_javascriptWithScope_rand_auto_altname": {
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "aws_javascriptWithScope_rand_explicit_id": {
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "aws_javascriptWithScope_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "aws_javascriptWithScope_det_explicit_id": {
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "aws_javascriptWithScope_det_explicit_altname": {
+    "kms": "aws",
+    "type": "javascriptWithScope",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "aws_int_rand_auto_id": {
+    "kms": "aws",
+    "type": "int",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "aws_int_rand_auto_altname": {
+    "kms": "aws",
+    "type": "int",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "aws_int_rand_explicit_id": {
+    "kms": "aws",
+    "type": "int",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "aws_int_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "int",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "aws_int_det_auto_id": {
+    "kms": "aws",
+    "type": "int",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "aws_int_det_auto_altname": {
+    "kms": "aws",
+    "type": "int",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "aws_int_det_explicit_id": {
+    "kms": "aws",
+    "type": "int",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "aws_int_det_explicit_altname": {
+    "kms": "aws",
+    "type": "int",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "aws_timestamp_rand_auto_id": {
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "aws_timestamp_rand_auto_altname": {
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "aws_timestamp_rand_explicit_id": {
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "aws_timestamp_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "aws_timestamp_det_auto_id": {
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "aws_timestamp_det_auto_altname": {
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "aws_timestamp_det_explicit_id": {
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "aws_timestamp_det_explicit_altname": {
+    "kms": "aws",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "aws_long_rand_auto_id": {
+    "kms": "aws",
+    "type": "long",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "aws_long_rand_auto_altname": {
+    "kms": "aws",
+    "type": "long",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "aws_long_rand_explicit_id": {
+    "kms": "aws",
+    "type": "long",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "aws_long_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "long",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "aws_long_det_auto_id": {
+    "kms": "aws",
+    "type": "long",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "aws_long_det_auto_altname": {
+    "kms": "aws",
+    "type": "long",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "aws_long_det_explicit_id": {
+    "kms": "aws",
+    "type": "long",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "aws_long_det_explicit_altname": {
+    "kms": "aws",
+    "type": "long",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "aws_decimal_rand_auto_id": {
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "aws_decimal_rand_auto_altname": {
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "aws_decimal_rand_explicit_id": {
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "aws_decimal_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "aws_decimal_det_explicit_id": {
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "aws_decimal_det_explicit_altname": {
+    "kms": "aws",
+    "type": "decimal",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "aws_minKey_rand_explicit_id": {
+    "kms": "aws",
+    "type": "minKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "aws_minKey_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "minKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "aws_minKey_det_explicit_id": {
+    "kms": "aws",
+    "type": "minKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "aws_minKey_det_explicit_altname": {
+    "kms": "aws",
+    "type": "minKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "aws_maxKey_rand_explicit_id": {
+    "kms": "aws",
+    "type": "maxKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "aws_maxKey_rand_explicit_altname": {
+    "kms": "aws",
+    "type": "maxKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "aws_maxKey_det_explicit_id": {
+    "kms": "aws",
+    "type": "maxKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "aws_maxKey_det_explicit_altname": {
+    "kms": "aws",
+    "type": "maxKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "local_double_rand_auto_id": {
+    "kms": "local",
+    "type": "double",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "local_double_rand_auto_altname": {
+    "kms": "local",
+    "type": "double",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "local_double_rand_explicit_id": {
+    "kms": "local",
+    "type": "double",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "local_double_rand_explicit_altname": {
+    "kms": "local",
+    "type": "double",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "local_double_det_explicit_id": {
+    "kms": "local",
+    "type": "double",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "local_double_det_explicit_altname": {
+    "kms": "local",
+    "type": "double",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$numberDouble": "1.234" }
+  },
+  "local_string_rand_auto_id": {
+    "kms": "local",
+    "type": "string",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "local_string_rand_auto_altname": {
+    "kms": "local",
+    "type": "string",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "local_string_rand_explicit_id": {
+    "kms": "local",
+    "type": "string",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "local_string_rand_explicit_altname": {
+    "kms": "local",
+    "type": "string",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "local_string_det_auto_id": {
+    "kms": "local",
+    "type": "string",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "local_string_det_auto_altname": {
+    "kms": "local",
+    "type": "string",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "local_string_det_explicit_id": {
+    "kms": "local",
+    "type": "string",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "local_string_det_explicit_altname": {
+    "kms": "local",
+    "type": "string",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": "mongodb"
+  },
+  "local_object_rand_auto_id": {
+    "kms": "local",
+    "type": "object",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "local_object_rand_auto_altname": {
+    "kms": "local",
+    "type": "object",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "local_object_rand_explicit_id": {
+    "kms": "local",
+    "type": "object",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "local_object_rand_explicit_altname": {
+    "kms": "local",
+    "type": "object",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "local_object_det_explicit_id": {
+    "kms": "local",
+    "type": "object",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "local_object_det_explicit_altname": {
+    "kms": "local",
+    "type": "object",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "x": { "$numberInt": "1" } }
+  },
+  "local_array_rand_auto_id": {
+    "kms": "local",
+    "type": "array",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "local_array_rand_auto_altname": {
+    "kms": "local",
+    "type": "array",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "local_array_rand_explicit_id": {
+    "kms": "local",
+    "type": "array",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "local_array_rand_explicit_altname": {
+    "kms": "local",
+    "type": "array",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "local_array_det_explicit_id": {
+    "kms": "local",
+    "type": "array",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "local_array_det_explicit_altname": {
+    "kms": "local",
+    "type": "array",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": [
+      { "$numberInt": "1" },
+      { "$numberInt": "2" },
+      { "$numberInt": "3" }
+    ]
+  },
+  "local_binData=00_rand_auto_id": {
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "local_binData=00_rand_auto_altname": {
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "local_binData=00_rand_explicit_id": {
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "local_binData=00_rand_explicit_altname": {
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "local_binData=00_det_auto_id": {
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "local_binData=00_det_auto_altname": {
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "local_binData=00_det_explicit_id": {
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "local_binData=00_det_explicit_altname": {
+    "kms": "local",
+    "type": "binData=00",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$binary": { "base64": "AQIDBA==", "subType": "00" } }
+  },
+  "local_binData=04_rand_auto_id": {
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "local_binData=04_rand_auto_altname": {
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "local_binData=04_rand_explicit_id": {
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "local_binData=04_rand_explicit_altname": {
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "local_binData=04_det_auto_id": {
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "local_binData=04_det_auto_altname": {
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "local_binData=04_det_explicit_id": {
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "local_binData=04_det_explicit_altname": {
+    "kms": "local",
+    "type": "binData=04",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" }
+    }
+  },
+  "local_undefined_rand_explicit_id": {
+    "kms": "local",
+    "type": "undefined",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "local_undefined_rand_explicit_altname": {
+    "kms": "local",
+    "type": "undefined",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "local_undefined_det_explicit_id": {
+    "kms": "local",
+    "type": "undefined",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "local_undefined_det_explicit_altname": {
+    "kms": "local",
+    "type": "undefined",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$undefined": true }
+  },
+  "local_objectId_rand_auto_id": {
+    "kms": "local",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "local_objectId_rand_auto_altname": {
+    "kms": "local",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "local_objectId_rand_explicit_id": {
+    "kms": "local",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "local_objectId_rand_explicit_altname": {
+    "kms": "local",
+    "type": "objectId",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "local_objectId_det_auto_id": {
+    "kms": "local",
+    "type": "objectId",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "local_objectId_det_auto_altname": {
+    "kms": "local",
+    "type": "objectId",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "local_objectId_det_explicit_id": {
+    "kms": "local",
+    "type": "objectId",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "local_objectId_det_explicit_altname": {
+    "kms": "local",
+    "type": "objectId",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$oid": "01234567890abcdef0123456" }
+  },
+  "local_bool_rand_auto_id": {
+    "kms": "local",
+    "type": "bool",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": true
+  },
+  "local_bool_rand_auto_altname": {
+    "kms": "local",
+    "type": "bool",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": true
+  },
+  "local_bool_rand_explicit_id": {
+    "kms": "local",
+    "type": "bool",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": true
+  },
+  "local_bool_rand_explicit_altname": {
+    "kms": "local",
+    "type": "bool",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": true
+  },
+  "local_bool_det_explicit_id": {
+    "kms": "local",
+    "type": "bool",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": true
+  },
+  "local_bool_det_explicit_altname": {
+    "kms": "local",
+    "type": "bool",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": true
+  },
+  "local_date_rand_auto_id": {
+    "kms": "local",
+    "type": "date",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "local_date_rand_auto_altname": {
+    "kms": "local",
+    "type": "date",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "local_date_rand_explicit_id": {
+    "kms": "local",
+    "type": "date",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "local_date_rand_explicit_altname": {
+    "kms": "local",
+    "type": "date",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "local_date_det_auto_id": {
+    "kms": "local",
+    "type": "date",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "local_date_det_auto_altname": {
+    "kms": "local",
+    "type": "date",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "local_date_det_explicit_id": {
+    "kms": "local",
+    "type": "date",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "local_date_det_explicit_altname": {
+    "kms": "local",
+    "type": "date",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$date": { "$numberLong": "12345" } }
+  },
+  "local_null_rand_explicit_id": {
+    "kms": "local",
+    "type": "null",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": null
+  },
+  "local_null_rand_explicit_altname": {
+    "kms": "local",
+    "type": "null",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": null
+  },
+  "local_null_det_explicit_id": {
+    "kms": "local",
+    "type": "null",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": null
+  },
+  "local_null_det_explicit_altname": {
+    "kms": "local",
+    "type": "null",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": null
+  },
+  "local_regex_rand_auto_id": {
+    "kms": "local",
+    "type": "regex",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "local_regex_rand_auto_altname": {
+    "kms": "local",
+    "type": "regex",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "local_regex_rand_explicit_id": {
+    "kms": "local",
+    "type": "regex",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "local_regex_rand_explicit_altname": {
+    "kms": "local",
+    "type": "regex",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "local_regex_det_auto_id": {
+    "kms": "local",
+    "type": "regex",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "local_regex_det_auto_altname": {
+    "kms": "local",
+    "type": "regex",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "local_regex_det_explicit_id": {
+    "kms": "local",
+    "type": "regex",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "local_regex_det_explicit_altname": {
+    "kms": "local",
+    "type": "regex",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$regularExpression": { "pattern": ".*", "options": "" } }
+  },
+  "local_dbPointer_rand_auto_id": {
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "local_dbPointer_rand_auto_altname": {
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "local_dbPointer_rand_explicit_id": {
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "local_dbPointer_rand_explicit_altname": {
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "local_dbPointer_det_auto_id": {
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "local_dbPointer_det_auto_altname": {
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "local_dbPointer_det_explicit_id": {
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "local_dbPointer_det_explicit_altname": {
+    "kms": "local",
+    "type": "dbPointer",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": {
+      "$dbPointer": {
+        "$ref": "db.example",
+        "$id": { "$oid": "01234567890abcdef0123456" }
+      }
+    }
+  },
+  "local_javascript_rand_auto_id": {
+    "kms": "local",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "local_javascript_rand_auto_altname": {
+    "kms": "local",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "local_javascript_rand_explicit_id": {
+    "kms": "local",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "local_javascript_rand_explicit_altname": {
+    "kms": "local",
+    "type": "javascript",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "local_javascript_det_auto_id": {
+    "kms": "local",
+    "type": "javascript",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "local_javascript_det_auto_altname": {
+    "kms": "local",
+    "type": "javascript",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "local_javascript_det_explicit_id": {
+    "kms": "local",
+    "type": "javascript",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "local_javascript_det_explicit_altname": {
+    "kms": "local",
+    "type": "javascript",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1" }
+  },
+  "local_symbol_rand_auto_id": {
+    "kms": "local",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "local_symbol_rand_auto_altname": {
+    "kms": "local",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "local_symbol_rand_explicit_id": {
+    "kms": "local",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "local_symbol_rand_explicit_altname": {
+    "kms": "local",
+    "type": "symbol",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "local_symbol_det_auto_id": {
+    "kms": "local",
+    "type": "symbol",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "local_symbol_det_auto_altname": {
+    "kms": "local",
+    "type": "symbol",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "local_symbol_det_explicit_id": {
+    "kms": "local",
+    "type": "symbol",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "local_symbol_det_explicit_altname": {
+    "kms": "local",
+    "type": "symbol",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$symbol": "mongodb-symbol" }
+  },
+  "local_javascriptWithScope_rand_auto_id": {
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "local_javascriptWithScope_rand_auto_altname": {
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "local_javascriptWithScope_rand_explicit_id": {
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "local_javascriptWithScope_rand_explicit_altname": {
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "local_javascriptWithScope_det_explicit_id": {
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "local_javascriptWithScope_det_explicit_altname": {
+    "kms": "local",
+    "type": "javascriptWithScope",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$code": "x=1", "$scope": {} }
+  },
+  "local_int_rand_auto_id": {
+    "kms": "local",
+    "type": "int",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "local_int_rand_auto_altname": {
+    "kms": "local",
+    "type": "int",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "local_int_rand_explicit_id": {
+    "kms": "local",
+    "type": "int",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "local_int_rand_explicit_altname": {
+    "kms": "local",
+    "type": "int",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "local_int_det_auto_id": {
+    "kms": "local",
+    "type": "int",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "local_int_det_auto_altname": {
+    "kms": "local",
+    "type": "int",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "local_int_det_explicit_id": {
+    "kms": "local",
+    "type": "int",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "local_int_det_explicit_altname": {
+    "kms": "local",
+    "type": "int",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberInt": "123" }
+  },
+  "local_timestamp_rand_auto_id": {
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "local_timestamp_rand_auto_altname": {
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "local_timestamp_rand_explicit_id": {
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "local_timestamp_rand_explicit_altname": {
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "local_timestamp_det_auto_id": {
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "local_timestamp_det_auto_altname": {
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "local_timestamp_det_explicit_id": {
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "local_timestamp_det_explicit_altname": {
+    "kms": "local",
+    "type": "timestamp",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$timestamp": { "t": 0, "i": 12345 } }
+  },
+  "local_long_rand_auto_id": {
+    "kms": "local",
+    "type": "long",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "local_long_rand_auto_altname": {
+    "kms": "local",
+    "type": "long",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "local_long_rand_explicit_id": {
+    "kms": "local",
+    "type": "long",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "local_long_rand_explicit_altname": {
+    "kms": "local",
+    "type": "long",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "local_long_det_auto_id": {
+    "kms": "local",
+    "type": "long",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "local_long_det_auto_altname": {
+    "kms": "local",
+    "type": "long",
+    "algo": "det",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "local_long_det_explicit_id": {
+    "kms": "local",
+    "type": "long",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "local_long_det_explicit_altname": {
+    "kms": "local",
+    "type": "long",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberLong": "456" }
+  },
+  "local_decimal_rand_auto_id": {
+    "kms": "local",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "local_decimal_rand_auto_altname": {
+    "kms": "local",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "auto",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "local_decimal_rand_explicit_id": {
+    "kms": "local",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": true,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "local_decimal_rand_explicit_altname": {
+    "kms": "local",
+    "type": "decimal",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": true,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "local_decimal_det_explicit_id": {
+    "kms": "local",
+    "type": "decimal",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "local_decimal_det_explicit_altname": {
+    "kms": "local",
+    "type": "decimal",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$numberDecimal": "1.234" }
+  },
+  "local_minKey_rand_explicit_id": {
+    "kms": "local",
+    "type": "minKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "local_minKey_rand_explicit_altname": {
+    "kms": "local",
+    "type": "minKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "local_minKey_det_explicit_id": {
+    "kms": "local",
+    "type": "minKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "local_minKey_det_explicit_altname": {
+    "kms": "local",
+    "type": "minKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$minKey": 1 }
+  },
+  "local_maxKey_rand_explicit_id": {
+    "kms": "local",
+    "type": "maxKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "local_maxKey_rand_explicit_altname": {
+    "kms": "local",
+    "type": "maxKey",
+    "algo": "rand",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "local_maxKey_det_explicit_id": {
+    "kms": "local",
+    "type": "maxKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "id",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  },
+  "local_maxKey_det_explicit_altname": {
+    "kms": "local",
+    "type": "maxKey",
+    "algo": "det",
+    "method": "explicit",
+    "identifier": "altname",
+    "allowed": false,
+    "value": { "$maxKey": 1 }
+  }
+}

--- a/source/client-side-encryption/etc/generate-corpus.py
+++ b/source/client-side-encryption/etc/generate-corpus.py
@@ -1,0 +1,136 @@
+
+"""
+A utility script written to generate the corpus data and schema.
+"""
+from pymongo import MongoClient
+from bson import json_util
+import bson 
+from bson.codec_options import CodecOptions
+
+# Generate test data from this matrix of axes.
+axes = [
+    ("kms", [ "aws", "local" ]),
+    ("type", [ "double", "string", "object", "array", "binData=00", "binData=04", "undefined", "objectId", "bool", "date", "null", "regex", "dbPointer", "javascript", "symbol", "javascriptWithScope", "int", "timestamp", "long", "decimal", "minKey", "maxKey" ]),
+    ("algo", [ "rand", "det" ]),
+    ("method", [ "auto", "explicit" ]),
+    ("identifier", [ "id", "altname" ])
+]
+
+codec_options = CodecOptions(uuid_representation=bson.binary.STANDARD)
+json_options = json_util.JSONOptions(json_mode=json_util.JSONMode.CANONICAL, uuid_representation=bson.binary.STANDARD)
+schema_fields = []
+corpus = []
+
+def prohibited(map):
+    if map["type"] in ["undefined", "minKey", "maxKey", "null"]:
+        return True
+    if map["type"] in ["object", "array", "double", "decimal", "javascriptWithScope", "javascript", "bool"]  and map["algo"] == "det":
+        return True
+    return False
+
+def gen_schema (map):
+    fmt = """"%s": { "encrypt": { "keyId": %s, "algorithm": "%s", "bsonType": "%s" } }"""
+    field_name = map["kms"] + "_" + map["type"] + "_" + map["algo"] + "_" + map["method"] + "_" + map["identifier"]
+
+    if map["method"] == "explicit":
+        return """"%s": { "bsonType": "binData" }""" % field_name
+
+    if map["identifier"] == "id":
+        if map["kms"] == "local":
+            key_id = """[ { "$binary": { "base64": "LOCALAAAAAAAAAAAAAAAAA==", "subType": "04" } } ]"""
+        else:
+            key_id = """[ { "$binary": { "base64": "AWSAAAAAAAAAAAAAAAAAAA==", "subType": "04" } } ]"""
+    else:
+        if map["kms"] == "local":
+            key_id = "\"/altname_local\""
+        else:
+            key_id = "\"/altname_aws\""
+
+    if map["algo"] == "rand":
+        algorithm = "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+    else:
+        algorithm = "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+
+    type = map["type"]
+    if map["type"].startswith("binData"):
+        type = "binData"
+            
+    return fmt % (field_name, key_id, algorithm, type)
+
+def get_bson_value (bson_type):
+    if bson_type == "double":
+        return """{ "$numberDouble" : 1.234 }"""
+    if bson_type == "string":
+        return """ "mongodb" """
+    if bson_type == "object":
+        return """ { "x" : { "$numberInt": 1 } } """
+    if bson_type == "array":
+        return """ [ { "$numberInt": 1 }, { "$numberInt": 2 }, { "$numberInt": 3 } ] """
+    if bson_type == "binData=00":
+        return """ { "$binary": { "base64": "AQIDBA==", "subType": "00" } } """
+    if bson_type == "binData=04":
+        return """ { "$binary": { "base64": "AAECAwQFBgcICQoLDA0ODw==", "subType": "04" } }"""
+    if bson_type == "objectId":
+        return """ { "$oid": "01234567890abcdef0123456" } """
+    if bson_type == "bool":
+        return """ true """
+    if bson_type == "date":
+        return """ { "$date": { "$numberLong": "12345" } } """
+    if bson_type == "regex":
+        return """ { "$regularExpression": { "pattern": ".*", "options": "" } } """
+    if bson_type == "dbPointer":
+        return """ { "$ref": "db.example", "$id": { "$oid": "01234567890abcdef0123456" } } """
+    if bson_type == "javascript":
+        return """ { "$code": "x=1" } """
+    if bson_type == "javascriptWithScope":
+        return """ { "$code": "x=1", "$scope": {} } """
+    if bson_type == "symbol":
+        return """ { "$symbol": "mongodb-symbol" } """
+    if bson_type == "int":
+        return """ { "$numberInt": "123" } """
+    if bson_type == "timestamp":
+        return """ { "$timestamp": { "t": 0, "i": 12345 } } """
+    if bson_type == "long":
+        return """ { "$numberLong": "456" } """
+    if bson_type == "decimal":
+        return """ { "$numberDecimal": "1.234" } """
+    if bson_type == "undefined":
+        return """ {"$undefined": true} """
+    if bson_type == "null":
+        return "null"
+    if bson_type == "minKey":
+        return """{"$minKey": 1}"""
+    if bson_type == "maxKey":
+        return """{"$maxKey": 1}"""
+
+def gen_field (map):
+    field_name = map["kms"] + "_" + map["type"] + "_" + map["algo"] + "_" + map["method"] + "_" + map["identifier"]
+
+    bson_value = get_bson_value (map["type"])
+    return """ "%s" : %s """ % (field_name, bson_value)
+
+def enumerate_axis (map, axis, remaining):
+    name = axis[0]
+    for item in axis[1]:
+        map[name] = item
+        if remaining == []:
+            is_prohibited = prohibited(map)
+            # for prohibited mappings, only allow explicit, replace it with prohibited.
+            if is_prohibited:
+                if map["method"] == "explicit":
+                    map["method"] = "prohibited"
+                else:
+                    continue
+                
+            if not is_prohibited:
+                schema_fields.append(gen_schema(map))
+
+            corpus.append(gen_field(map))
+        else:
+            enumerate_axis (map, remaining[0], remaining[1:])
+
+enumerate_axis({}, axes[0], axes[1:])
+
+schema = """{ "bsonType": "object", "properties": { %s } }""" % (",\n".join(schema_fields))
+open("schema.json", "w").write(schema)
+open("corpus.json", "w").write("{%s}" % ",\n".join(corpus))

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -243,7 +243,7 @@ as follows.
 Corpus Test
 ===========
 
-The corpus test exhaustively enumerates all ways to encrypt all BSON value types. Note, the test data includes BSON binary subtype 4 (or standard UUID). Run the test as follows.
+The corpus test exhaustively enumerates all ways to encrypt all BSON value types. Note, the test data includes BSON binary subtype 4 (or standard UUID), which MUST be decoded and encoded as subtype 4. Run the test as follows.
 
 1. Create a MongoClient without encryption enabled (referred to as ``client``).
 
@@ -253,10 +253,10 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
 
 4. Create the following:
 
-   - A MongoClient configured with auto encryption (referred to as `client_encrypted`)
-   - A `ClientEncryption` object (referred to as `client_encryption`)
+   - A MongoClient configured with auto encryption (referred to as ``client_encrypted``)
+   - A ``ClientEncryption`` object (referred to as ``client_encryption``)
 
-   Configure both objects with `aws` and the `local` KMS providers as follows:
+   Configure both objects with ``aws`` and the ``local`` KMS providers as follows:
 
    .. code:: javascript
 
@@ -271,9 +271,9 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
 
       Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk
 
-   Configure both objects with `keyVaultNamespace` set to `admin.datakeys`.
+   Configure both objects with ``keyVaultNamespace`` set to ``admin.datakeys``.
 
-5. Load `corpus/corpus.json <corpus/corpus.json>`_ to a variable named ``corpus``. Field names have the following layout: `<kms>_<type>_<algo>_<method>`.
+5. Load `corpus/corpus.json <corpus/corpus.json>`_ to a variable named ``corpus``. Field names have the following layout: ``<kms>_<type>_<algo>_<method>``.
 
    - ``kms`` is either ``aws`` or ``local``
    - ``type`` is a BSON type string `names coming from here <https://docs.mongodb.com/manual/reference/operator/query/type/>`_)
@@ -289,7 +289,7 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
    - If the field's method is ``explicit``, use ``client_encryption`` to explicitly encrypt the value.
    
      - Encrypt with the algorithm described by ``algo``.
-     - If `identifier` is ``id``
+     - If ``identifier`` is ``id``
         - If ``kms`` is ``local`` set the key_id to the UUID with base64 value ``LOCALAAAAAAAAAAAAAAAAA==``.
         - If ``kms`` is ``aws`` set the key_id to the UUID with base64 value ``AWSAAAAAAAAAAAAAAAAAAA==``.
      - If ``identifier`` is ``altname``

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -277,10 +277,11 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
    - ``kms`` is either ``aws`` or ``local``
    - ``type`` is a BSON type string `names coming from here <https://docs.mongodb.com/manual/reference/operator/query/type/>`_)
    - ``algo`` is either ``rand`` or ``det`` for random or deterministic encryption
-   - ``method`` is either ``auto`` or ``expl`` for automatic or explicit encryption
+   - ``method`` is either ``auto``, for automatic encryption ``explicit``,  explicit encryption, or ``prohibited`` for prohibited explicit encryption
    - ``identifier`` is either ``id`` or ``altname`` for the key identifier
 
-   Iterate over each ``_id`` field of ``corpus``. For each field, if the ``method`` is ``expl``, replace the value with a value explicitly encrypted with ``client_encryption``.
+   Iterate over each field of ``corpus`` excluding ``_id``, ``altname_aws`` and ``altname_local``.
+   For each field, if the ``method`` is ``explicit``, replace the value with a value explicitly encrypted with ``client_encryption``.
    
      - Encrypt with the algorithm described by ``algo``.
      - If `identifier` is ``id``
@@ -289,6 +290,8 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
      - If ``identifier`` is ``altname``
         - If ``kms`` is ``local`` set the key_alt_name to "local".
         - If ``kms`` is ``aws`` set the key_alt_name to "aws".
+
+   If the method if ``prohibited``, attempt to explicitly encrypt in the same manner, but verify that an exception is thrown.
 
 5. Using ``client_encrypted``, insert ``corpus`` into ``db.coll``.
 


### PR DESCRIPTION
This adds an exhaustive way of testing encryption and decryption of FLE with a single document where each field is encrypted in a different way by enumerating the matrix with the following axes:
- KMS (local, aws)
- BSON type
- algorithm (random, deterministic)
- method (explicit, automatic)
- key identifier (_id, keyAltName)

The test is also run with local and remote configured schema.

In the process of generating this corpus with the Java driver, this caught multiple bugs:
(CDRIVER-3204, CDRIVER-3205, CDRIVER-3216, JAVA-3335, SERVER-41994).