### PR TITLE
SPEC-1511: Lift restriction on authSource without credentials

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -1154,10 +1154,12 @@ Q: Why does SCRAM sometimes SASLprep and sometimes not?
 Version History
 ===============
 
-Version 1.8.2 Changes
-    * Added MONGODB-IAM auth mechanism
+Version 1.8.3 Changes
     * Clarify that authSource in URI is not treated as a user configuring
       auth credentials.
+
+Version 1.8.2 Changes
+    * Added MONGODB-IAM auth mechanism
 
 Version 1.8.1 Changes
     * Clarify database to use for auth mechanism negotiation.

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -6,7 +6,7 @@ Driver Authentication
 =====================
 
 :Spec: 100
-:Spec Version: 1.8.2
+:Spec Version: 1.8.3
 :Title: Driver Authentication
 :Author: Craig Wilson, David Golden
 :Advisors: Andy Schwerin, Bernie Hacket, Jeff Yemin, David Golden

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -13,7 +13,7 @@ Driver Authentication
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 2.6
-:Last Modified: 2020-01-13
+:Last Modified: 2020-01-16
 
 .. contents::
 
@@ -100,6 +100,10 @@ interpreted as a user configuring authentication credentials.  The URI database
 name is only used as a default source for some mechanisms when authentication
 has been configured and a source is required but has not been specified.  See
 individual mechanism definitions for details.
+
+Similarly, the presence of the ``authSource`` option in the URI connection
+string without other credential data such as Userinfo or authentication parameters
+in connection options MUST NOT be interpreted as a request for authentication.
 
 Errors
 ~~~~~~
@@ -1152,6 +1156,8 @@ Version History
 
 Version 1.8.2 Changes
     * Added MONGODB-IAM auth mechanism
+    * Clarify that authSource in URI is not treated as a user configuring
+      auth credentials.
 
 Version 1.8.1 Changes
     * Clarify database to use for auth mechanism negotiation.

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -92,8 +92,8 @@ Credential delimiter in URI implies authentication
 
 The presence of a credential delimiter (i.e. @) in the URI connection string is evidence that the user has unambiguously specified user information and MUST be interpreted as a user configuring authentication credentials (even if the username and/or password are empty strings).
 
-Ambiguity between authentication source and URI database
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Authentication source and URI database do not imply authentication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The presence of a database name in the URI connection string MUST NOT be
 interpreted as a user configuring authentication credentials.  The URI database

--- a/source/auth/tests/connection-string.json
+++ b/source/auth/tests/connection-string.json
@@ -352,9 +352,10 @@
       "credential": null
     },
     {
-      "description": "authSource without username is invalid (default mechanism)",
+      "description": "authSource without username doesn't create credential",
       "uri": "mongodb://localhost/?authSource=foo",
-      "valid": false
+      "valid": true,
+      "credential": null
     },
     {
       "description": "should throw an exception if no username provided (userinfo implies default mechanism)",

--- a/source/auth/tests/connection-string.yml
+++ b/source/auth/tests/connection-string.yml
@@ -288,9 +288,10 @@ tests:
         valid: true
         credential: ~
     -
-        description: "authSource without username is invalid (default mechanism)"
+        description: "authSource without username doesn't create credential"
         uri: "mongodb://localhost/?authSource=foo"
-        valid: false
+        valid: true
+        credential: ~
     -
         description: "should throw an exception if no username provided (userinfo implies default mechanism)"
         uri: "mongodb://@localhost.com/"


### PR DESCRIPTION
Lift the restriction against authSource without credentials introduced in SPEC-1270. 