### PR TITLE
SPEC-1475: add SDAM monitoring test for debouncing update events

### DIFF
--- a/source/server-discovery-and-monitoring/tests/monitoring/standalone_suppress_equal_description_changes.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/standalone_suppress_equal_description_changes.json
@@ -1,0 +1,113 @@
+{
+  "description": "Monitoring a standalone connection - suppress update events for equal server descriptions",
+  "uri": "mongodb://a:27017",
+  "phases": [
+    {
+      "responses": [
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 4
+          }
+        ],
+        [
+          "a:27017",
+          {
+            "ok": 1,
+            "ismaster": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 4
+          }
+        ]
+      ],
+      "outcome": {
+        "events": [
+          {
+            "topology_opening_event": {
+              "topologyId": "42"
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "Unknown",
+                "servers": []
+              },
+              "newDescription": {
+                "topologyType": "Single",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "server_opening_event": {
+              "topologyId": "42",
+              "address": "a:27017"
+            }
+          },
+          {
+            "server_description_changed_event": {
+              "topologyId": "42",
+              "address": "a:27017",
+              "previousDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "Unknown"
+              },
+              "newDescription": {
+                "address": "a:27017",
+                "arbiters": [],
+                "hosts": [],
+                "passives": [],
+                "type": "Standalone"
+              }
+            }
+          },
+          {
+            "topology_description_changed_event": {
+              "topologyId": "42",
+              "previousDescription": {
+                "topologyType": "Single",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Unknown"
+                  }
+                ]
+              },
+              "newDescription": {
+                "topologyType": "Single",
+                "servers": [
+                  {
+                    "address": "a:27017",
+                    "arbiters": [],
+                    "hosts": [],
+                    "passives": [],
+                    "type": "Standalone"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/monitoring/standalone_suppress_equal_description_changes.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/standalone_suppress_equal_description_changes.yml
@@ -1,0 +1,73 @@
+description: "Monitoring a standalone connection - suppress update events for equal server descriptions"
+uri: "mongodb://a:27017"
+phases:
+  -
+    responses:
+      -
+        - "a:27017"
+        - { ok: 1, ismaster: true, minWireVersion: 0, maxWireVersion: 4 }
+      -
+        - "a:27017"
+        - { ok: 1, ismaster: true, minWireVersion: 0, maxWireVersion: 4 }
+
+    outcome:
+      events:
+        -
+          topology_opening_event:
+            topologyId: "42"
+        -
+          topology_description_changed_event:
+            topologyId: "42"
+            previousDescription:
+              topologyType: "Unknown"
+              servers: []
+            newDescription:
+              topologyType: "Single"
+              servers:
+                -
+                  address: "a:27017"
+                  arbiters: []
+                  hosts: []
+                  passives: []
+                  type: "Unknown"
+        -
+          server_opening_event:
+            topologyId: "42"
+            address: "a:27017"
+        -
+          server_description_changed_event:
+            topologyId: "42"
+            address: "a:27017"
+            previousDescription:
+              address: "a:27017"
+              arbiters: []
+              hosts: []
+              passives: []
+              type: "Unknown"
+            newDescription:
+              address: "a:27017"
+              arbiters: []
+              hosts: []
+              passives: []
+              type: "Standalone"
+        -
+          topology_description_changed_event:
+            topologyId: "42"
+            previousDescription:
+              topologyType: "Single"
+              servers:
+                -
+                  address: "a:27017"
+                  arbiters: []
+                  hosts: []
+                  passives: []
+                  type: "Unknown"
+            newDescription:
+              topologyType: "Single"
+              servers:
+                -
+                  address: "a:27017"
+                  arbiters: []
+                  hosts: []
+                  passives: []
+                  type: "Standalone"


### PR DESCRIPTION
The SDAM specification describes an algorithm for ServerDescription
equality, and mandates that this equality operator should be used
during topology updates to guard event emission. We should include
a test that expresses this part of the spec.