### PR TITLE
SPEC-1471: Reorder assertion for "keep connnection pool" test

### DIFF
--- a/source/connections-survive-step-down/tests/README.rst
+++ b/source/connections-survive-step-down/tests/README.rst
@@ -100,11 +100,10 @@ This test requires a replica set with server version 4.2 or higher.
 - Execute an insert into the test collection of a ``{test: 1}``
   document.
 - Verify that the insert failed with an operation failure with 10107 code.
+- Verify that the connection pool has not been cleared,
+  following the instructions in section `How to verify the connection pool has not been cleared`_ 
 - Execute an insert into the test collection of a ``{test: 1}``
   document and verify that it succeeds.
-- Verify that the connection pool has not been cleared,
-  following the instructions in section `How to verify the connection pool has not been cleared`_
-
 
 
 Not Master - Reset Connection Pool


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1471

When verifying that the pool is not cleared, move the assertion immediately after the failed insert. This change should have no effect for drivers using CMAP for assertions, but may be relevant for those using connection counts from serverStatus.

See: https://github.com/mongodb/specifications/pull/627#issuecomment-540612468