### PR TITLE
SPEC-1565 Some Retryable Writes specification improvements

### DIFF
--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -3,14 +3,14 @@ Retryable Writes
 ================
 
 :Spec Title: Retryable Writes
-:Spec Version: 1.5.1
+:Spec Version: 1.5.2
 :Author: Jeremy Mikola
 :Lead: \A. Jesse Jiryu Davis
 :Advisors: Robert Stam, Esha Maharishi, Samantha Ritter, and Kaloian Manassiev
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: 2020-02-10
+:Last Modified: 2020-02-25
 
 .. contents::
 
@@ -808,6 +808,10 @@ to developers.
 
 Changes
 =======
+
+2020-02-25: State that the driver should only add the RetryableWriteError label
+when retryWrites is on, and make it clear that mongos will sometimes perform
+internal retries and not return the RetryableWriteError label.
 
 2020-02-10: Remove redundant content in Tests section.
 

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -212,7 +212,11 @@ Determining Retryable Errors
 
 When connected to a MongoDB instance that supports retryable writes (versions 3.6+),
 the driver MUST treat all errors with the RetryableWriteError label as retryable.
-This label might be added to an error in a variety of ways:
+This error label can be found in the top-level "errorLabels" field of the error.
+With a WriteConcernError response, the top level document or the
+WriteConcernError document may contain the RetryableWriteError error label.
+
+The RetryableWriteError label might be added to an error in a variety of ways:
 
 When the driver encounters a network error communicating with any server version
 that supports retryable writes, it MUST add a RetryableWriteError label to that
@@ -225,8 +229,12 @@ driver. As new server versions are released, the errors that are labeled with th
 RetryableWriteError label may change. When receiving a command result
 with an error from a 4.4+ server that supports retryable writes, the driver
 MUST NOT add a RetryableWriteError label to that error under any condition.
-Note: With a WriteConcernError response the top level document or the
-WriteConcernError document may contain the RetryableWriteError error label.
+
+During a retryable write operation on a sharded cluster, mongos may retry the
+operation internally, in which case it will not add a RetryableWriteError label to
+any error that occurs after those internal retries to prevent excessive retrying.
+The driver MUST NOT add a RetryableWriteError label to errors it receives from
+a version 4.4+ mongos.
 
 When receiving a command result with an error from a pre-4.4 server that supports
 retryable writes, the driver MUST add a RetryableWriteError label to errors that meet
@@ -269,7 +277,8 @@ performing the relevant operation:
 
 To understand why the driver should only add the RetryableWriteError label
 to an error when the retryWrites option is true on the MongoClient performing
-the operation, see ***
+the operation, see `Why does the driver only add the RetryableWriteError label
+to errors that occur on a MongoClient with retryWrites set to true?`_
 
 The criteria for retryable errors is similar to the discussion in the SDAM
 spec's section on `Error Handling`_, but includes additional error codes. See

--- a/source/retryable-writes/tests/bulkWrite-serverErrors.yml
+++ b/source/retryable-writes/tests/bulkWrite-serverErrors.yml
@@ -19,7 +19,7 @@ tests:
             data:
                 failCommands: ["update"]
                 errorCode: 189
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
         operation:
             name: "bulkWrite"
             arguments:
@@ -61,7 +61,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "bulkWrite"
             arguments:

--- a/source/retryable-writes/tests/deleteOne-serverErrors.yml
+++ b/source/retryable-writes/tests/deleteOne-serverErrors.yml
@@ -19,7 +19,7 @@ tests:
             data:
                 failCommands: ["delete"]
                 errorCode: 189
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
         operation:
             name: "deleteOne"
             arguments:
@@ -40,7 +40,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "deleteOne"
             arguments:

--- a/source/retryable-writes/tests/findOneAndDelete-serverErrors.yml
+++ b/source/retryable-writes/tests/findOneAndDelete-serverErrors.yml
@@ -19,7 +19,7 @@ tests:
             data:
                 failCommands: ["findAndModify"]
                 errorCode: 189
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
         operation:
             name: "findOneAndDelete"
             arguments:
@@ -40,7 +40,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "findOneAndDelete"
             arguments:

--- a/source/retryable-writes/tests/findOneAndReplace-serverErrors.yml
+++ b/source/retryable-writes/tests/findOneAndReplace-serverErrors.yml
@@ -19,7 +19,7 @@ tests:
             data:
                 failCommands: ["findAndModify"]
                 errorCode: 189
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
         operation:
             name: "findOneAndReplace"
             arguments:
@@ -42,7 +42,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "findOneAndReplace"
             arguments:

--- a/source/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
+++ b/source/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
@@ -19,7 +19,7 @@ tests:
             data:
                 failCommands: ["findAndModify"]
                 errorCode: 189
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
         operation:
             name: "findOneAndUpdate"
             arguments:
@@ -42,7 +42,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "findOneAndUpdate"
             arguments:

--- a/source/retryable-writes/tests/insertMany-serverErrors.yml
+++ b/source/retryable-writes/tests/insertMany-serverErrors.yml
@@ -18,7 +18,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 189
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertMany"
             arguments:
@@ -44,7 +44,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertMany"
             arguments:

