### PR TITLE
Add coefficient encoding detail to Decimal128 specification

### DIFF
--- a/source/bson-decimal128/decimal128.rst
+++ b/source/bson-decimal128/decimal128.rst
@@ -76,7 +76,9 @@ Clamping:
 
 Binary Integer Decimal (BID):
    MongoDB uses this binary encoding for the coefficient as specified in ``IEEE
-   754-2008``. The byte order is little-endian, like the rest of the BSON types.
+   754-2008`` section 3.5.2 using method 2 "binary encoding" rather than method 1
+   "decimal encoding". The byte order is little-endian, like the rest of the BSON
+   types.
 
 
 Value Object:
@@ -95,9 +97,12 @@ BSON Decimal128 implementation details
 
 The ``BSON Decimal128`` data type implements the `Decimal Arithmetic Encodings
 <http://speleotrove.com/decimal/decbits.html>`_ specification, with certain
-exceptions around value integrity.  When a value cannot be represented exactly,
-the value will be rejected.
+exceptions around value integrity and the coefficient encoding.  When a value
+cannot be represented exactly, the value will be rejected.
 
+The coefficient MUST be stored as an unsigned binary integer (BID) rather than
+the densely-packed decimal (DPD) shown in the specification. See either the 
+`IEEE Std 754-2008` spec or the driver examples for further detail.
 
 The specification defines several statuses which are meant to signal
 exceptional `circumstances <http://speleotrove.com/decimal/daexcep.html>`_,


### PR DESCRIPTION
The current decimal128 spec mentions that it is based on IEEE 754-2008. That standard allows the coefficient to be encoded in one of two ways:

1. "decimal encoding" using 10-bit declets for groups of 3 digits. This method is also called Densely Packed Decimal (DPD).
2. "binary encoding" using a simple unsigned integer number (BID).

The specification sheet later formally declares that the BSON encoding is based on "Decimal Arithmetic Encodings" (http://speleotrove.com/decimal/decbits.html) which only allows for the coefficient to be encoded as DPD (method 1). To quote from that document:

> coefficient continuation
>
> The remaining, less significant, digits of the coefficient. The coefficient continuation is a multiple of 10 bits (the multiple depending on the format), and the most significant group is on the left (is placed first).
> 
> Each 10-bit group represents three decimal digits, using Densely Packed Decimal encoding.[1]

However, the drivers, and the MongoDB server itself don't do this. They actually use the BID method. For example in the `libbson` code:

https://github.com/mongodb/libbson/blob/master/src/bson/bson-decimal128.c#L215

So, the changes in this PR explicitly let the reader know of which encoding is used and that it differs from the referenced "Decimal Arithmetic Encodings" document.

Also see ref #258

Side note: unfortunately, the IEEE document costs $104 USD and is legally restricted from public distribution; so the reference is of limited value to some.

