### PR TITLE
SPEC-1364: Clarify use of relative numbered bullets in prose tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,16 @@ Store all source documents in the ``source/`` directory.
 
 .. _`reStructuredText`: http://docutils.sourceforge.net/rst.html
 
+Prose test numbering
+--------------------
+
+When numbering prose tests, always use relative numbered bullets (``#.``). New
+tests must be appended at the end of the test list, since drivers may refer to
+existing tests by number.
+
+Outdated tests must not be removed completely, but may be marked as such (e.g.
+by striking through or replacing the entire test with a note (e.g. **Removed**).
+
 Building Documents
 ------------------
 

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -151,41 +151,43 @@ Prose Tests
 
 The following tests have not yet been automated, but MUST still be tested. All tests SHOULD be run on both replica sets and sharded clusters unless otherwise specified:
 
-1. ``ChangeStream`` must continuously track the last seen ``resumeToken``
-2. ``ChangeStream`` will throw an exception if the server response is missing the resume token (if wire version is < 8, this is a driver-side error; for 8+, this is a server-side error)
-3. After receiving a ``resumeToken``, ``ChangeStream`` will automatically resume one time on a resumable error with the initial pipeline and options, except for the addition/update of a ``resumeToken``.
-4. ``ChangeStream`` will not attempt to resume on any error encountered while executing an ``aggregate`` command. Note that retryable reads may retry ``aggregate`` commands. Drivers should be careful to distinguish retries from resume attempts. Alternatively, drivers may specify `retryReads=false` or avoid using a [retryable error](../../retryable-reads/retryable-reads.rst#retryable-error) for this test.
-5. ``ChangeStream`` will not attempt to resume after encountering error code 11601 (Interrupted), 136 (CappedPositionLost), or 237 (CursorKilled) while executing a ``getMore`` command.
-6. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
-7. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
-8. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
-9. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` and ``<4.0.7`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a change stream.
-10. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
-11. - For a ``ChangeStream`` under these conditions:
-      - Running against a server ``>=4.0.7``.
-      - The batch is empty or has been iterated to the last document.
-    - Expected result:
-       - ``getResumeToken`` must return the ``postBatchResumeToken`` from the current command response.
-12. - For a ``ChangeStream`` under these conditions:
-      - Running against a server ``<4.0.7``.
-      - The batch is empty or has been iterated to the last document.
-    - Expected result:
-      - ``getResumeToken`` must return the ``_id`` of the last document returned if one exists.
-      - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
-      - If ``resumeAfter`` was not specified, the ``getResumeToken`` result must be empty.
-13. - For a ``ChangeStream`` under these conditions:
-      - The batch is not empty.
-      - The batch has been iterated up to but not including the last element.
-    - Expected result:
-      - ``getResumeToken`` must return the ``_id`` of the previous document returned.
-14. - For a ``ChangeStream`` under these conditions:
-      - The batch is not empty.
-      - The batch hasn’t been iterated at all.
-      - Only the initial ``aggregate`` command has been executed.
-    - Expected result:
-      - ``getResumeToken`` must return ``startAfter`` from the initial aggregate if the option was specified.
-      - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
-      - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.
-    - Note that this test cannot be run against sharded topologies because in that case the initial ``aggregate`` command only establishes cursors on the shards and always returns an empty ``firstBatch``.
-17. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has not received any results yet MUST include a ``startAfter`` option and MUST NOT include a ``resumeAfter`` option when resuming a change stream.
-18. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has received at least one result MUST include a ``resumeAfter`` option and MUST NOT include a ``startAfter`` option when resuming a change stream.
+#. ``ChangeStream`` must continuously track the last seen ``resumeToken``
+#. ``ChangeStream`` will throw an exception if the server response is missing the resume token (if wire version is < 8, this is a driver-side error; for 8+, this is a server-side error)
+#. After receiving a ``resumeToken``, ``ChangeStream`` will automatically resume one time on a resumable error with the initial pipeline and options, except for the addition/update of a ``resumeToken``.
+#. ``ChangeStream`` will not attempt to resume on any error encountered while executing an ``aggregate`` command. Note that retryable reads may retry ``aggregate`` commands. Drivers should be careful to distinguish retries from resume attempts. Alternatively, drivers may specify `retryReads=false` or avoid using a [retryable error](../../retryable-reads/retryable-reads.rst#retryable-error) for this test.
+#. ``ChangeStream`` will not attempt to resume after encountering error code 11601 (Interrupted), 136 (CappedPositionLost), or 237 (CursorKilled) while executing a ``getMore`` command.
+#. ``ChangeStream`` will perform server selection before attempting to resume, using initial ``readPreference``
+#. Ensure that a cursor returned from an aggregate command with a cursor id and an initial empty batch is not closed on the driver side.
+#. The ``killCursors`` command sent during the "Resume Process" must not be allowed to throw an exception.
+#. ``$changeStream`` stage for ``ChangeStream`` against a server ``>=4.0`` and ``<4.0.7`` that has not received any results yet MUST include a ``startAtOperationTime`` option when resuming a change stream.
+#. ``ChangeStream`` will resume after a ``killCursors`` command is issued for its child cursor.
+#. - For a ``ChangeStream`` under these conditions:
+     - Running against a server ``>=4.0.7``.
+     - The batch is empty or has been iterated to the last document.
+   - Expected result:
+      - ``getResumeToken`` must return the ``postBatchResumeToken`` from the current command response.
+#. - For a ``ChangeStream`` under these conditions:
+     - Running against a server ``<4.0.7``.
+     - The batch is empty or has been iterated to the last document.
+   - Expected result:
+     - ``getResumeToken`` must return the ``_id`` of the last document returned if one exists.
+     - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
+     - If ``resumeAfter`` was not specified, the ``getResumeToken`` result must be empty.
+#. - For a ``ChangeStream`` under these conditions:
+     - The batch is not empty.
+     - The batch has been iterated up to but not including the last element.
+   - Expected result:
+     - ``getResumeToken`` must return the ``_id`` of the previous document returned.
+#. - For a ``ChangeStream`` under these conditions:
+     - The batch is not empty.
+     - The batch hasn’t been iterated at all.
+     - Only the initial ``aggregate`` command has been executed.
+   - Expected result:
+     - ``getResumeToken`` must return ``startAfter`` from the initial aggregate if the option was specified.
+     - ``getResumeToken`` must return ``resumeAfter`` from the initial aggregate if the option was specified.
+     - If neither the ``startAfter`` nor ``resumeAfter`` options were specified, the ``getResumeToken`` result must be empty.
+   - Note that this test cannot be run against sharded topologies because in that case the initial ``aggregate`` command only establishes cursors on the shards and always returns an empty ``firstBatch``.
+#. **Removed**
+#. **Removed**
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has not received any results yet MUST include a ``startAfter`` option and MUST NOT include a ``resumeAfter`` option when resuming a change stream.
+#. ``$changeStream`` stage for ``ChangeStream`` started with ``startAfter`` against a server ``>=4.1.1`` that has received at least one result MUST include a ``resumeAfter`` option and MUST NOT include a ``startAfter`` option when resuming a change stream.

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -302,7 +302,7 @@ Prose Tests
 The following tests ensure that retryable writes work properly with replica sets
 and sharded clusters.
 
-1. Test that retryable writes raise an exception when using the MMAPv1 storage
+#. Test that retryable writes raise an exception when using the MMAPv1 storage
    engine. For this test, execute a write operation, such as ``insertOne``,
    which should generate an exception. Assert that the error message is the
    replacement error message::


### PR DESCRIPTION
Initially, SPEC-1364 called for removing relative numbered bullets. This leaves a minor problem, where if the last spec test gets removed, future work on the spec could re-use this test number.

To avoid this problem, the spec readme clarifies that tests should no longer be removed, but instead marked as removed by either striking through (for short test descriptions) or removing the test description if it's a larger block of test. This shows readers that the test previously existed but is no longer relevant. At the same time, this ensures that new tests are always added to the end of the list.

Since the new changes no longer allow repurposing test numbers, there's no more reason to not use relative numbered bullets. Existing prose test lists have been changed to relative numbered bullets for consistency. Other lists remain unaffected.