### PR TITLE
SPEC-1396 test plan for connection pool clearing on monitoring connec…

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -150,22 +150,50 @@ Network error on monitoring connection
 Non-timeout network error
 '''''''''''''''''''''''''
 
-Scenario: mock a non-timeout network error on a monitoring connection.
-Alternatively, set a `failCommand fail point`_ on ``isMaster`` command
-with ``closeConnection: true`` parameter. Then, either perform a server
-scan manually or wait for the driver to scan the server.
+Scenario:
 
-Outcome: the server MUST be marked Unknown, and the server's connection
-pool MUST be cleared.
+Subscribe to `TopologyDescriptionChangedEvent
+<https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events>`_
+SDAM event on the MongoClient.
+
+Subsribe to `PoolClearedEvent
+<https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#events>`_
+CMAP event on the MongoClient.
+
+Set a `failCommand fail point`_ on ``isMaster`` command
+with ``closeConnection: true`` parameter.
+
+Perform a server scan manually or wait for the driver to scan the server.
+
+Outcome:
+
+A TopologyDescriptionChangedEvent must have been published with the server's
+address and new description set to Unknown.
+
+A PoolClearedEvent must have been published with the server's address.
 
 Network timeout error
 '''''''''''''''''''''
 
-Scenario: mock a network timeout error on a monitoring connection.
-Then, either perform a server scan manually or wait for the driver to scan
-the server.
+Scenario:
 
-Outcome: the server MUST be marked Unknown, and the server's connection
-pool MUST be cleared.
+Subscribe to `TopologyDescriptionChangedEvent
+<https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events>`_
+SDAM event on the MongoClient.
+
+Subsribe to `PoolClearedEvent
+<https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#events>`_
+CMAP event on the MongoClient.
+
+Mock a network timeout error on the monitoring connection.
+
+Perform a server scan manually or wait for the driver to scan the server.
+
+Outcome:
+
+A TopologyDescriptionChangedEvent must have been published with the server's
+address and new description set to Unknown.
+
+A PoolClearedEvent must have been published with the server's address.
 
 .. _failCommand fail point: https://github.com/mongodb/mongo/wiki/The-%22failCommand%22-fail-point

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -167,3 +167,5 @@ the server.
 
 Outcome: the server MUST be marked Unknown, and the server's connection
 pool must be cleared.
+
+.. _failCommand fail point: https://github.com/mongodb/mongo/wiki/The-%22failCommand%22-fail-point

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -160,6 +160,8 @@ Set a `failCommand fail point`_ on ``isMaster`` command
 with ``closeConnection: true`` parameter. The following pseudocode illustrates
 setting the fail point:
 
+.. code:: ruby
+
     admin_client.command(
       configureFailPoint: 'failCommand',
       mode: {times: 2},

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -152,13 +152,9 @@ Non-timeout network error
 
 Scenario:
 
-Subscribe to `TopologyDescriptionChangedEvent
-<https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events>`_
-SDAM event on the MongoClient.
+Subscribe to `TopologyDescriptionChanged SDAM event`_ on the MongoClient.
 
-Subsribe to `PoolClearedEvent
-<https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#events>`_
-CMAP event on the MongoClient.
+Subsribe to `PoolCleared CMAP event`_ on the MongoClient.
 
 Set a `failCommand fail point`_ on ``isMaster`` command
 with ``closeConnection: true`` parameter.
@@ -177,13 +173,9 @@ Network timeout error
 
 Scenario:
 
-Subscribe to `TopologyDescriptionChangedEvent
-<https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events>`_
-SDAM event on the MongoClient.
+Subscribe to `TopologyDescriptionChanged SDAM event`_ on the MongoClient.
 
-Subsribe to `PoolClearedEvent
-<https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#events>`_
-CMAP event on the MongoClient.
+Subsribe to `PoolCleared CMAP event`_ on the MongoClient.
 
 Mock a network timeout error on the monitoring connection.
 
@@ -197,3 +189,5 @@ address and new description set to Unknown.
 A PoolClearedEvent must have been published with the server's address.
 
 .. _failCommand fail point: https://github.com/mongodb/mongo/wiki/The-%22failCommand%22-fail-point
+.. _TopologyDescriptionChanged SDAM event: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events
+.. _PoolCleared CMAP event: https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#events

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -179,6 +179,13 @@ required to retry failing ``isMaster`` calls.
 
 Perform a server scan manually or wait for the driver to scan the server.
 
+disable the fail point to avoid spurious failures in subsequent tests.
+The fail point may be disabled like so:
+
+.. code:: ruby
+
+    admin_client.command(configureFailPoint: 'failCommand', mode: 'off')
+
 **Outcome:**
 
 A TopologyDescriptionChangedEvent must have been published with the server's

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -156,7 +156,7 @@ with ``closeConnection: true`` parameter. Then, either perform a server
 scan manually or wait for the driver to scan the server.
 
 Outcome: the server MUST be marked Unknown, and the server's connection
-pool must be cleared.
+pool MUST be cleared.
 
 Network timeout error
 '''''''''''''''''''''
