### PR TITLE
SPEC-1658 Replace empty object expectations with empty array in unacknowledged bulk write tests

### DIFF
--- a/source/crud/tests/v2/unacknowledged-bulkWrite-delete-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-bulkWrite-delete-hint-clientError.json
@@ -64,7 +64,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -132,7 +132,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-bulkWrite-delete-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-bulkWrite-delete-hint-clientError.yml
@@ -34,7 +34,7 @@ tests:
                 hint: &hint_doc { _id: 1 }
           options: { ordered: true }
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -62,5 +62,5 @@ tests:
                 hint: *hint_doc
           options: { ordered: true }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome

--- a/source/crud/tests/v2/unacknowledged-bulkWrite-update-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-bulkWrite-update-hint-clientError.json
@@ -74,7 +74,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -152,7 +152,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -222,7 +222,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-bulkWrite-update-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-bulkWrite-update-hint-clientError.yml
@@ -36,7 +36,7 @@ tests:
                 hint: &hint_doc { _id: 1 }
           options: { ordered: true }
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -66,7 +66,7 @@ tests:
                 hint: *hint_doc
           options: { ordered: true }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome
   -
     description: "Unacknowledged bulkWrite replaceOne with hints unsupported (client-side error)"
@@ -90,5 +90,5 @@ tests:
                 hint: *hint_doc
           options: { ordered: true }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome

--- a/source/crud/tests/v2/unacknowledged-deleteMany-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-deleteMany-hint-clientError.json
@@ -42,7 +42,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -86,7 +86,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-deleteMany-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-deleteMany-hint-clientError.yml
@@ -24,7 +24,7 @@ tests:
           filter: &filter { _id: { $gt: 1 } }
           hint: "_id_"
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -42,5 +42,5 @@ tests:
           filter: *filter
           hint: { _id: 1 }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome

--- a/source/crud/tests/v2/unacknowledged-deleteOne-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-deleteOne-hint-clientError.json
@@ -36,7 +36,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -74,7 +74,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-deleteOne-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-deleteOne-hint-clientError.yml
@@ -23,7 +23,7 @@ tests:
           filter: &filter { _id: 1 }
           hint: "_id_"
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -40,5 +40,5 @@ tests:
           filter: *filter
           hint: { _id: 1 }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome

--- a/source/crud/tests/v2/unacknowledged-findOneAndDelete-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-findOneAndDelete-hint-clientError.json
@@ -36,7 +36,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -74,7 +74,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-findOneAndDelete-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-findOneAndDelete-hint-clientError.yml
@@ -23,7 +23,7 @@ tests:
           filter: &filter { _id: 1 }
           hint: "_id_"
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -40,7 +40,7 @@ tests:
           filter: &filter { _id: 1 }
           hint: { _id: 1 }
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:

--- a/source/crud/tests/v2/unacknowledged-findOneAndReplace-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-findOneAndReplace-hint-clientError.json
@@ -39,7 +39,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -80,7 +80,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-findOneAndReplace-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-findOneAndReplace-hint-clientError.yml
@@ -24,7 +24,7 @@ tests:
           replacement: &replacement { x: 33 }
           hint: "_id_"
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -42,5 +42,5 @@ tests:
           replacement: *replacement
           hint: { _id: 1 }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome

--- a/source/crud/tests/v2/unacknowledged-findOneAndUpdate-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-findOneAndUpdate-hint-clientError.json
@@ -41,7 +41,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -84,7 +84,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-findOneAndUpdate-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-findOneAndUpdate-hint-clientError.yml
@@ -24,7 +24,7 @@ tests:
           update: &update { $inc: { x: 1 }}
           hint: "_id_"
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -42,5 +42,5 @@ tests:
           update: *update
           hint: { _id: 1 }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome

--- a/source/crud/tests/v2/unacknowledged-replaceOne-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-replaceOne-hint-clientError.json
@@ -41,7 +41,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -84,7 +84,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-replaceOne-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-replaceOne-hint-clientError.yml
@@ -24,7 +24,7 @@ tests:
           replacement: &replacement { x: 111 }
           hint: "_id_"
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -42,5 +42,5 @@ tests:
           replacement: *replacement
           hint: { _id: 1 }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome

--- a/source/crud/tests/v2/unacknowledged-updateMany-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-updateMany-hint-clientError.json
@@ -47,7 +47,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -96,7 +96,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-updateMany-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-updateMany-hint-clientError.yml
@@ -25,7 +25,7 @@ tests:
           update: &update { $inc: { x: 1 } }
           hint: "_id_"
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -44,6 +44,6 @@ tests:
           update: *update
           hint: { _id: 1 }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome
 

--- a/source/crud/tests/v2/unacknowledged-updateOne-hint-clientError.json
+++ b/source/crud/tests/v2/unacknowledged-updateOne-hint-clientError.json
@@ -43,7 +43,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [
@@ -88,7 +88,7 @@
           "error": true
         }
       ],
-      "expectations": {},
+      "expectations": [],
       "outcome": {
         "collection": {
           "data": [

--- a/source/crud/tests/v2/unacknowledged-updateOne-hint-clientError.yml
+++ b/source/crud/tests/v2/unacknowledged-updateOne-hint-clientError.yml
@@ -24,7 +24,7 @@ tests:
           update: &update { $inc: { x: 1 } }
           hint: "_id_"
         error: true
-    expectations: {}
+    expectations: []
     outcome: &outcome
       collection:
         data:
@@ -42,5 +42,5 @@ tests:
           update: *update
           hint: { _id: 1 }
         error: true
-    expectations: {}
+    expectations: []
     outcome: *outcome


### PR DESCRIPTION
The Ruby spec runner did not flag this error because it compares the length of the expectations, and `[].length` and `{}.length` in Ruby both return 0. Mikalai pointed out that this failed in the .NET driver test runner, so fixing it now.