### PR TITLE
SPEC-1352 remove other_collection_name field

### DIFF
--- a/source/read-write-concern/tests/operation/default-write-concern-2.6.json
+++ b/source/read-write-concern/tests/operation/default-write-concern-2.6.json
@@ -11,7 +11,6 @@
   ],
   "collection_name": "default_write_concern_coll",
   "database_name": "default_write_concern_db",
-  "other_collection_name": "other_collection_name",
   "runOn": [
     {
       "minServerVersion": "2.6"

--- a/source/read-write-concern/tests/operation/default-write-concern-2.6.yml
+++ b/source/read-write-concern/tests/operation/default-write-concern-2.6.yml
@@ -7,7 +7,6 @@ data:
   - {_id: 2, x: 22}
 collection_name: &collection_name default_write_concern_coll
 database_name: &database_name default_write_concern_db
-other_collection_name: &other_collection_name other_collection_name
 
 runOn:
     - minServerVersion: "2.6"

--- a/source/read-write-concern/tests/operation/default-write-concern-3.2.json
+++ b/source/read-write-concern/tests/operation/default-write-concern-3.2.json
@@ -11,7 +11,6 @@
   ],
   "collection_name": "default_write_concern_coll",
   "database_name": "default_write_concern_db",
-  "other_collection_name": "other_collection_name",
   "runOn": [
     {
       "minServerVersion": "3.2"

--- a/source/read-write-concern/tests/operation/default-write-concern-3.2.yml
+++ b/source/read-write-concern/tests/operation/default-write-concern-3.2.yml
@@ -8,7 +8,6 @@ data:
   - {_id: 2, x: 22}
 collection_name: &collection_name default_write_concern_coll
 database_name: &database_name default_write_concern_db
-other_collection_name: &other_collection_name other_collection_name
 
 runOn:
     - minServerVersion: "3.2"

--- a/source/read-write-concern/tests/operation/default-write-concern-3.4.json
+++ b/source/read-write-concern/tests/operation/default-write-concern-3.4.json
@@ -11,7 +11,6 @@
   ],
   "collection_name": "default_write_concern_coll",
   "database_name": "default_write_concern_db",
-  "other_collection_name": "other_collection_name",
   "runOn": [
     {
       "minServerVersion": "3.4"

--- a/source/read-write-concern/tests/operation/default-write-concern-3.4.yml
+++ b/source/read-write-concern/tests/operation/default-write-concern-3.4.yml
@@ -8,7 +8,6 @@ data:
   - {_id: 2, x: 22}
 collection_name: &collection_name default_write_concern_coll
 database_name: &database_name default_write_concern_db
-other_collection_name: &other_collection_name other_collection_name
 
 runOn:
     - minServerVersion: "3.4"
@@ -22,7 +21,7 @@ tests:
         arguments:
           pipeline: &out_pipeline
             - $match: {_id: {$gt: 1}}
-            - $out: *other_collection_name
+            - $out: &other_collection_name "other_collection_name"
     outcome:
       collection:
         name: *other_collection_name

--- a/source/read-write-concern/tests/operation/default-write-concern-4.2.json
+++ b/source/read-write-concern/tests/operation/default-write-concern-4.2.json
@@ -11,7 +11,6 @@
   ],
   "collection_name": "default_write_concern_coll",
   "database_name": "default_write_concern_db",
-  "other_collection_name": "other_collection_name",
   "runOn": [
     {
       "minServerVersion": "4.2"

--- a/source/read-write-concern/tests/operation/default-write-concern-4.2.yml
+++ b/source/read-write-concern/tests/operation/default-write-concern-4.2.yml
@@ -7,7 +7,6 @@ data:
   - {_id: 2, x: 22}
 collection_name: &collection_name default_write_concern_coll
 database_name: &database_name default_write_concern_db
-other_collection_name: &other_collection_name other_collection_name
 
 runOn:
     - minServerVersion: "4.2"
@@ -22,7 +21,7 @@ tests:
         arguments:
           pipeline: &merge_pipeline
             - $match: {_id: {$gt: 1}}
-            - $merge: {into: *other_collection_name}
+            - $merge: {into: &other_collection_name "other_collection_name" }
     expectations:
       - command_started_event:
           command:


### PR DESCRIPTION
Some follow-up of SPEC-1352. I accidentally introduced the top-level field "other_collection_name". Other spec tests of $out/$merge don't set that as a top-level field, and just reference it with YML anchors ([example](https://github.com/kevinAlbs/specifications/blob/wc-fix/source/crud/tests/v2/aggregate-out-readConcern.yml/#L26)). Credit to @divjotarora for catching this.

For a non-functional change like this, LMK if a separate SPEC ticket is warranted to resync the tests, or if I should add this commit to SPEC-1352.