### PR TITLE
SPEC-1562 transactions test fixes for RetryableWriteError label

### DIFF
--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -813,7 +813,10 @@
           "failCommands": [
             "commitTransaction"
           ],
-          "errorCode": 11602
+          "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ]
         }
       },
       "operations": [

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -500,6 +500,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11602  # InterruptedDueToReplStateChange
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
 
     operations:
       - name: startTransaction

--- a/source/transactions/tests/retryable-abort-errorLabels.json
+++ b/source/transactions/tests/retryable-abort-errorLabels.json
@@ -36,10 +36,11 @@
         {
           "name": "insertOne",
           "object": "collection",
-          "arguments": null,
-          "session": "session0",
-          "document": {
-            "_id": 1
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
           },
           "result": {
             "insertedId": 1
@@ -79,8 +80,9 @@
             "command": {
               "abortTransaction": 1,
               "lsid": "session0",
-              "txnNumber": null,
-              "$numberLong": "1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -94,8 +96,9 @@
             "command": {
               "abortTransaction": 1,
               "lsid": "session0",
-              "txnNumber": null,
-              "$numberLong": "1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -138,10 +141,10 @@
             "session": "session0",
             "document": {
               "_id": 1
-            },
-            "result": {
-              "insertedId": 1
             }
+          },
+          "result": {
+            "insertedId": 1
           }
         },
         {
@@ -156,34 +159,36 @@
       ],
       "expectations": [
         {
-          "command_started_event": null,
-          "command": {
-            "insert": "test",
-            "documents": [
-              {
-                "_id": 1
-              }
-            ],
-            "ordered": true,
-            "readConcern": null,
-            "lsid": "session0",
-            "txnNumber": {
-              "$numberLong": "1"
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
             },
-            "startTransaction": true,
-            "autocommit": false,
-            "writeConcern": null
-          },
-          "command_name": "insert",
-          "database_name": "transaction-tests"
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
         },
         {
           "command_started_event": {
             "command": {
               "abortTransaction": 1,
               "lsid": "session0",
-              "txnNumber": null,
-              "$numberLong": "1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null

--- a/source/transactions/tests/retryable-abort-errorLabels.yml
+++ b/source/transactions/tests/retryable-abort-errorLabels.yml
@@ -13,18 +13,18 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-        failCommands: ["abortTransaction"]
-        errorCode: 112 # WriteConflict, not a retryable error code
-        errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+          failCommands: ["abortTransaction"]
+          errorCode: 112 # WriteConflict, not a retryable error code
+          errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
     operations:
       - name: startTransaction
         object: session0
       - name: insertOne
         object: collection
         arguments:
-        session: session0
-        document:
-          _id: 1
+          session: session0
+          document:
+            _id: 1
         result:
           insertedId: 1
       - name: abortTransaction
@@ -50,7 +50,7 @@ tests:
             abortTransaction: 1
             lsid: session0
             txnNumber:
-            $numberLong: "1"
+              $numberLong: "1"
             startTransaction:
             autocommit: false
             writeConcern:
@@ -61,7 +61,7 @@ tests:
             abortTransaction: 1
             lsid: session0
             txnNumber:
-            $numberLong: "1"
+              $numberLong: "1"
             startTransaction:
             autocommit: false
             writeConcern:
@@ -76,9 +76,9 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 1 }
       data:
-        failCommands: ["abortTransaction"]
-        errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
-        errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+          failCommands: ["abortTransaction"]
+          errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+          errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
     operations:
       - name: startTransaction
         object: session0
@@ -88,34 +88,34 @@ tests:
           session: session0
           document:
             _id: 1
-          result:
-            insertedId: 1
+        result:
+          insertedId: 1
       - name: abortTransaction
         object: session0
         result:
           errorLabelsOmit: ["RetryableWriteError"]
     expectations:
       - command_started_event:
-        command:
-          insert: *collection_name
-          documents:
-            - _id: 1
-          ordered: true
-          readConcern:
-          lsid: session0
-          txnNumber:
-            $numberLong: "1"
-          startTransaction: true
-          autocommit: false
-          writeConcern:
-        command_name: insert
-        database_name: *database_name
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
       - command_started_event:
           command:
             abortTransaction: 1
             lsid: session0
             txnNumber:
-            $numberLong: "1"
+              $numberLong: "1"
             startTransaction:
             autocommit: false
             writeConcern:

--- a/source/transactions/tests/retryable-abort.json
+++ b/source/transactions/tests/retryable-abort.json
@@ -413,6 +413,9 @@
             "abortTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -514,6 +517,9 @@
             "abortTransaction"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -615,6 +621,9 @@
             "abortTransaction"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -716,6 +725,9 @@
             "abortTransaction"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -817,6 +829,9 @@
             "abortTransaction"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -918,6 +933,9 @@
             "abortTransaction"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1019,6 +1037,9 @@
             "abortTransaction"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1120,6 +1141,9 @@
             "abortTransaction"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1221,6 +1245,9 @@
             "abortTransaction"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1322,6 +1349,9 @@
             "abortTransaction"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1423,6 +1453,9 @@
             "abortTransaction"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1525,6 +1558,9 @@
           ],
           "writeConcernError": {
             "code": 11600,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1639,6 +1675,9 @@
           ],
           "writeConcernError": {
             "code": 11602,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1753,6 +1792,9 @@
           ],
           "writeConcernError": {
             "code": 189,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1867,6 +1909,9 @@
           ],
           "writeConcernError": {
             "code": 91,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/source/transactions/tests/retryable-abort.yml
+++ b/source/transactions/tests/retryable-abort.yml
@@ -274,6 +274,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 10107
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -341,6 +342,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 13436
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -408,6 +410,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 13435
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -475,6 +478,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 11602
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -542,6 +546,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 11600
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -609,6 +614,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 189
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -676,6 +682,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 91
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -743,6 +750,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 7
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -810,6 +818,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 6
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -877,6 +886,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 9001
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -944,6 +954,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 89
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -1012,6 +1023,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 11600
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1086,6 +1098,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 11602
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1160,6 +1173,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 189
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1234,6 +1248,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 91
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:

--- a/source/transactions/tests/retryable-commit-errorLabels.json
+++ b/source/transactions/tests/retryable-commit-errorLabels.json
@@ -38,13 +38,15 @@
         {
           "name": "insertOne",
           "object": "collection",
-          "arguments": null,
-          "session": "session0",
-          "document": {
-            "_id": 1
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
           },
-          "result": null,
-          "insertedId": 1
+          "result": {
+            "insertedId": 1
+          }
         },
         {
           "name": "commitTransaction",
@@ -71,8 +73,9 @@
               "ordered": true,
               "readConcern": null,
               "lsid": "session0",
-              "txnNumber": null,
-              "$numberLong": "1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -86,14 +89,12 @@
             "command": {
               "commitTransaction": 1,
               "lsid": "session0",
-              "txnNumber": null,
-              "$numberLong": "1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
               "startTransaction": null,
               "autocommit": false,
-              "writeConcern": {
-                "w": "majority",
-                "wtimeout": 10000
-              }
+              "writeConcern": null
             },
             "command_name": "commitTransaction",
             "database_name": "admin"
@@ -134,13 +135,15 @@
         {
           "name": "insertOne",
           "object": "collection",
-          "arguments": null,
-          "session": "session0",
-          "document": {
-            "_id": 1
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
           },
-          "result": null,
-          "insertedId": 1
+          "result": {
+            "insertedId": 1
+          }
         },
         {
           "name": "commitTransaction",
@@ -160,8 +163,9 @@
               "ordered": true,
               "readConcern": null,
               "lsid": "session0",
-              "txnNumber": null,
-              "$numberLong": "1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
               "startTransaction": true,
               "autocommit": false,
               "writeConcern": null
@@ -175,8 +179,9 @@
             "command": {
               "commitTransaction": 1,
               "lsid": "session0",
-              "txnNumber": null,
-              "$numberLong": "1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": null
@@ -190,8 +195,9 @@
             "command": {
               "commitTransaction": 1,
               "lsid": "session0",
-              "txnNumber": null,
-              "$numberLong": "1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
               "startTransaction": null,
               "autocommit": false,
               "writeConcern": {

--- a/source/transactions/tests/retryable-commit-errorLabels.yml
+++ b/source/transactions/tests/retryable-commit-errorLabels.yml
@@ -16,20 +16,20 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 1 }
       data:
-        failCommands: ["commitTransaction"]
-        errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
-        errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
+          failCommands: ["commitTransaction"]
+          errorCode: 11600 # InterruptedAtShutdown, normally a retryable error code
+          errorLabels: []  # Override server behavior: do not send RetryableWriteError label with retryable code
     operations:
       - name: startTransaction
         object: session0
       - name: insertOne
         object: collection
         arguments:
-        session: session0
-        document:
-          _id: 1
+          session: session0
+          document:
+            _id: 1
         result:
-        insertedId: 1
+          insertedId: 1
       - name: commitTransaction
         object: session0
         result:
@@ -39,12 +39,12 @@ tests:
           command:
             insert: *collection_name
             documents:
-            - _id: 1
+              - _id: 1
             ordered: true
             readConcern:
             lsid: session0
             txnNumber:
-            $numberLong: "1"
+              $numberLong: "1"
             startTransaction: true
             autocommit: false
             writeConcern:
@@ -55,10 +55,10 @@ tests:
             commitTransaction: 1
             lsid: session0
             txnNumber:
-            $numberLong: "1"
+              $numberLong: "1"
             startTransaction:
             autocommit: false
-            writeConcern: { w: majority, wtimeout: 10000 }
+            writeConcern:
           command_name: commitTransaction
           database_name: admin
     outcome: # Driver does not retry commit because there was no RetryableWriteError label on response
@@ -72,20 +72,20 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 1 }
       data:
-        failCommands: ["commitTransaction"]
-        errorCode: 112 # WriteConflict, not a retryable error code
-        errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
+          failCommands: ["commitTransaction"]
+          errorCode: 112 # WriteConflict, not a retryable error code
+          errorLabels: ["RetryableWriteError"] # Override server behavior: send RetryableWriteError label with non-retryable error code
     operations:
       - name: startTransaction
         object: session0
       - name: insertOne
         object: collection
         arguments:
-        session: session0
-        document:
+          session: session0
+          document:
             _id: 1
         result:
-        insertedId: 1
+          insertedId: 1
       - name: commitTransaction
         object: session0
     expectations:
@@ -93,12 +93,12 @@ tests:
           command:
             insert: *collection_name
             documents:
-                - _id: 1
+              - _id: 1
             ordered: true
             readConcern:
             lsid: session0
             txnNumber:
-            $numberLong: "1"
+              $numberLong: "1"
             startTransaction: true
             autocommit: false
             writeConcern:
@@ -109,7 +109,7 @@ tests:
             commitTransaction: 1
             lsid: session0
             txnNumber:
-            $numberLong: "1"
+              $numberLong: "1"
             startTransaction:
             autocommit: false
             writeConcern:
@@ -120,7 +120,7 @@ tests:
             commitTransaction: 1
             lsid: session0
             txnNumber:
-            $numberLong: "1"
+              $numberLong: "1"
             startTransaction:
             autocommit: false
             writeConcern: { w: majority, wtimeout: 10000 }

--- a/source/transactions/tests/retryable-commit.json
+++ b/source/transactions/tests/retryable-commit.json
@@ -635,6 +635,9 @@
             "commitTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -743,6 +746,9 @@
             "commitTransaction"
           ],
           "errorCode": 13436,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -851,6 +857,9 @@
             "commitTransaction"
           ],
           "errorCode": 13435,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -959,6 +968,9 @@
             "commitTransaction"
           ],
           "errorCode": 11602,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1067,6 +1079,9 @@
             "commitTransaction"
           ],
           "errorCode": 11600,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1175,6 +1190,9 @@
             "commitTransaction"
           ],
           "errorCode": 189,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1283,6 +1301,9 @@
             "commitTransaction"
           ],
           "errorCode": 91,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1391,6 +1412,9 @@
             "commitTransaction"
           ],
           "errorCode": 7,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1499,6 +1523,9 @@
             "commitTransaction"
           ],
           "errorCode": 6,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1607,6 +1634,9 @@
             "commitTransaction"
           ],
           "errorCode": 9001,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1715,6 +1745,9 @@
             "commitTransaction"
           ],
           "errorCode": 89,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },
