### PR TITLE
SPEC-1476 add constraints for single-threaded connection to mongocryptd

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -639,7 +639,7 @@ MongoClient fails to connect after spawning, the server selection error
 is propagated to the user.
 
 Single-threaded drivers MUST connect with `serverSelectionTryOnce=false <https://github.com/mongodb/specifications/blob/6bc8afe3516d2274c3f646e8293af15cf8651e8c/source/server-selection/server-selection.rst#serverselectiontryonce>`_
-and MUST bypass `cooldownMS <https://github.com/mongodb/specifications/blob/6bc8afe3516d2274c3f646e8293af15cf8651e8c/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`_ when connecting to mongocryptd. See `Why are serverSelectionTryOnce and cooldownMS disabled for single-threaded drivers?`_.
+and MUST bypass `cooldownMS <https://github.com/mongodb/specifications/blob/6bc8afe3516d2274c3f646e8293af15cf8651e8c/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`_ when connecting to mongocryptd. See `Why are serverSelectionTryOnce and cooldownMS disabled for single-threaded drivers connecting to mongocryptd?`_.
 
 If the ClientEncryption is configured with mongocryptdBypassSpawn=true,
 then the driver is not responsible for spawning mongocryptd. If server
@@ -1239,8 +1239,8 @@ Although not technically necessary for client side encryption, it does
 provide a fallback against accidentally sending unencrypted data from
 misconfigured clients.
 
-Why are serverSelectionTryOnce and cooldownMS disabled for single-threaded drivers?
------------------------------------------------------------------------------------
+Why are serverSelectionTryOnce and cooldownMS disabled for single-threaded drivers connecting to mongocryptd?
+-------------------------------------------------------------------------------------------------------------
 
 By default, single threaded clients set serverSelectionTryOnce to true, which
 means server selection fails if a topology scan fails the first time (i.e. it

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -428,7 +428,7 @@ key. If the kmsProvider is "aws" it is required and has the following fields:
 
    {
       region: String, // Required.
-      key: String // Required. The Amazon Resource Name (ARN) to the AWS customer master key (CMK).
+      key: String, // Required. The Amazon Resource Name (ARN) to the AWS customer master key (CMK).
       endpoint: String // Optional. An alternate host identifier to send KMS requests to. May include port number.
    }
 
@@ -638,8 +638,8 @@ server selection on the MongoClient to mongocryptd fails. If the
 MongoClient fails to connect after spawning, the server selection error
 is propagated to the user.
 
-Single-threaded drivers MUST connect with `serverSelectionTryOnce=false <https://github.com/mongodb/specifications/blob/6bc8afe3516d2274c3f646e8293af15cf8651e8c/source/server-selection/server-selection.rst#serverselectiontryonce>`_
-and MUST bypass `cooldownMS <https://github.com/mongodb/specifications/blob/6bc8afe3516d2274c3f646e8293af15cf8651e8c/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`_ when connecting to mongocryptd. See `Why are serverSelectionTryOnce and cooldownMS disabled for single-threaded drivers connecting to mongocryptd?`_.
+Single-threaded drivers MUST connect with `serverSelectionTryOnce=false <../server-selection/server-selection.rst#serverselectiontryonce>`_
+, connectTimeoutMS=1000, and MUST bypass `cooldownMS <../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`_ when connecting to mongocryptd. See `Why are serverSelectionTryOnce and cooldownMS disabled for single-threaded drivers connecting to mongocryptd?`_.
 
 If the ClientEncryption is configured with mongocryptdBypassSpawn=true,
 then the driver is not responsible for spawning mongocryptd. If server
@@ -1247,7 +1247,7 @@ means server selection fails if a topology scan fails the first time (i.e. it
 will not make repeat attempts until serverSelectionTimeoutMS expires). This
 behavior is overriden since there may be a small delay between spawning
 mongocryptd (which the driver may be responsible for) and for mongocryptd to
-listen on sockets. See the Server Selection spec description of `serverSelectionTryOnce <https://github.com/mongodb/specifications/blob/6bc8afe3516d2274c3f646e8293af15cf8651e8c/source/server-selection/server-selection.rst#serverselectiontryonce>`_.
+listen on sockets. See the Server Selection spec description of `serverSelectionTryOnce <../server-selection/server-selection.rst#serverselectiontryonce>`_.
 
 Similarly, single threaded clients will by default wait for 5 second cooldown
 period after failing to connect to a server before making another attempt.
@@ -1255,7 +1255,10 @@ Meaning if the first attempt to mongocryptd fails to connect, then the user
 would observe a 5 second delay. This is not configurable in the URI, so this
 must be overriden internally. Since mongocryptd is a local process, there should
 only be a very short delay after spawning mongocryptd for it to start listening
-on sockets. See the SDAM spec description of `cooldownMS <https://github.com/mongodb/specifications/blob/6bc8afe3516d2274c3f646e8293af15cf8651e8c/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`_.
+on sockets. See the SDAM spec description of `cooldownMS <../source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`_.
+
+Because single threaded drivers may exceed ``serverSelectionTimeoutMS`` by the
+duration of the topology scan, ``connectTimeoutMS`` is also reduced.
 
 Future work
 ===========


### PR DESCRIPTION
I believe this should only affect libmongoc's single-threaded client implementation currently. These were the changes I made in the implementation to prevent server selection from immediately failing, and from a delay of 5 seconds due to the cooldown. 