### PR TITLE
SPEC-1411 Avoid using readConcern snapshot in sharded txn tests

### DIFF
--- a/source/transactions-convenient-api/tests/transaction-options.json
+++ b/source/transactions-convenient-api/tests/transaction-options.json
@@ -192,7 +192,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "snapshot"
+              "level": "majority"
             },
             "writeConcern": {
               "w": 1
@@ -243,7 +243,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -308,7 +308,7 @@
             },
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": 1
@@ -335,7 +335,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -380,7 +380,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "majority"
+              "level": "snapshot"
             },
             "writeConcern": {
               "w": "majority"
@@ -412,7 +412,7 @@
             },
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": 1
@@ -439,7 +439,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -481,7 +481,7 @@
       "description": "withTransaction explicit transaction options override client options",
       "useMultipleMongoses": true,
       "clientOptions": {
-        "readConcernLevel": "majority",
+        "readConcernLevel": "local",
         "w": "majority"
       },
       "operations": [
@@ -508,7 +508,7 @@
             },
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": 1
@@ -535,7 +535,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },

--- a/source/transactions-convenient-api/tests/transaction-options.yml
+++ b/source/transactions-convenient-api/tests/transaction-options.yml
@@ -108,7 +108,7 @@ tests:
     sessionOptions:
       session0:
         defaultTransactionOptions:
-          readConcern: { level: snapshot }
+          readConcern: { level: majority }
           writeConcern: { w: 1 }
     operations: *operations
     expectations:
@@ -123,7 +123,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             startTransaction: true
             autocommit: false
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             # omitted fields
             writeConcern: ~
           command_name: insert
@@ -161,7 +161,7 @@ tests:
                 result:
                   insertedId: 1
           options:
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             writeConcern: { w: 1 }
     expectations:
       -
@@ -175,7 +175,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             startTransaction: true
             autocommit: false
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             # omitted fields
             writeConcern: ~
           command_name: insert
@@ -200,7 +200,7 @@ tests:
     sessionOptions:
       session0:
         defaultTransactionOptions:
-          readConcern: { level: majority }
+          readConcern: { level: snapshot }
           writeConcern: { w: majority }
     operations: *operations_explicit_transactionOptions
     expectations:
@@ -215,7 +215,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             startTransaction: true
             autocommit: false
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             # omitted fields
             writeConcern: ~
           command_name: insert
@@ -238,7 +238,7 @@ tests:
     description: withTransaction explicit transaction options override client options
     useMultipleMongoses: true
     clientOptions:
-      readConcernLevel: majority
+      readConcernLevel: local
       w: majority
     operations: *operations_explicit_transactionOptions
     expectations:
@@ -253,7 +253,7 @@ tests:
             txnNumber: { $numberLong: "1" }
             startTransaction: true
             autocommit: false
-            readConcern: { level: snapshot }
+            readConcern: { level: majority }
             # omitted fields
             writeConcern: ~
           command_name: insert

--- a/source/transactions/tests/read-concern.json
+++ b/source/transactions/tests/read-concern.json
@@ -39,7 +39,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -110,7 +110,7 @@
               "cursor": {},
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"
@@ -202,7 +202,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -274,7 +274,7 @@
               "batchSize": 3,
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"
@@ -389,7 +389,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -484,7 +484,7 @@
               },
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"
@@ -608,7 +608,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -664,7 +664,7 @@
               "key": "_id",
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"
@@ -741,7 +741,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               }
             }
           }
