### PR TITLE
SPEC-1705 Support connectTimeoutMS=0 in streaming heartbeat protocol

### DIFF
--- a/source/server-discovery-and-monitoring/tests/integration/connectTimeoutMS.json
+++ b/source/server-discovery-and-monitoring/tests/integration/connectTimeoutMS.json
@@ -1,0 +1,148 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "database_name": "sdam-tests",
+  "collection_name": "connectTimeoutMS",
+  "data": [],
+  "tests": [
+    {
+      "description": "connectTimeoutMS=0",
+      "clientOptions": {
+        "retryWrites": false,
+        "connectTimeoutMS": 0,
+        "heartbeatFrequencyMS": 500,
+        "appname": "connectTimeoutMS=0"
+      },
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 1
+              },
+              {
+                "_id": 2
+              }
+            ]
+          }
+        },
+        {
+          "name": "configureFailPoint",
+          "object": "testRunner",
+          "arguments": {
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "isMaster"
+                ],
+                "appName": "connectTimeoutMS=0",
+                "blockConnection": true,
+                "blockTimeMS": 550
+              }
+            }
+          }
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 750
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "ServerMarkedUnknownEvent",
+            "count": 0
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "event": "PoolClearedEvent",
+            "count": 0
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "connectTimeoutMS",
+              "documents": [
+                {
+                  "_id": 1
+                },
+                {
+                  "_id": 2
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "connectTimeoutMS",
+              "documents": [
+                {
+                  "_id": 3
+                },
+                {
+                  "_id": 4
+                }
+              ]
+            },
+            "command_name": "insert",
+            "database_name": "sdam-tests"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/integration/connectTimeoutMS.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/connectTimeoutMS.yml
@@ -1,0 +1,88 @@
+# Test SDAM error handling.
+runOn:
+    # failCommand appName requirements
+    - minServerVersion: "4.4"
+
+database_name: &database_name "sdam-tests"
+collection_name: &collection_name "connectTimeoutMS"
+
+data: []
+
+tests:
+  - description: connectTimeoutMS=0
+    clientOptions:
+      retryWrites: false
+      connectTimeoutMS: 0
+      heartbeatFrequencyMS: 500
+      appname: connectTimeoutMS=0
+    operations:
+      # Perform an operation to ensure the node is discovered.
+      - name: insertMany
+        object: collection
+        arguments:
+          documents:
+            - _id: 1
+            - _id: 2
+      # Block the next streaming isMaster check for longer than
+      # heartbeatFrequencyMS to ensure that the connection timeout remains
+      # unlimited.
+      - name: configureFailPoint
+        object: testRunner
+        arguments:
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+                failCommands: ["isMaster"]
+                appName: connectTimeoutMS=0
+                blockConnection: true
+                blockTimeMS: 550
+      - name: wait
+        object: testRunner
+        arguments:
+          ms: 750
+      # Perform an operation to ensure the node is still selectable.
+      - name: insertMany
+        object: collection
+        arguments:
+          documents:
+            - _id: 3
+            - _id: 4
+      # Assert that the server was never marked Unknown and the pool was never
+      # cleared.
+      - name: assertEventCount
+        object: testRunner
+        arguments:
+          event: ServerMarkedUnknownEvent
+          count: 0
+      - name: assertEventCount
+        object: testRunner
+        arguments:
+          event: PoolClearedEvent
+          count: 0
+
+    expectations:
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 1
+              - _id: 2
+          command_name: insert
+          database_name: *database_name
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - _id: 3
+              - _id: 4
+          command_name: insert
+          database_name: *database_name
+
+    outcome:
+      collection:
+        data:
+          - {_id: 1}
+          - {_id: 2}
+          - {_id: 3}
+          - {_id: 4}


### PR DESCRIPTION
Jira: [SPEC-1705](https://jira.mongodb.org/browse/SPEC-1705)

The test passes in Python. I've also verified that the test will fail if a driver incorrectly sets a timeout on the connectTimeoutMS=0 connection. For example the failure in python would be:
```
FAIL: test_discovery_and_monitoring_integration_connectTimeoutMS_connectTimeoutMS=0 (test.test_discovery_and_monitoring.TestIntegration)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/shane/git/mongo-python-driver/test/__init__.py", line 449, in wrap
    return f(*args, **kwargs)
  File "/Users/shane/git/mongo-python-driver/test/__init__.py", line 449, in wrap
    return f(*args, **kwargs)
  File "/Users/shane/git/mongo-python-driver/test/test_discovery_and_monitoring.py", line 409, in run_scenario
    self.run_scenario(scenario_def, test)
  File "/Users/shane/git/mongo-python-driver/test/utils_spec_runner.py", line 641, in run_scenario
    self.run_test_ops(sessions, collection, test)
  File "/Users/shane/git/mongo-python-driver/test/utils_spec_runner.py", line 547, in run_test_ops
    self.run_operations(sessions, collection, test['operations'])
  File "/Users/shane/git/mongo-python-driver/test/utils_spec_runner.py", line 458, in run_operations
    self._run_op(sessions, collection, op, in_with_transaction)
  File "/Users/shane/git/mongo-python-driver/test/utils_spec_runner.py", line 448, in _run_op
    result = self.run_operation(sessions, collection, op.copy())
  File "/Users/shane/git/mongo-python-driver/test/utils_spec_runner.py", line 393, in run_operation
    result = cmd(**dict(arguments))
  File "/Users/shane/git/mongo-python-driver/test/test_discovery_and_monitoring.py", line 337, in assert_event_count
    self.assertEqual(self._event_count(event), count)
AssertionError: 3 != 0
```