### PR TITLE
SPEC-1534 Remove requirement that application-provided serverSelector…

### DIFF
--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -269,9 +269,3 @@ of the spec MUST test that:
   set: Register a server selector that selects the suitable server with the highest port number. Execute 10
   queries with nearest read preference and, using command monitoring, assert that all the operations execute
   on the member with the highest port number.
-
-- The application-provided server selector is not executed as part of the server selection process when
-  there are no candidate or eligible servers. For example, execute a test against a replica set
-  with no primary: Register a server selector that increments an internal counter (starting at 0) each time
-  it is called. Attempt server selection with primary read preference, catch the resulting server selection
-  timeout exception, and assert that the internal counter of the server selector is still 0.

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -1173,7 +1173,7 @@ Pseudocode for `multi-threaded or asynchronous server selection`_::
 
             servers = all servers in topologyDescription matching criteria
 
-            if serverSelector is not null and servers is not empty:
+            if serverSelector is not null:
                 servers = serverSelector(servers)
 
             if servers is not empty:
@@ -1248,7 +1248,7 @@ Pseudocode for `single-threaded server selection`_::
 
             servers = all servers in topologyDescription matching criteria
 
-            if serverSelector is not null and servers is not empty:
+            if serverSelector is not null:
                 servers = serverSelector(servers)
 
             if servers is not empty:


### PR DESCRIPTION
… NOT be called when no suitable servers are found

Closes https://jira.mongodb.org/browse/SPEC-1534