@@ -166,6 +166,6 @@ Then, either perform a server scan manually or wait for the driver to scan
 the server.
 
 Outcome: the server MUST be marked Unknown, and the server's connection
-pool must be cleared.
+pool MUST be cleared.
 
 .. _failCommand fail point: https://github.com/mongodb/mongo/wiki/The-%22failCommand%22-fail-point

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -143,3 +143,27 @@ Command response on an arbiter, recovering member, ghost, or secondary
 when slaveOk is false:
 
     {ok: 0, errmsg: "not master"}
+
+Network error on monitoring connection
+--------------------------------------
+
+Non-timeout network error
+'''''''''''''''''''''''''
+
+Scenario: mock a non-timeout network error on a monitoring connection.
+Alternatively, set a `failCommand fail point`_ on ``isMaster`` command
+with ``closeConnection: true`` parameter. Then, either perform a server
+scan manually or wait for the driver to scan the server.
+
+Outcome: the server MUST be marked Unknown, and the server's connection
+pool must be cleared.
+
+Network timeout error
+'''''''''''''''''''''
+
+Scenario: mock a network timeout error on a monitoring connection.
+Then, either perform a server scan manually or wait for the driver to scan
+the server.
+
+Outcome: the server MUST be marked Unknown, and the server's connection
+pool must be cleared.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -150,7 +150,7 @@ Network error on monitoring connection
 Non-timeout network error
 '''''''''''''''''''''''''
 
-Scenario:
+**Scenario:**
 
 Subscribe to `TopologyDescriptionChanged SDAM event`_ on the MongoClient.
 
@@ -161,7 +161,7 @@ with ``closeConnection: true`` parameter.
 
 Perform a server scan manually or wait for the driver to scan the server.
 
-Outcome:
+**Outcome:**
 
 A TopologyDescriptionChangedEvent must have been published with the server's
 address and new description set to Unknown.
@@ -171,7 +171,7 @@ A PoolClearedEvent must have been published with the server's address.
 Network timeout error
 '''''''''''''''''''''
 
-Scenario:
+**Scenario:**
 
 Subscribe to `TopologyDescriptionChanged SDAM event`_ on the MongoClient.
 
@@ -181,7 +181,7 @@ Mock a network timeout error on the monitoring connection.
 
 Perform a server scan manually or wait for the driver to scan the server.
 
-Outcome:
+**Outcome:**
 
 A TopologyDescriptionChangedEvent must have been published with the server's
 address and new description set to Unknown.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -157,7 +157,23 @@ Subscribe to `TopologyDescriptionChanged SDAM event`_ on the MongoClient.
 Subsribe to `PoolCleared CMAP event`_ on the MongoClient.
 
 Set a `failCommand fail point`_ on ``isMaster`` command
-with ``closeConnection: true`` parameter.
+with ``closeConnection: true`` parameter. The following pseudocode illustrates
+setting the fail point:
+
+    admin_client.command(
+      configureFailPoint: 'failCommand',
+      mode: {times: 2},
+      data: {
+        failCommands: %w(isMaster),
+        closeConnection: true,
+      },
+    )
+
+Note that:
+
+- The fail point MUST be set to trigger twice because the server monitor is
+required to retry failing ``isMaster`` calls.
+- The "m" in ``isMaster`` MUST be capitalized.
 
 Perform a server scan manually or wait for the driver to scan the server.
 


### PR DESCRIPTION
…tion errors

This is a follow-up PR to https://github.com/mongodb/specifications/pull/665. This PR adds prose tests for clearing connection pool when monitoring connection experiences network errors.