### PR TITLE
SPEC-1708 Increase replSetStepDown timeout and run replSetFreeze instead of retrying

### DIFF
--- a/source/connections-survive-step-down/tests/README.rst
+++ b/source/connections-survive-step-down/tests/README.rst
@@ -67,7 +67,7 @@ Perform the following operations:
 - Send a ``{replSetFreeze: 0}`` command to any secondary and verify that the
   command succeeded. This command will unfreeze the secondary and ensure that
   it will be eligible to be elected immediately.
-- Send a ``{replSetStepDown: 20, force: true}`` command to the current primary and verify that
+- Send a ``{replSetStepDown: 30, force: true}`` command to the current primary and verify that
   the command succeeded.
 - Retrieve the next batch of results from the cursor obtained in the find
   operation, and verify that this operation succeeded.

--- a/source/connections-survive-step-down/tests/README.rst
+++ b/source/connections-survive-step-down/tests/README.rst
@@ -64,26 +64,16 @@ Perform the following operations:
 - Insert 5 documents into a collection with a majority write concern.
 - Start a find operation on the collection with a batch size of 2, and
   retrieve the first batch of results.
-- Send a ``{replSetStepDown: 5, force: true}`` command to the current primary and verify that
+- Send a ``{replSetFreeze: 0}`` command to any secondary and verify that the
+  command succeeded. This command will unfreeze the secondary and ensure that
+  it will be eligible to be elected immediately.
+- Send a ``{replSetStepDown: 20, force: true}`` command to the current primary and verify that
   the command succeeded.
 - Retrieve the next batch of results from the cursor obtained in the find
   operation, and verify that this operation succeeded.
 - If the driver implements the `CMAP`_ specification, verify that no new `PoolClearedEvent`_ has been
   published. Otherwise verify that `connections.totalCreated`_ in `serverStatus`_ has not changed.
 
