### PR TITLE
SPEC-1669 admin => keyvault for FLE tests/examples

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -506,7 +506,7 @@ collection is unsupported (mongocryptd returns an error):
 .. code:: python
 
    opts = AutoEncryptionOpts (
-      key_vault_namespace="admin.keyvault",
+      key_vault_namespace="datakeys.keyvault",
       kms_providers=kms)
    client = MongoClient(auto_encryption_opts=opts)
    accounts = client.db.accounts
@@ -534,14 +534,14 @@ occurs).
 .. code:: python
 
    opts = AutoEncryptionOpts (
-      key_vault_namespace="admin.keyvault",
+      key_vault_namespace="datakeys.keyvault",
       kms_providers=kms,
       bypass_auto_encryption=True)
    client = MongoClient(auto_encryption_opts=opts)
 
    opts = ClientEncryptionOpts (
       key_vault_client=client,
-      key_vault_namespace="admin.keyvault",
+      key_vault_namespace="datakeys.keyvault",
       kms_providers=kms,
       bypass_auto_encryption=True)
    client_encryption = ClientEncryption(opts)

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -506,7 +506,7 @@ collection is unsupported (mongocryptd returns an error):
 .. code:: python
 
    opts = AutoEncryptionOpts (
-      key_vault_namespace="datakeys.keyvault",
+      key_vault_namespace="keyvault.datakeys",
       kms_providers=kms)
    client = MongoClient(auto_encryption_opts=opts)
    accounts = client.db.accounts
@@ -534,14 +534,14 @@ occurs).
 .. code:: python
 
    opts = AutoEncryptionOpts (
-      key_vault_namespace="datakeys.keyvault",
+      key_vault_namespace="keyvault.datakeys",
       kms_providers=kms,
       bypass_auto_encryption=True)
    client = MongoClient(auto_encryption_opts=opts)
 
    opts = ClientEncryptionOpts (
       key_vault_client=client,
-      key_vault_namespace="datakeys.keyvault",
+      key_vault_namespace="keyvault.datakeys",
       kms_providers=kms,
       bypass_auto_encryption=True)
    client_encryption = ClientEncryption(opts)

--- a/source/client-side-encryption/etc/test-templates/aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/aggregate.yml.template
@@ -35,14 +35,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -88,14 +88,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
     outcome:

--- a/source/client-side-encryption/etc/test-templates/basic.yml.template
+++ b/source/client-side-encryption/etc/test-templates/basic.yml.template
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -87,14 +87,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/bulk.yml.template
+++ b/source/client-side-encryption/etc/test-templates/bulk.yml.template
@@ -44,14 +44,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/bypassAutoEncryption.yml.template
+++ b/source/client-side-encryption/etc/test-templates/bypassAutoEncryption.yml.template
@@ -43,7 +43,7 @@ tests:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
     outcome:
@@ -89,7 +89,7 @@ tests:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
     outcome:

--- a/source/client-side-encryption/etc/test-templates/count.yml.template
+++ b/source/client-side-encryption/etc/test-templates/count.yml.template
@@ -33,14 +33,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/countDocuments.yml.template
+++ b/source/client-side-encryption/etc/test-templates/countDocuments.yml.template
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/delete.yml.template
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -81,14 +81,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/distinct.yml.template
+++ b/source/client-side-encryption/etc/test-templates/distinct.yml.template
@@ -36,14 +36,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/explain.yml.template
+++ b/source/client-side-encryption/etc/test-templates/explain.yml.template
@@ -38,14 +38,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/find.yml.template
+++ b/source/client-side-encryption/etc/test-templates/find.yml.template
@@ -35,14 +35,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -83,14 +83,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/findOneAndDelete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/findOneAndDelete.yml.template
@@ -33,14 +33,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/findOneAndReplace.yml.template
+++ b/source/client-side-encryption/etc/test-templates/findOneAndReplace.yml.template
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/findOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/findOneAndUpdate.yml.template
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/getMore.yml.template
+++ b/source/client-side-encryption/etc/test-templates/getMore.yml.template
@@ -43,14 +43,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/insert.yml.template
+++ b/source/client-side-encryption/etc/test-templates/insert.yml.template
@@ -30,14 +30,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -76,14 +76,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/keyAltName.yml.template
+++ b/source/client-side-encryption/etc/test-templates/keyAltName.yml.template
@@ -30,14 +30,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {$or: [ { _id: { $in: [] } }, { keyAltNames: { $in: [ "altname" ] } } ] }
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/localKMS.yml.template
+++ b/source/client-side-encryption/etc/test-templates/localKMS.yml.template
@@ -31,14 +31,14 @@ tests:
           listCollections: 1
           filter:
             name: "datakeys"
