### PR TITLE
Remainder of FLE GA

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -255,12 +255,12 @@ feature. and that auto encryption only occurs on collection level
 operations by including the following in the driver documentation for
 AutoEncryptionOpts:
 
-Automatic encryption is an enterprise only feature that only applies to
-operations on a collection. Automatic encryption is not supported for
-operations on a database or view, and operations that are not bypassed
-will result in error (see `libmongocrypt: Auto Encryption Whitelist`_).
-To bypass automatic encryption for all operations, set
-bypassAutoEncryption=true in AutoEncryptionOpts.
+   Automatic encryption is an enterprise only feature that only applies to
+   operations on a collection. Automatic encryption is not supported for
+   operations on a database or view, and operations that are not bypassed
+   will result in error (see `libmongocrypt: Auto Encryption Whitelist`_).
+   To bypass automatic encryption for all operations, set
+   bypassAutoEncryption=true in AutoEncryptionOpts.
 
 Explicit encryption/decryption and automatic decryption is a community
 feature. A MongoClient configured with bypassAutoEncryption=true will
@@ -270,9 +270,9 @@ Drivers MUST document that auto encryption requires the authenticated
 user to have the listCollections privilege action by including the
 following in the driver documentation for MongoClient.
 
-Automatic encryption requires the authenticated user to have the
-`listCollections privilege
-action <https://docs.mongodb.com/manual/reference/command/listCollections/#dbcmd.listCollections>`__.
+   Automatic encryption requires the authenticated user to have the
+   `listCollections privilege
+   action <https://docs.mongodb.com/manual/reference/command/listCollections/#dbcmd.listCollections>`__.
 
 See `Why is client side encryption configured on a MongoClient?`_
 

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -82,6 +82,9 @@ commands and decrypts results. Automatic encryption is enterprise only.
 But users can manually encrypt and decrypt with a new ClientEncryption
 object.
 
+Client side encryption requires MongoDB 4.2 compatible drivers, and is
+only supported against 4.2 or higher servers. See `Why is a 4.2 server required?`_.
+
 The following shows basic usage of the new API.
 
 .. code:: python
@@ -685,6 +688,11 @@ Drivers MUST raise an error when attempting to auto encrypt a command if
 the maxWireVersion is less than 8. The error message MUST contain
 "Auto-encryption requires a minimum MongoDB version of 4.2".
 
+Note, all client side features (including all of ``ClientEncryption``)
+are only supported against 4.2 or higher servers. However, errors are
+only raised for automatic encryption/decryption against older servers.
+See `Why is a 4.2 server required?`_.
+
 Interaction with Command Monitoring
 ===================================
 Unencrypted data MUST NOT appear in the data of any command monitoring
@@ -1196,6 +1204,15 @@ would be necessary to know the schema of the underlying collection. But,
 the driver does know whether or not a namespace is a view based on the
 response to listCollections. And the driver will run listCollections on
 all namespaces omitted from the schemaMap.
+
+Why is a 4.2 server required?
+-----------------------------
+
+Limiting to 4.2 reduces testing complexity. Additionally The ``encrypt``
+subdocument in JSON schema is only supported on 4.2 or higher servers.
+Although not technically necessary for client side encryption, it does
+provide a fallback against accidentally sending unencrypted data from
+misconfigured clients.
 
 Future work
 ===========

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -610,9 +610,15 @@ If a MongoClient is configured for Client Side Encryption, than by
 default (unless mongocryptdBypassSpawn=true), mongocryptd MUST be
 spawned by the driver. Spawning MUST include the command line argument
 --idleShutdownTimeoutSecs. If the user does not supply one through
