### PR TITLE
SPEC-1419 Support for collection and index creation in Transactions

### DIFF
--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -384,6 +384,70 @@ the given session is not pinned to a mongos::
         arguments:
           session: session0
 
+assertCollectionExists
+~~~~~~~~~~~~~~~~~~~~~~
+
+The "assertCollectionExists" operation instructs the test runner to assert that
+the given collection exists in the database::
+
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: db
+          collection: test
+
+Use a ``listCollections`` command to check whether the collection exists. Note
+that it is currently not possible to run ``listCollections`` from within a
+transaction.
+
+assertCollectionNotExists
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The "assertCollectionNotExists" operation instructs the test runner to assert
+that the given collection does not exist in the database::
+
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: db
+          collection: test
+
+Use a ``listCollections`` command to check whether the collection exists. Note
+that it is currently not possible to run ``listCollections`` from within a
+transaction.
+
+assertIndexExists
+~~~~~~~~~~~~~~~~~
+
+The "assertIndexExists" operation instructs the test runner to assert that the
+index with the given name exists on the collection::
+
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: db
+          collection: test
+          index: t_1
+
+Use a ``listIndexes`` command to check whether the index exists. Note that it is
+currently not possible to run ``listIndexes`` from within a transaction.
+
+assertIndexNotExists
+~~~~~~~~~~~~~~~~~~~~
+
+The "assertIndexNotExists" operation instructs the test runner to assert that
+the index with the given name does not exist on the collection::
+
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          database: db
+          collection: test
+          index: t_1
+
+Use a ``listIndexes`` command to check whether the index exists. Note that it is
+currently not possible to run ``listIndexes`` from within a transaction.
+
 Command-Started Events
 ``````````````````````
 

