### PR TITLE
RetryableWrites: findOneAndModify --> findAndModify

### DIFF
--- a/source/retryable-writes/tests/findOneAndReplace-errorLabels.json
+++ b/source/retryable-writes/tests/findOneAndReplace-errorLabels.json
@@ -28,7 +28,7 @@
         },
         "data": {
           "failCommands": [
-            "findOneAndModify"
+            "findAndModify"
           ],
           "errorCode": 112,
           "errorLabels": [
@@ -77,7 +77,7 @@
         },
         "data": {
           "failCommands": [
-            "findOneAndModify"
+            "findAndModify"
           ],
           "errorCode": 11600,
           "errorLabels": []

--- a/source/retryable-writes/tests/findOneAndReplace-errorLabels.yml
+++ b/source/retryable-writes/tests/findOneAndReplace-errorLabels.yml
@@ -12,7 +12,7 @@ tests:
           configureFailPoint: failCommand
           mode: { times: 1 }
           data:
-              failCommands: ["findOneAndModify"]
+              failCommands: ["findAndModify"]
               errorCode: 112 # WriteConflict, not a retryable error code
               errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
       operation:
@@ -33,7 +33,7 @@ tests:
           configureFailPoint: failCommand
           mode: { times: 1 }
           data:
-              failCommands: ["findOneAndModify"]
+              failCommands: ["findAndModify"]
               errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
               errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
       operation:


### PR DESCRIPTION
I mistyped the command on which to execute the failPoint. It should read "findAndModify" rather than "findOneAndModify."