### PR TITLE
SPEC-1666 Clarify the conditions for adding the retryable writes error label during transactions

### DIFF
--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -799,10 +799,10 @@ Why does the driver only add the RetryableWriteError label to errors that occur 
 
 The driver does this to maintain consistency with the MongoDB server.
 Servers that support the RetryableWriteError label (MongoDB version 4.4 and newer)
-only the label to an error when the operation is a retryable write (when it has
-a txnNumber). For the driver to add the label even if the operation was not a
-retryable write would be inconsistent with the server and potentially confusing
-to developers.
+only add the label to an error when the client has added a txnNumber to the 
+command, which only happens when the retryWrites option is true on the client.
+For the driver to add the label even if retryWrites is not true would be
+inconsistent with the server and potentially confusing to developers.
 
 Changes
 =======

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -1144,11 +1144,10 @@
             }
           },
           "result": {
-            "errorLabelsContain": [
-              "TransientTransactionError"
-            ],
+            "errorLabelsContain": [],
             "errorLabelsOmit": [
               "RetryableWriteError",
+              "TransientTransactionError",
               "UnknownTransactionCommitResult"
             ]
           }

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -1106,6 +1106,109 @@
       }
     },
     {
+      "description": "do not add RetryableWriteError label to writeConcernError ShutdownInProgress that occurs within transaction",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "writeConcernError": {
+            "code": 91,
+            "errmsg": "Replication is being shut down",
+            "errorLabels": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0",
+          "arguments": {
+            "options": {
+              "writeConcern": {
+                "w": "majority"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ],
+            "errorLabelsOmit": [
+              "RetryableWriteError",
+              "UnknownTransactionCommitResult"
+            ]
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "transaction-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
+    },
+    {
       "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed",
       "failPoint": {
         "configureFailPoint": "failCommand",

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -1118,10 +1118,7 @@
           ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -1174,8 +1174,7 @@
                 "$numberLong": "1"
               },
               "startTransaction": true,
-              "autocommit": false,
-              "writeConcern": null
+              "autocommit": false
             },
             "command_name": "insert",
             "database_name": "transaction-tests"
@@ -1190,11 +1189,10 @@
                 "$numberLong": "1"
               },
               "startTransaction": null,
-              "autocommit": false,
-              "writeConcern": null
+              "autocommit": false
             },
             "command_name": "abortTransaction",
-            "database_name": "transaction-tests"
+            "database_name": "admin"
           }
         }
       ],

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -465,7 +465,7 @@
       }
     },
     {
-      "description": "add TransientTransactionError label to connection errors",
+      "description": "add TransientTransactionError label to connection errors, but do not add RetryableWriteError label",
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {

--- a/source/transactions/tests/error-labels.json
+++ b/source/transactions/tests/error-labels.json
@@ -134,6 +134,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -223,6 +224,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -312,6 +314,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -497,6 +500,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -512,6 +516,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -534,6 +539,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }
@@ -550,6 +556,7 @@
               "TransientTransactionError"
             ],
             "errorLabelsOmit": [
+              "RetryableWriteError",
               "UnknownTransactionCommitResult"
             ]
           }

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -698,8 +698,8 @@ tests:
           document:
             _id: 1
         result:
-          errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
+          errorLabelsContain: []
+          errorLabelsOmit: ["RetryableWriteError", "TransientTransactionError", "UnknownTransactionCommitResult"]
       - name: abortTransaction
         object: session0
 

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -673,6 +673,69 @@ tests:
         data:
           - _id: 1
 
