### PR TITLE
Fix yaml typo

### DIFF
--- a/source/auth/tests/connection-string.json
+++ b/source/auth/tests/connection-string.json
@@ -355,6 +355,16 @@
       "description": "authSource without username is invalid (default mechanism)",
       "uri": "mongodb://localhost/?authSource=foo",
       "valid": false
+    },
+    {
+      "description": "should throw an exception if no username provided (userinfo implies default mechanism)",
+      "uri": "mongodb://@localhost.com/",
+      "valid": false
+    },
+    {
+      "description": "should throw an exception if no username/password provided (userinfo implies default mechanism)",
+      "uri": "mongodb://:@localhost.com/",
+      "valid": false
     }
   ]
 }

--- a/source/auth/tests/connection-string.yml
+++ b/source/auth/tests/connection-string.yml
@@ -291,11 +291,11 @@ tests:
         description: "authSource without username is invalid (default mechanism)"
         uri: "mongodb://localhost/?authSource=foo"
         valid: false
-
+    -
         description: "should throw an exception if no username provided (userinfo implies default mechanism)"
         uri: "mongodb://@localhost.com/"
         valid: false
-
+    -
         description: "should throw an exception if no username/password provided (userinfo implies default mechanism)"
         uri: "mongodb://:@localhost.com/"
         valid: false

--- a/source/crud/tests/v2/aggregate-out-readConcern.json
+++ b/source/crud/tests/v2/aggregate-out-readConcern.json
@@ -1,4 +1,13 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "4.1.0",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -13,7 +22,6 @@
       "x": 33
     }
   ],
-  "minServerVersion": "4.1",
   "collection_name": "test_aggregate_out_readconcern",
   "tests": [
     {

--- a/source/crud/tests/v2/bulkWrite-arrayFilters.json
+++ b/source/crud/tests/v2/bulkWrite-arrayFilters.json
@@ -1,4 +1,9 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.5.6"
+    }
+  ],
   "data": [
     {
       "_id": 1,
@@ -23,7 +28,6 @@
       ]
     }
   ],
-  "minServerVersion": "3.5.6",
   "collection_name": "test",
   "database_name": "crud-tests",
   "tests": [

--- a/source/crud/tests/v2/db-aggregate.json
+++ b/source/crud/tests/v2/db-aggregate.json
@@ -1,6 +1,10 @@
 {
+  "runOn": [
+    {
+      "minServerVersion": "3.6.0"
+    }
+  ],
   "database_name": "admin",
-  "minServerVersion": "3.6",
   "tests": [
     {
       "description": "Aggregate with $listLocalSessions",


### PR DESCRIPTION
The YAML in the most recent changes to the auth spec tests was invalid, which caused the generation to JSON to fail when I attempted to run it for a different change. I've fixed it and generated the JSON again (which also picked up some unrelated changes to the CRUD spec tests, which were also updated without the makefile being run).