### PR TITLE
SPEC-1503: Add dirty sessions tests

### DIFF
--- a/source/sessions/tests/dirty-session-errors.json
+++ b/source/sessions/tests/dirty-session-errors.json
@@ -358,6 +358,149 @@
       }
     },
     {
+      "description": "Dirty explicit session is discarded (non-bulk write)",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "assertSessionNotDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "assertSessionDirty",
+          "object": "testRunner",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "endSession",
+          "object": "session0"
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "new": false,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "new": false,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              }
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            }
+          ]
+        }
+      }
+    },
+    {
       "description": "Dirty implicit session is discarded (write)",
       "clientOptions": {
         "retryWrites": true
@@ -466,6 +609,128 @@
       }
     },
     {
+      "description": "Dirty implicit session is discarded (non-bulk write)",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "findAndModify"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            },
+            "returnDocument": "Before"
+          },
+          "result": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "new": false,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "findAndModify": "test",
+              "query": {
+                "_id": 1
+              },
+              "update": {
+                "$inc": {
+                  "x": 1
+                }
+              },
+              "new": false,
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "findAndModify",
+            "database_name": "session-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "test",
+              "filter": {
+                "_id": -1
+              }
+            },
+            "command_name": "find",
+            "database_name": "session-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 1
+            }
+          ]
+        }
+      }
+    },
+    {
       "description": "Dirty implicit session is discarded (read)",
       "failPoint": {
         "configureFailPoint": "failCommand",
@@ -491,6 +756,54 @@
                 }
               }
             ]
+          },
+          "error": true
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": -1
+            }
+          },
+          "result": []
+        },
+        {
+          "name": "assertDifferentLsidOnLastTwoCommands",
+          "object": "testRunner"
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Dirty implicit session is discarded (non-cursor returning read)",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 2
+        },
+        "data": {
+          "failCommands": [
+            "count"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "count",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
           },
           "error": true
         },

--- a/source/sessions/tests/dirty-session-errors.json
+++ b/source/sessions/tests/dirty-session-errors.json
@@ -793,14 +793,14 @@
         },
         "data": {
           "failCommands": [
-            "count"
+            "aggregate"
           ],
           "closeConnection": true
         }
       },
       "operations": [
         {
-          "name": "count",
+          "name": "countDocuments",
           "object": "collection",
           "arguments": {
             "filter": {}

--- a/source/sessions/tests/dirty-session-errors.yml
+++ b/source/sessions/tests/dirty-session-errors.yml
@@ -418,11 +418,11 @@ tests:
         configureFailPoint: failCommand
         mode: { times: 2 }
         data:
-            failCommands: ["count"]
+            failCommands: ["aggregate"]
             closeConnection: true
 
     operations:
-      - name: count
+      - name: countDocuments
         object: collection
         arguments:
           filter: {}

--- a/source/sessions/tests/dirty-session-errors.yml
+++ b/source/sessions/tests/dirty-session-errors.yml
@@ -188,6 +188,82 @@ tests:
           - {_id: 2}
           - {_id: 3}
 
+  - description: Dirty explicit session is discarded (non-bulk write)
+
+    clientOptions:
+      retryWrites: true
+
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 1 }
+        data:
+            failCommands: ["findAndModify"]
+            closeConnection: true
+
+    operations:
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - &find_and_update_with_explicit_session
+        name: findOneAndUpdate
+        object: collection
+        arguments:
+          session: session0
+          filter: {_id: 1}
+          update:
+            $inc: {x: 1}
+          returnDocument: Before
+        result: {_id: 1}
+      - name: assertSessionDirty
+        object: testRunner
+        arguments:
+          session: session0
+      - name: endSession
+        object: session0
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$inc: {x: 1}}
+            new: false
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$inc: {x: 1}}
+            new: false
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 1}
+
   - description: Dirty implicit session is discarded (write)
 
     clientOptions:
@@ -240,6 +316,69 @@ tests:
           - {_id: 1}
           - {_id: 2}
 
+  - description: Dirty implicit session is discarded (non-bulk write)
+
+    clientOptions:
+      retryWrites: true
+
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 1 }
+        data:
+            failCommands: ["findAndModify"]
+            closeConnection: true
+
+    operations:
+      - &find_and_update_with_implicit_session
+        name: findOneAndUpdate
+        object: collection
+        arguments:
+          filter: {_id: 1}
+          update:
+            $inc: {x: 1}
+          returnDocument: Before
+        result: {_id: 1}
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+    expectations:
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$inc: {x: 1}}
+            new: false
+            txnNumber:
+              $numberLong: "1"
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - command_started_event:
+          command:
+            findAndModify: *collection_name
+            query: {_id: 1}
+            update: {$inc: {x: 1}}
+            new: false
+            txnNumber:
+              $numberLong: "1"
+            readConcern:
+            writeConcern:
+          command_name: findAndModify
+          database_name: *database_name
+      - command_started_event:
+          command:
+            find: *collection_name
+            filter: {_id: -1}
+          command_name: find
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1, x: 1}
+
   - description: Dirty implicit session is discarded (read)
 
     # Enable the failpoint with times:2 so that this test can pass with or
@@ -265,6 +404,35 @@ tests:
 
     # Don't include expectations because a driver may or may not retry the
     # aggregate depending on if they have implemented the retryable reads spec.
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+
+  - description: Dirty implicit session is discarded (non-cursor returning read)
+
+    # Enable the failpoint with times:2 so that this test can pass with or
+    # without retryable reads.
+    failPoint:
+        configureFailPoint: failCommand
+        mode: { times: 2 }
+        data:
+            failCommands: ["count"]
+            closeConnection: true
+
+    operations:
+      - name: count
+        object: collection
+        arguments:
+          filter: {}
+        error: true
+      - *find_with_implicit_session
+      - name: assertDifferentLsidOnLastTwoCommands
+        object: testRunner
+
+    # Don't include expectations because a driver may or may not retry the
+    # count depending on if they have implemented the retryable reads spec.
 
     outcome:
       collection:


### PR DESCRIPTION
Add dirty sessions tests that execute non-bulk write commands and non-cursor returning read commands.

https://jira.mongodb.org/browse/SPEC-1503