--- a/source/retryable-writes/tests/insertOne-serverErrors.yml
+++ b/source/retryable-writes/tests/insertOne-serverErrors.yml
@@ -39,7 +39,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 10107
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -61,7 +61,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 13436
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -83,7 +83,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 13435
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -105,7 +105,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 11602
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -127,7 +127,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 11600
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -149,7 +149,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 189
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -171,7 +171,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 91
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -193,7 +193,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 7
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -215,7 +215,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 6
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -237,7 +237,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 9001
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -259,7 +259,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 89
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -281,7 +281,7 @@ tests:
             data:
                 failCommands: ["insert"]
                 errorCode: 262
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
                 closeConnection: false
         operation:
             name: "insertOne"
@@ -326,7 +326,7 @@ tests:
                 writeConcernError:
                     code: 11600
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:
@@ -349,7 +349,7 @@ tests:
                 writeConcernError:
                     code: 11602
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:
@@ -372,7 +372,7 @@ tests:
                 writeConcernError:
                     code: 189
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:
@@ -395,7 +395,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:

--- a/source/retryable-writes/tests/replaceOne-serverErrors.yml
+++ b/source/retryable-writes/tests/replaceOne-serverErrors.yml
@@ -19,7 +19,7 @@ tests:
             data:
                 failCommands: ["update"]
                 errorCode: 189
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
         operation:
             name: "replaceOne"
             arguments:
@@ -44,7 +44,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "replaceOne"
             arguments:

--- a/source/retryable-writes/tests/updateOne-serverErrors.yml
+++ b/source/retryable-writes/tests/updateOne-serverErrors.yml
@@ -19,7 +19,7 @@ tests:
             data:
                 failCommands: ["update"]
                 errorCode: 189
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
         operation:
             name: "updateOne"
             arguments:
@@ -44,7 +44,7 @@ tests:
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"] # SPEC-1565
+                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "updateOne"
             arguments:

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -500,7 +500,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11602  # InterruptedDueToReplStateChange
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
 
     operations:
       - name: startTransaction

--- a/source/transactions/tests/mongos-recovery-token.yml
+++ b/source/transactions/tests/mongos-recovery-token.yml
@@ -119,7 +119,7 @@ tests:
               writeConcernError:
                 code: 91
                 errmsg: Replication is being shut down
-                errorLabels: ["RetryableWriteError"] # SPEC-1565
+                errorLabels: ["RetryableWriteError"]
       # The client sees a retryable writeConcernError on the first
       # commitTransaction due to the fail point but it actually succeeds on the
       # server (SERVER-39346). The retry will succeed both on a new mongos and

--- a/source/transactions/tests/retryable-abort.yml
+++ b/source/transactions/tests/retryable-abort.yml
@@ -274,7 +274,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 10107
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -342,7 +342,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 13436
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -410,7 +410,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 13435
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -470,7 +470,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after InterruptedDueToReplStateChange 
+  - description: abortTransaction succeeds after InterruptedDueToReplStateChange
 
     failPoint:
       configureFailPoint: failCommand
@@ -478,7 +478,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 11602
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -546,7 +546,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 11600
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -614,7 +614,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 189
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -682,7 +682,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 91
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -750,7 +750,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 7
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -818,7 +818,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 6
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -886,7 +886,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 9001
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -954,7 +954,7 @@ tests:
       data:
           failCommands: ["abortTransaction"]
           errorCode: 89
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -1023,7 +1023,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 11600
-            errorLabels: ["RetryableWriteError"] # SPEC-1565
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1089,7 +1089,7 @@ tests:
       collection:
         data: []
 
-  - description: abortTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange 
+  - description: abortTransaction succeeds after WriteConcernError InterruptedDueToReplStateChange
 
     failPoint:
       configureFailPoint: failCommand
@@ -1098,7 +1098,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 11602
-            errorLabels: ["RetryableWriteError"] # SPEC-1565
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1173,7 +1173,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 189
-            errorLabels: ["RetryableWriteError"] # SPEC-1565
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1248,7 +1248,7 @@ tests:
           failCommands: ["abortTransaction"]
           writeConcernError:
             code: 91
-            errorLabels: ["RetryableWriteError"] # SPEC-1565
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:

--- a/source/transactions/tests/retryable-commit.yml
+++ b/source/transactions/tests/retryable-commit.yml
@@ -393,7 +393,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 10107
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -463,7 +463,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 13436
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -533,7 +533,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 13435
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -603,7 +603,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11602
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -673,7 +673,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 11600
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -743,7 +743,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 189
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -813,7 +813,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 91
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -883,7 +883,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 7
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -953,7 +953,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 6
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -1023,7 +1023,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 9001
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -1093,7 +1093,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 89
-          errorLabels: ["RetryableWriteError"] # SPEC-1565
+          errorLabels: ["RetryableWriteError"]
           closeConnection: false
 
     operations:
@@ -1164,7 +1164,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 11600
-            errorLabels: ["RetryableWriteError"] # SPEC-1565
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1240,7 +1240,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 11602
-            errorLabels: ["RetryableWriteError"] # SPEC-1565
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1316,7 +1316,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 189
-            errorLabels: ["RetryableWriteError"] # SPEC-1565
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1392,7 +1392,7 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 91
-            errorLabels: ["RetryableWriteError"] # SPEC-1565
+            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:


### PR DESCRIPTION
Three small changes:
* Remove the SPEC-1565 comments from the test files; we were originally going to remove the error labels from the failPoint command and have mongos always propagate RetryableWriteError labels, but it looks like the current behavior is here to stay (see discussion in [SERVER-45939](https://jira.mongodb.org/browse/SERVER-45939)).
* Specify that the driver should only add the error label if retryWrite is true.
* Make it clear that mongos will sometimes choose to retry internally, in which case it won't propagate the error label to the driver.