### PR TITLE
SPEC-1578 ensure WriteConcernError 'errInfo' is propagated

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -1371,10 +1371,10 @@ Any result class with all parameters marked NOT REQUIRED is ultimately NOT REQUI
 Error Handling
 ~~~~~~~~~~~~~~
 
-Below are defined the exceptions that should be thrown from the various write methods. Since exceptions across languages would be impossible to reconcile, the below definitions represent the fields and names for the information that should be present. Structure isn't important as long as the information is available.
+Defined below are error and exception types that should be reported from the various write methods. Since error types across languages would be impossible to reconcile, the below definitions represent the fields and names for the information that should be present. Structure isn't important as long as the information is available.
 
-.. note::
-    The actual implementation of correlating, merging, and interpreting write errors from the server is not defined here. This spec is solely about the API for users.
+Drivers SHOULD report errors however they report other server errors: by raising an exception, returning "false", or another idiom that is consistent with other server errors.
+
 
 .. code:: typescript
 
@@ -1402,6 +1402,15 @@ Below are defined the exceptions that should be thrown from the various write me
     message: String;
 
   }
+
+Drivers MUST construct a ``WriteConcernError`` from a server reply as follows:
+- set ``code`` to ``writeConcernError.code``.
+- set ``message`` to ``writeConcernError.errmsg`` if available.
+- set ``details`` to ``writeConcernError.errInfo`` if available. Drivers MUST NOT parse inside ``errInfo``.
+
+See the `Read/Write Concern specification </source/read-write-concern/read-write-concern.rst#Errors>`_ for examples of how a server represents write concern errors in replies.
+
+.. code:: typescript
 
   class WriteError {
 
@@ -1490,6 +1499,8 @@ Below are defined the exceptions that should be thrown from the various write me
     writeErrors: Optional<Iterable<BulkWriteError>>;
 
   }
+
+See the `Bulk Write Specification </source/driver-bulk-update.rst#on-errors>`_ for more information on constructing errors from bulk writes.
 
 
 ~~~~~~~~~~~~~~~
@@ -1815,7 +1826,7 @@ Q: Where is read concern?
   However, it might be that a driver needs to expose read concern to a user per operation for various reasons. As noted before, it is permitted to specify this, along with other driver-specific options, in some alternative way.
 
 Q: Where is write concern?
-  Write concern is about indicating how writes are acknowledged. Since all operations defined in this specification are performed on a collection, it's uncommon that two different write operations on the same collection would use a different write concern, potentially causing mismatched and out-of-sync data. As such, the most natural place to indicate write concern is on the client, the database, or the collection itself and not the operations within it.
+  Write concern is about indicating how writes are acknowledged. Since all operations defined in this specification are performed on a collection, it's uncommon that two different write operations on the same collection would use a different write concern, potentially causing mismatched and out-of-sync data. As such, the most natural place to indicate write concern is on the client, the database, or the collection itself and not the operations within it. See the `Read/Write Concern specification </source/read-write-concern/read-write-concern.rst>`_ for the API of constructing a read/write concern and associated API.
 
   However, it might be that a driver needs to expose write concern to a user per operation for various reasons. As noted before, it is permitted to specify this, along with other driver-specific options, in some alternative way.
 

--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -1500,8 +1500,6 @@ See the `Read/Write Concern specification </source/read-write-concern/read-write
 
   }
 
-See the `Bulk Write Specification </source/driver-bulk-update.rst#on-errors>`_ for more information on constructing errors from bulk writes.
-
 
 ~~~~~~~~~~~~~~~
 Find And Modify

--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -313,6 +313,7 @@ The following tests have not yet been automated, but MUST still be tested.
 Test that a writeConcernError "errInfo" is propagated to the user in whatever way is idiomatic to the driver (exception, error object, etc.). Using a 4.0+ server, set the following failpoint:
 
 .. code:: javascript
