### PR TITLE
Add heartbeatFrequencyMS default value for retryable read/writes and transaction tests.

### DIFF
--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -148,7 +148,7 @@ data.
 .. _GridFSBucket spec: https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#configurable-gridfsbucket-class
     
 Speeding Up Tests
------------------
+===================
 
 Drivers may benefit reducing `minHeartbeatFrequencyMS`_ in order to speed up
 tests. Python was able to decrease the run time of the tests greatly by lowering

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -156,6 +156,9 @@ the SDAM's ``minHeartbeatFrequencyMS`` from 500ms to 50ms, thus decreasing the
 waiting time after a "not master" error:
 
 .. _minHeartbeatFrequencyMS: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#minheartbeatfrequencyms
+
+Drivers should set the default heartbeatFrequencyMS to 5ms in order to take into account the latest changes regarding streaming protocol. If a test has an explicit heartbeatFrequencyMS value, drivers should use the explicit value.
+
 Optional Enumeration Commands
 =============================
 
@@ -171,3 +174,5 @@ Changelog
              now expressed within ``runOn`` elements.
 
              Add test-level ``useMultipleMongoses`` field.
+
+:2020-06-12: Add the default value for heartbeatFrequencyMS.

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -150,15 +150,13 @@ data.
 Speeding Up Tests
 -----------------
 
-Drivers may benefit reducing `minHeartbeatFrequencyMS`_ in order to speed up
-tests. Python was able to decrease the run time of the tests greatly by lowering
-the SDAM's ``minHeartbeatFrequencyMS`` from 500ms to 50ms, thus decreasing the
-waiting time after a "not master" error:
+Drivers can greatly reduce the execution time of tests by setting `heartbeatFrequencyMS`_
+and `minHeartbeatFrequencyMS`_ (internally) to a small value (e.g. 5ms), below what
+is normally permitted in the SDAM spec. If a test specifies an explicit value for
+heartbeatFrequencyMS (e.g. client or URI options), drivers SHOULD use that value.
 
-Also, similar improvement can be added for `heartbeatFrequencyMS`_ by setting the default heartbeatFrequencyMS to 5ms in order to take into account the latest changes regarding streaming protocol. If a test has an explicit heartbeatFrequencyMS value, drivers should use the explicit value.
-
-.. _minHeartbeatFrequencyMS: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#minheartbeatfrequencyms	
-.. _heartbeatFrequencyMS: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#heartbeatfrequencyms
+.. _minHeartbeatFrequencyMS: ../../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#minheartbeatfrequencyms
+.. _heartbeatFrequencyMS: ../../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#heartbeatfrequencyms
 
 Optional Enumeration Commands
 =============================

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -148,16 +148,17 @@ data.
 .. _GridFSBucket spec: https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst#configurable-gridfsbucket-class
     
 Speeding Up Tests
-===================
+-----------------
 
 Drivers may benefit reducing `minHeartbeatFrequencyMS`_ in order to speed up
 tests. Python was able to decrease the run time of the tests greatly by lowering
 the SDAM's ``minHeartbeatFrequencyMS`` from 500ms to 50ms, thus decreasing the
 waiting time after a "not master" error:
 
-.. _minHeartbeatFrequencyMS: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#minheartbeatfrequencyms
+Also, similar improvement can be added for `heartbeatFrequencyMS`_ by setting the default heartbeatFrequencyMS to 5ms in order to take into account the latest changes regarding streaming protocol. If a test has an explicit heartbeatFrequencyMS value, drivers should use the explicit value.
 
-See also `Speeding Up Tests </source/transactions/tests/README.rst#speeding-up-tests>`_ in the Transactions spec tests.
+.. _minHeartbeatFrequencyMS: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#minheartbeatfrequencyms	
+.. _heartbeatFrequencyMS: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#heartbeatfrequencyms
 
 Optional Enumeration Commands
 =============================
@@ -175,4 +176,4 @@ Changelog
 
              Add test-level ``useMultipleMongoses`` field.
 
-:2020-06-12: Add the default value for heartbeatFrequencyMS.
+:2020-09-16: Suggest lowering heartbeatFrequencyMS in addition to minHeartbeatFrequencyMS.

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -157,7 +157,7 @@ waiting time after a "not master" error:
 
 .. _minHeartbeatFrequencyMS: https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#minheartbeatfrequencyms
 
-Drivers should set the default heartbeatFrequencyMS to 5ms in order to take into account the latest changes regarding streaming protocol. If a test has an explicit heartbeatFrequencyMS value, drivers should use the explicit value.
+See also `Speeding Up Tests </source/transactions/tests/README.rst#speeding-up-tests>`_ in the Transactions spec tests.
 
 Optional Enumeration Commands
 =============================

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -153,7 +153,7 @@ Speeding Up Tests
 Drivers can greatly reduce the execution time of tests by setting `heartbeatFrequencyMS`_
 and `minHeartbeatFrequencyMS`_ (internally) to a small value (e.g. 5ms), below what
 is normally permitted in the SDAM spec. If a test specifies an explicit value for
