### PR TITLE
SPEC-1398: Hint option for findAndModify update/replace operations

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -12,7 +12,7 @@ Driver CRUD API
 :Status: Approved
 :Type: Standards
 :Minimum Server Version: 2.6
-:Last Modified: January 17, 2020
+:Last Modified: January 24, 2020
 
 .. contents::
 
@@ -1602,6 +1602,17 @@ Find And Modify
     collation: Optional<Document>;
 
     /**
+     * The index to use.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * This option is only supported by servers >= 4.4. Older servers >= 4.2 will report an error for using this option.
+     * For servers < 4.2, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
+     */
+    hint: Optional<(String | Document)>;
+
+    /**
      * The maximum amount of time to allow the query to run.
      *
      * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
@@ -1681,6 +1692,17 @@ Find And Modify
      * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
      */
     collation: Optional<Document>;
+
+    /**
+     * The index to use.
+     *
+     * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+     * This option is only supported by servers >= 4.4. Older servers >= 4.2 will report an error for using this option.
+     * For servers < 4.2, the driver MUST raise an error if the caller explicitly provides a value.
+     *
+     * @see https://docs.mongodb.com/manual/reference/command/findAndModify/
+     */
+    hint: Optional<(String | Document)>;
 
     /**
      * The maximum amount of time to allow the query to run.
@@ -1837,6 +1859,7 @@ Q: Why are client-side errors raised for some unsupported options?
 Changes
 =======
 
+* 2020-01-24: Added hint option for findAndModify update/replace operations.
 * 2020-01-17: Add allowDiskUse to FindOptions.
 * 2020-01-14: Deprecate oplogReplay option for find command
 * 2020-01-10: Clarify client-side error reporting for unsupported options

--- a/source/crud/tests/v2/findOneAndReplace-hint-clientError.json
+++ b/source/crud/tests/v2/findOneAndReplace-hint-clientError.json
@@ -1,0 +1,90 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndReplace_hint",
+  "tests": [
+    {
+      "description": "FindOneAndReplace with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/crud/tests/v2/findOneAndReplace-hint-clientError.yml
+++ b/source/crud/tests/v2/findOneAndReplace-hint-clientError.yml
@@ -1,0 +1,40 @@
+runOn:
+  - { maxServerVersion: "4.0.99" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndReplace_hint'
+
+tests:
+  -
+    description: "FindOneAndReplace with hint string unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: &filter { _id: 1 }
+          replacement: &replacement { x: 33 }
+          hint: "_id_"
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndReplace with hint document unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          hint: { _id: 1 }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/source/crud/tests/v2/findOneAndReplace-hint-serverError.json
+++ b/source/crud/tests/v2/findOneAndReplace-hint-serverError.json
@@ -1,0 +1,123 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0",
+      "maxServerVersion": "4.3.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndReplace_hint",
+  "tests": [
+    {
+      "description": "FindOneAndReplace with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/crud/tests/v2/findOneAndReplace-hint-serverError.yml
+++ b/source/crud/tests/v2/findOneAndReplace-hint-serverError.yml
@@ -1,0 +1,59 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Server versions >= 4.1.10
+  # raise errors for unknown findAndModify options (SERVER-40005), but the spec
+  # requires client-side errors for < 4.2. Support for findAndModify hint was
+  # added in 4.3.1 (SERVER-42099), so we'll allow up to 4.3.0 (inclusive).
+  - { minServerVersion: "4.2.0", maxServerVersion: "4.3.0" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndReplace_hint'
+
+tests:
+  -
+    description: "FindOneAndReplace with hint string unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: &filter { _id: 1 }
+          replacement: &replacement { x: 33 }
+          hint: "_id_"
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *replacement
+            hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndReplace with hint document unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          hint: { _id: 1 }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *replacement
+            hint: { _id: 1 }
+    outcome: *outcome

--- a/source/crud/tests/v2/findOneAndReplace-hint.json
+++ b/source/crud/tests/v2/findOneAndReplace-hint.json
@@ -1,0 +1,128 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndReplace_hint",
+  "tests": [
+    {
+      "description": "FindOneAndReplace with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 33
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndReplace with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndReplace",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "replacement": {
+              "x": 33
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndReplace_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "x": 33
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 33
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/crud/tests/v2/findOneAndReplace-hint.yml
+++ b/source/crud/tests/v2/findOneAndReplace-hint.yml
@@ -1,0 +1,55 @@
+runOn:
+  - { minServerVersion: "4.3.1" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndReplace_hint'
+
+tests:
+  -
+    description: "FindOneAndReplace with hint string"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: &filter { _id: 1 }
+          replacement: &replacement { x: 33 }
+          hint: "_id_"
+        # original document is returned by default
+        result: &result { _id: 1, x: 11 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *replacement
+            hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 33 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndReplace with hint document"
+    operations:
+      -
+        object: collection
+        name: findOneAndReplace
+        arguments:
+          filter: *filter
+          replacement: *replacement
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *replacement
+            hint: { _id: 1 }
+    outcome: *outcome

--- a/source/crud/tests/v2/findOneAndUpdate-hint-clientError.json
+++ b/source/crud/tests/v2/findOneAndUpdate-hint-clientError.json
@@ -1,0 +1,94 @@
+{
+  "runOn": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndUpdate_hint",
+  "tests": [
+    {
+      "description": "FindOneAndUpdate with hint string unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate with hint document unsupported (client-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/crud/tests/v2/findOneAndUpdate-hint-clientError.yml
+++ b/source/crud/tests/v2/findOneAndUpdate-hint-clientError.yml
@@ -1,0 +1,40 @@
+runOn:
+  - { maxServerVersion: "4.0.99" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndUpdate_hint'
+
+tests:
+  -
+    description: "FindOneAndUpdate with hint string unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: &filter { _id: 1 }
+          update: &update { $inc: { x: 1 }}
+          hint: "_id_"
+        error: true
+    expectations: []
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndUpdate with hint document unsupported (client-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        error: true
+    expectations: []
+    outcome: *outcome

--- a/source/crud/tests/v2/findOneAndUpdate-hint-serverError.json
+++ b/source/crud/tests/v2/findOneAndUpdate-hint-serverError.json
@@ -1,0 +1,131 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.2.0",
+      "maxServerVersion": "4.3.0"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndUpdate_hint",
+  "tests": [
+    {
+      "description": "FindOneAndUpdate with hint string unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate with hint document unsupported (server-side error)",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "error": true
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/crud/tests/v2/findOneAndUpdate-hint-serverError.yml
+++ b/source/crud/tests/v2/findOneAndUpdate-hint-serverError.yml
@@ -1,0 +1,58 @@
+runOn:
+  # These tests assert that the driver does not raise client-side errors and
+  # instead relies on the server to raise an error. Support for findAndModify
+  # hint was added in 4.3.1 (SERVER-42099), so we'll allow up to 4.3.0
+  # (inclusive).
+  - { minServerVersion: "4.2.0", maxServerVersion: "4.3.0" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndUpdate_hint'
+
+tests:
+  -
+    description: "FindOneAndUpdate with hint string unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: &filter { _id: 1 }
+          update: &update { $inc: { x: 1 }}
+          hint: "_id_"
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *update
+            hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndUpdate with hint document unsupported (server-side error)"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        error: true
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *update
+            hint: { _id: 1 }
+    outcome: *outcome

--- a/source/crud/tests/v2/findOneAndUpdate-hint.json
+++ b/source/crud/tests/v2/findOneAndUpdate-hint.json
@@ -1,0 +1,136 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.1"
+    }
+  ],
+  "data": [
+    {
+      "_id": 1,
+      "x": 11
+    },
+    {
+      "_id": 2,
+      "x": 22
+    }
+  ],
+  "collection_name": "findOneAndUpdate_hint",
+  "tests": [
+    {
+      "description": "FindOneAndUpdate with hint string",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": "_id_"
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": "_id_"
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "FindOneAndUpdate with hint document",
+      "operations": [
+        {
+          "object": "collection",
+          "name": "findOneAndUpdate",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "hint": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "_id": 1,
+            "x": 11
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "findOneAndUpdate_hint",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "hint": {
+                "_id": 1
+              }
+            }
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 12
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/crud/tests/v2/findOneAndUpdate-hint.yml
+++ b/source/crud/tests/v2/findOneAndUpdate-hint.yml
@@ -1,0 +1,55 @@
+runOn:
+  - { minServerVersion: "4.3.1" }
+
+data:
+  - { _id: 1, x: 11 }
+  - { _id: 2, x: 22 }
+
+collection_name: &collection_name 'findOneAndUpdate_hint'
+
+tests:
+  -
+    description: "FindOneAndUpdate with hint string"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: &filter { _id: 1 }
+          update: &update { $inc: { x: 1 }}
+          hint: "_id_"
+        # original document is returned by default
+        result: &result { _id: 1, x: 11 }
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *update
+            hint: "_id_"
+    outcome: &outcome
+      collection:
+        data:
+          - { _id: 1, x: 12 }
+          - { _id: 2, x: 22 }
+  -
+    description: "FindOneAndUpdate with hint document"
+    operations:
+      -
+        object: collection
+        name: findOneAndUpdate
+        arguments:
+          filter: *filter
+          update: *update
+          hint: { _id: 1 }
+        result: *result
+    expectations:
+      -
+        command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: *filter
+            update: *update
+            hint: { _id: 1 }
+    outcome: *outcome


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1398

This is related to #596 but I've split it out into its own PR since `findAndModify` support for `hint` is still waiting on [SERVER-42099](https://jira.mongodb.org/browse/SERVER-42099).