### PR TITLE
SPEC-1562 Add missing RetryableWriteError label

### DIFF
--- a/source/transactions-convenient-api/tests/commit-retry.json
+++ b/source/transactions-convenient-api/tests/commit-retry.json
@@ -304,6 +304,9 @@
             "commitTransaction"
           ],
           "errorCode": 10107,
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "closeConnection": false
         }
       },

--- a/source/transactions-convenient-api/tests/commit-retry.yml
+++ b/source/transactions-convenient-api/tests/commit-retry.yml
@@ -192,6 +192,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           errorCode: 10107 # NotMaster
+          errorLabels: ["RetryableWriteError"] # SPEC-1565
           closeConnection: false
     operations:
       - *withTransaction


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1562

I noticed that the libmongoc test suite failed on MongoDB 4.3 due to a commit not being retried. This label was likely forgotten in #737, as adding it fixes the test in question.