@@ -780,7 +780,7 @@
               "find": "test",
               "lsid": "session0",
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "txnNumber": {
                 "$numberLong": "1"

--- a/source/transactions/tests/read-concern.yml
+++ b/source/transactions/tests/read-concern.yml
@@ -25,7 +25,7 @@ tests:
         arguments:
           options:
             readConcern:
-              level: snapshot
+              level: majority
       - &countDocuments
         name: countDocuments
         object: collection
@@ -51,7 +51,7 @@ tests:
             cursor: {}
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true
@@ -116,7 +116,7 @@ tests:
             batchSize: 3
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true
@@ -202,7 +202,7 @@ tests:
               batchSize: 3
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true
@@ -282,7 +282,7 @@ tests:
             key: _id
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true
@@ -328,7 +328,7 @@ tests:
             find: *collection_name
             lsid: session0
             readConcern:
-              level: snapshot
+              level: majority
             txnNumber:
               $numberLong: "1"
             startTransaction: true

--- a/source/transactions/tests/transaction-options-repl.json
+++ b/source/transactions/tests/transaction-options-repl.json
@@ -1,0 +1,181 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "readConcern snapshot in startTransaction options",
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot",
+                "afterClusterTime": 42
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/transactions/tests/transaction-options-repl.yml
+++ b/source/transactions/tests/transaction-options-repl.yml
@@ -1,0 +1,117 @@
+runOn:
+  - minServerVersion: "4.0"
+    topology: ["replicaset"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+
+  - description: readConcern snapshot in startTransaction options
+
+    sessionOptions:
+      session0:
+        defaultTransactionOptions:
+          readConcern:
+            level: majority # Overridden.
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            readConcern:
+              level: snapshot
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: commitTransaction
+        object: session0
+      # Now test abort.
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            readConcern:
+              level: snapshot
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 2
+        result:
+          insertedId: 2
+      - name: abortTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+              level: snapshot
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 2
+            ordered: true
+            lsid: session0
+            txnNumber:
+              $numberLong: "2"
+            startTransaction: true
+            autocommit: false
+            readConcern:
+              level: snapshot
+              afterClusterTime: 42
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "2"
+            startTransaction:
+            autocommit: false
+            readConcern:
+            writeConcern:
+          command_name: abortTransaction
+          database_name: admin
+
+    outcome:
+      collection:
+        data:
+          - _id: 1

--- a/source/transactions/tests/transaction-options.json
+++ b/source/transactions/tests/transaction-options.json
@@ -322,7 +322,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "snapshot"
+              "level": "majority"
             },
             "writeConcern": {
               "w": 1
@@ -393,7 +393,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null
             },
@@ -438,7 +438,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot",
+                "level": "majority",
                 "afterClusterTime": 42
               },
               "writeConcern": null