-extraOptions.mongocryptdSpawnArgs, then the driver MUST append
---idleShutdownTimeoutSecs=60 to the arguments. This tells mongocryptd to
-automatically terminate after 60 seconds of non-use.
+extraOptions.mongocryptdSpawnArgs (which may be either in the form
+"--idleShutdownTimeoutSecs=60" or as two consecutive arguments
+["--idleShutdownTimeoutSecs", 60], then the driver MUST append
+--idleShutdownTimeoutSecs=60 to the arguments. This tells mongocryptd
+to automatically terminate after 60 seconds of non-use. The stdout
+and stderr of the spawned process MUST not be exposed in the driver (e.g.
+redirect to /dev/null). Users can pass the argument --logpath to
+extraOptions.mongocryptdSpawnArgs if they need to inspect mongocryptd
+logs.
 
 Upon construction, the ClientEncryption MUST create a MongoClient to
 mongocryptd configured with serverSelectionTimeoutMS=1000.

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -374,8 +374,8 @@ ClientEncryption
       ClientEncryption (opts: ClientEncryptionOpts);
 
       // Creates a new key document and inserts into the key vault collection.
-      // Returns the \_id of the created document.
-      createDataKey(kmsProvider: String, opts: Optional<DataKeyOpts>): BSONValue;
+      // Returns the \_id of the created document as a UUID (BSON binary subtype 4).
+      createDataKey(kmsProvider: String, opts: Optional<DataKeyOpts>): Binary;
 
       // Encrypts a BSONValue with a given key and algorithm.
       // Returns an encrypted value (BSON binary of subtype 6). The underlying implementation may return an error for prohibited BSON values.

--- a/source/client-side-encryption/etc/test-templates/aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/aggregate.yml.template
@@ -27,14 +27,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -45,6 +43,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -74,7 +73,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
@@ -88,7 +86,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -99,6 +96,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
     outcome:
       collection:

--- a/source/client-side-encryption/etc/test-templates/basic.yml.template
+++ b/source/client-side-encryption/etc/test-templates/basic.yml.template
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -80,14 +79,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -98,6 +95,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/bulk.yml.template
+++ b/source/client-side-encryption/etc/test-templates/bulk.yml.template
@@ -36,14 +36,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -54,6 +52,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/bypassAutoEncryption.yml.template
+++ b/source/client-side-encryption/etc/test-templates/bypassAutoEncryption.yml.template
@@ -44,6 +44,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
     outcome:
       collection:
@@ -89,6 +90,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
     outcome:
       collection:

--- a/source/client-side-encryption/etc/test-templates/count.yml.template
+++ b/source/client-side-encryption/etc/test-templates/count.yml.template
@@ -25,14 +25,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -43,6 +41,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/countDocuments.yml.template
+++ b/source/client-side-encryption/etc/test-templates/countDocuments.yml.template
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/delete.yml.template
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -74,14 +73,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -92,6 +89,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/distinct.yml.template
+++ b/source/client-side-encryption/etc/test-templates/distinct.yml.template
@@ -28,14 +28,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -46,6 +44,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/explain.yml.template
+++ b/source/client-side-encryption/etc/test-templates/explain.yml.template
@@ -30,14 +30,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -48,6 +46,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/find.yml.template
+++ b/source/client-side-encryption/etc/test-templates/find.yml.template
@@ -27,14 +27,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -45,6 +43,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -76,14 +75,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -94,6 +91,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/findOneAndDelete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/findOneAndDelete.yml.template
@@ -25,14 +25,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -43,6 +41,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/findOneAndReplace.yml.template
+++ b/source/client-side-encryption/etc/test-templates/findOneAndReplace.yml.template
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/findOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/findOneAndUpdate.yml.template
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/getMore.yml.template
+++ b/source/client-side-encryption/etc/test-templates/getMore.yml.template
@@ -30,7 +30,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
@@ -42,7 +41,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -53,6 +51,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/insert.yml.template
+++ b/source/client-side-encryption/etc/test-templates/insert.yml.template
@@ -22,14 +22,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -40,6 +38,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -69,14 +68,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -87,6 +84,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/keyAltName.yml.template
+++ b/source/client-side-encryption/etc/test-templates/keyAltName.yml.template
@@ -22,14 +22,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -40,6 +38,7 @@ tests:
             find: datakeys
             filter: {$or: [ { _id: { $in: [] } }, { keyAltNames: { $in: [ "altname" ] } } ] }
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/localKMS.yml.template
+++ b/source/client-side-encryption/etc/test-templates/localKMS.yml.template
@@ -23,14 +23,12 @@ tests:
     - command_started_event:
         command:
           listCollections: 1
-          cursor: {}
           filter:
             name: *collection_name
         command_name: listCollections
     - command_started_event:
         command:
           listCollections: 1
-          cursor: {}
           filter:
             name: "datakeys"
           $db: admin

--- a/source/client-side-encryption/etc/test-templates/localSchema.yml.template
+++ b/source/client-side-encryption/etc/test-templates/localSchema.yml.template
@@ -28,7 +28,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -39,6 +38,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/missingKey.yml.template
+++ b/source/client-side-encryption/etc/test-templates/missingKey.yml.template
@@ -29,14 +29,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "different"
             $db: admin
@@ -47,4 +45,5 @@ tests:
             find: different
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find

--- a/source/client-side-encryption/etc/test-templates/replaceOne.yml.template
+++ b/source/client-side-encryption/etc/test-templates/replaceOne.yml.template
@@ -28,14 +28,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -46,6 +44,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/types.yml.template
+++ b/source/client-side-encryption/etc/test-templates/types.yml.template
@@ -30,7 +30,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -41,6 +40,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -78,7 +78,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -89,6 +88,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -126,7 +126,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -137,6 +136,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -200,7 +200,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -211,6 +210,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -248,7 +248,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -259,6 +258,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -322,7 +322,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -333,6 +332,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -370,7 +370,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -381,6 +380,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -418,7 +418,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -429,6 +428,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/updateMany.yml.template
+++ b/source/client-side-encryption/etc/test-templates/updateMany.yml.template
@@ -29,14 +29,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -47,6 +45,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/updateOne.yml.template
+++ b/source/client-side-encryption/etc/test-templates/updateOne.yml.template
@@ -28,14 +28,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -46,6 +44,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -91,7 +90,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
@@ -127,7 +125,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -212,7 +212,7 @@ Data key and double encryption
 
 First, perform the setup.
 
-#. Create a MongoClient without encryption enabled (referred to as ``client``).
+#. Create a MongoClient without encryption enabled (referred to as ``client``). Enable command monitoring to listen for command_started events.
 
 #. Using ``client``, drop the collections ``admin.datakeys`` and ``db.coll``.
 
@@ -251,6 +251,8 @@ First, perform the setup.
         }
       }
 