+
    {
      "configureFailPoint": "failCommand",
      "data": {

--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -302,3 +302,34 @@ specification, such as ``insertedId`` (for InsertOneResult), ``insertedIds``
 (for InsertManyResult), and ``upsertedCount`` (for UpdateResult). Drivers that
 do not implement these fields should ignore them when comparing ``actual`` with
 ``expected``.
+
+Prose Tests
+===========
+
+The following tests have not yet been automated, but MUST still be tested.
+
+"errInfo" is propagated
+-----------------------
+Test that a writeConcernError "errInfo" is propagated to the user in whatever way is idiomatic to the driver (exception, error object, etc.). Using a 4.0+ server, set the following failpoint:
+
+.. code:: javascript
+   {
+     "configureFailPoint": "failCommand",
+     "data": {
+       "failCommands": ["insert"],
+       "writeConcernError": {
+         "code": 100,
+         "codeName": "UnsatisfiableWriteConcern",
+         "errmsg": "Not enough data-bearing nodes",
+         "errInfo": {
+           "writeConcern": {
+             "w": 2,
+             "wtimeout": 0,
+             "provenance": "clientSupplied"
+           }
+         }
+       }
+     },
+     "mode": { "times": 1 }
+   }
+Then, perform an insert on the same database. Assert that an error occurs and that the "errInfo" is accessible and matches the one set in the failpoint.

--- a/source/read-write-concern/read-write-concern.rst
+++ b/source/read-write-concern/read-write-concern.rst
@@ -517,6 +517,30 @@ have been abbreviated:
 - ``{ok:1, writeConcernError: {code: 100, codeName: "UnsatisfiableWriteConcern", errmsg: "Not enough data-bearing nodes"}}``
 - ``{ok:1, writeConcernError: {code: 79, codeName: "UnknownReplWriteConcern"}}``
 
+A writeConcernError may include an "errInfo" field providing additional information (e.g. the source of the write concern associated with the error, which is useful when ). Here is an example:
+
+.. code:: javascript
+
+   {
+    "ok": 1,
+    "writeConcernError" : {
+        "code" : 64,
+        "codeName" : "WriteConcernFailed",
+        "errmsg" : "waiting for replication timed out",
+        "errInfo" : {
+            "wtimeout" : true,
+            "writeConcern" : {
+                "w" : 2,
+                "wtimeout" : 1000,
+                "provenance" : "clientSupplied"
+            }
+        }
+    }
+    /* ... */
+  }
+
+Drivers MUST not parse "errInfo" but MUST ensure that the "errInfo" object is propagated to the user in whatever way is idiomatic to the driver (exception, error object, etc.).
+
 Note also that it is possible for a writeConcernError to be attached to a
 command failure. For example:
 

--- a/source/read-write-concern/tests/README.rst
+++ b/source/read-write-concern/tests/README.rst
@@ -70,6 +70,38 @@ The spec test format is an extension of `transactions spec tests <https://github
     If the driver has no way to explicitly set a default write concern on a database or collection, ignore the empty ``writeConcern`` document and continue with the test.
 - The operations ``createIndex``, ``dropIndex`` are introduced.
 
+Prose
+~~~~~
+
+The following tests have not yet been automated, but MUST still be tested.
+
+"errInfo" is propagated
+```````````````````````
+Test that a writeConcernError "errInfo" is propagated to the user in whatever way is idiomatic to the driver (exception, error object, etc.). Using a 4.0+ server, set the following failpoint:
+
+.. code:: javascript
+
+   {
+     "configureFailPoint": "failCommand",
+     "data": {
+       "failCommands": ["insert"],
+       "writeConcernError": {
+         "code": 100,
+         "codeName": "UnsatisfiableWriteConcern",
+         "errmsg": "Not enough data-bearing nodes",
+         "errInfo": {
+           "writeConcern": {
+             "w": 2,
+             "wtimeout": 0,
+             "provenance": "clientSupplied"
+           }
+         }
+       }
+     },
+     "mode": { "times": 1 }
+   }
+
+Then, perform an insert on the same database. Assert that an error occurs and that the "errInfo" is accessible and matches the one set in the failpoint.
 
 Use as unit tests
 =================

--- a/source/read-write-concern/tests/README.rst
+++ b/source/read-write-concern/tests/README.rst
@@ -70,38 +70,6 @@ The spec test format is an extension of `transactions spec tests <https://github
     If the driver has no way to explicitly set a default write concern on a database or collection, ignore the empty ``writeConcern`` document and continue with the test.
 - The operations ``createIndex``, ``dropIndex`` are introduced.
 
-Prose
-~~~~~
-
-The following tests have not yet been automated, but MUST still be tested.
-
-"errInfo" is propagated
-```````````````````````
-Test that a writeConcernError "errInfo" is propagated to the user in whatever way is idiomatic to the driver (exception, error object, etc.). Using a 4.0+ server, set the following failpoint:
-
-.. code:: javascript
-
-   {
-     "configureFailPoint": "failCommand",
-     "data": {
-       "failCommands": ["insert"],
-       "writeConcernError": {
-         "code": 100,
-         "codeName": "UnsatisfiableWriteConcern",
-         "errmsg": "Not enough data-bearing nodes",
-         "errInfo": {
-           "writeConcern": {
-             "w": 2,
-             "wtimeout": 0,
-             "provenance": "clientSupplied"
-           }
-         }
-       }
-     },
-     "mode": { "times": 1 }
-   }
-
-Then, perform an insert on the same database. Assert that an error occurs and that the "errInfo" is accessible and matches the one set in the failpoint.
 
 Use as unit tests
 =================


### PR DESCRIPTION
Based on the "Read/Write Concern Provenance" downstream changes:

> - It is believed that drivers should not currently be attempting to parse "errInfo", but it would be good to add the necessary test coverage and/or spec definitions.
> 
> - Drivers should ensure that the contents of the "errInfo" object are propagated up to the application-visible error/exception, so that developers/admins can be aware of situations such as custom write concern defaults causing wtimeouts, etc.

PoC'ed the test with libmongoc.