-          $db: admin
+          $db: keyvault
         command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:
           find: datakeys
           filter: { $or: [ { _id: { $in: [ {{key("local")["_id"]}} ] } }, { keyAltNames: { $in: [] } } ] }
-          $db: admin
+          $db: keyvault
         command_name: find
     - command_started_event:
         command:

--- a/source/client-side-encryption/etc/test-templates/localSchema.yml.template
+++ b/source/client-side-encryption/etc/test-templates/localSchema.yml.template
@@ -30,14 +30,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/missingKey.yml.template
+++ b/source/client-side-encryption/etc/test-templates/missingKey.yml.template
@@ -11,7 +11,7 @@ tests:
   - description: "Insert with encryption on a missing key"
     clientOptions:
       autoEncryptOpts:
-        keyVaultNamespace: "admin.different"
+        keyVaultNamespace: "keyvault.different"
         kmsProviders:
           aws: {} # Credentials filled in from environment.
     operations:
@@ -37,13 +37,13 @@ tests:
             listCollections: 1
             filter:
               name: "different"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: different
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find

--- a/source/client-side-encryption/etc/test-templates/replaceOne.yml.template
+++ b/source/client-side-encryption/etc/test-templates/replaceOne.yml.template
@@ -36,14 +36,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/types.yml.template
+++ b/source/client-side-encryption/etc/test-templates/types.yml.template
@@ -32,14 +32,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -80,14 +80,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -128,14 +128,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -202,14 +202,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -250,14 +250,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -324,14 +324,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -372,14 +372,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -420,14 +420,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/updateMany.yml.template
+++ b/source/client-side-encryption/etc/test-templates/updateMany.yml.template
@@ -37,14 +37,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/updateOne.yml.template
+++ b/source/client-side-encryption/etc/test-templates/updateOne.yml.template
@@ -36,14 +36,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {{key()["_id"]}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -83,7 +83,7 @@ Each YAML file has the following keys:
 
       - ``schemaMap``: Optional, a map from namespaces to local JSON schemas.
 
-      - ``keyVaultNamespace``: Optional, a namespace to the key vault collection. Defaults to "admin.datakeys".
+      - ``keyVaultNamespace``: Optional, a namespace to the key vault collection. Defaults to "keyvault.datakeys".
 
       - ``bypassAutoEncryption``: Optional, a boolean to indicate whether or not auto encryption should be bypassed. Defaults to ``false``.
 
@@ -124,8 +124,8 @@ Then for each element in ``tests``:
 #. If the ``skipReason`` field is present, skip this test completely.
 #. If the ``key_vault_data`` field is present:
 
-   #. Drop the ``admin.datakeys`` collection using writeConcern "majority".
-   #. Insert the data specified into the ``admin.datakeys`` with write concern "majority".
+   #. Drop the ``keyvault.datakeys`` collection using writeConcern "majority".
+   #. Insert the data specified into the ``keyvault.datakeys`` with write concern "majority".
 
 #. Create a MongoClient.
 
@@ -144,7 +144,7 @@ Then for each element in ``tests``:
 #. Create a **new** MongoClient using ``clientOptions``.
 
    #. If ``autoEncryptOpts`` includes ``aws`` as a KMS provider, pass in AWS credentials from the environment.
-   #. If ``autoEncryptOpts`` does not include ``keyVaultNamespace``, default it to ``admin.datakeys``.
+   #. If ``autoEncryptOpts`` does not include ``keyVaultNamespace``, default it to ``keyvault.datakeys``.
 
 #. For each element in ``operations``:
 
@@ -217,7 +217,7 @@ First, perform the setup.
 
 #. Create a MongoClient without encryption enabled (referred to as ``client``). Enable command monitoring to listen for command_started events.
 
-#. Using ``client``, drop the collections ``admin.datakeys`` and ``db.coll``.
+#. Using ``client``, drop the collections ``keyvault.datakeys`` and ``db.coll``.
 
 #. Create the following:
 
@@ -233,7 +233,7 @@ First, perform the setup.
           "local": { "key": <base64 decoding of LOCAL_MASTERKEY> }
       }
 
