### PR TITLE
SPEC-1687 Add SDAM isMaster cancellation test

### DIFF
--- a/source/server-discovery-and-monitoring/tests/integration/cancel-server-check.json
+++ b/source/server-discovery-and-monitoring/tests/integration/cancel-server-check.json
@@ -1,0 +1,130 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.0",
+      "topology": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.2",
+      "topology": [
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "cancel-server-check",
+  "data": [],
+  "tests": [
+    {
+      "description": "Cancel server check",
+      "clientOptions": {
+        "retryWrites": true,
+        "heartbeatFrequencyMS": 10000,
+        "serverSelectionTimeoutMS": 5000,
+        "appname": "cancelServerCheckTest"
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 3
+            }
+          },
+          "result": {
+            "insertedId": 3
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 1
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 1
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/integration/cancel-server-check.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/cancel-server-check.yml
@@ -1,0 +1,96 @@
+# Test SDAM error handling.
+runOn:
+  # General failCommand requirements (this file does not use appName
+  # with failCommand).
+  - minServerVersion: "4.0"
+    topology: ["replicaset"]
+  - minServerVersion: "4.2"
+    topology: ["sharded"]
+
+database_name: &database_name "sdam-tests"
+collection_name: &collection_name "cancel-server-check"
+
+data: []
+
+tests:
+  - description: Cancel server check
+    clientOptions:
+      retryWrites: true
+      heartbeatFrequencyMS: 10000
+      # Server selection timeout MUST be less than heartbeatFrequencyMS for
+      # this test. This setting ensures that the retried insert will fail
+      # after 5 seconds if the driver does not properly cancel the in progress
+      # check.
+      serverSelectionTimeoutMS: 5000
+      appname: cancelServerCheckTest
+    operations:
+      # Perform an operation to ensure the node is discovered.
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 1
+      # Configure the next inserts to fail with a non-timeout network error.
+      # This should:
+      # 1) Mark the server Unknown
+      # 2) Clear the connection pool
+      # 3) Cancel the in progress isMaster check and close the Monitor
+      #    connection
+      # 4) The write will be then we retried, server selection will request an
+      #    immediate check, and block for ~500ms until the next Monitor check
+      #    proceeds.
+      # 5) The write will succeed on the second attempt.
+      - name: configureFailPoint
+        object: testRunner
+        arguments:
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+                failCommands: ["insert"]
+                closeConnection: True
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 2
+        result:
+          insertedId: 2
+      # The first error should mark the server Unknown and then clear the pool.
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          event: ServerMarkedUnknownEvent
+          count: 1
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          event: PoolClearedEvent
+          count: 1
+      # Perform another operation to ensure the node still selectable.
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: 3
+        result:
+          insertedId: 3
+      # Assert the server was marked Unknown and pool was cleared exactly once.
+      - name: assertEventCount
+        object: testRunner
+        arguments:
+          event: ServerMarkedUnknownEvent
+          count: 1
+      - name: assertEventCount
+        object: testRunner
+        arguments:
+          event: PoolClearedEvent
+          count: 1
+
+    # Order of operations is non-deterministic so we cannot check events.
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+          - {_id: 3}


### PR DESCRIPTION
This change adds `tests/integration/cancel-server-check.yml`. This test verifies the "isMaster Cancellation" section of the spec. If a driver mistakenly did not cancel the isMaster check, the server would remain in the Unknown state for 10 seconds (until the in-progress streaming isMaster checks succeeds)  and thus the retried "insertOne" would fail during server selection (serverSelectionTimeoutMS=5000).

I have verified that the test succeeds in Python (https://evergreen.mongodb.com/version/5eb9d90a0ae6063d1374c3e1). I've also verified that the test fails when the cancellation logic is removed.