### PR TITLE
SPEC-1470: Explicitly state when authentication should occur

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -6,7 +6,7 @@ Driver Authentication
 =====================
 
 :Spec: 100
-:Spec Version: 1.8.2
+:Spec Version: 1.9.1
 :Title: Driver Authentication
 :Author: Craig Wilson, David Golden
 :Advisors: Andy Schwerin, Bernie Hacket, Jeff Yemin, David Golden
@@ -87,7 +87,7 @@ mechanism (string)
 mechanism_properties
 	* Includes additional properties for the given mechanism.
 
-Each mechanism requires certain pieces of information to be present in a MongoCredential for authentication to occur. For example, `username`, `source` and `password` must be present if the mechanism is SCRAM-SHA-256. See the individual mechanism definitions for the information each mechanism requires for authentication.
+Each mechanism requires certain pieces of information to be present in a MongoCredential for authentication to occur. See the individual mechanism definitions in the "MongoCredential Properties" section. All requirements listed for a mechanism must be met for authentication to occur.
 
 Credential delimiter in URI implies authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,6 +107,8 @@ Errors
 ~~~~~~
 
 Drivers SHOULD raise an error as early as possible when detecting invalid values in a credential. For instance, if a ``mechanism_property`` is specified for `MONGODB-CR`_, the driver should raise an error indicating that the property does not apply.
+
+Drivers MUST raise an error if any required information for a mechanism is missing. For instance, if a ``username`` is not specified for `SCRAM-SHA-256`, the driver must raise an error indicating the the property is missing.
 
 
 Naming

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -108,7 +108,7 @@ Errors
 
 Drivers SHOULD raise an error as early as possible when detecting invalid values in a credential. For instance, if a ``mechanism_property`` is specified for `MONGODB-CR`_, the driver should raise an error indicating that the property does not apply.
 
-Drivers MUST raise an error if any required information for a mechanism is missing. For instance, if a ``username`` is not specified for `SCRAM-SHA-256`, the driver must raise an error indicating the the property is missing.
+Drivers MUST raise an error if any required information for a mechanism is missing. For instance, if a ``username`` is not specified for SCRAM-SHA-256, the driver must raise an error indicating the the property is missing.
 
 
 Naming

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -87,7 +87,7 @@ mechanism (string)
 mechanism_properties
 	* Includes additional properties for the given mechanism.
 
-Each mechanism requires certain pieces of information to be present in a MongoCredential for authentication to occur. See the individual mechanism definitions in the "MongoCredential Properties" section. All requirements listed for a mechanism must be met for authentication to occur.
+Each mechanism requires certain properties to be present in a MongoCredential for authentication to occur. See the individual mechanism definitions in the "MongoCredential Properties" section. All requirements listed for a mechanism must be met for authentication to occur.
 
 Credential delimiter in URI implies authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -280,7 +280,7 @@ mechanism negotiation, then SCRAM-SHA-1 MUST be used when talking to servers >=
 3.0. Prior to server 3.0, MONGODB-CR MUST be used.
 
 When a user has specified a mechanism, regardless of the server version, the
-driver MUST honor this and attempt to authenticate.
+driver MUST honor this.
 
 Determining Server Version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -13,7 +13,7 @@ Driver Authentication
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 2.6
-:Last Modified: 2020-01-13
+:Last Modified: 2020-01-21
 
 .. contents::
 
@@ -86,6 +86,8 @@ mechanism (string)
 	* Indicates which mechanism to use with the credential.
 mechanism_properties
 	* Includes additional properties for the given mechanism.
+
+Each mechanism requires certain pieces of information to be present in a MongoCredential for authentication to occur. For example, `username`, `source` and `password` must be present if the mechanism is SCRAM-SHA-256. See the individual mechanism definitions for the information each mechanism requires for authentication.
 
 Credential delimiter in URI implies authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1149,6 +1151,9 @@ Q: Why does SCRAM sometimes SASLprep and sometimes not?
 
 Version History
 ===============
+
+Version 1.9.1 Changes
+    * Clarify when authentication will occur.
 
 Version 1.8.2 Changes
     * Added MONGODB-IAM auth mechanism


### PR DESCRIPTION
@kevinAlbs Note that the sections of the authentication specification that you referenced in the SPEC-1470 ticket will be revised. See the PR for SPEC-1511 (https://github.com/mongodb/specifications/pull/713/files) for details.