### PR TITLE
Change json type of getMore placeholder value.

### DIFF
--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -63,7 +63,7 @@ The definition of MATCH or MATCHES in the Spec Test Runner is as follows:
 
 - MATCH takes two values, ``expected`` and ``actual``
 - Notation is "Assert [actual] MATCHES [expected]
-- Assertion passes if ``expected`` is a subset of ``actual``, with the values ``42`` and ``"42"`` acting as placeholders for "any value"
+- Assertion passes if ``expected`` is a subset of ``actual``, with the value ``42`` acting as placeholders for "any value"
 
 Pseudocode implementation of ``actual`` MATCHES ``expected``:
 

--- a/source/change-streams/tests/change-streams-resume-errorLabels.json
+++ b/source/change-streams/tests/change-streams-resume-errorLabels.json
@@ -53,7 +53,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -146,7 +146,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -239,7 +239,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -332,7 +332,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -425,7 +425,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -518,7 +518,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -611,7 +611,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -704,7 +704,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -797,7 +797,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -890,7 +890,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -983,7 +983,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1076,7 +1076,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1169,7 +1169,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1262,7 +1262,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1355,7 +1355,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1448,7 +1448,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1541,7 +1541,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1640,7 +1640,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",

--- a/source/change-streams/tests/change-streams-resume-errorLabels.yml
+++ b/source/change-streams/tests/change-streams-resume-errorLabels.yml
@@ -39,7 +39,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -102,7 +102,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -165,7 +165,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -228,7 +228,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -291,7 +291,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -354,7 +354,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -417,7 +417,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -480,7 +480,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -543,7 +543,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -606,7 +606,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -669,7 +669,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -732,7 +732,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -795,7 +795,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -858,7 +858,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -921,7 +921,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -984,7 +984,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -1047,7 +1047,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -1113,7 +1113,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name

--- a/source/change-streams/tests/change-streams-resume-whitelist.json
+++ b/source/change-streams/tests/change-streams-resume-whitelist.json
@@ -55,7 +55,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -152,7 +152,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -249,7 +249,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -346,7 +346,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -443,7 +443,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -540,7 +540,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -637,7 +637,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -734,7 +734,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -831,7 +831,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -928,7 +928,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1025,7 +1025,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1122,7 +1122,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1219,7 +1219,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1316,7 +1316,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1413,7 +1413,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1510,7 +1510,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1607,7 +1607,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",
@@ -1704,7 +1704,7 @@
         {
           "command_started_event": {
             "command": {
-              "getMore": "42",
+              "getMore": 42,
               "collection": "test"
             },
             "command_name": "getMore",

--- a/source/change-streams/tests/change-streams-resume-whitelist.yml
+++ b/source/change-streams/tests/change-streams-resume-whitelist.yml
@@ -39,7 +39,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -104,7 +104,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -169,7 +169,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -234,7 +234,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -299,7 +299,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -364,7 +364,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -429,7 +429,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -494,7 +494,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -559,7 +559,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -624,7 +624,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -689,7 +689,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -754,7 +754,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -819,7 +819,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -884,7 +884,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -949,7 +949,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -1014,7 +1014,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -1079,7 +1079,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name
@@ -1144,7 +1144,7 @@ tests:
       -
         command_started_event:
           command:
-            getMore: "42"
+            getMore: 42
             collection: *collection_name
           command_name: getMore
           database_name: *database_name


### PR DESCRIPTION
Removing the ability to specify the placeholder value as a simple string.

I was concerned only about a getMore expectation node. Since c# driver makes validations on value **and** type. 
Let me know if we need to change the other values.