@@ -487,7 +487,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "majority"
+              "level": "snapshot"
             },
             "writeConcern": {
               "w": 1
@@ -503,7 +503,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": "majority"
@@ -535,7 +535,7 @@
           "arguments": {
             "options": {
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": {
                 "w": "majority"
@@ -579,7 +579,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null,
               "maxTimeMS": null
@@ -625,7 +625,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot",
+                "level": "majority",
                 "afterClusterTime": 42
               },
               "writeConcern": null,
@@ -676,7 +676,7 @@
         "session0": {
           "defaultTransactionOptions": {
             "readConcern": {
-              "level": "snapshot"
+              "level": "majority"
             },
             "writeConcern": {
               "w": "majority"
@@ -747,7 +747,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot"
+                "level": "majority"
               },
               "writeConcern": null,
               "maxTimeMS": null
@@ -793,7 +793,7 @@
               "startTransaction": true,
               "autocommit": false,
               "readConcern": {
-                "level": "snapshot",
+                "level": "majority",
                 "afterClusterTime": 42
               },
               "writeConcern": null,
@@ -977,172 +977,6 @@
               "writeConcern": {
                 "w": 1
               }
-            },
-            "command_name": "abortTransaction",
-            "database_name": "admin"
-          }
-        }
-      ],
-      "outcome": {
-        "collection": {
-          "data": [
-            {
-              "_id": 1
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "readConcern snapshot in startTransaction options",
-      "sessionOptions": {
-        "session0": {
-          "defaultTransactionOptions": {
-            "readConcern": {
-              "level": "majority"
-            }
-          }
-        }
-      },
-      "operations": [
-        {
-          "name": "startTransaction",
-          "object": "session0",
-          "arguments": {
-            "options": {
-              "readConcern": {
-                "level": "snapshot"
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session0",
-            "document": {
-              "_id": 1
-            }
-          },
-          "result": {
-            "insertedId": 1
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session0"
-        },
-        {
-          "name": "startTransaction",
-          "object": "session0",
-          "arguments": {
-            "options": {
-              "readConcern": {
-                "level": "snapshot"
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session0",
-            "document": {
-              "_id": 2
-            }
-          },
-          "result": {
-            "insertedId": 2
-          }
-        },
-        {
-          "name": "abortTransaction",
-          "object": "session0"
-        }
-      ],
-      "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "test",
-              "documents": [
-                {
-                  "_id": 1
-                }
-              ],
-              "ordered": true,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": true,
-              "autocommit": false,
-              "readConcern": {
-                "level": "snapshot"
-              },
-              "writeConcern": null
-            },
-            "command_name": "insert",
-            "database_name": "transaction-tests"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "commitTransaction": 1,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "1"
-              },
-              "startTransaction": null,
-              "autocommit": false,
-              "readConcern": null,
-              "writeConcern": null
-            },
-            "command_name": "commitTransaction",
-            "database_name": "admin"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "insert": "test",
-              "documents": [
-                {
-                  "_id": 2
-                }
-              ],
-              "ordered": true,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "2"
-              },
-              "startTransaction": true,
-              "autocommit": false,
-              "readConcern": {
-                "level": "snapshot",
-                "afterClusterTime": 42
-              },
-              "writeConcern": null
-            },
-            "command_name": "insert",
-            "database_name": "transaction-tests"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "abortTransaction": 1,
-              "lsid": "session0",
-              "txnNumber": {
-                "$numberLong": "2"
-              },
-              "startTransaction": null,
-              "autocommit": false,
-              "readConcern": null,
-              "writeConcern": null
             },
             "command_name": "abortTransaction",
             "database_name": "admin"

--- a/source/transactions/tests/transaction-options.yml
+++ b/source/transactions/tests/transaction-options.yml
@@ -188,7 +188,7 @@ tests:
       session0:
         defaultTransactionOptions:
           readConcern:
-            level: snapshot
+            level: majority
           writeConcern:
             w: 1
           maxCommitTimeMS: 60000
@@ -208,7 +208,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
           command_name: insert
           database_name: *database_name
@@ -238,7 +238,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
               afterClusterTime: 42
             writeConcern:
           command_name: insert
@@ -269,7 +269,7 @@ tests:
       session0:
         defaultTransactionOptions:
           readConcern:
-            level: majority
+            level: snapshot
           writeConcern:
             w: 1
           maxCommitTimeMS: 30000
@@ -280,7 +280,7 @@ tests:
         arguments:
           options:
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
               w: majority
             maxCommitTimeMS: 60000
@@ -299,7 +299,7 @@ tests:
         arguments:
           options:
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
               w: majority
       - name: insertOne
@@ -326,7 +326,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
             maxTimeMS:
           command_name: insert
@@ -357,7 +357,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
               afterClusterTime: 42
             writeConcern:
             maxTimeMS:
@@ -390,7 +390,7 @@ tests:
       session0:
         defaultTransactionOptions:
           readConcern:
-            level: snapshot
+            level: majority
           writeConcern:
             w: majority
           maxCommitTimeMS: 60000
@@ -410,7 +410,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
             writeConcern:
             maxTimeMS:
           command_name: insert
@@ -441,7 +441,7 @@ tests:
             startTransaction: true
             autocommit: false
             readConcern:
-              level: snapshot
+              level: majority
               afterClusterTime: 42
             writeConcern:
             maxTimeMS:
@@ -535,110 +535,6 @@ tests:
             readConcern:
             writeConcern:
               w: 1
-          command_name: abortTransaction
-          database_name: admin
-
-    outcome: *outcome
-
-  - description: readConcern snapshot in startTransaction options
-
-    sessionOptions:
-      session0:
-        defaultTransactionOptions:
-          readConcern:
-            level: majority # Overridden.
-
-    operations:
-      - name: startTransaction
-        object: session0
-        arguments:
-          options:
-            readConcern:
-              level: snapshot
-      - name: insertOne
-        object: collection
-        arguments:
-          session: session0
-          document:
-            _id: 1
-        result:
-          insertedId: 1
-      - name: commitTransaction
-        object: session0
-      # Now test abort.
-      - name: startTransaction
-        object: session0
-        arguments:
-          options:
-            readConcern:
-              level: snapshot
-      - name: insertOne
-        object: collection
-        arguments:
-          session: session0
-          document:
-            _id: 2
-        result:
-          insertedId: 2
-      - name: abortTransaction
-        object: session0
-
-    expectations:
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - _id: 1
-            ordered: true
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction: true
-            autocommit: false
-            readConcern:
-              level: snapshot
-            writeConcern:
-          command_name: insert
-          database_name: *database_name
-      - command_started_event:
-          command:
-            commitTransaction: 1
-            lsid: session0
-            txnNumber:
-              $numberLong: "1"
-            startTransaction:
-            autocommit: false
-            readConcern:
-            writeConcern:
-          command_name: commitTransaction
-          database_name: admin
-      - command_started_event:
-          command:
-            insert: *collection_name
-            documents:
-              - _id: 2
-            ordered: true
-            lsid: session0
-            txnNumber:
-              $numberLong: "2"
-            startTransaction: true
-            autocommit: false
-            readConcern:
-              level: snapshot
-              afterClusterTime: 42
-            writeConcern:
-          command_name: insert
-          database_name: *database_name
-      - command_started_event:
-          command:
-            abortTransaction: 1
-            lsid: session0
-            txnNumber:
-              $numberLong: "2"
-            startTransaction:
-            autocommit: false
-            readConcern:
-            writeConcern:
           command_name: abortTransaction
           database_name: admin
 


### PR DESCRIPTION
Passing patch (note the failures are due to an unrelated issue [PYTHON-1935](https://jira.mongodb.org/browse/PYTHON-1935)):  https://evergreen.mongodb.com/version/5d519ffa1e2d174dcb14bcef