### PR TITLE
SPEC-1552 Ban ismaster from being published in APM events

### DIFF
--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -250,7 +250,7 @@ value MUST be replaced with an empty BSON document. The list is as follows:
    * - ``copydbgetnonce``
    * - ``copydbsaslstart``
    * - ``copydb``
-   * - ``isMaster`` when ``speculativeAuthenticate`` is present
+   * - ``isMaster`` or ``ismaster`` when ``speculativeAuthenticate`` is present
 
 ---
 API


### PR DESCRIPTION
When the driver sends an isMaster command, the server replies with
ismaster in all lowercase. This commit updates the command monitoring
spec to account for this when redacting isMaster commands with
speculative authentication fields.