### PR TITLE
SPEC-1525 Fix SDAM spec's description of opTime

### DIFF
--- a/source/max-staleness/max-staleness.rst
+++ b/source/max-staleness/max-staleness.rst
@@ -121,7 +121,7 @@ with these fields (SERVER-8858):
 
 * lastWriteDate: a BSON UTC datetime,
   the wall-clock time of the **primary** when it most recently recorded a write to the oplog.
-* opTime: an opaque value representing the most recent replicated write.
+* opTime: an opaque value representing the position in the oplog of the most recently seen write.
   Needed for sharding, not used for the maxStalenessSeconds read preference option.
 
 

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -305,7 +305,7 @@ Fields:
 * opTime: an opTime or null.
   An opaque value representing the position in the oplog of the most recent write. Default null.
   (Only mongos and shard servers record this field when monitoring
-  config servers as replica sets, at least until `drivers allow applications to use readConcern "afterOptime".<https://github.com/mongodb/specifications/blob/master/source/max-staleness/max-staleness.rst#future-feature-to-support-readconcern-afteroptime>`_)
+  config servers as replica sets, at least until `drivers allow applications to use readConcern "afterOptime". <https://github.com/mongodb/specifications/blob/master/source/max-staleness/max-staleness.rst#future-feature-to-support-readconcern-afteroptime>`_)
 * (=) type: a `ServerType`_ enum value. Default Unknown.
 * (=) minWireVersion, maxWireVersion:
   the wire protocol version range supported by the server.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -303,7 +303,7 @@ Fields:
 * lastWriteDate: a 64-bit BSON datetime or null.
   The "lastWriteDate" from the server's most recent ismaster response.
 * opTime: an opTime or null.
-  An opaque value representing the position in the oplog of the most recent write. Default null.
+  An opaque value representing the position in the oplog of the most recently seen write. Default null.
   (Only mongos and shard servers record this field when monitoring
   config servers as replica sets, at least until `drivers allow applications to use readConcern "afterOptime". <https://github.com/mongodb/specifications/blob/master/source/max-staleness/max-staleness.rst#future-feature-to-support-readconcern-afteroptime>`_)
 * (=) type: a `ServerType`_ enum value. Default Unknown.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -302,10 +302,10 @@ Fields:
 * roundTripTime: the duration of the ismaster call. Default null.
 * lastWriteDate: a 64-bit BSON datetime or null.
   The "lastWriteDate" from the server's most recent ismaster response.
-* opTime: an ObjectId or null.
-  The last opTime reported by the server; an ObjectId or null.
+* opTime: an opTime or null.
+  An opaque value representing the position in the oplog of the most recent write. Default null.
   (Only mongos and shard servers record this field when monitoring
-  config servers as replica sets.)
+  config servers as replica sets, at least until `drivers allow applications to use readConcern "afterOptime".<https://github.com/mongodb/specifications/blob/master/source/max-staleness/max-staleness.rst#future-feature-to-support-readconcern-afteroptime>`_)
 * (=) type: a `ServerType`_ enum value. Default Unknown.
 * (=) minWireVersion, maxWireVersion:
   the wire protocol version range supported by the server.


### PR DESCRIPTION
[SPEC-1525](https://jira.mongodb.org/browse/SPEC-1525).

This PR fixes the description of opTime in the SDAM spec, and it also updates the section to clarify why only mongos records the value.