### PR TITLE
SPEC-1392 Make bson-corpus array test descriptions unique

### DIFF
--- a/source/bson-corpus/tests/array.json
+++ b/source/bson-corpus/tests/array.json
@@ -14,13 +14,13 @@
             "canonical_extjson": "{\"a\" : [{\"$numberInt\": \"10\"}]}"
         },
         {
-            "description": "Single Element Array with index set incorrectly",
+            "description": "Single Element Array with index set incorrectly to empty string",
             "degenerate_bson": "130000000461000B00000010000A0000000000",
             "canonical_bson": "140000000461000C0000001030000A0000000000",
             "canonical_extjson": "{\"a\" : [{\"$numberInt\": \"10\"}]}"
         },
         {
-            "description": "Single Element Array with index set incorrectly",
+            "description": "Single Element Array with index set incorrectly to ab",
             "degenerate_bson": "150000000461000D000000106162000A0000000000",
             "canonical_bson": "140000000461000C0000001030000A0000000000",
             "canonical_extjson": "{\"a\" : [{\"$numberInt\": \"10\"}]}"

--- a/source/bson-corpus/tests/array.json
+++ b/source/bson-corpus/tests/array.json
@@ -24,6 +24,12 @@
             "degenerate_bson": "150000000461000D000000106162000A0000000000",
             "canonical_bson": "140000000461000C0000001030000A0000000000",
             "canonical_extjson": "{\"a\" : [{\"$numberInt\": \"10\"}]}"
+        },
+        {
+            "description": "Multi Element Array with duplicate indexes",
+            "degenerate_bson": "1b000000046100130000001030000a000000103000140000000000",
+            "canonical_bson": "1b000000046100130000001030000a000000103100140000000000",
+            "canonical_extjson": "{\"a\" : [{\"$numberInt\": \"10\"}, {\"$numberInt\": \"20\"}]}"
         }
     ],
     "decodeErrors": [


### PR DESCRIPTION
Fixes #625.

For reference this is the first test:
```
$ echo "130000000461000B00000010000A0000000000" | perl bsonview -x
 13000000 04 "a" 00 [ 0b000000 10 "" 00 0A000000 00 ] 00
```
And this is the second:
```
$ echo "150000000461000D000000106162000A0000000000" | perl bsonview -x
 15000000 04 "a" 00 [ 0d000000 10 "ab" 00 0A000000 00 ] 00
```