### PR TITLE
SPEC-1423: Update auth URI options spec for Ruby Driver

### DIFF
--- a/source/uri-options/tests/auth-options.json
+++ b/source/uri-options/tests/auth-options.json
@@ -25,7 +25,6 @@
       "auth": null,
       "options": {
         "authMechanism": "SCRAM-SHA-1",
-        "authMechanismProperties": null,
         "authSource": "authSourceDB"
       }
     }

--- a/source/uri-options/tests/auth-options.json
+++ b/source/uri-options/tests/auth-options.json
@@ -1,7 +1,7 @@
 {
   "tests": [
     {
-      "description": "Valid auth options are parsed correctly",
+      "description": "Valid auth options are parsed correctly (GSSAPI)",
       "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external",
       "valid": true,
       "warning": false,
@@ -14,6 +14,19 @@
           "CANONICALIZE_HOST_NAME": true
         },
         "authSource": "$external"
+      }
+    },
+    {
+      "description": "Valid auth options are parsed correctly (SCRAM-SHA-1)",
+      "uri": "mongodb://foo:bar@example.com/?authMechanism=SCRAM-SHA-1&authSource=authSourceDB",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "authMechanism": "SCRAM-SHA-1",
+        "authMechanismProperties": null,
+        "authSource": "authSourceDB"
       }
     }
   ]

--- a/source/uri-options/tests/auth-options.yml
+++ b/source/uri-options/tests/auth-options.yml
@@ -21,5 +21,4 @@ tests:
         auth: ~
         options:
             authMechanism: "SCRAM-SHA-1"
-            authMechanismProperties: ~
             authSource: "authSourceDB"

--- a/source/uri-options/tests/auth-options.yml
+++ b/source/uri-options/tests/auth-options.yml
@@ -1,6 +1,6 @@
 tests:
     -
-        description: "Valid auth options are parsed correctly"
+        description: "Valid auth options are parsed correctly (GSSAPI)"
         uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external"
         valid: true
         warning: false
@@ -12,3 +12,14 @@ tests:
                 SERVICE_NAME: "other"
                 CANONICALIZE_HOST_NAME: true
             authSource: "$external"
+    -
+        description: "Valid auth options are parsed correctly (SCRAM-SHA-1)"
+        uri: "mongodb://foo:bar@example.com/?authMechanism=SCRAM-SHA-1&authSource=authSourceDB"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            authMechanism: "SCRAM-SHA-1"
+            authMechanismProperties: ~
+            authSource: "authSourceDB"


### PR DESCRIPTION
The Ruby driver implements GSSAPI authentication in another gem, mongo-ruby-kerberos, which is not included in the driver by default. To handle this, the Ruby driver tests skip GSSAPI-related tests unless this gem is installed by checking whether the word "GSSAPI" is present in the test description. To make the URI-option tests easier to run on the Ruby Driver, I have made two changes:

1. I added "(GSSAPI)" to the description of the first test so that the Ruby test runner will know to skip it if GSSAPI is not installed. This is consistent with the way descriptions are written in the [auth spec tests](https://github.com/mongodb/specifications/blob/master/source/auth/tests/connection-string.yml#L33).
2. I added a second test using a different mechanism that exists by default in the Ruby driver, so that the Ruby driver can verify that auth-related URI options are being correctly parsed even if the mongo-ruby-kerberos gem is not present.