### PR TITLE
Note topology requirements for step down tests

### DIFF
--- a/source/connections-survive-step-down/tests/README.rst
+++ b/source/connections-survive-step-down/tests/README.rst
@@ -77,7 +77,7 @@ The driver should implement the following tests:
 getMore Iteration
 `````````````````
 
-This test requires server version 4.2 or higher.
+This test requires a replica set with server version 4.2 or higher.
 
 Perform the following operations:
 
@@ -93,7 +93,7 @@ Perform the following operations:
 Not Master - Keep Connection Pool
 `````````````````````````````````
 
-This test requires server version 4.2 or higher.
+This test requires a replica set with server version 4.2 or higher.
 
 - Set the following fail point: ``{configureFailPoint: "failCommand", mode: {times: 1},
   data: {failCommands: ["insert"], errorCode: 10107}}``
@@ -110,7 +110,7 @@ This test requires server version 4.2 or higher.
 Not Master - Reset Connection Pool
 ``````````````````````````````````
 
-This test requires server version 4.0.
+This test requires a replica set with server version 4.0.
 
 
 - Set the following fail point: ``{configureFailPoint: "failCommand", mode: {times: 1},


### PR DESCRIPTION
The getMore test requires a replica set because it invokes the `replSetStepDown` command.

I think it also makes sense for the other two "not master" tests to require a replica set, even if the fail point technically makes it possible to simulate the error in other topologies.

I've left the final two shutdown tests alone, as I don't think those codes are specific to replica sets and I imagine those tests could be executed against a sharded cluster or standalone. That said, perhaps we should note thjat sharded cluster URIs should only include a single mongos node since the test calls `configureFailPoint`.