### PR TITLE
SPEC-1579 Add SDAM Monitoring rules for streaming heartbeat protocol

### DIFF
--- a/source/message/OP_MSG.rst
+++ b/source/message/OP_MSG.rst
@@ -250,11 +250,13 @@ responses will have the ``moreToCome`` bit set.
 MongoDB server only handles the ``exhaustAllowed`` bit on the following
 operations. A driver MUST NOT set the ``exhaustAllowed`` bit on other operations.
 
-============== ============================================================ 
+============== ============================================================
 Operation      Minimum MongoDB Version
-============== ============================================================ 
+============== ============================================================
 getMore        4.2
-============== ============================================================ 
+-------------- ------------------------------------------------------------
+isMaster       4.4 (discoverable via topologyVersion)
+============== ============================================================
 
 
 .. This RST artwork improves the readability of the rendered document

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst
@@ -14,7 +14,7 @@ SDAM Monitoring Specification
 :Status: Approved
 :Type: Standards
 :Minimum Server Version: 2.4
-:Last Modified: 12-Dec-2018
+:Last Modified: 20-April-2020
 
 .. contents::
 
@@ -120,6 +120,8 @@ Heartbeats
 ----------
 
 The driver MUST guarantee that every ServerHeartbeatStartedEvent has either a correlating ServerHeartbeatSucceededEvent or ServerHeartbeatFailedEvent.
+
+Drivers that use the streaming heartbeat protocol MUST publish a ServerHeartbeatStartedEvent before attempting to read the next isMaster exhaust response.
 
 Error Handling
 --------------
@@ -267,6 +269,11 @@ API
      */
     connectionId: ConnectionId;
 
+   /**
+     * Determines if this heartbeat event is for an awaitable isMaster.
+     */
+    awaited: Boolean;
+
   }
 
   /**
@@ -278,8 +285,11 @@ API
      * Returns the execution time of the event in the highest possible resolution for the platform.
      * The calculated value MUST be the time to send the message and receive the reply from the server,
      * including BSON serialization and deserialization. The name can imply the units in which the
-     * value is returned, i.e. durationMS, durationNanos. The time measurement used
-     * MUST be the same measurement used for the RTT calculation.
+     * value is returned, i.e. durationMS, durationNanos.
+     *
+     * When the awaited field is false, the time measurement used MUST be the
+     * same measurement used for the RTT calculation. When the awaited field is
+     * true, the time measurement is not used for RTT calculation.
      */
     duration: Int64;
 
@@ -294,6 +304,13 @@ API
      * The name of this field is flexible to match the object that is returned from the driver.
      */
     connectionId: ConnectionId;
+
+   /**
+     * Determines if this heartbeat event is for an awaitable isMaster. If
+     * true, then the duration field cannot be used for RTT calculation
+     * because the command blocks on the server.
+     */
+    awaited: Boolean;
 
   }
 
@@ -322,6 +339,13 @@ API
      * The name of this field is flexible to match the object that is returned from the driver.
      */
     connectionId: ConnectionId;
