### PR TITLE
SPEC-1349: Expanding test coverage for percent encoding in connection strings

### DIFF
--- a/source/connection-string/tests/invalid-uris.json
+++ b/source/connection-string/tests/invalid-uris.json
@@ -269,6 +269,24 @@
       "hosts": null,
       "auth": null,
       "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped percent sign and an escaped one",
+      "uri": "mongodb://user%20%:password@localhost",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped percent sign (non hex digit)",
+      "uri": "mongodb://user%w:password@localhost",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
     }
   ]
 }

--- a/source/connection-string/tests/invalid-uris.yml
+++ b/source/connection-string/tests/invalid-uris.yml
@@ -239,3 +239,23 @@ tests:
         hosts: ~
         auth: ~
         options: ~
+
+    -
+        description: "Username with password containing an unescaped percent sign and an escaped one"
+        uri: "mongodb://user%20%:password@localhost"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+
+    -
+        description: "Username with password containing an unescaped percent sign (non hex digit)"
+        uri: "mongodb://user%w:password@localhost"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+
+    


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1349