### PR TITLE
SPEC-1533 primary mismatched me is not removed from server set

### DIFF
--- a/source/server-discovery-and-monitoring/tests/rs/primary_mismatched_me_not_removed.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_mismatched_me_not_removed.json
@@ -1,0 +1,77 @@
+{
+  "description": "Primary mismatched me is not removed",
+  "uri": "mongodb://localhost:27017,localhost:27018/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "localhost:27017",
+          {
+            "ok": 1,
+            "hosts": [
+              "localhost:27017",
+              "localhost:27018"
+            ],
+            "ismaster": true,
+            "setName": "rs",
+            "primary": "localhost:27017",
+            "me": "a:27017",
+            "minWireVersion": 0,
+            "maxWireVersion": 7
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "localhost:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "localhost:27018": {
+            "type": "Unknown",
+            "setName": null
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "localhost:27018",
+          {
+            "ok": 1,
+            "hosts": [
+              "localhost:27017",
+              "localhost:27018"
+            ],
+            "ismaster": false,
+            "secondary": true,
+            "setName": "rs",
+            "primary": "localhost:27017",
+            "me": "localhost:27018",
+            "minWireVersion": 0,
+            "maxWireVersion": 7
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "localhost:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "localhost:27018": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": null,
+        "setName": "rs"
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/rs/primary_mismatched_me_not_removed.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_mismatched_me_not_removed.yml
@@ -1,0 +1,73 @@
+description: Primary mismatched me is not removed
+uri: mongodb://localhost:27017,localhost:27018/?replicaSet=rs
+
+phases: [
+  {
+    responses: [
+      ["localhost:27017", {
+        ok: 1,
+        hosts: [
+          "localhost:27017",
+          "localhost:27018"
+        ],
+        ismaster: true,
+        setName: "rs",
+        primary: "localhost:27017",
+        # me does not match the primary responder's address, but the server
+        # is still added because we don't me mismatch check the primary and all
+        # servers from a primary ismaster are added to the working server set
+        me: "a:27017",
+        minWireVersion: 0,
+        maxWireVersion: 7
+      }]
+    ],
+    outcome: {
+      servers: {
+        "localhost:27017": {
+          type: "RSPrimary",
+          setName: "rs"
+        },
+        "localhost:27018": {
+          type: "Unknown",
+          setName: null
+        }
+      },
+      topologyType: "ReplicaSetWithPrimary",
+      logicalSessionTimeoutMinutes: null,
+      setName: "rs"
+    }
+  },
+  {
+    responses: [
+      ["localhost:27018", {
+        ok: 1,
+        hosts: [
+          "localhost:27017",
+          "localhost:27018"
+        ],
+        ismaster: false,
+        secondary: true,
+        setName: "rs",
+        primary: "localhost:27017",
+        me: "localhost:27018",
+        minWireVersion: 0,
+        maxWireVersion: 7
+      }]
+    ],
+    outcome: {
+      servers: {
+        "localhost:27017": {
+          type: "RSPrimary",
+          setName: "rs"
+        },
+        "localhost:27018": {
+          type: "RSSecondary",
+          setName: "rs"
+        }
+      },
+      topologyType: "ReplicaSetWithPrimary",
+      logicalSessionTimeoutMinutes: null,
+      setName: "rs"
+    }
+  }
+]


### PR DESCRIPTION
This test validates the pseudocode provided in the SDAM specification, ensuring that a primary is always added to the working server set even if it has a `me` mismatch.