-heartbeatFrequencyMS (e.g. client or URI options), drivers SHOULD use that value.
+heartbeatFrequencyMS (e.g. client or URI options), drivers MUST use that value.
 
 .. _minHeartbeatFrequencyMS: ../../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#minheartbeatfrequencyms
 .. _heartbeatFrequencyMS: ../../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#heartbeatfrequencyms

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -92,7 +92,7 @@ disabled like so::
     });
 
 Speeding Up Tests
------------------
+=================
 
 See `Speeding Up Tests </source/transactions/tests/README.rst#speeding-up-tests>`_ in the Transactions spec tests.
 

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -91,6 +91,11 @@ disabled like so::
         mode: "off"
     });
 
+Speeding Up Tests
+-----------------
+
+Drivers should set the default heartbeatFrequencyMS to 5ms in order to take into account the latest changes regarding streaming protocol. If a test has an explicit heartbeatFrequencyMS value, drivers should use the explicit value.
+
 Use as Integration Tests
 ========================
 
@@ -337,3 +342,5 @@ Changelog
              which are now expressed within ``runOn`` elements.
 
              Add test-level ``useMultipleMongoses`` field.
+
+:2020-06-12: Add the default value for heartbeatFrequencyMS.

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -94,7 +94,7 @@ disabled like so::
 Speeding Up Tests
 =================
 
-See `Speeding Up Tests </source/transactions/tests/README.rst#speeding-up-tests>`_ in the Transactions spec tests.
+See `Speeding Up Tests <../../retryable-reads/tests/README.rst#speeding-up-tests>`_ in the retryable reads spec tests.
 
 Use as Integration Tests
 ========================
@@ -342,5 +342,3 @@ Changelog
              which are now expressed within ``runOn`` elements.
 
              Add test-level ``useMultipleMongoses`` field.
-
-:2020-06-12: Add the default value for heartbeatFrequencyMS.

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -94,7 +94,7 @@ disabled like so::
 Speeding Up Tests
 -----------------
 
-Drivers should set the default heartbeatFrequencyMS to 5ms in order to take into account the latest changes regarding streaming protocol. If a test has an explicit heartbeatFrequencyMS value, drivers should use the explicit value.
+See `Speeding Up Tests </source/transactions/tests/README.rst#speeding-up-tests>`_ in the Transactions spec tests.
 
 Use as Integration Tests
 ========================

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -78,7 +78,7 @@ control the fail point's behavior. ``failCommand`` supports the following
   `New in mongod 4.3.4 <https://jira.mongodb.org/browse/SERVER-41070>`_.
 
 Speeding Up Tests
------------------
+=================
 
 Drivers should set the default heartbeatFrequencyMS to 5ms in order to take into account the latest changes regarding streaming protocol. If a test has an explicit heartbeatFrequencyMS value, drivers should use the explicit value.
 

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -80,7 +80,7 @@ control the fail point's behavior. ``failCommand`` supports the following
 Speeding Up Tests
 =================
 
-Drivers should set the default heartbeatFrequencyMS to 5ms in order to take into account the latest changes regarding streaming protocol. If a test has an explicit heartbeatFrequencyMS value, drivers should use the explicit value.
+See `Speeding Up Tests <../../retryable-reads/tests/README.rst#speeding-up-tests>`_ in the retryable reads spec tests.
 
 Test Format
 ===========
@@ -645,4 +645,3 @@ Changelog
 :2019-02-13: Modify test format for 4.2 sharded transactions, including
              "useMultipleMongoses", ``object: testRunner``, the
              ``targetedFailPoint`` operation, and recoveryToken assertions.
-:2020-06-12: Add the default value for heartbeatFrequencyMS.

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -77,6 +77,11 @@ control the fail point's behavior. ``failCommand`` supports the following
   blocked for. Required when blockConnection is true.
   `New in mongod 4.3.4 <https://jira.mongodb.org/browse/SERVER-41070>`_.
 
+Speeding Up Tests
+-----------------
+
+Drivers should set the default heartbeatFrequencyMS to 5ms in order to take into account the latest changes regarding streaming protocol. If a test has an explicit heartbeatFrequencyMS value, drivers should use the explicit value.
+
 Test Format
 ===========
 
@@ -640,3 +645,4 @@ Changelog
 :2019-02-13: Modify test format for 4.2 sharded transactions, including
              "useMultipleMongoses", ``object: testRunner``, the
              ``targetedFailPoint`` operation, and recoveryToken assertions.
+:2020-06-12: Add the default value for heartbeatFrequencyMS.


### PR DESCRIPTION
Questions:
1. Should the same change be added for transactions-convenient-api?
2. Should I create a DRIVER ticket?