### PR TITLE
SPEC-1576 A monitor's connection handshake satisfies a check and updates the topology

### DIFF
--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -7,7 +7,7 @@ Server Monitoring
 :Status: Accepted
 :Type: Standards
 :Version: Same as the `Server Discovery And Monitoring`_ spec
-:Last Modified: 2020-02-20
+:Last Modified: 2020-03-09
 
 .. contents::
 
@@ -85,10 +85,6 @@ The client begins monitoring a server when:
 * ... `updateRSWithoutPrimary`_ or `updateRSFromPrimary`_
   discovers new replica set members.
 
-When checking a server, clients MUST NOT include SCRAM mechanism
-negotiation requests with the ``isMaster`` command, as doing so would
-make monitoring checks more expensive for the server.
-
 The following subsections specify how monitoring works,
 first in multi-threaded or asynchronous clients,
 and second in single-threaded clients.
@@ -117,7 +113,9 @@ to acquire a socket;
 it uses a dedicated socket that does not count toward the pool's
 maximum size.
 
-Drivers MUST NOT authenticate on sockets used for monitoring.
+Drivers MUST NOT authenticate on sockets used for monitoring nor include
+SCRAM mechanism negotiation (i.e. ``saslSupportedMechs``), as doing so would
+make monitoring checks more expensive for the server.
 
 Servers are checked periodically
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -157,6 +155,10 @@ be able to proceed anyway.
 
 Clients update the topology from each handshake
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a monitor check creates a new connection, it MUST perform the
+`connection handshake`_ and MUST use the handshake's ismaster response to
+create the next ServerDescription and update the topology.
 
 When a client successfully calls ismaster to handshake a new connection for application
 operations, it SHOULD use the ismaster reply to update the ServerDescription
@@ -449,6 +451,9 @@ then it is probably down.
 Changelog
 ---------
 
+- 2020-03-09 A monitor check that creates a new connection MUST use the
+  connection's handshake to update the topology.
+
 - 2020-02-20 Extracted server monitoring from SDAM into this new spec.
 
 .. Section for links.
@@ -461,3 +466,4 @@ Changelog
 .. _initial servers: server-discovery-and-monitoring.rst#initial-servers
 .. _updateRSWithoutPrimary: server-discovery-and-monitoring.rst#updateRSWithoutPrimary
 .. _updateRSFromPrimary: server-discovery-and-monitoring.rst#updateRSFromPrimary
+.. _connection handshake: mongodb-handshake/handshake.rst

--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -157,7 +157,7 @@ Clients update the topology from each handshake
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a monitor check creates a new connection, it MUST perform the
-`connection handshake`_ and MUST use the handshake's ismaster response to
+`connection handshake`_ and MUST use the handshake's response to
 create the next ServerDescription and update the topology.
 
 When a client successfully calls ismaster to handshake a new connection for application

--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -156,9 +156,8 @@ be able to proceed anyway.
 Clients update the topology from each handshake
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a monitor check creates a new connection, it MUST perform the
-`connection handshake`_ and MUST use the handshake's response to
-create the next ServerDescription and update the topology.
+When a monitor check creates a new connection, the `connection handshake`_
+response MUST be used to satisfy the check and update the topology.
 
 When a client successfully calls ismaster to handshake a new connection for application
 operations, it SHOULD use the ismaster reply to update the ServerDescription


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/SPEC-1576

The motivation for this ticket is faster initial SDAM discovery and faster rediscovery. If a client does not use the initial handshake then it require 2 ismasters to update a server's description.