+   Configure ``client_encryption`` with the ``keyVaultClient`` of the previously created ``client``.
+
 Then, test creating and using data keys from a ``local`` KMS provider:
 
 #. Call ``client_encryption.createDataKey()`` with the ``local`` KMS provider and keyAltNames set to ``["local_altname"]``.
@@ -258,6 +260,7 @@ Then, test creating and using data keys from a ``local`` KMS provider:
    - Expect a BSON binary with subtype 4 to be returned, referred to as ``local_datakey_id``.
    - Use ``client`` to run a ``find`` on ``admin.datakeys`` by querying with the ``_id`` set to the ``local_datakey_id``.
    - Expect that exactly one document is returned with the "masterKey.provider" equal to "local".
+   - Check that ``client`` captured a command_started event for the ``insert`` command containing a majority writeConcern.
 
 #. Call ``client_encryption.encrypt()`` with the value "hello local", the algorithm ``AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic``, and the ``key_id`` of ``local_datakey_id``.
 
@@ -284,6 +287,7 @@ Then, repeat the above tests with the ``aws`` KMS provider:
    - Expect a BSON binary with subtype 4 to be returned, referred to as ``aws_datakey_id``.
    - Use ``client`` to run a ``find`` on ``admin.datakeys`` by querying with the ``_id`` set to the ``aws_datakey_id``.
    - Expect that exactly one document is returned with the "masterKey.provider" equal to "aws".
+   - Check that ``client`` captured a command_started event for the ``insert`` command containing a majority writeConcern.
 
 #. Call ``client_encryption.encrypt()`` with the value "hello aws", the algorithm ``AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic``, and the ``key_id`` of ``aws_datakey_id``.
 

--- a/source/client-side-encryption/tests/aggregate.json
+++ b/source/client-side-encryption/tests/aggregate.json
@@ -143,7 +143,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -155,7 +154,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -189,7 +187,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -255,7 +256,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -277,7 +277,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -311,7 +310,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/aggregate.yml
+++ b/source/client-side-encryption/tests/aggregate.yml
@@ -27,14 +27,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -45,6 +43,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -74,7 +73,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
@@ -88,7 +86,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -99,6 +96,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
     outcome:
       collection:

--- a/source/client-side-encryption/tests/basic.json
+++ b/source/client-side-encryption/tests/basic.json
@@ -137,7 +137,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -149,7 +148,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -183,7 +181,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -275,7 +276,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -287,7 +287,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -321,7 +320,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/basic.yml
+++ b/source/client-side-encryption/tests/basic.yml
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -80,14 +79,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -98,6 +95,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/bulk.json
+++ b/source/client-side-encryption/tests/bulk.json
@@ -171,7 +171,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -183,7 +182,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -217,7 +215,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/bulk.yml
+++ b/source/client-side-encryption/tests/bulk.yml
@@ -36,14 +36,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -54,6 +52,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/bypassAutoEncryption.json
+++ b/source/client-side-encryption/tests/bypassAutoEncryption.json
@@ -196,7 +196,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -366,7 +369,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/bypassAutoEncryption.yml
+++ b/source/client-side-encryption/tests/bypassAutoEncryption.yml
@@ -44,6 +44,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
     outcome:
       collection:
