### PR TITLE
test that ElectionInProgress is not resumed

### DIFF
--- a/source/change-streams/tests/change-streams-errors.json
+++ b/source/change-streams/tests/change-streams-errors.json
@@ -127,13 +127,7 @@
         "replicaset",
         "sharded"
       ],
-      "changeStreamPipeline": [
-        {
-          "$project": {
-            "_id": 0
-          }
-        }
-      ],
+      "changeStreamPipeline": [],
       "changeStreamOptions": {},
       "operations": [
         {
@@ -150,6 +144,47 @@
       "result": {
         "error": {
           "code": 50
+        }
+      }
+    },
+    {
+      "description": "change stream errors on ElectionInProgress",
+      "minServerVersion": "4.2",
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "getMore"
+          ],
+          "errorCode": 216,
+          "closeConnection": false
+        }
+      },
+      "target": "collection",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ],
+      "changeStreamPipeline": [],
+      "changeStreamOptions": {},
+      "operations": [
+        {
+          "database": "change-stream-tests",
+          "collection": "test",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "z": 3
+            }
+          }
+        }
+      ],
+      "result": {
+        "error": {
+          "code": 216
         }
       }
     }

--- a/source/change-streams/tests/change-streams-errors.json
+++ b/source/change-streams/tests/change-streams-errors.json
@@ -107,47 +107,6 @@
       }
     },
     {
-      "description": "change stream errors on MaxTimeMSExpired",
-      "minServerVersion": "4.2",
-      "failPoint": {
-        "configureFailPoint": "failCommand",
-        "mode": {
-          "times": 1
-        },
-        "data": {
-          "failCommands": [
-            "getMore"
-          ],
-          "errorCode": 50,
-          "closeConnection": false
-        }
-      },
-      "target": "collection",
-      "topology": [
-        "replicaset",
-        "sharded"
-      ],
-      "changeStreamPipeline": [],
-      "changeStreamOptions": {},
-      "operations": [
-        {
-          "database": "change-stream-tests",
-          "collection": "test",
-          "name": "insertOne",
-          "arguments": {
-            "document": {
-              "z": 3
-            }
-          }
-        }
-      ],
-      "result": {
-        "error": {
-          "code": 50
-        }
-      }
-    },
-    {
       "description": "change stream errors on ElectionInProgress",
       "minServerVersion": "4.2",
       "failPoint": {

--- a/source/change-streams/tests/change-streams-errors.yml
+++ b/source/change-streams/tests/change-streams-errors.yml
@@ -86,9 +86,7 @@ tests:
     topology:
       - replicaset
       - sharded
-    changeStreamPipeline:
-      -
-        $project: { _id: 0 }
+    changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
       -
@@ -101,3 +99,30 @@ tests:
     result:
       error:
         code: 50
+  -
+    description: change stream errors on ElectionInProgress
+    minServerVersion: "4.2"
+    failPoint:
+      configureFailPoint: failCommand
+      mode: { times: 1 }
+      data:
+          failCommands: ["getMore"]
+          errorCode: 216 # An error code that's not on the old blacklist or whitelist
+          closeConnection: false
+    target: collection
+    topology:
+      - replicaset
+      - sharded
+    changeStreamPipeline: []
+    changeStreamOptions: {}
+    operations:
+      -
+        database: *database_name
+        collection: *collection_name
+        name: insertOne
+        arguments:
+          document:
+            z: 3
+    result:
+      error:
+        code: 216

--- a/source/change-streams/tests/change-streams-errors.yml
+++ b/source/change-streams/tests/change-streams-errors.yml
@@ -73,33 +73,6 @@ tests:
       error:
         code: 280
   -
-    description: change stream errors on MaxTimeMSExpired
-    minServerVersion: "4.2"
-    failPoint:
-      configureFailPoint: failCommand
-      mode: { times: 1 }
-      data:
-          failCommands: ["getMore"]
-          errorCode: 50 # An error code that's not on the old blacklist or whitelist
-          closeConnection: false
-    target: collection
-    topology:
-      - replicaset
-      - sharded
-    changeStreamPipeline: []
-    changeStreamOptions: {}
-    operations:
-      -
-        database: *database_name
-        collection: *collection_name
-        name: insertOne
-        arguments:
-          document:
-            z: 3
-    result:
-      error:
-        code: 50
-  -
     description: change stream errors on ElectionInProgress
     minServerVersion: "4.2"
     failPoint:


### PR DESCRIPTION
I mistakenly did not remove `ElectionInProgress` from the error allowlist in [CDRIVER-3589](https://jira.mongodb.org/browse/CDRIVER-3589).

Fortunately Clyde caught this when validating the behavior in the C++ driver.

This tests that ElectionInProgress does not resume, and also removes an unnecessary projection.

Validated the tests in libmongoc.