### PR TITLE
SPEC-1371 add prose test for external key vault

### DIFF
--- a/source/client-side-encryption/external/external-key.json
+++ b/source/client-side-encryption/external/external-key.json
@@ -1,0 +1,31 @@
+{
+    "status": {
+        "$numberInt": "1"
+    }, 
+    "_id": {
+        "$binary": {
+            "base64": "LOCALAAAAAAAAAAAAAAAAA==", 
+            "subType": "04"
+        }
+    }, 
+    "masterKey": {
+        "provider": "local"
+    }, 
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1557827033449"
+        }
+    }, 
+    "keyMaterial": {
+        "$binary": {
+            "base64": "Ce9HSz/HKKGkIt4uyy+jDuKGA+rLC2cycykMo6vc8jXxqa1UVDYHWq1r+vZKbnnSRBfB981akzRKZCFpC05CTyFqDhXv6OnMjpG97OZEREGIsHEYiJkBW0jJJvfLLgeLsEpBzsro9FztGGXASxyxFRZFhXvHxyiLOKrdWfs7X1O/iK3pEoHMx6uSNSfUOgbebLfIqW7TO++iQS5g1xovXA==", 
+            "subType": "00"
+        }
+    }, 
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1557827033449"
+        }
+    },
+    "keyAltNames": [ "local" ]
+}

--- a/source/client-side-encryption/external/external-schema.json
+++ b/source/client-side-encryption/external/external-schema.json
@@ -1,0 +1,18 @@
+{
+    "properties": {
+       "encrypted": {
+           "encrypt": {
+               "keyId": [
+                   {
+                       "$binary": {
+                           "base64": "LOCALAAAAAAAAAAAAAAAAA==", 
+                           "subType": "04"
+                       }
+                   }
+               ], 
+               "bsonType": "string", 
+               "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+           }
+       }
+    }
+}


### PR DESCRIPTION
A simple test of external key vault by configuring the external key vault to use a bad username/password.

Validated with a Java driver PoC here:
https://github.com/kevinAlbs/JavaFLEProsePoC/blob/95e9fc211f7ac33f7672885723f9d9794111e32f/src/main/java/ExternalKeyVaultTest.java