@@ -89,6 +90,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
     outcome:
       collection:

--- a/source/client-side-encryption/tests/count.json
+++ b/source/client-side-encryption/tests/count.json
@@ -142,7 +142,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -154,7 +153,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -188,7 +186,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/count.yml
+++ b/source/client-side-encryption/tests/count.yml
@@ -25,14 +25,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -43,6 +41,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/countDocuments.json
+++ b/source/client-side-encryption/tests/countDocuments.json
@@ -143,7 +143,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -155,7 +154,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -189,7 +187,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/countDocuments.yml
+++ b/source/client-side-encryption/tests/countDocuments.yml
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/delete.json
+++ b/source/client-side-encryption/tests/delete.json
@@ -144,7 +144,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -156,7 +155,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -190,7 +188,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -268,7 +269,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -280,7 +280,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -314,7 +313,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/delete.yml
+++ b/source/client-side-encryption/tests/delete.yml
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -74,14 +73,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -92,6 +89,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/distinct.json
+++ b/source/client-side-encryption/tests/distinct.json
@@ -154,7 +154,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -166,7 +165,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -200,7 +198,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/distinct.yml
+++ b/source/client-side-encryption/tests/distinct.yml
@@ -28,14 +28,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -46,6 +44,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/explain.json
+++ b/source/client-side-encryption/tests/explain.json
@@ -148,7 +148,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -160,7 +159,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -194,7 +192,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/explain.yml
+++ b/source/client-side-encryption/tests/explain.yml
@@ -30,14 +30,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -48,6 +46,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/find.json
+++ b/source/client-side-encryption/tests/find.json
@@ -153,7 +153,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -165,7 +164,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -199,7 +197,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -294,7 +295,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -306,7 +306,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -340,7 +339,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/find.yml
+++ b/source/client-side-encryption/tests/find.yml
@@ -27,14 +27,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -45,6 +43,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -76,14 +75,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -94,6 +91,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/findOneAndDelete.json
+++ b/source/client-side-encryption/tests/findOneAndDelete.json
@@ -141,7 +141,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -153,7 +152,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -187,7 +185,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/findOneAndDelete.yml
+++ b/source/client-side-encryption/tests/findOneAndDelete.yml
@@ -25,14 +25,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -43,6 +41,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/findOneAndReplace.json
+++ b/source/client-side-encryption/tests/findOneAndReplace.json
@@ -140,7 +140,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -152,7 +151,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -186,7 +184,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/findOneAndReplace.yml
+++ b/source/client-side-encryption/tests/findOneAndReplace.yml
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/findOneAndUpdate.json
+++ b/source/client-side-encryption/tests/findOneAndUpdate.json
@@ -142,7 +142,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -154,7 +153,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -188,7 +186,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/findOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/findOneAndUpdate.yml
@@ -26,14 +26,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -44,6 +42,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/getMore.json
+++ b/source/client-side-encryption/tests/getMore.json
@@ -163,7 +163,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -184,7 +183,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -218,7 +216,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/getMore.yml
+++ b/source/client-side-encryption/tests/getMore.yml
@@ -30,7 +30,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
@@ -42,7 +41,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -53,6 +51,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/insert.json
+++ b/source/client-side-encryption/tests/insert.json
@@ -124,7 +124,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -136,7 +135,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -170,7 +168,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -250,7 +251,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -262,7 +262,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -296,7 +295,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/insert.yml
+++ b/source/client-side-encryption/tests/insert.yml
@@ -22,14 +22,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -40,6 +38,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -69,14 +68,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -87,6 +84,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/keyAltName.json
+++ b/source/client-side-encryption/tests/keyAltName.json
@@ -124,7 +124,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -136,7 +135,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -165,7 +163,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/keyAltName.yml
+++ b/source/client-side-encryption/tests/keyAltName.yml
@@ -22,14 +22,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -40,6 +38,7 @@ tests:
             find: datakeys
             filter: {$or: [ { _id: { $in: [] } }, { keyAltNames: { $in: [ "altname" ] } } ] }
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/localKMS.json
+++ b/source/client-side-encryption/tests/localKMS.json
@@ -107,7 +107,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -119,7 +118,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },

--- a/source/client-side-encryption/tests/localKMS.yml
+++ b/source/client-side-encryption/tests/localKMS.yml
@@ -23,14 +23,12 @@ tests:
     - command_started_event:
         command:
           listCollections: 1
