### PR TITLE
SPEC-1431 add endpoint to AWS masterkey

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -419,14 +419,14 @@ DataKeyOpts
 masterKey
 ^^^^^^^^^
 The masterKey identifies a KMS-specific key used to encrypt the new data
-key. If the kmsProvider is "aws" it is required and must have the
-following fields:
+key. If the kmsProvider is "aws" it is required and has the following fields:
 
 .. code:: typescript
 
    {
-      region: String,
-      key: String // The Amazon Resource Name (ARN) to the AWS customer master key (CMK).
+      region: String, // Required.
+      key: String // Required. The Amazon Resource Name (ARN) to the AWS customer master key (CMK).
+      endpoint: String // Optional. An alternate host to send KMS requests to. May include port number.
    }
 
 Drivers MUST document the expected value of masterKey for "aws" and that

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -11,7 +11,7 @@ Client Side Encryption
 :Type: Standards
 :Minimum Server Version: 4.2
 :Last Modified: June 14, 2019
-:Version: 1.0.0
+:Version: 1.1.0
 
 .. contents::
 
@@ -1254,3 +1254,7 @@ in the end libmongocrypt would create multiple OP_MSGs to send.
 
 Changelog
 =========
+
++------------+------------------------------------------------------------+
+| 2019-10-11 | Add 'endpoint' to AWS masterkey                            |
++------------+------------------------------------------------------------+

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -128,15 +128,16 @@ Then for each element in ``tests``:
    #. Insert the data specified into the ``admin.datakeys`` with write concern "majority".
 
 #. Create a MongoClient.
-   
+
 #. Create a collection object from the MongoClient, using the ``database_name``
-   and ``collection_name`` fields from the YAML file. If a ``json_schema`` is defined in the test,
+   and ``collection_name`` fields from the YAML file. Drop the collection 
+   with writeConcern "majority". If a ``json_schema`` is defined in the test,
    use the ``createCollection`` command to explicitly create the collection:
+
    .. code:: typescript
 
       {"create": <collection>, "validator": {"$jsonSchema": <json_schema>}}
 
-#. Drop the test collection, using writeConcern "majority".
 #. If the YAML file contains a ``data`` array, insert the documents in ``data``
    into the test collection, using writeConcern "majority".
 
@@ -496,4 +497,92 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
    - If ``allowed`` is false, validate the value exactly equals the value of the corresponding field of ``corpus`` (neither was encrypted).
 
 9. Repeat steps 1-8 with a local JSON schema. I.e. amend step 4 to configure the schema on ``client_encrypted`` with the ``schema_map`` option.
+
+Custom Endpoint Test
+====================
+
+Data keys created with AWS KMS may specify a custom endpoint to contact (instead of the default endpoint derived from the AWS region).
+
+1. Create a ``ClientEncryption`` object (referred to as ``client_encryption``)
+
+   Configure with ``aws`` KMS providers as follows:
+
+   .. code:: javascript
+
+      {
+          "aws": { <AWS credentials> }
+      }
+
+   Configure with ``keyVaultNamespace`` set to ``admin.datakeys``, and a default MongoClient as the ``keyVaultClient``.
+
+2. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
+
+   .. code:: javascript
+
+      {
+        region: "us-east-1",
+        key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+      }
+
+   Expect this to succeed. Use the returned UUID of the key to explicitly encrypt and decrypt the string "test" to validate it works.
+
+3. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
+
+   .. code:: javascript
+
+      {
+        region: "us-east-1",
+        key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        endpoint: "kms.us-east-1.amazonaws.com"
+      }
+
+   Expect this to succeed. Use the returned UUID of the key to explicitly encrypt and decrypt the string "test" to validate it works.
+
+4. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
+
+   .. code:: javascript
+
+      {
+        region: "us-east-1",
+        key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        endpoint: "kms.us-east-1.amazonaws.com:443"
+      }
+
+   Expect this to succeed. Use the returned UUID of the key to explicitly encrypt and decrypt the string "test" to validate it works.
+
+5. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
+
+   .. code:: javascript
+
+      {
+        region: "us-east-1",
+        key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        endpoint: "kms.us-east-1.amazonaws.com:12345"
+      }
+
+   Expect this to fail with a socket connection error.
+
+6. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
+
+   .. code:: javascript
+
+      {
+        region: "us-east-1",
+        key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        endpoint: "kms.us-east-2.amazonaws.com"
+      }
+
+   Expect this to fail with an exception containing the message: "Credential should be scoped to a valid region, not 'us-east-1'"
+
+7. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
+
+   .. code:: javascript
+
+      {
+        region: "us-east-1",
+        key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        endpoint: "example.com"
+      }
+
+   Expect this to fail with an exception containing the message: "parse error"
 


### PR DESCRIPTION
Note:
- Before drivers can start, MONGOCRYPT-181 and MONGOCRYPT-153 need to be merged (both of which are in review).
- Drivers will need to update bindings to wrap the new function `mongocrypt_ctx_setopt_masterkey_aws_endpoint`, and call that for data key creation if the optional "endpoint" is passed as part of the DataKeyOpts.masterkey
- Prototyped the tests this with Java here: https://github.com/kevinAlbs/JavaFLEProsePoC/blob/master/src/main/java/EndpointTest.java I had some trouble using my locally built bindings. I managed to get it passing as-is, then messed up my gradle configuration... which is why not all tests were implemented in that PoC.
- Shell needs to update as well