+
+   /**
+     * Determines if this heartbeat event is for an awaitable isMaster. If
+     * true, then the duration field cannot be used for RTT calculation
+     * because the command blocks on the server.
+     */
+    awaited: Boolean;
   }
 
   /**
@@ -403,6 +427,7 @@ See the `README <https://github.com/mongodb/specifications/server-discovery-and-
 Changelog
 =========
 
+- 20 APR 2020: Add rules for streaming heartbeat protocol and add "awaited" field to heartbeat events.
 - 12 DEC 2018: Clarified table of rules for readable/writable servers
 - 31 AUG 2016: Added table of rules for determining if topology has readable/writable servers.
 - 11 OCT 2016: TopologyDescription objects MAY have additional methods and properties.

--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -591,37 +591,18 @@ Error handling
 Network error during server check
 `````````````````````````````````
 
-When a server `check`_ fails due to a network error (including a network timeout),
-the client MUST clear its connection pool for the server:
+When a server `check`_ fails due to a network error (including a network
+timeout), the client MUST clear its connection pool for the server:
 if the monitor's socket is bad it is likely that all are.
 (See `JAVA-1252 <https://jira.mongodb.org/browse/JAVA-1252>`_).
 
-Once a server is connected, the client MUST change its type
-to Unknown
-only after it has retried the server once.
+If the server was in a known state before the error, the client MUST NOT sleep
+and MUST begin the next check immediately.
 (This rule applies to server checks during monitoring.
 It does *not* apply when multi-threaded
 `clients update the topology from each handshake`_.)
 
-In this pseudocode, "description" is the prior ServerDescription::
-
-    def checkServer(description):
-        try:
-            call ismaster
-            return new ServerDescription
-        except NetworkError as e0:
-            clear connection pool for the server
-
-            if description.type is Unknown or PossiblePrimary:
-                # Failed on first try to reach this server, give up.
-                return new ServerDescription with type=Unknown, error=e0
-            else:
-                # We've been connected to this server in the past, retry once.
-                try:
-                    reconnect and call ismaster
-                    return new ServerDescription
-                except NetworkError as e1:
-                    return new ServerDescription with type=Unknown, error=e1
+See the pseudocode in the `Monitor thread` section.
 
 (See `retry ismaster calls once`_ and
 `JAVA-1159 <https://jira.mongodb.org/browse/JAVA-1159>`_.)
@@ -929,17 +910,13 @@ Azure closes an idle connection in the application pool.
 Retry ismaster calls once
 '''''''''''''''''''''''''
 
-A monitor's connection to a server is long-lived
-and used only for ismaster calls.
-So if a server has responded in the past,
-a network error on the monitor's connection likely means there was
-a network glitch or a server restart since the last check,
-rather than that the server is down.
-Marking the server Unknown in this case costs unnecessary effort.
-
-However,
-if the server still doesn't respond when the monitor attempts to reconnect,
-then it is probably down.
+A monitor's connection to a server is long-lived and used only for ismaster
+calls. So if a server has responded in the past, a network error on the
+monitor's connection means that there was a network glitch, or a server restart
+since the last check, or that the server is truly down. To handle the case
+that the server is truly down, the monitor makes the server unselectable by
+marking it Unknown. To handle the case of a transient network glitch or
+restart, the Monitor immediately runs the next check without waiting.
 
 Why must streaming isMaster clients publish ServerHeartbeatStartedEvents?
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''

--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -506,19 +506,18 @@ responses strictly in the order they were received.)
 
 A client follows these rules when processing the isMaster exhaust response:
 
+- If the response indicates a command error, or a network error or timeout
+  occurs, the client MUST close the connection and restart the monitoring
+  protocol on a new connection. (See `Network error during server check`_ and
+  `Command error during server check`_.)
+- If the response omits topologyVersion, the client MUST close the connection
+  and restart the monitoring protocol on a new connection. This is an
+  unexpected state as 4.4+ servers always include topologyVersion.
 - If the response is successful (includes "ok:1") and includes the OP_MSG
   moreToCome flag, then the client begins reading the next response.
 - If the response is successful (includes "ok:1") and does not include the
   OP_MSG moreToCome flag, then the client initiates a new awaitable isMaster
   with the topologyVersion field from the previous response.
-- If the response omits topologyVersion, the client MUST exit the streaming
-  process and run a regular isMaster on the next check.
-- If the response indicates a command error, or a network error or
-  timeout occurs, the client MUST close the connection and wait
-  heartbeatFrequencyMS (or minHeartbeatFrequencyMS according to SDAM rules)
-  before restarting the isMaster protocol on a new connection. (See
-  `Network error during server check`_ and
-  `Command error during server check`_.)
 
 Socket timeout
 ``````````````

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -148,49 +148,145 @@ Streaming protocol Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Drivers that implement the streaming protocol (multi-threaded or
-asynchronous drivers) must implement the following tests:
+asynchronous drivers) must implement the following tests. Each test should be
+run against a standalone, replica set, and sharded cluster unless otherwise
+noted.
 
 Some of these cases should already be tested with the old protocol; in
 that case just verify the test cases succeed with the new protocol.
 
-1.  When the client sends an awaitable isMaster, cease all isMaster
-    replies while holding the connection open, using the waitInIsMaster
-    failpoint. Assert the client marks the server as Unknown after
-    approximately connectTimeoutMS+maxAwaitTimeMS.
+1.  Test that the Monitor does not time out sooner than
+    connectTimeoutMS+heartbeatFrequencyMS:
 
-2.  Same as above, but make mongod send ok: 0 in subsequent isMaster
+    #. Create a MongoClient with ``appName=monitorTimeoutTest``,
+       ``connectTimeoutMS=100``, and ``heartbeatFrequencyMS=500``.
+
+    #. Run an insert operation to prove the client has discovered the server.
+
+    #. Sleep for 2 seconds. This must be long enough for multiple heartbeats
+       to succeed.
+
+    #. Assert the client never marked the server Unknown and never cleared
+       the connection pool. If the Monitor had mistakenly neglected to set
+       the connection timeout to connectTimeoutMS+heartbeatFrequencyMS the
+       connection would have seen a timeout error after 100ms.
+
+    #. Run an insert operation to prove the server is still selectable.
+
+2.  Test that the Monitor times out after connectTimeoutMS+heartbeatFrequencyMS:
+
+    #. Create a MongoClient with ``appName=monitorTimeoutTest``,
+       ``connectTimeoutMS=100``, and ``heartbeatFrequencyMS=500``.
+
+    #. Run an insert operation to prove the client has discovered the server.
+
+    #. Configure the following failpoint to block isMaster replies longer
+       than connectTimeoutMS+heartbeatFrequencyMS::
+
+         db.adminCommand({
+             configureFailPoint: "failCommand",
+             mode: {times: 2},
+             data: {
+               failCommands: ["isMaster"],
+               blockConnection: true,
+               blockTimeMS: 700,
+             },
+         });
+
+    #. Assert the client marks the server as Unknown after
+       approximately connectTimeoutMS+maxAwaitTimeMS. For example, wait for
+       a ServerDescriptionChangedEvent that marks the server Unknown or wait
+       for a PoolClearEvent.
+
+    #. Assert the client rediscovers the server in the next second. For
+       example, wait for a ServerDescriptionChangedEvent where the server
+       changes from Unknown to Known.
+
+    #. Run an insert operation to prove the client has rediscovered the server.
+
+3.  Same as above, but make mongod send ok: 0 in subsequent isMaster
     replies (with the failCommand fail point). Assert the client
-    marks the server Unknown and closes the monitoring connection.
+    marks the server Unknown. If possible, assert that the Monitor closes the
+    monitoring connection.
 
-3.  When the client sends an awaitable isMaster, configure the server to
-    send ok: 1 but *without* the moreToCome bit set. Assert that the client
-    does not mark the server Unknown and immediately sends a new awaitable
-    isMaster on the next check.
+4.  Test that the Monitor handles ok: 1 but *without* the moreToCome flag set:
 
-4.  Configure the client with heartbeatFrequencyMS set to 500,
+    #. Create a MongoClient with ``connectTimeoutMS=100`` and
+       ``heartbeatFrequencyMS=500``.
+
+    #. Run an insert operation to prove the client has discovered the server.
+
+    #. Configure the server to not add the moreToCome flag via the
+       ``doNotSetMoreToCome`` failpoint::
+
+         db.adminCommand({
+             configureFailPoint: "doNotSetMoreToCome",
+             mode: {times: 1000},
+         });
+
+    #. Sleep for 2 seconds. This must be long enough for multiple heartbeats
+       to succeed.
+
+    #. Assert the client never marked the server Unknown and never cleared
+       the connection pool. If the Monitor had mistakenly neglected to handle
+       the missing moreToCome flag, then it would have timed out attempting
+       to read the the next response after
+       connectTimeoutMS+heartbeatFrequencyMS.
+
+    #. Run an insert operation to prove the server is still selectable.
+
+    #. Finally disable the doNotSetMoreToCome failpoint::
+
+         db.adminCommand({
+             configureFailPoint: "doNotSetMoreToCome",
+             mode: {times: 'off'},
+         });
+
+
+5.  Configure the client with heartbeatFrequencyMS set to 500,
     overriding the default of 10000. Assert the client processes
-    isMaster replies more frequently without waiting
-    minHeartbeatFrequencyMS.
+    isMaster replies more frequently (approximately every 500ms).
 
-5.  With a replica set. Configure the client to set heartbeatFrequencyMS
+6.  With a replica set. Configure the client to set heartbeatFrequencyMS
     to 5 minutes, overriding the default of 10000. Run
     replSetStepDown on the primary and assert the client discovers
     the new primary quickly.
 
-6.  Configure the server to hang up on all "find" commands (using the
+7.  Configure the server to hang up on all "find" commands (using the
     "failCommand" failpoint). Execute a find command and assert the
     client marks the server Unknown. (See "Network error when reading
     or writing" in the main design doc.)
 
-7.  Configure the server to hangup on all "ping" requests (with the
-    failCommand fail point). Then create a client and assert it
-    discovers the server and then marks the server Unknown when
-    "ping" fails.
+8.  Test that a MongoClient ignores errors from previous generations.
 
-8.  Issue a write from 2 threads using two connections at the same time.
-    Cause the server to hangup on both operations (using the
-    failCommand failpoint). Assert that the server is only reset to
-    Unknown once and the application pool is only cleared once.
+    #. Create a MongoClient with ``retryWrites=false``.
+
+    #. Run an insert operation to prove the client has discovered the server.
+
+    #. Configure the following failpoint to block insert command for 500ms
+       and then close the connection. Blocking the insert commands allows
+       both commands to be executed on connections from the same pool
+       generation::
+
+         db.adminCommand({
+             configureFailPoint: "failCommand",
+             mode: {times: 2},
+             data: {
+               failCommands: ["insert"],
+               closeConnection: true,
+               blockConnection: true,
+               blockTimeMS: 500,
+             },
+         });
+
+    #. Run 2 insertOne operations concurrently and assert that both operations
+       fail with network errors.
+
+    #. Assert that the server is reset to Unknown exactly once and the
+       application pool is cleared exactly once. For example, assert that
+       there was a single single ServerDescriptionChangedEvent that marks the server Unknown and a single PoolClearEvent.
+
+    #. Run an insert operation to prove the server is rediscovered.
 
 9.  Issue a write from 2 threads using two connections at the same time.
     Cause the server to fail both operations with a State Change

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -327,7 +327,10 @@ Run the following test(s) on MongoDB 4.4+.
          });
 
     #. Wait for the server's RTT to exceed 250ms. Eventually the average RTT
-       should also exceed 500ms but we use 250ms to speed up the test.
+       should also exceed 500ms but we use 250ms to speed up the test. Note
+       that the `Server Description Equality`_ means that
+       ServerDescriptionChangedEvents will not be published. This test may
+       need to use a driver specific helper to obtain the latest RTT instead.
 
     #. Disable the failpoint::
 
@@ -335,3 +338,7 @@ Run the following test(s) on MongoDB 4.4+.
              configureFailPoint: "failCommand",
              mode: "off",
          });
+
+.. Section for links.
+
+.. _Server Description Equality: /source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#server-description-equality

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -297,10 +297,12 @@ that case just verify the test cases succeed with the new protocol.
 RTT Tests
 ~~~~~~~~~
 
+Run the following test(s) on MongoDB 4.4+.
+
 1.  Test that RTT is continuously updated.
 
-    #. Create a client with  ``heartbeatFrequencyMS=500`` and subscribe to
-       server events.
+    #. Create a client with  ``heartbeatFrequencyMS=500``,
+       ``appName=streamingRttTest``, and subscribe to server events.
 
     #. Run a find command to wait for the server to be discovered.
 
@@ -319,11 +321,13 @@ RTT Tests
              data: {
                failCommands: ["isMaster"],
                blockConnection: true,
-               blockTimeMS: 250,
+               blockTimeMS: 500,
+               appName: "streamingRttTest",
              },
          });
 
-    #. Wait for the server's RTT to exceed 250ms.
+    #. Wait for the server's RTT to exceed 250ms. Eventually the average RTT
+       should also exceed 500ms but we use 250ms to speed up the test.
 
     #. Disable the failpoint::
 

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -6,8 +6,8 @@ The YAML and JSON files in this directory tree are platform-independent tests
 that drivers can use to prove their conformance to the
 Server Discovery And Monitoring Spec.
 
-Additional prose tests, that cannot represented as spec tests, are described
-and MUST be implemented.
+Additional prose tests, that cannot be represented as spec tests, are
+described and MUST be implemented.
 
 Version
 -------
@@ -141,7 +141,7 @@ Continue until all phases have been executed.
 Prose Tests
 -----------
 
-The following prose tests cannot represented as spec tests and MUST be
+The following prose tests cannot be represented as spec tests and MUST be
 implemented.
 
 Streaming protocol Tests


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/SPEC-1579

Summary:
- Clients stream isMaster responses from the server with OP_MSG exhaust to
reduce the time to recovery after server maintenance.
- Add "awaited" field to heartbeat events.
- Add section for awaitable isMaster server spec.
- Add section for SDAM prose tests.
- Update OP_MSG exhaustAllowed to mention isMaster.

I am working on converting some of the prose tests into a spec tests in the transaction runner format. 