-**Note:** The "replSetStepDown" command often fails with the following
-transient error (see `SERVER-48154`_)::
-
-  {
-    "ok" : 0,
-    "errmsg" : "Unable to acquire X lock on '{4611686018427387905: ReplicationStateTransition, 1}' within 1000ms. opId: 922, op: conn30, connId: 30.",
-    "code" : 24,
-    "codeName" : "LockTimeout",
-  }
-
-When running the "replSetStepDown" command, drivers MUST retry until the
-command succeeds. The number of retries should be limited to avoid an infinite
-failure loop. For example, the Python driver uses a 10 second retry period.
 
 Not Master - Keep Connection Pool
 `````````````````````````````````
@@ -186,4 +176,3 @@ server communication.
 .. _PoolClearedEvent: /source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#events
 .. _serverStatus: https://docs.mongodb.com/manual/reference/command/serverStatus
 .. _connections.totalCreated: https://docs.mongodb.com/manual/reference/command/serverStatus/#serverstatus.connections.totalCreated
-.. _SERVER-48154: https://jira.mongodb.org/browse/SERVER-48154

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -296,26 +296,12 @@ MongoClient from the one used for test operations. For example::
 
       - name: runAdminCommand
         object: testRunner
-        command_name: replSetStepDown
+        command_name: replSetFreeze
         arguments:
           command:
-            replSetStepDown: 1
-            secondaryCatchUpPeriodSecs: 1
-            force: false
-
-**Note:** The "replSetStepDown" command often fails with the following
-transient error (see `SERVER-48154`_)::
-
-  {
-    "ok" : 0,
-    "errmsg" : "Unable to acquire X lock on '{4611686018427387905: ReplicationStateTransition, 1}' within 1000ms. opId: 922, op: conn30, connId: 30.",
-    "code" : 24,
-    "codeName" : "LockTimeout",
-  }
-
-When running the "replSetStepDown" command, drivers MUST retry until the
-command succeeds. The number of retries should be limited to avoid an infinite
-failure loop. For example, the Python driver uses a 10 second retry period.
+            replSetFreeze: 0
+          readPreference:
+            mode: Secondary
 
 waitForPrimaryChange
 ''''''''''''''''''''
@@ -446,4 +432,3 @@ Run the following test(s) on MongoDB 4.4+.
 .. Section for links.
 
 .. _Server Description Equality: /source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#server-description-equality
-.. _SERVER-48154: https://jira.mongodb.org/browse/SERVER-48154

--- a/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.json
+++ b/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.json
@@ -74,7 +74,7 @@
           "name": "waitForPrimaryChange",
           "object": "testRunner",
           "arguments": {
-            "timeoutMS": 5000
+            "timeoutMS": 15000
           }
         },
         {

--- a/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.json
+++ b/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.json
@@ -64,8 +64,8 @@
           "command_name": "replSetStepDown",
           "arguments": {
             "command": {
-              "replSetStepDown": 20,
-              "secondaryCatchUpPeriodSecs": 20,
+              "replSetStepDown": 30,
+              "secondaryCatchUpPeriodSecs": 30,
               "force": false
             }
           }

--- a/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.json
+++ b/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.json
@@ -48,11 +48,24 @@
         {
           "name": "runAdminCommand",
           "object": "testRunner",
+          "command_name": "replSetFreeze",
+          "arguments": {
+            "command": {
+              "replSetFreeze": 0
+            },
+            "readPreference": {
+              "mode": "Secondary"
+            }
+          }
+        },
+        {
+          "name": "runAdminCommand",
+          "object": "testRunner",
           "command_name": "replSetStepDown",
           "arguments": {
             "command": {
-              "replSetStepDown": 1,
-              "secondaryCatchUpPeriodSecs": 1,
+              "replSetStepDown": 20,
+              "secondaryCatchUpPeriodSecs": 20,
               "force": false
             }
           }

--- a/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.yml
@@ -52,7 +52,9 @@ tests:
       - name: waitForPrimaryChange
         object: testRunner
         arguments:
-          timeoutMS: 5000
+          # We use a relatively large timeout here to workaround slow
+          # elections on Windows, possibly caused by SERVER-48154.
+          timeoutMS: 15000
       # Rediscover the new primary.
       - name: insertMany
         object: collection

--- a/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.yml
@@ -46,8 +46,8 @@ tests:
         command_name: replSetStepDown
         arguments:
           command:
-            replSetStepDown: 20
-            secondaryCatchUpPeriodSecs: 20
+            replSetStepDown: 30
+            secondaryCatchUpPeriodSecs: 30
             force: false
       - name: waitForPrimaryChange
         object: testRunner

--- a/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/rediscover-quickly-after-step-down.yml
@@ -31,14 +31,23 @@ tests:
             - _id: 4
       - name: recordPrimary
         object: testRunner
+      # Unfreeze a secondary with replSetFreeze:0 to ensure a speedy election.
+      - name: runAdminCommand
+        object: testRunner
+        command_name: replSetFreeze
+        arguments:
+          command:
+            replSetFreeze: 0
+          readPreference:
+            mode: Secondary
       # Run replSetStepDown on the meta client.
       - name: runAdminCommand
         object: testRunner
         command_name: replSetStepDown
         arguments:
           command:
-            replSetStepDown: 1
-            secondaryCatchUpPeriodSecs: 1
+            replSetStepDown: 20
+            secondaryCatchUpPeriodSecs: 20
             force: false
       - name: waitForPrimaryChange
         object: testRunner


### PR DESCRIPTION
Taking Eric's advice on [DRIVERS-1290](https://jira.mongodb.org/browse/DRIVERS-1290). @DmitryLukyanov can you POC these changes to see if it resolves the Windows C# issues?

Instead of retrying after LockTimeout errors, we increase the replSetStepDown timeout to avoid them altogether. Before we run replSetStepDown, run `{replSetFreeze:0}` to reset a secondary's timeout to ensure there is an electable node. This ensures a speedy election when the tests are run multiple times in a row (as is the case in C# for testing both sync and async).

We also increase the waitForPrimaryChange timeout from 5 seconds to 15 seconds to workaround slow elections on Windows (again found by C#). The slow elections are possibly caused by SERVER-48154.