+  - description: do not add RetryableWriteError label to writeConcernError ShutdownInProgress that occurs within transaction
+
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["insert"]
+          writeConcernError:
+            code: 91
+            errmsg: Replication is being shut down
+            errorLabels: ["RetryableWriteError"]
+
+    operations:
+      - name: startTransaction
+        object: session0
+        arguments:
+          options:
+            writeConcern:
+              w: majority
+      - name: insertOne
+        object: collection
+        arguments:
+          session: session0
+          document:
+            _id: 1
+        result:
+          errorLabelsContain: ["TransientTransactionError"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
+      - name: abortTransaction
+        object: session0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+            ordered: true
+            readConcern:
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction: true
+            autocommit: false
+            writeConcern:
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            abortTransaction: 1
+            lsid: session0
+            txnNumber:
+              $numberLong: "1"
+            startTransaction:
+            autocommit: false
+            writeConcern:
+          command_name: abortTransaction
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data: []
+
   - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed
 
     failPoint:

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -716,7 +716,6 @@ tests:
               $numberLong: "1"
             startTransaction: true
             autocommit: false
-            writeConcern:
           command_name: insert
           database_name: *database_name
       - command_started_event:
@@ -727,9 +726,8 @@ tests:
               $numberLong: "1"
             startTransaction:
             autocommit: false
-            writeConcern:
           command_name: abortTransaction
-          database_name: *database_name
+          database_name: admin
 
     outcome:
       collection:

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -295,7 +295,7 @@ tests:
       collection:
         data: []
 
-  - description: add TransientTransactionError label to connection errors
+  - description: add TransientTransactionError label to connection errors, but do not add RetryableWriteError label
 
     failPoint:
       configureFailPoint: failCommand
@@ -315,6 +315,9 @@ tests:
             _id: 1
         result: &transient_label_only
           errorLabelsContain: ["TransientTransactionError"]
+          # While a connection error would normally be retryable, these are not because
+          # they occur within a transaction; ensure the driver does not add the
+          # RetryableWriteError label to these errors.
           errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
       - name: find
         object: collection

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -86,7 +86,7 @@ tests:
         result:
           # Note, the server will return the errorLabel in this case.
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
       - name: abortTransaction
         object: session0
 
@@ -143,7 +143,7 @@ tests:
         result:
           # Note, the server will return the errorLabel in this case.
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
       - name: abortTransaction
         object: session0
 
@@ -200,7 +200,7 @@ tests:
         result:
           # Note, the server will return the errorLabel in this case.
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
       - name: abortTransaction
         object: session0
 
@@ -315,7 +315,7 @@ tests:
             _id: 1
         result: &transient_label_only
           errorLabelsContain: ["TransientTransactionError"]
-          errorLabelsOmit: ["UnknownTransactionCommitResult"]
+          errorLabelsOmit: ["RetryableWriteError", "UnknownTransactionCommitResult"]
       - name: find
         object: collection
         arguments:

--- a/source/transactions/tests/error-labels.yml
+++ b/source/transactions/tests/error-labels.yml
@@ -683,7 +683,6 @@ tests:
           writeConcernError:
             code: 91
             errmsg: Replication is being shut down
-            errorLabels: ["RetryableWriteError"]
 
     operations:
       - name: startTransaction

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -712,9 +712,13 @@ commands in a transaction.
 In MongoDB 4.0 the only supported retryable write commands within a
 transaction are commitTransaction and abortTransaction. Therefore
 drivers MUST NOT retry write commands within transactions even when
-retryWrites has been enabled on the MongoClient. Drivers MUST retry the
-commitTransaction and abortTransaction commands even when retryWrites
-has been disabled on the MongoClient. commitTransaction and
+retryWrites has been enabled on the MongoClient. In addition, drivers MUST NOT
+add the RetryableWriteError label to any error that occurs during a write
+command within a transaction (excepting commitTransation and abortTransaction),
+even when retryWrites has been enabled on the MongoClient.
+
+Drivers MUST retry the commitTransaction and abortTransaction commands even when
+retryWrites has been disabled on the MongoClient. commitTransaction and
 abortTransaction are retryable write commands and MUST be retried
 according to the `Retryable Writes Specification`_.
 


### PR DESCRIPTION
Clarify that the RetryableWriteError label should not be added to errors that occur during writes within a transaction. @divjotarora did a POC and confirmed that these changes work in Go.