### PR TITLE
Fix tests for tlsDisableOCSPEndpointCheck

### DIFF
--- a/source/ocsp-support/ocsp-support.rst
+++ b/source/ocsp-support/ocsp-support.rst
@@ -105,7 +105,7 @@ invalid, the driver SHOULD end the connection.
 
 7.  If the server’s certificate remains unvalidated, that certificate
     has a list of OCSP responder endpoints, and
-    ``tlsDisableOcspEndpointCheck`` is true (`if the driver supports
+    ``tlsDisableOCSPEndpointCheck`` is false (`if the driver supports
     this option <MongoClient Configuration>`_), the driver SHOULD send
     HTTP requests to the responders in parallel. The first valid
     response that concretely marks the certificate status as good or

--- a/source/uri-options/tests/tls-options.json
+++ b/source/uri-options/tests/tls-options.json
@@ -250,7 +250,7 @@
       }
     },
     {
-      "description": "tlsDisableOCSPEndpointCheck parses correctly",
+      "description": "tlsDisableOCSPEndpointCheck can be set to true",
       "uri": "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=true",
       "valid": true,
       "warning": false,
@@ -259,6 +259,18 @@
       "options": {
         "tls": true,
         "tlsDisableOCSPEndpointCheck": true
+      }
+    },
+    {
+      "description": "tlsDisableOCSPEndpointCheck can be set to false",
+      "uri": "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "tls": true,
+        "tlsDisableOCSPEndpointCheck": false
       }
     },
     {

--- a/source/uri-options/tests/tls-options.json
+++ b/source/uri-options/tests/tls-options.json
@@ -238,32 +238,32 @@
       "options": {}
     },
     {
-      "description": "tlsDisableOcspEndpointCheck defaults to false",
+      "description": "tlsDisableOCSPEndpointCheck defaults to false",
       "uri": "mongodb://example.com/?tls=true",
-      "valid": false,
+      "valid": true,
       "warning": false,
       "hosts": null,
       "auth": null,
       "options": {
         "tls": true,
-        "tlsDisableOcspEndpointCheck": false
+        "tlsDisableOCSPEndpointCheck": false
       }
     },
     {
-      "description": "tlsDisableOcspEndpointCheck parses correctly",
-      "uri": "mongodb://example.com/?tls=true&tlsDisableOcspEndpointCheck=true",
-      "valid": false,
+      "description": "tlsDisableOCSPEndpointCheck parses correctly",
+      "uri": "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=true",
+      "valid": true,
       "warning": false,
       "hosts": null,
       "auth": null,
       "options": {
         "tls": true,
-        "tlsDisableOcspEndpointCheck": true
+        "tlsDisableOCSPEndpointCheck": true
       }
     },
     {
-      "description": "tlsInsecure and tlsDisableOcspEndpointCheck both present (and true) raises an error",
-      "uri": "mongodb://example.com/?tlsInsecure=true&tlsDisableOcspEndpointCheck=true",
+      "description": "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=true",
       "valid": false,
       "warning": false,
       "hosts": null,
@@ -271,8 +271,8 @@
       "options": {}
     },
     {
-      "description": "tlsInsecure=true and tlsDisableOcspEndpointCheck=false raises an error",
-      "uri": "mongodb://example.com/?tlsInsecure=true&tlsDisableOcspEndpointCheck=false",
+      "description": "tlsInsecure=true and tlsDisableOCSPEndpointCheck=false raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=false",
       "valid": false,
       "warning": false,
       "hosts": null,
@@ -280,8 +280,8 @@
       "options": {}
     },
     {
-      "description": "tlsInsecure=false and tlsDisableOcspEndpointCheck=true raises an error",
-      "uri": "mongodb://example.com/?tlsInsecure=false&tlsDisableOcspEndpointCheck=true",
+      "description": "tlsInsecure=false and tlsDisableOCSPEndpointCheck=true raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=true",
       "valid": false,
       "warning": false,
       "hosts": null,
@@ -289,8 +289,8 @@
       "options": {}
     },
     {
-      "description": "tlsInsecure and tlsDisableOcspEndpointCheck both present (and false) raises an error",
-      "uri": "mongodb://example.com/?tlsInsecure=false&tlsDisableOcspEndpointCheck=false",
+      "description": "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=false",
       "valid": false,
       "warning": false,
       "hosts": null,
@@ -298,8 +298,8 @@
       "options": {}
     },
     {
-      "description": "tlsDisableOcspEndpointCheck and tlsInsecure both present (and true) raises an error",
-      "uri": "mongodb://example.com/?tlsDisableOcspEndpointCheck=true&tlsInsecure=true",
+      "description": "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and true) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsInsecure=true",
       "valid": false,
       "warning": false,
       "hosts": null,
@@ -307,8 +307,8 @@
       "options": {}
     },
     {
-      "description": "tlsDisableOcspEndpointCheck=true and tlsInsecure=false raises an error",
-      "uri": "mongodb://example.com/?tlsDisableOcspEndpointCheck=true&tlsInsecure=false",
+      "description": "tlsDisableOCSPEndpointCheck=true and tlsInsecure=false raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsInsecure=false",
       "valid": false,
       "warning": false,
       "hosts": null,
@@ -316,8 +316,8 @@
       "options": {}
     },
     {
-      "description": "tlsDisableOcspEndpointCheck=false and tlsInsecure=true raises an error",
-      "uri": "mongodb://example.com/?tlsDisableOcspEndpointCheck=false&tlsInsecure=true",
+      "description": "tlsDisableOCSPEndpointCheck=false and tlsInsecure=true raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=true",
       "valid": false,
       "warning": false,
       "hosts": null,
@@ -325,8 +325,8 @@
       "options": {}
     },
     {
-      "description": "tlsDisableOcspEndpointCheck and tlsInsecure both present (and false) raises an error",
-      "uri": "mongodb://example.com/?tlsDisableOcspEndpointCheck=false&tlsInsecure=false",
+      "description": "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and false) raises an error",
+      "uri": "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=false",
       "valid": false,
       "warning": false,
       "hosts": null,

--- a/source/uri-options/tests/tls-options.yml
+++ b/source/uri-options/tests/tls-options.yml
@@ -217,7 +217,7 @@ tests:
             tls: true
             tlsDisableOCSPEndpointCheck: false
     -
-        description: "tlsDisableOCSPEndpointCheck parses correctly"
+        description: "tlsDisableOCSPEndpointCheck can be set to true"
         uri: "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=true"
         valid: true
         warning: false
@@ -226,6 +226,16 @@ tests:
         options:
             tls: true
             tlsDisableOCSPEndpointCheck: true
+    -
+        description: "tlsDisableOCSPEndpointCheck can be set to false"
+        uri: "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=false"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            tls: true
+            tlsDisableOCSPEndpointCheck: false
     -
         description: "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and true) raises an error"
         uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=true"

--- a/source/uri-options/tests/tls-options.yml
+++ b/source/uri-options/tests/tls-options.yml
@@ -207,84 +207,84 @@ tests:
         auth: ~
         options: {}
     -
-        description: "tlsDisableOcspEndpointCheck defaults to false"
+        description: "tlsDisableOCSPEndpointCheck defaults to false"
         uri: "mongodb://example.com/?tls=true"
-        valid: false
+        valid: true
         warning: false
         hosts: ~
         auth: ~
         options:
             tls: true
-            tlsDisableOcspEndpointCheck: false
+            tlsDisableOCSPEndpointCheck: false
     -
-        description: "tlsDisableOcspEndpointCheck parses correctly"
-        uri: "mongodb://example.com/?tls=true&tlsDisableOcspEndpointCheck=true"
-        valid: false
+        description: "tlsDisableOCSPEndpointCheck parses correctly"
+        uri: "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=true"
+        valid: true
         warning: false
         hosts: ~
         auth: ~
         options:
             tls: true
-            tlsDisableOcspEndpointCheck: true
+            tlsDisableOCSPEndpointCheck: true
     -
-        description: "tlsInsecure and tlsDisableOcspEndpointCheck both present (and true) raises an error"
-        uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableOcspEndpointCheck=true"
+        description: "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=true"
         valid: false
         warning: false
         hosts: ~
         auth: ~
         options: {}
     -
-        description: "tlsInsecure=true and tlsDisableOcspEndpointCheck=false raises an error"
-        uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableOcspEndpointCheck=false"
+        description: "tlsInsecure=true and tlsDisableOCSPEndpointCheck=false raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=false"
         valid: false
         warning: false
         hosts: ~
         auth: ~
         options: {}
     -
-        description: "tlsInsecure=false and tlsDisableOcspEndpointCheck=true raises an error"
-        uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableOcspEndpointCheck=true"
+        description: "tlsInsecure=false and tlsDisableOCSPEndpointCheck=true raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=true"
         valid: false
         warning: false
         hosts: ~
         auth: ~
         options: {}
     -
-        description: "tlsInsecure and tlsDisableOcspEndpointCheck both present (and false) raises an error"
-        uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableOcspEndpointCheck=false"
+        description: "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=false"
         valid: false
         warning: false
         hosts: ~
         auth: ~
         options: {}
     -
-        description: "tlsDisableOcspEndpointCheck and tlsInsecure both present (and true) raises an error"
-        uri: "mongodb://example.com/?tlsDisableOcspEndpointCheck=true&tlsInsecure=true"
+        description: "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and true) raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsInsecure=true"
         valid: false
         warning: false
         hosts: ~
         auth: ~
         options: {}
     -
-        description: "tlsDisableOcspEndpointCheck=true and tlsInsecure=false raises an error"
-        uri: "mongodb://example.com/?tlsDisableOcspEndpointCheck=true&tlsInsecure=false"
+        description: "tlsDisableOCSPEndpointCheck=true and tlsInsecure=false raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsInsecure=false"
         valid: false
         warning: false
         hosts: ~
         auth: ~
         options: {}
     -
-        description: "tlsDisableOcspEndpointCheck=false and tlsInsecure=true raises an error"
-        uri: "mongodb://example.com/?tlsDisableOcspEndpointCheck=false&tlsInsecure=true"
+        description: "tlsDisableOCSPEndpointCheck=false and tlsInsecure=true raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=true"
         valid: false
         warning: false
         hosts: ~
         auth: ~
         options: {}
     -
-        description: "tlsDisableOcspEndpointCheck and tlsInsecure both present (and false) raises an error"
-        uri: "mongodb://example.com/?tlsDisableOcspEndpointCheck=false&tlsInsecure=false"
+        description: "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and false) raises an error"
+        uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=false"
         valid: false
         warning: false
         hosts: ~


### PR DESCRIPTION
`OCSP` was not consistently capitalized and two of the URI options tests said `valid: false` rather than `valid: true` which was causing tests to fail.