### PR TITLE
add prose test for bypassing mongocryptd spawning

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -596,3 +596,66 @@ Data keys created with AWS KMS may specify a custom endpoint to contact (instead
 
    Expect this to fail with an exception with a message containing the string: "parse error"
 
+Bypass spawning mongocryptd
+===========================
+
+The following tests that setting ``mongocryptdBypassSpawn`` really does bypass spawning mongocryptd.
+
+#. Create a MongoClient configured with auto encryption (referred to as ``client_encrypted``)
+
+   Configure the required options. Use the ``local`` KMS provider as follows:
+
+   .. code:: javascript
+
+      { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
+
+   Configure with the ``keyVaultNamespace`` set to ``admin.datakeys``.
+
+   Configure the following ``extraOptions``:
+
+   .. code:: javascript
+
+      {
+        "mongocryptdBypassSpawn": true
+        "mongocryptdSpawnArgs": [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"]
+      }
+
+   Drivers MAY pass a different value to ``--port`` if they expect their testing infrastructure to be using port 27021. Pass a port that should be free.
+
+#. Use ``client_encrypted`` to run a "ping" command.
+
+#. Validate that mongocryptd was not spawned. This may be done in one of the following was:
+
+   - Check that the file ``bypass-spawning-mongocryptd.pid`` does not exist (preferred)
+   - Creating a MongoClient to localhost:27021 (or whatever was passed via ``--port``) with serverSelectionTimeoutMS=100
+
+The following tests that setting ``bypassAutoEncryption`` really does bypass spawning mongocryptd.
+
+#. Create a MongoClient configured with auto encryption (referred to as ``client_encrypted``)
+
+   Configure the required options. Use the ``local`` KMS provider as follows:
+
+   .. code:: javascript
+
+      { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
+
+   Configure with the ``keyVaultNamespace`` set to ``admin.datakeys``.
+
+   Configure with ``bypassAutoEncryption=true``.
+
+   Configure the following ``extraOptions``:
+
+   .. code:: javascript
+
+      {
+        "mongocryptdSpawnArgs": [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"]
+      }
+
+   Drivers MAY pass a different value to ``--port`` if they expect their testing infrastructure to be using port 27021. Pass a port that should be free.
+
+#. Use ``client_encrypted`` to run a "ping" command.
+
+#. Validate that mongocryptd was not spawned. This may be done in one of the following was:
+
+   - Check that the file ``bypass-spawning-mongocryptd.pid`` does not exist (preferred)
+   - Creating a MongoClient to localhost:27021 (or whatever was passed via ``--port``) with serverSelectionTimeoutMS=100

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -428,7 +428,7 @@ Views are prohibited
 
 
 Corpus Test
-===========
+~~~~~~~~~~~
 
 The corpus test exhaustively enumerates all ways to encrypt all BSON value types. Note, the test data includes BSON binary subtype 4 (or standard UUID), which MUST be decoded and encoded as subtype 4. Run the test as follows.
 
@@ -509,7 +509,7 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
 9. Repeat steps 1-8 with a local JSON schema. I.e. amend step 4 to configure the schema on ``client_encrypted`` with the ``schema_map`` option.
 
 Custom Endpoint Test
-====================
+~~~~~~~~~~~~~~~~~~~~
 
 Data keys created with AWS KMS may specify a custom endpoint to contact (instead of the default endpoint derived from the AWS region).
 
@@ -597,9 +597,17 @@ Data keys created with AWS KMS may specify a custom endpoint to contact (instead
    Expect this to fail with an exception with a message containing the string: "parse error"
 
 Bypass spawning mongocryptd
-===========================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following tests that setting ``mongocryptdBypassSpawn`` really does bypass spawning mongocryptd.
+Via mongocryptdBypassSpawn
+``````````````````````````
+
+The following tests that setting ``mongocryptdBypassSpawn=true`` really does bypass spawning mongocryptd.
+
+#. Create a MongoClient without encryption enabled (referred to as ``client``).
+
+#. Using ``client``, drop the collections ``admin.datakeys`` and ``db.coll``.
+   Insert the document `external/external-key.json <../external/external-key.json>`_ into ``admin.datakeys``.
 
 #. Create a MongoClient configured with auto encryption (referred to as ``client_encrypted``)
 
@@ -610,6 +618,8 @@ The following tests that setting ``mongocryptdBypassSpawn`` really does bypass s
       { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
 
    Configure with the ``keyVaultNamespace`` set to ``admin.datakeys``.
+
+   Configure ``client_encrypted`` to use the schema `external/external-schema.json <../external/external-schema.json>`_  for ``db.coll`` by setting a schema map like: ``{ "db.coll": <contents of external-schema.json>}``
 
    Configure the following ``extraOptions``:
 
@@ -629,7 +639,16 @@ The following tests that setting ``mongocryptdBypassSpawn`` really does bypass s
    - Check that the file ``bypass-spawning-mongocryptd.pid`` does not exist (preferred)
    - Creating a MongoClient to localhost:27021 (or whatever was passed via ``--port``) with serverSelectionTimeoutMS=100
 
-The following tests that setting ``bypassAutoEncryption`` really does bypass spawning mongocryptd.
+#. Spawn mongocryptd manually. This may be done by creating a separate MongoClient with automatic encryption enabled and running a ``ping`` command.
+
+#. Use ``client_encrypted`` to insert the document ``{"encrypted": "test"}`` into ``db.coll``. Since ``client_encrypted`` was not configured with a custom ``mongocryptdURI``, it should use the recently spawned mongocryptd for auto encryption.
+
+#. Use ``client`` to find the inserted document from ``db.coll`` and assert that the field ``encrypted`` is a BSON binary of subtype 6.
+
+Via bypassAutoEncryption
+````````````````````````
+
+The following tests that setting ``bypassAutoEncryption=true`` really does bypass spawning mongocryptd.
 
 #. Create a MongoClient configured with auto encryption (referred to as ``client_encrypted``)
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -634,7 +634,7 @@ The following tests that setting ``mongocryptdBypassSpawn=true`` really does byp
 
 #. Use ``client_encrypted`` to run a "ping" command.
 
-#. Validate that mongocryptd was not spawned. This may be done in one of the following was:
+#. Validate that mongocryptd was not spawned. This may be done in one of the following ways:
 
    - Check that the file ``bypass-spawning-mongocryptd.pid`` does not exist (preferred)
    - Creating a MongoClient to localhost:27021 (or whatever was passed via ``--port``) with serverSelectionTimeoutMS=100


### PR DESCRIPTION
By passing a custom pidfilepath and port that differs from any possible existing mongocryptd running in the background, if the driver was mistakenly spawning mongocryptd when it should not have, the spawned mongocryptd will not self-terminate, so it can be detected by either the pidfile or by connecting with a MongoClient.

I've PoC'ed this test with libmongoc.