@@ -1824,6 +1857,9 @@
           ],
           "writeConcernError": {
             "code": 11600,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1943,6 +1979,9 @@
           ],
           "writeConcernError": {
             "code": 11602,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2062,6 +2101,9 @@
           ],
           "writeConcernError": {
             "code": 189,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2181,6 +2223,9 @@
           ],
           "writeConcernError": {
             "code": 91,
+            "errorLabels": [
+              "RetryableWriteError"
+            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/source/transactions/tests/retryable-commit.yml
+++ b/source/transactions/tests/retryable-commit.yml
@@ -393,6 +393,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 10107
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -462,6 +463,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 13436
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -531,6 +533,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 13435
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -600,6 +603,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11602
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -669,6 +673,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11600
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -738,6 +743,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 189
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -807,6 +813,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 91
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -876,6 +883,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 7
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -945,6 +953,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 6
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -1014,6 +1023,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 9001
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -1083,6 +1093,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 89
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
 
     operations:
@@ -1153,6 +1164,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 11600
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1228,6 +1240,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 11602
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1303,6 +1316,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 189
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:
@@ -1378,6 +1392,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 91
+            errorLabels: ["RetryableWriteError"] # SPEC-1565
             errmsg: Replication is being shut down
 
     operations:


### PR DESCRIPTION
Cleaning up some of the files and adding the RetryableWriteError label to the failpoints that need it.