-   Configure both objects with ``keyVaultNamespace`` set to ``admin.datakeys``.
+   Configure both objects with ``keyVaultNamespace`` set to ``keyvault.datakeys``.
 
    Configure the ``MongoClient`` with the following ``schema_map``:
 
@@ -261,7 +261,7 @@ Then, test creating and using data keys from a ``local`` KMS provider:
 #. Call ``client_encryption.createDataKey()`` with the ``local`` KMS provider and keyAltNames set to ``["local_altname"]``.
 
    - Expect a BSON binary with subtype 4 to be returned, referred to as ``local_datakey_id``.
-   - Use ``client`` to run a ``find`` on ``admin.datakeys`` by querying with the ``_id`` set to the ``local_datakey_id``.
+   - Use ``client`` to run a ``find`` on ``keyvault.datakeys`` by querying with the ``_id`` set to the ``local_datakey_id``.
    - Expect that exactly one document is returned with the "masterKey.provider" equal to "local".
    - Check that ``client`` captured a command_started event for the ``insert`` command containing a majority writeConcern.
 
@@ -288,7 +288,7 @@ Then, repeat the above tests with the ``aws`` KMS provider:
 
 
    - Expect a BSON binary with subtype 4 to be returned, referred to as ``aws_datakey_id``.
-   - Use ``client`` to run a ``find`` on ``admin.datakeys`` by querying with the ``_id`` set to the ``aws_datakey_id``.
+   - Use ``client`` to run a ``find`` on ``keyvault.datakeys`` by querying with the ``_id`` set to the ``aws_datakey_id``.
    - Expect that exactly one document is returned with the "masterKey.provider" equal to "aws".
    - Check that ``client`` captured a command_started event for the ``insert`` command containing a majority writeConcern.
 
@@ -319,8 +319,8 @@ Run the following tests twice, parameterized by a boolean ``withExternalKeyVault
 
 #. Create a MongoClient without encryption enabled (referred to as ``client``).
 
-#. Using ``client``, drop the collections ``admin.datakeys`` and ``db.coll``.
-   Insert the document `external/external-key.json <../external/external-key.json>`_ into ``admin.datakeys``.
+#. Using ``client``, drop the collections ``keyvault.datakeys`` and ``db.coll``.
+   Insert the document `external/external-key.json <../external/external-key.json>`_ into ``keyvault.datakeys``.
 
 #. Create the following:
 
