### PR TITLE
SPEC-1418: Note allowDiskUse find option is ignored for OP_QUERY

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -412,7 +412,8 @@ Read
      * can write temporary data to disk while executing the find operation.
      *
      * This option is sent only if the caller explicitly provides a value. The default
-     * is to not send a value.
+     * is to not send a value. For servers < 3.2, this option is ignored and not sent
+     * as allowDiskUse does not exist in the OP_QUERY wire protocol.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
      */

--- a/source/gridfs/gridfs-spec.rst
+++ b/source/gridfs/gridfs-spec.rst
@@ -745,7 +745,8 @@ Generic Find on Files Collection
      * can write temporary data to disk while executing the find operation on the files collection.
      *
      * This option is sent only if the caller explicitly provides a value. The default
-     * is to not send a value.
+     * is to not send a value. For servers < 3.2, this option is ignored and not sent
+     * as allowDiskUse does not exist in the OP_QUERY wire protocol.
      *
      * @see https://docs.mongodb.com/manual/reference/command/find/
      */


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1418

Requested in https://github.com/mongodb/specifications/pull/692#discussion_r367667587 but this was missed before that PR was merged.