### PR TITLE
DRIVERS-989: add uri options test for single `readPreferenceTags`

### DIFF
--- a/source/uri-options/tests/read-preference-options.json
+++ b/source/uri-options/tests/read-preference-options.json
@@ -22,6 +22,21 @@
       }
     },
     {
+      "description": "Single readPreferenceTags is parsed as array of size one",
+      "uri": "mongodb://example.com/?readPreferenceTags=dc:ny",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "readPreferenceTags": [
+          {
+            "dc": "ny"
+          }
+        ]
+      }
+    },
+    {
       "description": "Invalid readPreferenceTags causes a warning",
       "uri": "mongodb://example.com/?readPreferenceTags=invalid",
       "valid": true,

--- a/source/uri-options/tests/read-preference-options.yml
+++ b/source/uri-options/tests/read-preference-options.yml
@@ -9,12 +9,23 @@ tests:
         options:
             readPreference: "primaryPreferred"
             readPreferenceTags:
-                - 
+                -
                     dc: "ny"
                     rack: "1"
                 -
                     dc: "ny"
             maxStalenessSeconds: 120
+    -
+        description: "Single readPreferenceTags is parsed as array of size one"
+        uri: "mongodb://example.com/?readPreferenceTags=dc:ny"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options:
+            readPreferenceTags:
+                -
+                    dc: "ny"
     -
         description: "Invalid readPreferenceTags causes a warning"
         uri: "mongodb://example.com/?readPreferenceTags=invalid"


### PR DESCRIPTION
This test validates that drivers parse a single instance of the
`readPreferenceTags` option as an array.