### PR TITLE
Fix log message example for unsupported keys

### DIFF
--- a/source/connection-string/connection-string-spec.rst
+++ b/source/connection-string/connection-string-spec.rst
@@ -161,10 +161,11 @@ Keys are strings and the character case must be normalized by lower casing the u
 
 When defining and documenting keys, specifications should follow the camelCase naming convention with the first letter in lowercase, snake\_case MUST not be used. Keys that aren't supported by a driver MUST be ignored.
 
-A WARN level logging message MUST be issued. For example::
+Keys that aren't supported by a driver MUST be ignored. A WARN level logging message MUST be issued for unsupported keys. For example::
 
-  Unsupported option 'connectMS'. Keys should be descriptive and follow existing conventions:
-
+  Unsupported option 'connectMS'.
+  
+Keys should be descriptive and follow existing conventions:
 
 Time based keys
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
This is just a formatting change, so I'm not bothering with a SPEC ticket or change log bump.

This formatting error dates back to https://github.com/mongodb/specifications/commit/3cf351d1265bc8833776f3a8c7e0fead1957846b.