-          cursor: {}
           filter:
             name: *collection_name
         command_name: listCollections
     - command_started_event:
         command:
           listCollections: 1
-          cursor: {}
           filter:
             name: "datakeys"
           $db: admin

--- a/source/client-side-encryption/tests/localSchema.json
+++ b/source/client-side-encryption/tests/localSchema.json
@@ -140,7 +140,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -174,7 +173,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/localSchema.yml
+++ b/source/client-side-encryption/tests/localSchema.yml
@@ -28,7 +28,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -39,6 +38,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/missingKey.json
+++ b/source/client-side-encryption/tests/missingKey.json
@@ -133,7 +133,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -145,7 +144,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "different"
               },
@@ -179,7 +177,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/missingKey.yml
+++ b/source/client-side-encryption/tests/missingKey.yml
@@ -29,14 +29,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "different"
             $db: admin
@@ -47,4 +45,5 @@ tests:
             find: different
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find

--- a/source/client-side-encryption/tests/replaceOne.json
+++ b/source/client-side-encryption/tests/replaceOne.json
@@ -141,7 +141,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -153,7 +152,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -187,7 +185,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/replaceOne.yml
+++ b/source/client-side-encryption/tests/replaceOne.yml
@@ -28,14 +28,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -46,6 +44,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/types.json
+++ b/source/client-side-encryption/tests/types.json
@@ -107,7 +107,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -141,7 +140,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -256,7 +258,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -290,7 +291,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -405,7 +409,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -439,7 +442,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -654,7 +660,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -688,7 +693,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -803,7 +811,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -837,7 +844,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -1051,7 +1061,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -1085,7 +1094,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -1206,7 +1218,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -1240,7 +1251,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -1359,7 +1373,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -1393,7 +1406,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/types.yml
+++ b/source/client-side-encryption/tests/types.yml
@@ -30,7 +30,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -41,6 +40,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -78,7 +78,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -89,6 +88,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -126,7 +126,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -137,6 +136,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -200,7 +200,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -211,6 +210,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -248,7 +248,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -259,6 +258,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -322,7 +322,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -333,6 +332,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -370,7 +370,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -381,6 +380,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -418,7 +418,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -429,6 +428,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/updateMany.json
+++ b/source/client-side-encryption/tests/updateMany.json
@@ -157,7 +157,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -169,7 +168,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -203,7 +201,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/updateMany.yml
+++ b/source/client-side-encryption/tests/updateMany.yml
@@ -29,14 +29,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -47,6 +45,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/updateOne.json
+++ b/source/client-side-encryption/tests/updateOne.json
@@ -143,7 +143,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -155,7 +154,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "datakeys"
               },
@@ -189,7 +187,10 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "admin",
+              "readConcern": {
+                "level": "majority"
+              }
             },
             "command_name": "find"
           }
@@ -310,7 +311,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }
@@ -380,7 +380,6 @@
           "command_started_event": {
             "command": {
               "listCollections": 1,
-              "cursor": {},
               "filter": {
                 "name": "default"
               }

--- a/source/client-side-encryption/tests/updateOne.yml
+++ b/source/client-side-encryption/tests/updateOne.yml
@@ -28,14 +28,12 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: "datakeys"
             $db: admin
@@ -46,6 +44,7 @@ tests:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
             $db: admin
+            readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
           command:
@@ -91,7 +90,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections
@@ -127,7 +125,6 @@ tests:
       - command_started_event:
           command:
             listCollections: 1
-            cursor: {}
             filter:
               name: *collection_name
           command_name: listCollections


### PR DESCRIPTION
A batch of the remaining small SPEC changes.

JSON spec test changes were validated using C driver in-progress implementation.

Note for drivers implementers. The relevant changes that impact the FLE implementation are as follows:

- Update the return type (if necessary) of createDataKey to be a BSON binary (SPEC-1449 createDataKey returns UUID)
- Spawned mongocryptd should redirect stdout and stderr to /dev/null (SPEC-1469 silence 
mongocryptd by default)
- Resync the FLE JSON spec tests (SPEC-1466 test that fetching keys uses readConcern=majority)
- Update the prose test of "Data key and double encryption" to check command started events (SPEC-1452 test that created data keys insert with majority writeConcern)
- Check that bulk write batch splitting logic matches the section "Size limits for Write Commands" and update the prose test of "BSON size limits and batch splitting". (SPEC-1397 limit 2MiB limit to bulk writes)

cc @egiurleo 