### PR TITLE
SPEC-1434: Clarify ignoring configureFailPoint command in spec tests

### DIFF
--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -342,6 +342,12 @@ fail point on the mongos server which "session0" is pinned to::
               failCommands: ["commitTransaction"]
               closeConnection: true
 
+Tests that use the "targetedFailPoint" operation do not include
+``configureFailPoint`` commands in their command expectations. Drivers MUST
+ensure that ``configureFailPoint`` commands do not appear in the list of logged
+commands, either by manually filtering it from the list of observed commands or
+by using a different MongoClient to execute ``configureFailPoint``.
+
 assertSessionTransactionState
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
This clarifies that drivers should either run the `configureFailPoint` command used for the `targetedFailPoint` operation on a different client, or need to filter commands in the logger as the tests don't include `configureFailPoint` in the command expectations.