### PR TITLE
SPEC-1514: Specify behavior of empty URI authentication options

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -1161,7 +1161,7 @@ Version History
 ===============
 
 Version 1.9.0 Changes
-    * Clarify that drivers should raise and error when a connection string
+    * Clarify that drivers must raise an error when a connection string
       has an empty value for authSource.
 
 Version 1.8.3 Changes

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -6,7 +6,7 @@ Driver Authentication
 =====================
 
 :Spec: 100
-:Spec Version: 1.8.3
+:Spec Version: 1.9.0
 :Title: Driver Authentication
 :Author: Craig Wilson, David Golden
 :Advisors: Andy Schwerin, Bernie Hacket, Jeff Yemin, David Golden
@@ -978,7 +978,7 @@ gssapiServiceName (deprecated)
 Errors
 ------
 
-Drivers SHOULD raise an error if the ``authSource`` option is specified in the connection string with an empty value, e.g. ``mongodb://localhost/admin?authSource=``.
+Drivers MUST raise an error if the ``authSource`` option is specified in the connection string with an empty value, e.g. ``mongodb://localhost/admin?authSource=``.
 
 
 Implementation
@@ -1160,14 +1160,16 @@ Q: Why does SCRAM sometimes SASLprep and sometimes not?
 Version History
 ===============
 
+Version 1.9.0 Changes
+    * Clarify that drivers should raise and error when a connection string
+      has an empty value for authSource.
+
 Version 1.8.3 Changes
     * Clarify that authSource in URI is not treated as a user configuring
       auth credentials.
 
 Version 1.8.2 Changes
     * Added MONGODB-IAM auth mechanism
-    * Clarify that drivers should raise and error when a connection string
-      has an empty value for authSource.
 
 Version 1.8.1 Changes
     * Clarify database to use for auth mechanism negotiation.

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -974,6 +974,8 @@ authMechanismProperties=PROPERTY_NAME:PROPERTY_VALUE,PROPERTY_NAME2:PROPERTY_VAL
 gssapiServiceName (deprecated)
 	An alias for ``authMechanismProperties=SERVICE_NAME:mongodb``.
 
+If any of the auth related options are specified in the connection string without a value, e.g. ``mongodb://localhost/admin?authSource=``, the default value for the option should be used.
+
 
 Implementation
 --------------

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -974,7 +974,11 @@ authMechanismProperties=PROPERTY_NAME:PROPERTY_VALUE,PROPERTY_NAME2:PROPERTY_VAL
 gssapiServiceName (deprecated)
 	An alias for ``authMechanismProperties=SERVICE_NAME:mongodb``.
 
-If any of the auth related options are specified in the connection string without a value, e.g. ``mongodb://localhost/admin?authSource=``, the default value for the option should be used.
+
+Errors
+------
+
+Drivers SHOULD raise an error if the ``authSource`` option is specified in the connection string with an empty value, e.g. ``mongodb://localhost/admin?authSource=``.
 
 
 Implementation
@@ -1162,6 +1166,8 @@ Version 1.8.3 Changes
 
 Version 1.8.2 Changes
     * Added MONGODB-IAM auth mechanism
+    * Clarify that drivers should raise and error when a connection string
+      has an empty value for authSource.
 
 Version 1.8.1 Changes
     * Clarify database to use for auth mechanism negotiation.

