### PR TITLE
Reset connection pool after setting server to Unknown in pseudocode

### DIFF
--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -668,6 +668,9 @@ The event API here is assumed to be like the standard `Python Event
                 wait()
                 continue
             topology.onServerDescriptionChanged(description)
+            if description.error != Null:
+                # Clear the connection pool only after the server description is set to Unknown.
+                clear connection pool for server
 
             # Immediately proceed to the next check if the previous response
             # was successful and included the topologyVersion field, or the
@@ -714,7 +717,6 @@ The event API here is assumed to be like the standard `Python Event
         except Exception as exc:
             close connection
             rttMonitor.reset()
-            clear connection pool for the server
             return ServerDescription(type=Unknown, error=exc)
 
     def wait():


### PR DESCRIPTION
The spec prose (https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-monitoring.rst#network-or-command-error-during-server-check) already does things in this order and this PR updates the pseudocode to match.

See https://jira.mongodb.org/browse/PYTHON-2236?focusedCommentId=3076780&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-3076780 for a description of the race this addresses.