### PR TITLE
SPEC-1353 and small test fix

### DIFF
--- a/source/connections-survive-step-down/tests/README.rst
+++ b/source/connections-survive-step-down/tests/README.rst
@@ -110,7 +110,7 @@ This test requires server version 4.2 or higher.
 Not Master - Reset Connection Pool
 ``````````````````````````````````
 
-This test requires server version 4.0 or lower.
+This test requires server version 4.0.
 
 
 - Set the following fail point: ``{configureFailPoint: "failCommand", mode: {times: 1},
@@ -124,7 +124,7 @@ This test requires server version 4.0 or lower.
 Shutdown in progress - Reset Connection Pool
 ````````````````````````````````````````````
 
-This test should be run on all supported server versions.
+This test should be run on all server versions >= 4.0.
 
 Perform the following operations on a client configured to NOT retry writes:
 
@@ -139,7 +139,7 @@ Perform the following operations on a client configured to NOT retry writes:
 Interrupted at shutdown - Reset Connection Pool
 ```````````````````````````````````````````````
 
-This test should be run on all supported server versions.
+This test should be run on all server versions >= 4.0.
 
 Perform the following operations on a client configured to NOT retry writes:
 

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-summary.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-summary.rst
@@ -8,7 +8,7 @@ Server Discovery And Monitoring -- Summary
 :Advisors: David Golden, Craig Wilson
 :Status: Draft
 :Type: Standards
-:Last Modified: September 8, 2014
+:Last Modified: July 11, 2019
 
 .. contents::
 
@@ -212,7 +212,7 @@ the behavior is different from a failed application operation.
 The ismaster call is retried once, immediately,
 before the server is marked "down".
 
-In either case the client SHOULD clear its connection pool for the server:
+In either case the client MUST clear its connection pool for the server:
 if one socket is bad, it is likely that all are.
 
 An algorithm is specified for parsing
@@ -221,6 +221,6 @@ When the client sees such an error it knows its topology view is out of date.
 It MUST mark the server type "unknown."
 Multi-threaded and asynchronous clients MUST re-check the server soon,
 and single-threaded clients MUST request a scan before the next operation.
-The client SHOULD clear its connection pool for the server if the
-server is 4.0 or earlier, and SHOULD NOT clear its connection pool for the
+The client MUST clear its connection pool for the server if the
+server is 4.0 or earlier, and MUST NOT clear its connection pool for the
 server if the server is 4.2 or later.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -8,8 +8,8 @@ Server Discovery And Monitoring
 :Advisors: David Golden, Craig Wilson
 :Status: Accepted
 :Type: Standards
-:Version: 2.13
-:Last Modified: 2019-05-29
+:Version: 2.14
+:Last Modified: 2019-07-11
 
 .. contents::
 
@@ -1233,9 +1233,9 @@ updateRSFromPrimary
   see `multi-threaded or asynchronous monitoring`_.)
 
   If the old primary server version is 4.0 or earlier,
-  the client SHOULD clear its connection pool for the old primary, too:
+  the client MUST clear its connection pool for the old primary, too:
   the connections are all bad because the old primary has closed its sockets.
-  If the old primary server version is 4.2 or newer, the client SHOULD NOT
+  If the old primary server version is 4.2 or newer, the client MUST NOT
   clear its connection pool for the old primary.
 
   See `replica set monitoring with and without a primary`_.
@@ -1372,7 +1372,7 @@ referring to the table above we see the subroutine is `checkIfHasPrimary`_.
 The result is the TopologyType changes to ReplicaSetNoPrimary.
 See the test scenario called "Network error writing to primary".
 
-The client SHOULD close all idle sockets in its connection pool for the server:
+The client MUST close all idle sockets in its connection pool for the server:
 if one socket is bad, it is likely that all are.
 
 Clients MUST NOT request an immediate check of the server;


### PR DESCRIPTION
The "connections survive primary stepdown" tests mandate that connection pools be cleared, so the SDAM spec should mandate this, too.

Also, failCommand is only available in server versions 4.0 and later, so only run the "connections survive primary stepdown" tests on those versions.