### PR TITLE
Include rationale for why we don't use `awaitedTimeMS` for RTT

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -8,7 +8,7 @@ Server Discovery And Monitoring
 :Advisors: David Golden, Craig Wilson
 :Status: Accepted
 :Type: Standards
-:Version: 2.17
+:Version: 2.18
 :Last Modified: 2020-05-07
 
 .. contents::
@@ -1296,7 +1296,7 @@ unusable. These are called "node is recovering" errors:
     - Error Code
   * - InterruptedAtShutdown
     - 11600
-  * - InterruptedDueToReplStateChange 
+  * - InterruptedDueToReplStateChange
     - 11602
   * - NotMasterOrSecondary
     - 13436


### PR DESCRIPTION
Most developers confronted with the problem of calculating the RTT of an awaited isMaster ultimately have a similar "eureka" moment: "why aren't we just returning the milliseconds awaited on the server!?" Hopefully this rationale saves future implementers from spending too much time down that seemingly virtuous path.