@@ -333,7 +333,7 @@ Run the following tests twice, parameterized by a boolean ``withExternalKeyVault
 
       { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
 
-   Configure both objects with ``keyVaultNamespace`` set to ``admin.datakeys``.
+   Configure both objects with ``keyVaultNamespace`` set to ``keyvault.datakeys``.
 
    Configure ``client_encrypted`` to use the schema `external/external-schema.json <../external/external-schema.json>`_  for ``db.coll`` by setting a schema map like: ``{ "db.coll": <contents of external-schema.json>}``
 
@@ -356,7 +356,7 @@ First, perform the setup.
 
 #. Using ``client``, drop and create the collection ``db.coll`` configured with the included JSON schema `limits/limits-schema.json <../limits/limits-schema.json>`_.
 
-#. Using ``client``, drop the collection ``admin.datakeys``. Insert the document `limits/limits-key.json <../limits/limits-key.json>`_
+#. Using ``client``, drop the collection ``keyvault.datakeys``. Insert the document `limits/limits-key.json <../limits/limits-key.json>`_
 
 #. Create a MongoClient configured with auto encryption (referred to as ``client_encrypted``)
 
@@ -366,7 +366,7 @@ First, perform the setup.
 
       { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
 
-   Configure with the ``keyVaultNamespace`` set to ``admin.datakeys``.
+   Configure with the ``keyVaultNamespace`` set to ``keyvault.datakeys``.
 
 Using ``client_encrypted`` perform the following operations:
 
@@ -422,7 +422,7 @@ Views are prohibited
 
       { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
 
-   Configure with the ``keyVaultNamespace`` set to ``admin.datakeys``.
+   Configure with the ``keyVaultNamespace`` set to ``keyvault.datakeys``.
 
 #. Using ``client_encrypted``, attempt to insert a document into ``db.view``. Expect an exception to be thrown containing the message: "cannot auto encrypt a view".
 
@@ -436,7 +436,7 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
 
 2. Using ``client``, drop and create the collection ``db.coll`` configured with the included JSON schema `corpus/corpus-schema.json <../corpus/corpus-schema.json>`_.
 
-3. Using ``client``, drop the collection ``admin.datakeys``. Insert the documents `corpus/corpus-key-local.json <../corpus/corpus-key-local.json>`_ and `corpus/corpus-key-aws.json <../corpus/corpus-key-aws.json>`_.
+3. Using ``client``, drop the collection ``keyvault.datakeys``. Insert the documents `corpus/corpus-key-local.json <../corpus/corpus-key-local.json>`_ and `corpus/corpus-key-aws.json <../corpus/corpus-key-aws.json>`_.
 
 4. Create the following:
 
@@ -458,7 +458,7 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
 
       Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk
 
-   Configure both objects with ``keyVaultNamespace`` set to ``admin.datakeys``.
+   Configure both objects with ``keyVaultNamespace`` set to ``keyvault.datakeys``.
 
 5. Load `corpus/corpus.json <../corpus/corpus.json>`_ to a variable named ``corpus``. The corpus contains subdocuments with the following fields:
 
@@ -523,7 +523,7 @@ Data keys created with AWS KMS may specify a custom endpoint to contact (instead
           "aws": { <AWS credentials> }
       }
 
-   Configure with ``keyVaultNamespace`` set to ``admin.datakeys``, and a default MongoClient as the ``keyVaultClient``.
+   Configure with ``keyVaultNamespace`` set to ``keyvault.datakeys``, and a default MongoClient as the ``keyVaultClient``.
 
 2. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
 
@@ -612,7 +612,7 @@ The following tests that setting ``mongocryptdBypassSpawn=true`` really does byp
 
       { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
 
-   Configure with the ``keyVaultNamespace`` set to ``admin.datakeys``.
+   Configure with the ``keyVaultNamespace`` set to ``keyvault.datakeys``.
 
    Configure ``client_encrypted`` to use the schema `external/external-schema.json <../external/external-schema.json>`_  for ``db.coll`` by setting a schema map like: ``{ "db.coll": <contents of external-schema.json>}``
 
@@ -643,7 +643,7 @@ The following tests that setting ``bypassAutoEncryption=true`` really does bypas
 
       { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
 
-   Configure with the ``keyVaultNamespace`` set to ``admin.datakeys``.
+   Configure with the ``keyVaultNamespace`` set to ``keyvault.datakeys``.
 
    Configure with ``bypassAutoEncryption=true``.
 

--- a/source/client-side-encryption/tests/aggregate.json
+++ b/source/client-side-encryption/tests/aggregate.json
@@ -157,7 +157,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -187,7 +187,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -280,7 +280,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -310,7 +310,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/aggregate.yml
+++ b/source/client-side-encryption/tests/aggregate.yml
@@ -35,14 +35,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -88,14 +88,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
     outcome:

--- a/source/client-side-encryption/tests/basic.json
+++ b/source/client-side-encryption/tests/basic.json
@@ -151,7 +151,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -181,7 +181,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -290,7 +290,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -320,7 +320,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/basic.yml
+++ b/source/client-side-encryption/tests/basic.yml
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -87,14 +87,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/bulk.json
+++ b/source/client-side-encryption/tests/bulk.json
@@ -185,7 +185,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -215,7 +215,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/bulk.yml
+++ b/source/client-side-encryption/tests/bulk.yml
@@ -44,14 +44,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/bypassAutoEncryption.json
+++ b/source/client-side-encryption/tests/bypassAutoEncryption.json
@@ -196,7 +196,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -369,7 +369,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/bypassAutoEncryption.yml
+++ b/source/client-side-encryption/tests/bypassAutoEncryption.yml
@@ -43,7 +43,7 @@ tests:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
     outcome:
@@ -89,7 +89,7 @@ tests:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
     outcome:

--- a/source/client-side-encryption/tests/count.json
+++ b/source/client-side-encryption/tests/count.json
@@ -156,7 +156,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -186,7 +186,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/count.yml
+++ b/source/client-side-encryption/tests/count.yml
@@ -33,14 +33,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/countDocuments.json
+++ b/source/client-side-encryption/tests/countDocuments.json
@@ -157,7 +157,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -187,7 +187,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/countDocuments.yml
+++ b/source/client-side-encryption/tests/countDocuments.yml
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/delete.json
+++ b/source/client-side-encryption/tests/delete.json
@@ -158,7 +158,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -188,7 +188,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -283,7 +283,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -313,7 +313,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/delete.yml
+++ b/source/client-side-encryption/tests/delete.yml
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -81,14 +81,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/distinct.json
+++ b/source/client-side-encryption/tests/distinct.json
@@ -168,7 +168,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -198,7 +198,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/distinct.yml
+++ b/source/client-side-encryption/tests/distinct.yml
@@ -36,14 +36,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/explain.json
+++ b/source/client-side-encryption/tests/explain.json
@@ -162,7 +162,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -192,7 +192,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/explain.yml
+++ b/source/client-side-encryption/tests/explain.yml
@@ -38,14 +38,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/find.json
+++ b/source/client-side-encryption/tests/find.json
@@ -167,7 +167,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -197,7 +197,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -309,7 +309,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -339,7 +339,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/find.yml
+++ b/source/client-side-encryption/tests/find.yml
@@ -35,14 +35,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -83,14 +83,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/findOneAndDelete.json
+++ b/source/client-side-encryption/tests/findOneAndDelete.json
@@ -155,7 +155,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -185,7 +185,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/findOneAndDelete.yml
+++ b/source/client-side-encryption/tests/findOneAndDelete.yml
@@ -33,14 +33,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/findOneAndReplace.json
+++ b/source/client-side-encryption/tests/findOneAndReplace.json
@@ -154,7 +154,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -184,7 +184,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/findOneAndReplace.yml
+++ b/source/client-side-encryption/tests/findOneAndReplace.yml
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/findOneAndUpdate.json
+++ b/source/client-side-encryption/tests/findOneAndUpdate.json
@@ -156,7 +156,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -186,7 +186,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/findOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/findOneAndUpdate.yml
@@ -34,14 +34,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/getMore.json
+++ b/source/client-side-encryption/tests/getMore.json
@@ -186,7 +186,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -216,7 +216,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/getMore.yml
+++ b/source/client-side-encryption/tests/getMore.yml
@@ -43,14 +43,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/insert.json
+++ b/source/client-side-encryption/tests/insert.json
@@ -138,7 +138,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -168,7 +168,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -265,7 +265,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -295,7 +295,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/insert.yml
+++ b/source/client-side-encryption/tests/insert.yml
@@ -30,14 +30,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -76,14 +76,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/keyAltName.json
+++ b/source/client-side-encryption/tests/keyAltName.json
@@ -138,7 +138,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -163,7 +163,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/keyAltName.yml
+++ b/source/client-side-encryption/tests/keyAltName.yml
@@ -30,14 +30,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {$or: [ { _id: { $in: [] } }, { keyAltNames: { $in: [ "altname" ] } } ] }
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/localKMS.json
+++ b/source/client-side-encryption/tests/localKMS.json
@@ -121,7 +121,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -151,7 +151,7 @@
                   }
                 ]
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "find"
           }

--- a/source/client-side-encryption/tests/localKMS.yml
+++ b/source/client-side-encryption/tests/localKMS.yml
@@ -31,14 +31,14 @@ tests:
           listCollections: 1
           filter:
             name: "datakeys"
-          $db: admin
+          $db: keyvault
         command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:
           find: datakeys
           filter: { $or: [ { _id: { $in: [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] } }, { keyAltNames: { $in: [] } } ] }
-          $db: admin
+          $db: keyvault
         command_name: find
     - command_started_event:
         command:

--- a/source/client-side-encryption/tests/localSchema.json
+++ b/source/client-side-encryption/tests/localSchema.json
@@ -143,7 +143,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -173,7 +173,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/localSchema.yml
+++ b/source/client-side-encryption/tests/localSchema.yml
@@ -30,14 +30,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/missingKey.json
+++ b/source/client-side-encryption/tests/missingKey.json
@@ -102,7 +102,7 @@
       "description": "Insert with encryption on a missing key",
       "clientOptions": {
         "autoEncryptOpts": {
-          "keyVaultNamespace": "admin.different",
+          "keyVaultNamespace": "keyvault.different",
           "kmsProviders": {
             "aws": {}
           }
@@ -147,7 +147,7 @@
               "filter": {
                 "name": "different"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -177,7 +177,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/missingKey.yml
+++ b/source/client-side-encryption/tests/missingKey.yml
@@ -11,7 +11,7 @@ tests:
   - description: "Insert with encryption on a missing key"
     clientOptions:
       autoEncryptOpts:
-        keyVaultNamespace: "admin.different"
+        keyVaultNamespace: "keyvault.different"
         kmsProviders:
           aws: {} # Credentials filled in from environment.
     operations:
@@ -37,13 +37,13 @@ tests:
             listCollections: 1
             filter:
               name: "different"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: different
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find

--- a/source/client-side-encryption/tests/replaceOne.json
+++ b/source/client-side-encryption/tests/replaceOne.json
@@ -155,7 +155,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -185,7 +185,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/replaceOne.yml
+++ b/source/client-side-encryption/tests/replaceOne.yml
@@ -36,14 +36,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/types.json
+++ b/source/client-side-encryption/tests/types.json
@@ -110,7 +110,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -140,7 +140,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -261,7 +261,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -291,7 +291,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -412,7 +412,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -442,7 +442,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -663,7 +663,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -693,7 +693,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -814,7 +814,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -844,7 +844,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -1064,7 +1064,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -1094,7 +1094,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -1221,7 +1221,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -1251,7 +1251,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }
@@ -1376,7 +1376,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -1406,7 +1406,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/types.yml
+++ b/source/client-side-encryption/tests/types.yml
@@ -32,14 +32,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -80,14 +80,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -128,14 +128,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -202,14 +202,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -250,14 +250,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -324,14 +324,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -372,14 +372,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:
@@ -420,14 +420,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/updateMany.json
+++ b/source/client-side-encryption/tests/updateMany.json
@@ -171,7 +171,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -201,7 +201,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/updateMany.yml
+++ b/source/client-side-encryption/tests/updateMany.yml
@@ -37,14 +37,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:

--- a/source/client-side-encryption/tests/updateOne.json
+++ b/source/client-side-encryption/tests/updateOne.json
@@ -157,7 +157,7 @@
               "filter": {
                 "name": "datakeys"
               },
-              "$db": "admin"
+              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }
@@ -187,7 +187,7 @@
                   }
                 ]
               },
-              "$db": "admin",
+              "$db": "keyvault",
               "readConcern": {
                 "level": "majority"
               }

--- a/source/client-side-encryption/tests/updateOne.yml
+++ b/source/client-side-encryption/tests/updateOne.yml
@@ -36,14 +36,14 @@ tests:
             listCollections: 1
             filter:
               name: "datakeys"
-            $db: admin
+            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
             find: datakeys
             filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
-            $db: admin
+            $db: keyvault
             readConcern: { level: "majority" }
           command_name: find
       - command_started_event:


### PR DESCRIPTION
Do not use the admin database for the key vault in FLE tests
because it cannot be dropped in sharded clusters in 4.4.

The change is entirely find-replace. I validated by syncing and running libmongoc's client side encryption tests.