### PR TITLE
SPEC-1659 add explicit readPreference to test

### DIFF
--- a/source/uri-options/tests/read-preference-options.json
+++ b/source/uri-options/tests/read-preference-options.json
@@ -23,7 +23,7 @@
     },
     {
       "description": "Single readPreferenceTags is parsed as array of size one",
-      "uri": "mongodb://example.com/?readPreferenceTags=dc:ny",
+      "uri": "mongodb://example.com/?readPreference=secondary&readPreferenceTags=dc:ny",
       "valid": true,
       "warning": false,
       "hosts": null,

--- a/source/uri-options/tests/read-preference-options.yml
+++ b/source/uri-options/tests/read-preference-options.yml
@@ -17,7 +17,7 @@ tests:
             maxStalenessSeconds: 120
     -
         description: "Single readPreferenceTags is parsed as array of size one"
-        uri: "mongodb://example.com/?readPreferenceTags=dc:ny"
+        uri: "mongodb://example.com/?readPreference=secondary&readPreferenceTags=dc:ny"
         valid: true
         warning: false
         hosts: ~


### PR DESCRIPTION
libmongoc gives an error when parsing the URI `mongodb://example.com/?readPreferenceTags=dc:ny` because no explicit readPreference is considered a primary read preference. And a primary read preference is invalid with tags.

@ShaneHarvey pymongo is passing this test, because I think read preference validation won't occur at URI parse time, but at client construction time. E.g.
```
# This succeeds:
parsed = uri_parser.parse_uri ("mongodb://localhost/?readPreferenceTags=dc:ny")
# This errors:
client = MongoClient("mongodb://localhost/?readPreferenceTags=dc:ny")
```

I'm not totally sure what the behavior should be for that URI. I made the non-controversial change here to add an explicit readPreference to the test. I plan to create a DRIVERS ticket to consider what should happen for this URI. Some thoughts:

The URI options spec says for readPreferenceTags:
> only valid if the read preference mode is not primary

So that indicates we should consider it invalid. But then this  would be a breaking change for drivers like pymongo that do not validate until usage, right? And the URI option specs is pretty explicit about not making breaking changes:

> THIS SPEC DOES NOT REQUIRE DRIVERS TO MAKE ANY BREAKING CHANGES.

And similarly, the [connection string spec's rationale for warnings instead of exceptions](https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.rst#qa), argues that connection strings should be portable across drivers.

So perhaps the thing to do there is make it a warning if a user specifies readPreferenceTags with readPreference=primary or no explicit readPreference?