### PR TITLE
SPEC-1700: Remove reference to addSpecial

### DIFF
--- a/source/driver-read-preferences.rst
+++ b/source/driver-read-preferences.rst
@@ -336,7 +336,7 @@ Read Preference Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Applications may set mode and/or tag sets on a per-operation basis similar to
-how ``addSpecial``, ``hint``, or ``batchSize`` are set. E.g., in Python::
+how ``hint`` or ``batchSize`` are set. E.g., in Python::
 
     db.collection.find({}).read_preference(ReadPreference.SECONDARY)
     db.collection.find({}).read_preference(ReadPreference.NEAREST, [ {'dc': 'ny'} ])

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -565,8 +565,7 @@ specific object takes precedence.  I.e. ``Collection`` is preferred over
 ``Database``, which is preferred over ``MongoClient``.
 
 Drivers MAY allow users to set a read preference on queries on a per-operation
-basis similar to how ``addSpecial``, ``hint``, or ``batchSize`` are set. E.g.,
-in Python::
+basis similar to how ``hint`` or ``batchSize`` are set. E.g., in Python::
 
     db.collection.find({}, read_preference=ReadPreference.SECONDARY)
     db.collection.find(


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1700

addSpecial referred to a generic method for assigning query modifiers for OP_QUERY, which is no longer relevant to the find command API.