### PR TITLE
separate tlsCertificateKeyFilePassword test to facilitate skippi…

### DIFF
--- a/source/uri-options/tests/tls-options.json
+++ b/source/uri-options/tests/tls-options.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "Valid required tls options are parsed correctly",
-      "uri": "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem&tlsCertificateKeyFilePassword=hunter2",
+      "uri": "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem",
       "valid": true,
       "warning": false,
       "hosts": null,
@@ -10,10 +10,20 @@
       "options": {
         "tls": true,
         "tlsCAFile": "ca.pem",
-        "tlsCertificateKeyFile": "cert.pem",
-        "tlsCertificateKeyFilePassword": "hunter2"
+        "tlsCertificateKeyFile": "cert.pem"
       }
     },
+	{
+		"description": "Valid tlsCertificateKeyFilePassword is parsed correctly",
+        "uri": "mongodb://example.com/?tlsCertificateKeyFilePassword=hunter2",
+      	"valid": true,
+		"warning": false,
+		"hosts": null,
+		"auth": null,
+		"options": {
+		  "tlsCertificateKeyFilePassword": "hunter2"
+		}
+	},
     {
       "description": "Invalid tlsAllowInvalidCertificates causes a warning",
       "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=invalid",

--- a/source/uri-options/tests/tls-options.yml
+++ b/source/uri-options/tests/tls-options.yml
@@ -1,7 +1,7 @@
 tests:
     -
         description: "Valid required tls options are parsed correctly"
-        uri: "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem&tlsCertificateKeyFilePassword=hunter2"
+        uri: "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem"
         valid: true
         warning: false
         hosts: ~
@@ -10,6 +10,14 @@ tests:
             tls: true
             tlsCAFile: "ca.pem"
             tlsCertificateKeyFile: "cert.pem"
+    -
+        description: "Valid tlsCertificateKeyFilePassword is parsed correctly"
+        uri: "mongodb://example.com/?tlsCertificateKeyFilePassword=hunter2"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
             tlsCertificateKeyFilePassword: "hunter2"
     -  
         description: "Invalid tlsAllowInvalidCertificates causes a warning"


### PR DESCRIPTION
Currently, the test for `tlsCertificateKeyPassword` is bundled with the required TLS options, but the URI options spec specifies that `tlsCertificateKeyFilePassword` is only required if the language/runtime supports it. Similar to other non-required options, we should separate this test so that drivers that don't implement this option can skip it without skipping the required options.