### PR TITLE
SPEC-1464 Workaround for unordered JSON parsers in FLE test

### DIFF
--- a/source/client-side-encryption/etc/test-templates/bulk.yml.template
+++ b/source/client-side-encryption/etc/test-templates/bulk.yml.template
@@ -29,7 +29,7 @@ tests:
                 update: { $set: { encrypted_string: "string1" } }
             - name: deleteOne
               arguments:
-                filter: { encrypted_string: "string1", _id: 2 }
+                filter: { $and: [{ encrypted_string: "string1" }, { _id: 2 }]}
           options: { ordered: true }
     expectations:
       # Auto encryption will request the collection info.

--- a/source/client-side-encryption/tests/bulk.json
+++ b/source/client-side-encryption/tests/bulk.json
@@ -148,8 +148,14 @@
                 "name": "deleteOne",
                 "arguments": {
                   "filter": {
-                    "encrypted_string": "string1",
-                    "_id": 2
+                    "$and": [
+                      {
+                        "encrypted_string": "string1"
+                      },
+                      {
+                        "_id": 2
+                      }
+                    ]
                   }
                 }
               }

--- a/source/client-side-encryption/tests/bulk.yml
+++ b/source/client-side-encryption/tests/bulk.yml
@@ -29,7 +29,7 @@ tests:
                 update: { $set: { encrypted_string: "string1" } }
             - name: deleteOne
               arguments:
-                filter: { encrypted_string: "string1", _id: 2 }
+                filter: { $and: [{ encrypted_string: "string1" }, { _id: 2 }]}
           options: { ordered: true }
     expectations:
       # Auto encryption will request the collection info.


### PR DESCRIPTION
I hope this is uncontroversial. This fixes a test failure in Python: https://evergreen.mongodb.com/version/5d97d4647742ae4dbe7aaeea

See the Jira ticket for an explanation of why: https://jira.mongodb.org/browse/SPEC-1464