--- a/source/transactions/tests/create-collection.json
+++ b/source/transactions/tests/create-collection.json
@@ -1,0 +1,204 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.4",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "explicitly create collection using create command",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "session": "session0",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "test",
+              "writeConcern": null
+            },
+            "command_name": "drop",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "test",
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "create",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
+      "description": "implicitly create collection using insert",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "test",
+              "writeConcern": null
+            },
+            "command_name": "drop",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/transactions/tests/create-collection.yml
+++ b/source/transactions/tests/create-collection.yml
@@ -1,0 +1,131 @@
+runOn:
+  -
+    minServerVersion: "4.3.4"
+    topology: ["replicaset", "sharded"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  - description: explicitly create collection using create command
+
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: *collection_name
+      - name: startTransaction
+        object: session0
+      - name: createCollection
+        object: database
+        arguments:
+          session: session0
+          collection: *collection_name
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+      - name: commitTransaction
+        object: session0
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+
+    expectations:
+      - command_started_event:
+          command:
+            drop: *collection_name
+            writeConcern:
+          command_name: drop
+          database_name: *database_name
+      - command_started_event:
+          command:
+            create: *collection_name
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: create
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+
+  - description: implicitly create collection using insert
+
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: *collection_name
+      - name: startTransaction
+        object: session0
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          insertedId: 1
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+      - name: commitTransaction
+        object: session0
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+
+    expectations:
+      - command_started_event:
+          command:
+            drop: *collection_name
+            writeConcern:
+          command_name: drop
+          database_name: *database_name
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin

--- a/source/transactions/tests/create-index.json
+++ b/source/transactions/tests/create-index.json
@@ -1,0 +1,237 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.3.4",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "create index on a non-existing collection",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createIndex",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "name": "t_1",
+            "key": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test",
+            "index": "t_1"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test",
+            "index": "t_1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "test",
+              "writeConcern": null
+            },
+            "command_name": "drop",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "test",
+              "indexes": [
+                {
+                  "name": "t_1",
+                  "key": {
+                    "x": 1
+                  }
+                }
+              ],
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "createIndexes",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
+      "description": "create index on a collection created within the same transaction",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "test"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "session": "session0",
+            "collection": "test"
+          }
+        },
+        {
+          "name": "createIndex",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "name": "t_1",
+            "key": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertIndexNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test",
+            "index": "t_1"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "transaction-tests",
+            "collection": "test",
+            "index": "t_1"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "test",
+              "writeConcern": null
+            },
+            "command_name": "drop",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "create": "test",
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "create",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "createIndexes": "test",
+              "indexes": [
+                {
+                  "name": "t_1",
+                  "key": {
+                    "x": 1
+                  }
+                }
+              ],
+              "lsid": "session0",
+              "writeConcern": null
+            },
+            "command_name": "createIndexes",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/transactions/tests/create-index.yml
+++ b/source/transactions/tests/create-index.yml
@@ -1,0 +1,152 @@
+runOn:
+  -
+    minServerVersion: "4.3.4"
+    topology: ["replicaset", "sharded"]
+
+database_name: &database_name "transaction-tests"
+collection_name: &collection_name "test"
+
+data: []
+
+tests:
+  - description: create index on a non-existing collection
+
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: *collection_name
+      - name: startTransaction
+        object: session0
+      - name: createIndex
+        object: collection
+        arguments:
+          session: session0
+          name: &index_name "t_1"
+          key:
+            x: 1
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+          index: *index_name
+      - name: commitTransaction
+        object: session0
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+          index: *index_name
+
+    expectations:
+      - command_started_event:
+          command:
+            drop: *collection_name
+            writeConcern:
+          command_name: drop
+          database_name: *database_name
+      - command_started_event:
+          command:
+            createIndexes: *collection_name
+            indexes:
+              - name: *index_name
+                key:
+                  x: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: createIndexes
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin
+
+  - description: create index on a collection created within the same transaction
+
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: *collection_name
+      - name: startTransaction
+        object: session0
+      - name: createCollection
+        object: database
+        arguments:
+          session: session0
+          collection: *collection_name
+      - name: createIndex
+        object: collection
+        arguments:
+          session: session0
+          name: *index_name
+          key:
+            x: 1
+      - name: assertIndexNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+          index: *index_name
+      - name: commitTransaction
+        object: session0
+      - name: assertIndexExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: *collection_name
+          index: *index_name
+
+    expectations:
+      - command_started_event:
+          command:
+            drop: *collection_name
+            writeConcern:
+          command_name: drop
+          database_name: *database_name
+      - command_started_event:
+          command:
+            create: *collection_name
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: create
+          database_name: *database_name
+      - command_started_event:
+          command:
+            createIndexes: *collection_name
+            indexes:
+              - name: *index_name
+                key:
+                  x: 1
+            lsid: session0
+            writeConcern:
+          command_name: createIndexes
+          database_name: *database_name
+      - command_started_event:
+          command:
+            commitTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: commitTransaction
+          database_name: admin

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -1288,7 +1288,7 @@ The following commands are allowed inside transactions:
 
 3.  killCursors
 
-4.  insert
+4.  insert, including into a non-existing collection that implicitly creates it
 
 5.  update
 
@@ -1303,6 +1303,11 @@ The following commands are allowed inside transactions:
 9.  distinct
 
 10. geoSearch
+
+11. create
+
+12. createIndexes on an empty collection created in the same transaction or on a
+    non-existing collection
 
 Why don’t drivers automatically retry commit after a write concern timeout error?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1419

This PR adds spec changes to allow for collection and index creation within a transaction. The tests are added to ensure that drivers don't inspect commands or prevent creating collections or indexes in transaction on their own.

The test include four new test runner operations to check if collections/indexes exist/do not exist. Note that these currently can't be used along with a `session` argument as the server does not allow running `listCollections` and `listIndexes` commands in a transaction. The tests thus only assert against the state outside of the transaction.

Along with test runner operations, the new `createCollection` and `dropCollection` operations have been added on the `database` object and `createIndex` to the `collection` object.

A POC for the PHP library can be found in https://github.com/mongodb/mongo-php-library/pull/722.