### PR TITLE
make minor clarifications to server monitoring

### DIFF
--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -540,8 +540,8 @@ Clients MUST update the RTT from the isMaster duration of the initial
 connection handshake. Clients MUST NOT update RTT based on streaming isMaster
 responses.
 
-Errors encountered when running a "isMaster" command MUST NOT update the
-topology.
+Clients MUST ignore the response to the isMaster command when measuring RTT.
+Errors encountered when running a isMaster command MUST NOT update the topology.
 (See `Why don't clients mark a server unknown when an RTT command fails?`_)
 
 When constructing a ServerDescription from a streaming isMaster response,

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -272,7 +272,7 @@ MongoClient has published a specific event a given number of times. For
 example, the following instructs the test runner to assert that a single
 PoolClearedEvent was published::
 
-      - name: waitForEvent
+      - name: assertEventCount
         object: testRunner
         arguments:
           event: PoolClearedEvent

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.yml
@@ -27,7 +27,7 @@ tests:
       appname: commandErrorHandshakeTest
     operations:
       # The command error on the initial handshake should mark the server
-      # Unknown and clear the pool.
+      # Unknown (emitting a ServerDescriptionChangedEvent) and clear the pool.
       - name: waitForEvent
         object: testRunner
         arguments:

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.yml
@@ -26,7 +26,7 @@ tests:
       appname: networkErrorHandshakeTest
     operations:
       # The network error on the initial handshake should mark the server
-      # Unknown and clear the pool.
+      # Unknown (emitting a ServerDescriptionChangedEvent) and clear the pool.
       - name: waitForEvent
         object: testRunner
         arguments:

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-timeout.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-timeout.yml
@@ -27,7 +27,7 @@ tests:
       appname: timeoutMonitorHandshakeTest
     operations:
       # The network error on the initial handshake should mark the server
-      # Unknown and clear the pool.
+      # Unknown (emitting a ServerDescriptionChangedEvent) and clear the pool.
       - name: waitForEvent
         object: testRunner
         arguments:


### PR DESCRIPTION
- Note that the RTT monitor should ignore the ismaster response.
- Typo fix in test readme example "waitForEvent" => "assertEventCount".
- Note in tests that a ServerChangedEvent is expected in the beginning.