### PR TITLE
SPEC-1455: Add missing tests for aggregation pipeline in bulk write updates

### DIFF
--- a/source/crud/tests/v2/updateWithPipelines.json
+++ b/source/crud/tests/v2/updateWithPipelines.json
@@ -238,6 +238,171 @@
           ]
         }
       }
+    },
+    {
+      "description": "UpdateOne in bulk write using pipelines",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateOne",
+                "arguments": {
+                  "filter": {
+                    "_id": 1
+                  },
+                  "update": [
+                    {
+                      "$replaceRoot": {
+                        "newRoot": "$t"
+                      }
+                    },
+                    {
+                      "$addFields": {
+                        "foo": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "result": {
+            "matchedCount": 1,
+            "modifiedCount": 1,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {
+                    "_id": 1
+                  },
+                  "u": [
+                    {
+                      "$replaceRoot": {
+                        "newRoot": "$t"
+                      }
+                    },
+                    {
+                      "$addFields": {
+                        "foo": 1
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "command_name": "update",
+            "database_name": "crud-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "u": {
+                "v": 1
+              },
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "y": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "UpdateMany in bulk write using pipelines",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "name": "updateMany",
+                "arguments": {
+                  "filter": {},
+                  "update": [
+                    {
+                      "$project": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$addFields": {
+                        "foo": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "result": {
+            "matchedCount": 2,
+            "modifiedCount": 2,
+            "upsertedCount": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "update": "test",
+              "updates": [
+                {
+                  "q": {},
+                  "u": [
+                    {
+                      "$project": {
+                        "x": 1
+                      }
+                    },
+                    {
+                      "$addFields": {
+                        "foo": 1
+                      }
+                    }
+                  ],
+                  "multi": true
+                }
+              ]
+            },
+            "command_name": "update",
+            "database_name": "crud-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 1,
+              "foo": 1
+            },
+            {
+              "_id": 2,
+              "x": 2,
+              "foo": 1
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/crud/tests/v2/updateWithPipelines.yml
+++ b/source/crud/tests/v2/updateWithPipelines.yml
@@ -90,3 +90,68 @@ tests:
         data:
           - { _id: 1, x: 1, foo: 1 }
           - { _id: 2, x: 2, y: 1 }
+  -
+    description: "UpdateOne in bulk write using pipelines"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateOne"
+              arguments:
+                filter: { _id: 1 }
+                update: [ { $replaceRoot: { newRoot: "$t" } }, { $addFields: { foo: 1 } } ]
+        result:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: { _id: 1 }
+                u: [ { $replaceRoot: { newRoot: "$t" } }, { $addFields: { foo: 1 } } ]
+          command_name: update
+          database_name: *database_name
+    outcome:
+      collection:
+        data:
+          - { _id: 1, u: {v: 1}, foo: 1 }
+          - { _id: 2, x: 2, y: 1 }
+  -
+    description: "UpdateMany in bulk write using pipelines"
+    operations:
+      -
+        name: "bulkWrite"
+        arguments:
+          requests:
+            -
+              name: "updateMany"
+              arguments:
+                filter: {}
+                update: [ { $project: { x: 1 } }, { $addFields: { foo: 1 } } ]
+        result:
+          matchedCount: 2
+          modifiedCount: 2
+          upsertedCount: 0
+    expectations:
+      -
+        command_started_event:
+          command:
+            update: *collection_name
+            updates:
+              -
+                q: { }
+                u: [ { $project: { x: 1 } }, { $addFields: { foo: 1 } } ]
+                multi: true
+          command_name: update
+          database_name: *database_name
+    outcome:
+      collection:
+        data:
+          - { _id: 1, x: 1, foo: 1 }
+          - { _id: 2, x: 2, foo: 1 }


### PR DESCRIPTION
This adds two tests to ensure that drivers implement pipeline-style updates for bulkwrite operations as well. I'm not sure whether this warrants bumping the crud spec version. These new tests are used in the PHP driver: https://github.com/mongodb/mongo-php-library/pull/684