### PR TITLE
SPEC-1289: Use specific server version for $merge tests

### DIFF
--- a/source/crud/tests/v2/aggregate-merge.json
+++ b/source/crud/tests/v2/aggregate-merge.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.2.0"
+      "minServerVersion": "4.1.11"
     }
   ],
   "data": [

--- a/source/crud/tests/v2/aggregate-merge.yml
+++ b/source/crud/tests/v2/aggregate-merge.yml
@@ -1,6 +1,6 @@
 runOn:
     -
-        minServerVersion: "4.2.0"
+        minServerVersion: "4.1.11"
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-reads/tests/aggregate-merge.json
+++ b/source/retryable-reads/tests/aggregate-merge.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.2.0"
+      "minServerVersion": "4.1.11"
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/aggregate-merge.yml
+++ b/source/retryable-reads/tests/aggregate-merge.yml
@@ -1,6 +1,6 @@
 runOn:
   -
-    minServerVersion: "4.2.0"
+    minServerVersion: "4.1.11"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1289

`$merge` was added in 4.1.11 in [SERVER-40429](https://jira.mongodb.org/browse/SERVER-40429). 

In https://github.com/mongodb/mongo-php-library/pull/644#discussion_r306576915, I realized that I used 4.2.0 when writing these tests instead of the exact version.