### PR TITLE
SPEC-1335 clarify resume process for changeStreams started with startAfter

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -10,7 +10,7 @@ Change Streams
 :Type: Standards
 :Minimum Server Version: 3.6
 :Last Modified: April 3, 2019
-:Version: 1.6.2
+:Version: 1.6.3
 
 .. contents::
 

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -481,10 +481,19 @@ Once a ``ChangeStream`` has encountered a resumable error, it MUST attempt to re
 - Connect to selected server.
 - If there is a cached ``resumeToken``:
 
-  - The driver MUST set ``resumeAfter`` to the cached ``resumeToken``.
-  - The driver MUST NOT set ``startAfter``. If ``startAfter`` was in the original aggregation command, the driver MUST remove it.
-  - The driver MUST NOT set ``startAtOperationTime``. If ``startAtOperationTime`` was in the original aggregation command, the driver MUST remove it.
-- If there is no cached ``resumeToken`` and the ``ChangeStream`` has a saved operation time (either from an originally specified ``startAtOperationTime`` or saved from the original aggregation) and the max wire version is >= ``7``:
+  - If the ``ChangeStream`` was started with ``startAfter`` and has yet to return a result document:
+
+    - The driver MUST set ``startAfter`` to the cached ``resumeToken``.
+    - The driver MUST NOT set ``resumeAfter``.
+    - The driver MUST NOT set ``startAtOperationTime``. If ``startAtOperationTime`` was in the original aggregation command, the driver MUST remove it.
+
+  - Else:
+
+    - The driver MUST set ``resumeAfter`` to the cached ``resumeToken``.
+    - The driver MUST NOT set ``startAfter``. If ``startAfter`` was in the original aggregation command, the driver MUST remove it.
+    - The driver MUST NOT set ``startAtOperationTime``. If ``startAtOperationTime`` was in the original aggregation command, the driver MUST remove it.
+
+- Else if there is no cached ``resumeToken`` and the ``ChangeStream`` has a saved operation time (either from an originally specified ``startAtOperationTime`` or saved from the original aggregation) and the max wire version is >= ``7``:
 
   - The driver MUST NOT set ``resumeAfter``.
   - The driver MUST NOT set ``startAfter``.
@@ -781,4 +790,7 @@ Changelog
 |            | patterns instead of a method.                              |
 +------------+------------------------------------------------------------+
 | 2019-07-02 | Fix server version for startAfter                          |
++------------+------------------------------------------------------------+
+| 2019-07-15 | Clarify resume process for change streams started with     |
+|            | the ``startAfter`` option.                                 |
 +------------+------------------------------------------------------------+

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -160,6 +160,8 @@ The following tests have not yet been automated, but MUST still be tested
 #. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
 #. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
 #. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` and ``<4.0.7`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a changestream.
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has not received any results yet MUST include a ``startAfter`` option and MUST NOT include a ``resumeAfter`` option when resuming a changestream.
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has received at least one result MUST include a ``resumeAfter`` option and MUST NOT include a ``startAfter`` option when resuming a changestream.
 #. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
 #. - For a ``ChangeStream`` under these conditions:
       - Running against a server ``>=4.0.7``.

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -159,7 +159,7 @@ The following tests have not yet been automated, but MUST still be tested
 #. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
 #. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
 #. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
-#. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` and ``<4.0.7`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a changestream.
+#. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` and ``<4.0.7`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a ``ChangeStream``.
 #. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
 #. - For a ``ChangeStream`` under these conditions:
       - Running against a server ``>=4.0.7``.
@@ -202,5 +202,5 @@ The following tests have not yet been automated, but MUST still be tested
       - ``getResumeToken`` must return the ``_id`` of the previous document returned if one exists.
       - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
       - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.
-#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has not received any results yet MUST include a ``startAfter`` option and MUST NOT include a ``resumeAfter`` option when resuming a changestream.
-#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has received at least one result MUST include a ``resumeAfter`` option and MUST NOT include a ``startAfter`` option when resuming a changestream.
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has not received any results yet MUST include a ``startAfter`` option and MUST NOT include a ``resumeAfter`` option when resuming a ``ChangeStream``.
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has received at least one result MUST include a ``resumeAfter`` option and MUST NOT include a ``startAfter`` option when resuming a ``ChangeStream``.

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -159,7 +159,7 @@ The following tests have not yet been automated, but MUST still be tested
 #. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
 #. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
 #. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
-#. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` and ``<4.0.7`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a ``ChangeStream``.
+#. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` and ``<4.0.7`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a change stream.
 #. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
 #. - For a ``ChangeStream`` under these conditions:
       - Running against a server ``>=4.0.7``.
@@ -202,5 +202,5 @@ The following tests have not yet been automated, but MUST still be tested
       - ``getResumeToken`` must return the ``_id`` of the previous document returned if one exists.
       - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
       - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.
-#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has not received any results yet MUST include a ``startAfter`` option and MUST NOT include a ``resumeAfter`` option when resuming a ``ChangeStream``.
-#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has received at least one result MUST include a ``resumeAfter`` option and MUST NOT include a ``startAfter`` option when resuming a ``ChangeStream``.
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has not received any results yet MUST include a ``startAfter`` option and MUST NOT include a ``resumeAfter`` option when resuming a change stream.
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has received at least one result MUST include a ``resumeAfter`` option and MUST NOT include a ``startAfter`` option when resuming a change stream.

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -160,8 +160,6 @@ The following tests have not yet been automated, but MUST still be tested
 #. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
 #. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
 #. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` and ``<4.0.7`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a changestream.
-#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has not received any results yet MUST include a ``startAfter`` option and MUST NOT include a ``resumeAfter`` option when resuming a changestream.
-#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has received at least one result MUST include a ``resumeAfter`` option and MUST NOT include a ``startAfter`` option when resuming a changestream.
 #. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
 #. - For a ``ChangeStream`` under these conditions:
       - Running against a server ``>=4.0.7``.
@@ -204,3 +202,5 @@ The following tests have not yet been automated, but MUST still be tested
       - ``getResumeToken`` must return the ``_id`` of the previous document returned if one exists.
       - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
       - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has not received any results yet MUST include a ``startAfter`` option and MUST NOT include a ``resumeAfter`` option when resuming a changestream.
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has received at least one result MUST include a ``resumeAfter`` option and MUST NOT include a ``startAfter`` option when resuming a changestream.


### PR DESCRIPTION
Supersedes #580 

Prose tests had to be added instead of spec tests because the spec test format does not provide a way to initialize a change stream with a valid `startAfter` token.