### PR TITLE
Change index key name from "key" to "keys"

### DIFF
--- a/source/transactions/tests/create-index.json
+++ b/source/transactions/tests/create-index.json
@@ -32,7 +32,7 @@
           "arguments": {
             "session": "session0",
             "name": "t_1",
-            "key": {
+            "keys": {
               "x": 1
             }
           }
@@ -141,7 +141,7 @@
           "arguments": {
             "session": "session0",
             "name": "t_1",
-            "key": {
+            "keys": {
               "x": 1
             }
           }

--- a/source/transactions/tests/create-index.yml
+++ b/source/transactions/tests/create-index.yml
@@ -23,7 +23,7 @@ tests:
         arguments:
           session: session0
           name: &index_name "t_1"
-          key:
+          keys:
             x: 1
       - name: assertIndexNotExists
         object: testRunner
@@ -93,7 +93,7 @@ tests:
         arguments:
           session: session0
           name: *index_name
-          key:
+          keys:
             x: 1
       - name: assertIndexNotExists
         object: testRunner


### PR DESCRIPTION
This change was made because the read/write concern tests added for the 4.4 cycle also have a `createIndex` operation and they use "keys" as the YAML/JSON key name instead of "key". See https://github.com/mongodb/specifications/blob/master/source/read-write-concern/tests/operation/default-write-concern-3.4.json#L120 for an example.