--- a/source/auth/tests/connection-string.json
+++ b/source/auth/tests/connection-string.json
@@ -113,6 +113,11 @@
       "valid": false
     },
     {
+      "description": "must raise an error when the authSource is empty without credentials",
+      "uri": "mongodb://localhost/admin?authSource=",
+      "valid": false
+    },
+    {
       "description": "should throw an exception if authSource is invalid (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo",
       "valid": false

--- a/source/auth/tests/connection-string.json
+++ b/source/auth/tests/connection-string.json
@@ -25,6 +25,18 @@
       }
     },
     {
+      "description": "should use the database when the authSource is empty",
+      "uri": "mongodb://user:password@localhost/foo?authSource=",
+      "valid": true,
+      "credential": {
+        "username": "user",
+        "password": "password",
+        "source": "foo",
+        "mechanism": null,
+        "mechanism_properties": null
+      }
+    },
+    {
       "description": "should use the authSource when specified",
       "uri": "mongodb://user:password@localhost/foo?authSource=bar",
       "valid": true,
@@ -37,8 +49,34 @@
       }
     },
     {
+      "description": "should use the authSource when specified and authMechanism is empty",
+      "uri": "mongodb://user:password@localhost/foo?authSource=bar&authMechanism=",
+      "valid": true,
+      "credential": {
+        "username": "user",
+        "password": "password",
+        "source": "bar",
+        "mechanism": null,
+        "mechanism_properties": null
+      }
+    },
+    {
       "description": "should recognise the mechanism (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI",
+      "valid": true,
+      "credential": {
+        "username": "user@DOMAIN.COM",
+        "password": null,
+        "source": "$external",
+        "mechanism": "GSSAPI",
+        "mechanism_properties": {
+          "SERVICE_NAME": "mongodb"
+        }
+      }
+    },
+    {
+      "description": "should recognise the mechanism (GSSAPI) and properties is empty",
+      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=",
       "valid": true,
       "credential": {
         "username": "user@DOMAIN.COM",
@@ -132,6 +170,18 @@
     {
       "description": "should use the database when no authSource is specified (MONGODB-CR)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR",
+      "valid": true,
+      "credential": {
+        "username": "user",
+        "password": "password",
+        "source": "foo",
+        "mechanism": "MONGODB-CR",
+        "mechanism_properties": null
+      }
+    },
+    {
+      "description": "should use the database when authSource is empty (MONGODB-CR)",
+      "uri": "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR&authSource=",
       "valid": true,
       "credential": {
         "username": "user",

--- a/source/auth/tests/connection-string.json
+++ b/source/auth/tests/connection-string.json
@@ -108,7 +108,7 @@
       }
     },
     {
-      "description": "should raise an error when the authSource is empty",
+      "description": "must raise an error when the authSource is empty",
       "uri": "mongodb://user:password@localhost/foo?authSource=",
       "valid": false
     },

--- a/source/auth/tests/connection-string.json
+++ b/source/auth/tests/connection-string.json
@@ -25,18 +25,6 @@
       }
     },
     {
-      "description": "should use the database when the authSource is empty",
-      "uri": "mongodb://user:password@localhost/foo?authSource=",
-      "valid": true,
-      "credential": {
-        "username": "user",
-        "password": "password",
-        "source": "foo",
-        "mechanism": null,
-        "mechanism_properties": null
-      }
-    },
-    {
       "description": "should use the authSource when specified",
       "uri": "mongodb://user:password@localhost/foo?authSource=bar",
       "valid": true,
@@ -49,34 +37,8 @@
       }
     },
     {
-      "description": "should use the authSource when specified and authMechanism is empty",
-      "uri": "mongodb://user:password@localhost/foo?authSource=bar&authMechanism=",
-      "valid": true,
-      "credential": {
-        "username": "user",
-        "password": "password",
-        "source": "bar",
-        "mechanism": null,
-        "mechanism_properties": null
-      }
-    },
-    {
       "description": "should recognise the mechanism (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI",
-      "valid": true,
-      "credential": {
-        "username": "user@DOMAIN.COM",
-        "password": null,
-        "source": "$external",
-        "mechanism": "GSSAPI",
-        "mechanism_properties": {
-          "SERVICE_NAME": "mongodb"
-        }
-      }
-    },
-    {
-      "description": "should recognise the mechanism (GSSAPI) and properties is empty",
-      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=",
       "valid": true,
       "credential": {
         "username": "user@DOMAIN.COM",
@@ -146,6 +108,11 @@
       }
     },
     {
+      "description": "should raise an error when the authSource is empty",
+      "uri": "mongodb://user:password@localhost/foo?authSource=",
+      "valid": false
+    },
+    {
       "description": "should throw an exception if authSource is invalid (GSSAPI)",
       "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo",
       "valid": false
@@ -170,18 +137,6 @@
     {
       "description": "should use the database when no authSource is specified (MONGODB-CR)",
       "uri": "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR",
-      "valid": true,
-      "credential": {
-        "username": "user",
-        "password": "password",
-        "source": "foo",
-        "mechanism": "MONGODB-CR",
-        "mechanism_properties": null
-      }
-    },
-    {
-      "description": "should use the database when authSource is empty (MONGODB-CR)",
-      "uri": "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR&authSource=",
       "valid": true,
       "credential": {
         "username": "user",

--- a/source/auth/tests/connection-string.yml
+++ b/source/auth/tests/connection-string.yml
@@ -86,7 +86,7 @@ tests:
             mechanism_properties:
                 SERVICE_NAME: "mongodb"
     -
-        description: "should raise an error when the authSource is empty"
+        description: "must raise an error when the authSource is empty"
         uri: "mongodb://user:password@localhost/foo?authSource="
         valid: false
     -

--- a/source/auth/tests/connection-string.yml
+++ b/source/auth/tests/connection-string.yml
@@ -90,6 +90,10 @@ tests:
         uri: "mongodb://user:password@localhost/foo?authSource="
         valid: false
     -
+        description: "must raise an error when the authSource is empty without credentials"
+        uri: "mongodb://localhost/admin?authSource="
+        valid: false
+    -
         description: "should throw an exception if authSource is invalid (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo"
         valid: false

--- a/source/auth/tests/connection-string.yml
+++ b/source/auth/tests/connection-string.yml
@@ -20,16 +20,6 @@ tests:
             mechanism: ~
             mechanism_properties: ~
     -
-        description: "should use the database when the authSource is empty"
-        uri: "mongodb://user:password@localhost/foo?authSource="
-        valid: true
-        credential:
-            username: "user"
-            password: "password"
-            source: "foo"
-            mechanism: ~
-            mechanism_properties: ~
-    -
         description: "should use the authSource when specified"
         uri: "mongodb://user:password@localhost/foo?authSource=bar"
         valid: true
@@ -40,29 +30,8 @@ tests:
             mechanism: ~
             mechanism_properties: ~
     -
-        description: "should use the authSource when specified and authMechanism is empty"
-        uri: "mongodb://user:password@localhost/foo?authSource=bar&authMechanism="
-        valid: true
-        credential:
-            username: "user"
-            password: "password"
-            source: "bar"
-            mechanism: ~
-            mechanism_properties: ~
-    -
         description: "should recognise the mechanism (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI"
-        valid: true
-        credential:
-            username: "user@DOMAIN.COM"
-            password: ~
-            source: "$external"
-            mechanism: "GSSAPI"
-            mechanism_properties:
-                SERVICE_NAME: "mongodb"
-    -
-        description: "should recognise the mechanism (GSSAPI) and properties is empty"
-        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties="
         valid: true
         credential:
             username: "user@DOMAIN.COM"
@@ -117,6 +86,10 @@ tests:
             mechanism_properties:
                 SERVICE_NAME: "mongodb"
     -
+        description: "should raise an error when the authSource is empty"
+        uri: "mongodb://user:password@localhost/foo?authSource="
+        valid: false
+    -
         description: "should throw an exception if authSource is invalid (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authSource=foo"
         valid: false
@@ -137,16 +110,6 @@ tests:
     -
         description: "should use the database when no authSource is specified (MONGODB-CR)"
         uri: "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR"
-        valid: true
-        credential:
-            username: "user"
-            password: "password"
-            source: "foo"
-            mechanism: "MONGODB-CR"
-            mechanism_properties: ~
-    -
-        description: "should use the database when authSource is empty (MONGODB-CR)"
-        uri: "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR&authSource="
         valid: true
         credential:
             username: "user"

--- a/source/auth/tests/connection-string.yml
+++ b/source/auth/tests/connection-string.yml
@@ -20,6 +20,16 @@ tests:
             mechanism: ~
             mechanism_properties: ~
     -
+        description: "should use the database when the authSource is empty"
+        uri: "mongodb://user:password@localhost/foo?authSource="
+        valid: true
+        credential:
+            username: "user"
+            password: "password"
+            source: "foo"
+            mechanism: ~
+            mechanism_properties: ~
+    -
         description: "should use the authSource when specified"
         uri: "mongodb://user:password@localhost/foo?authSource=bar"
         valid: true
@@ -30,8 +40,29 @@ tests:
             mechanism: ~
             mechanism_properties: ~
     -
+        description: "should use the authSource when specified and authMechanism is empty"
+        uri: "mongodb://user:password@localhost/foo?authSource=bar&authMechanism="
+        valid: true
+        credential:
+            username: "user"
+            password: "password"
+            source: "bar"
+            mechanism: ~
+            mechanism_properties: ~
+    -
         description: "should recognise the mechanism (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI"
+        valid: true
+        credential:
+            username: "user@DOMAIN.COM"
+            password: ~
+            source: "$external"
+            mechanism: "GSSAPI"
+            mechanism_properties:
+                SERVICE_NAME: "mongodb"
+    -
+        description: "should recognise the mechanism (GSSAPI) and properties is empty"
+        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties="
         valid: true
         credential:
             username: "user@DOMAIN.COM"
@@ -106,6 +137,16 @@ tests:
     -
         description: "should use the database when no authSource is specified (MONGODB-CR)"
         uri: "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR"
+        valid: true
+        credential:
+            username: "user"
+            password: "password"
+            source: "foo"
+            mechanism: "MONGODB-CR"
+            mechanism_properties: ~
+    -
+        description: "should use the database when authSource is empty (MONGODB-CR)"
+        uri: "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR&authSource="
         valid: true
         credential:
             username: "user"


### PR DESCRIPTION
SPEC-1514

Added language to define how empty authentication-related options are to be handled. If an auth related option is specified but empty, the option should be assigned the default value.