### PR TITLE
fix: ensure viable servers are used for latency window calculation

### DIFF
--- a/source/server-selection/tests/server_selection/ReplicaSetWithPrimary/read/Nearest.json
+++ b/source/server-selection/tests/server_selection/ReplicaSetWithPrimary/read/Nearest.json
@@ -4,7 +4,7 @@
     "servers": [
       {
         "address": "b:27017",
-        "avg_rtt_ms": 5,
+        "avg_rtt_ms": 21,
         "type": "RSSecondary",
         "tags": {
           "data_center": "nyc"
@@ -20,8 +20,16 @@
       },
       {
         "address": "a:27017",
-        "avg_rtt_ms": 26,
+        "avg_rtt_ms": 37,
         "type": "RSPrimary",
+        "tags": {
+          "data_center": "nyc"
+        }
+      },
+      {
+        "address": "d:27017",
+        "avg_rtt_ms": 5,
+        "type": "RSOther",
         "tags": {
           "data_center": "nyc"
         }
@@ -40,7 +48,7 @@
   "suitable_servers": [
     {
       "address": "b:27017",
-      "avg_rtt_ms": 5,
+      "avg_rtt_ms": 21,
       "type": "RSSecondary",
       "tags": {
         "data_center": "nyc"
@@ -48,7 +56,7 @@
     },
     {
       "address": "a:27017",
-      "avg_rtt_ms": 26,
+      "avg_rtt_ms": 37,
       "type": "RSPrimary",
       "tags": {
         "data_center": "nyc"
@@ -66,7 +74,7 @@
   "in_latency_window": [
     {
       "address": "b:27017",
-      "avg_rtt_ms": 5,
+      "avg_rtt_ms": 21,
       "type": "RSSecondary",
       "tags": {
         "data_center": "nyc"

--- a/source/server-selection/tests/server_selection/ReplicaSetWithPrimary/read/Nearest.yml
+++ b/source/server-selection/tests/server_selection/ReplicaSetWithPrimary/read/Nearest.yml
@@ -3,7 +3,7 @@ topology_description:
   servers:
   - &1
     address: b:27017
-    avg_rtt_ms: 5
+    avg_rtt_ms: 21
     type: RSSecondary
     tags:
       data_center: nyc
@@ -15,8 +15,13 @@ topology_description:
       data_center: nyc
   - &2
     address: a:27017
-    avg_rtt_ms: 26
+    avg_rtt_ms: 37
     type: RSPrimary
+    tags:
+      data_center: nyc
+  - address: d:27017
+    avg_rtt_ms: 5
+    type: RSOther
     tags:
       data_center: nyc
 operation: read

--- a/source/server-selection/tests/server_selection/ReplicaSetWithPrimary/read/Secondary.json
+++ b/source/server-selection/tests/server_selection/ReplicaSetWithPrimary/read/Secondary.json
@@ -4,7 +4,7 @@
     "servers": [
       {
         "address": "b:27017",
-        "avg_rtt_ms": 5,
+        "avg_rtt_ms": 21,
         "type": "RSSecondary",
         "tags": {
           "data_center": "nyc"
@@ -20,7 +20,7 @@
       },
       {
         "address": "a:27017",
-        "avg_rtt_ms": 26,
+        "avg_rtt_ms": 5,
         "type": "RSPrimary",
         "tags": {
           "data_center": "nyc"
@@ -40,7 +40,7 @@
   "suitable_servers": [
     {
       "address": "b:27017",
-      "avg_rtt_ms": 5,
+      "avg_rtt_ms": 21,
       "type": "RSSecondary",
       "tags": {
         "data_center": "nyc"
@@ -58,7 +58,7 @@
   "in_latency_window": [
     {
       "address": "b:27017",
-      "avg_rtt_ms": 5,
+      "avg_rtt_ms": 21,
       "type": "RSSecondary",
       "tags": {
         "data_center": "nyc"

--- a/source/server-selection/tests/server_selection/ReplicaSetWithPrimary/read/Secondary.yml
+++ b/source/server-selection/tests/server_selection/ReplicaSetWithPrimary/read/Secondary.yml
@@ -3,18 +3,18 @@ topology_description:
   servers:
   - &1
     address: b:27017
-    avg_rtt_ms: 5
+    avg_rtt_ms: 21 # outside the latency window if primary is considered
     type: RSSecondary
     tags:
       data_center: nyc
   - &2
     address: c:27017
-    avg_rtt_ms: 100
+    avg_rtt_ms: 100 # outside the latency window if both secondaries are considered
     type: RSSecondary
     tags:
       data_center: nyc
   - address: a:27017
-    avg_rtt_ms: 26
+    avg_rtt_ms: 5
     type: RSPrimary
     tags:
       data_center: nyc


### PR DESCRIPTION
By slightly modifying these two tests we can ensure only viable servers are used to calculate the latency window. In the first set the RTT values are slightly modified such that only the RSSecondary servers are used to calculate the latency window. In the second case we introduce an RSOther server, and ensure that its RTT is not used for the latency window calculation.

SPEC-1694