### PR TITLE
SPEC-1676 Add support for hidden option to index creation

### DIFF
--- a/source/index-management.rst
+++ b/source/index-management.rst
@@ -782,6 +782,15 @@ Common API Components
      * Optionally specifies the wildcard projection of a wildcard index.
      */
     wildcardProjection: Document;
+
+    /**
+     * Optionally specifies that the index should exist on the target collection but should not be used by the query
+     * planner when executing operations.
+     *
+     * This option is only supported by servers >= 4.4. For servers < 3.4, drivers MUST raise an error if the caller
+     * explicitly provides a value.
+     */
+    hidden: Boolean;
   }
 
 ---------

--- a/source/index-management.rst
+++ b/source/index-management.rst
@@ -787,8 +787,7 @@ Common API Components
      * Optionally specifies that the index should exist on the target collection but should not be used by the query
      * planner when executing operations.
      *
-     * This option is only supported by servers >= 4.4. For servers < 3.4, drivers MUST raise an error if the caller
-     * explicitly provides a value.
+     * This option is only supported by servers >= 4.4.
      */
     hidden: Boolean;
   }


### PR DESCRIPTION
A few things I wasn't sure of:

1. The `hidden` property for an index can be changed via the `collMod` command. I don't see any references to it in our existing specs, so I didn't mention this anywhere. Is a note in the resulting DRIVERS ticket sufficient so that any drivers with `collMod` helpers can update accordingly?

2. The `hidden` property is now returned in the `listIndexes` results documents. An example is `{v: 2, key: {x: 1}, hidden: true}`. This might affect drivers that have helper types for `listIndexes` results, but I don't see any other index options mentioned in https://github.com/mongodb/specifications/blob/master/source/enumerate-indexes.rst#getting-full-index-information, so I didn't make any edits to that spec.