### PR TITLE
SPEC-1712: Default OCSP to "off" for drivers that hard-fail when an OCSP responder is unavailable

### DIFF
--- a/source/ocsp-support/ocsp-support.rst
+++ b/source/ocsp-support/ocsp-support.rst
@@ -467,7 +467,7 @@ Backwards Compatibility
 
 An application behind a firewall with an outbound whitelist that
 upgrades to a driver implementing this specification may experience
-connectivity issues. This is because the driver may need to contact
+connectivity issues when OCSP is enabled. This is because the driver may need to contact
 OCSP endpoints or CRL distribution points [1]_ specified in the
 server’s certificate and if these OCSP endpoints and/or CRL
 distribution points are not accessible, then the connection to the

--- a/source/ocsp-support/ocsp-support.rst
+++ b/source/ocsp-support/ocsp-support.rst
@@ -198,7 +198,7 @@ endpoints if needed (as described in
 `Specification: Suggested OCSP Behavior <ocsp-support.rst#id1>`__).
 
 For drivers that pass the `"Soft Fail Test"
-<tests/README.rst#integration-tests-permutations-to-be-tested>`__ , this
+<tests/README.rst#integration-tests-permutations-to-be-tested>`__, this
 option MUST default to false.
 
 For drivers that fail the "Soft Fail Test" because their TLS library

--- a/source/ocsp-support/ocsp-support.rst
+++ b/source/ocsp-support/ocsp-support.rst
@@ -229,13 +229,15 @@ For drivers that pass the `"Soft Fail Test"
 <tests/README.rst#integration-tests-permutations-to-be-tested>`__ , this
 option MUST default to false.
 
-For drivers that fail the "Soft Fail Test" because their TLS library
-exhibits hard-fail behavior when a responder is unreachable, this option
-MUST default to true, and a driver MUST document this behavior. If this
-hard-failure behavior is specific to a particular platform (e.g. the TLS
-library hard-fails only on Windows) then this option MUST default to
-true only on the platform where the driver exhibits hard-fail behavior,
-and a driver MUST document this behavior.
+If a driver has not already defaulted `tlsDisableOCSPEndpointCheck` to
+true, and if that driver fails the "Soft Fail Test" because their TLS
+library exhibits hard-fail behavior when a responder is unreachable,
+then that driver must default `tlsDisableCertificateRevocationCheck` to
+true. Such a driver also MUST document this behavior. If this
+hard-failure behavior is specific to a particular platform (e.g. the
+TLS library hard-fails only on Windows) then this option MUST default
+to true only on the platform where the driver exhibits hard-fail
+behavior, and a driver MUST document this behavior.
 
 Naming Deviations
 ^^^^^^^^^^^^^^^^^^
@@ -786,8 +788,8 @@ of checking this are:
 Changelog
 ==========
 
-**2020-07-01**: 2.0.0: Default tlsDisableCertificateRevocationCheck
-and tlsDisableOCSPEndpointCheck to true in the case that a driver's
+**2020-07-01**: 2.0.0: Default tlsDisableOCSPEndpointCheck or
+tlsDisableCertificateRevocationCheck to true in the case that a driver's
 TLS library exhibits hard-fail behavior and add provision for
 platform-specific defaults.
 

--- a/source/ocsp-support/ocsp-support.rst
+++ b/source/ocsp-support/ocsp-support.rst
@@ -203,11 +203,11 @@ library exhibits hard-fail behavior (i.e. the driver fails the
 ).
 
 In the case of a driver whose TLS library exhibits hard-fail behavior,
-this value MUST default to true. If this hard-failure behavior is
-specific to a particular platform (e.g. the TLS library hard-fails
-only on Windows) then this boolean MUST default to true only on the
-platform where the exhibits hard-fail behavior, and a driver MUST
-document this behavior.
+this value MUST default to true and a driver MUST document this
+behavior.  If this hard-failure behavior is specific to a particular
+platform (e.g. the TLS library hard-fails only on Windows) then this
+boolean MUST default to true only on the platform where the exhibits
+hard-fail behavior, and a driver MUST document this behavior.
 
 
 tlsDisableCertificateRevocationCheck
@@ -231,11 +231,11 @@ library exhibits hard-fail behavior (i.e. the driver fails the
 "<https://github.com/mongodb/specifications/tree/master/source/ocsp-support/tests#integration-tests-permutations-to-be-tested>`__
 
 In the case of a driver whose TLS library exhibits hard-fail behavior,
-this value MUST default to true. If this hard-failure behavior is
-specific to a particular platform (e.g. the TLS library hard-fails
-only on Windows) then this boolean MUST default to true only on the
-platform where the exhibits hard-fail behavior, and a driver MUST
-document this behavior.
+this value MUST default to true and a driver MUST document this
+behavior.  If this hard-failure behavior is specific to a particular
+platform (e.g. the TLS library hard-fails only on Windows) then this
+boolean MUST default to true only on the platform where the exhibits
+hard-fail behavior, and a driver MUST document this behavior.
 
 Naming Deviations
 ^^^^^^^^^^^^^^^^^^

--- a/source/ocsp-support/ocsp-support.rst
+++ b/source/ocsp-support/ocsp-support.rst
@@ -203,11 +203,11 @@ library exhibits hard-fail behavior (i.e. the driver fails the
 ).
 
 In the case of a driver whose TLS library exhibits hard-fail behavior,
-this value MUST default to true and a driver MUST document this
+this value MUST default to true, and a driver MUST document this
 behavior.  If this hard-failure behavior is specific to a particular
 platform (e.g. the TLS library hard-fails only on Windows) then this
-boolean MUST default to true only on the platform where the exhibits
-hard-fail behavior, and a driver MUST document this behavior.
+boolean MUST default to true only on the platform where the driver
+exhibits hard-fail behavior, and a driver MUST document this behavior.
 
 
 tlsDisableCertificateRevocationCheck
@@ -231,11 +231,11 @@ library exhibits hard-fail behavior (i.e. the driver fails the
 "<https://github.com/mongodb/specifications/tree/master/source/ocsp-support/tests#integration-tests-permutations-to-be-tested>`__
 
 In the case of a driver whose TLS library exhibits hard-fail behavior,
-this value MUST default to true and a driver MUST document this
+this value MUST default to true, and a driver MUST document this
 behavior.  If this hard-failure behavior is specific to a particular
 platform (e.g. the TLS library hard-fails only on Windows) then this
-boolean MUST default to true only on the platform where the exhibits
-hard-fail behavior, and a driver MUST document this behavior.
+boolean MUST default to true only on the platform where the driver
+exhibits hard-fail behavior, and a driver MUST document this behavior.
 
 Naming Deviations
 ^^^^^^^^^^^^^^^^^^
@@ -784,7 +784,7 @@ Changelog
 ==========
 
 **2020-07-01**: 2.0.0: Default tlsDisableCertificateRevocationCheck
-and tlsDisableOCSPEndpointCheck to false in the case that a driver's
+and tlsDisableOCSPEndpointCheck to true in the case that a driver's
 TLS library exhibits hard-fail behavior and add provision for
 platform-specific defaults.
 

--- a/source/ocsp-support/tests/README.rst
+++ b/source/ocsp-support/tests/README.rst
@@ -57,6 +57,9 @@ server’s certificate (configured with the mock OCSP responder). We will
 also test the case where an OCSP responder is unavailable and two
 malicious server cases.
 
+Drivers that do not default to enabling by OCSP default MUST enable
+OCSP for these tests.
+
 +----------------------------------------+-----------------------------------------+-------------------------------------------+-------------------------------------------------+---------------------------------------------------+-----------------------------------------------------+-----------------------------------------------------------------------+--------------------------------------------------------------------+
 | **URI options**                        | **Test 1\:**                            | **Test 2\:**                              | **Test 3\:**                                    | **Test 4\:**                                      | **Soft Fail Test\:**                                | **Malicious Server Test 1\:**                                         | **Malicious Server Test 2\: No OCSP Responder + server w/ Must-**  |
 |                                        | **Valid cert + server that staples**    | **Invalid cert + server that staples**    | **Valid cert + server that does not staple**    | **Invalid cert + server that does not staple**    | **No OCSP Responder + server that does not staple** | **Invalid cert + server w/ Must- Staple cert that does not staple**   | **Staple cert that does not staple**                               |
@@ -85,6 +88,9 @@ extra cases and may help reveal unexpected behavior.
 library’s implementation of OCSP will need to document these failures as
 described under `Documentation
 Requirements <../ocsp-support.rst#documentation-requirements>`__
+Additionally, drivers that fail the "Soft Fail" will need to change any applicable defaults as described under
+`MongoClient
+Configuration <../ocsp-support.rst#mongoclient-configuration>`__
 
 Mock OCSP Responder Testing Suite
 ==================================
@@ -228,7 +234,11 @@ to simplify the testing procedure.
 
 Changelog
 ==========
-**2020-03-20**: Clarify that the mock OCSP responder must be started 
+
+**2020-07-01**: Clarify that drivers that do not enable OCSP by
+default MUST enable OCSP for the tests.
+
+**2020-03-20**: Clarify that the mock OCSP responder must be started
 before the mongod.
 
 **2020-03-11**: Reduce and clarify Windows testing requirements.

--- a/source/ocsp-support/tests/README.rst
+++ b/source/ocsp-support/tests/README.rst
@@ -84,13 +84,13 @@ Malicious Server Test 2}. For drivers with full control over their OCSP behavior
 server tests are identical as well. However, it does no harm to test these
 extra cases and may help reveal unexpected behavior.
 
-\*: Drivers that cannot pass these tests due to limitations in their TLS
-library’s implementation of OCSP will need to document these failures as
-described under `Documentation
-Requirements <../ocsp-support.rst#documentation-requirements>`__
-Additionally, drivers that fail the "Soft Fail" will need to change any applicable defaults as described under
-`MongoClient
-Configuration <../ocsp-support.rst#mongoclient-configuration>`__
+\*: Drivers that cannot pass these tests due to limitations in their
+TLS library’s implementation of OCSP will need to document these
+failures as described under `Documentation Requirements
+<../ocsp-support.rst#documentation-requirements>`__. Additionally,
+drivers that fail the "Soft Fail Test" will need to change any
+applicable defaults as described under `MongoClient Configuration
+<../ocsp-support.rst#mongoclient-configuration>`__
 
 Mock OCSP Responder Testing Suite
 ==================================

--- a/source/ocsp-support/tests/README.rst
+++ b/source/ocsp-support/tests/README.rst
@@ -57,8 +57,8 @@ server’s certificate (configured with the mock OCSP responder). We will
 also test the case where an OCSP responder is unavailable and two
 malicious server cases.
 
-Drivers that do not default to enabling by OCSP default MUST enable
-OCSP for these tests.
+Drivers that do not default to enabling OCSP MUST enable OCSP for
+these tests.
 
 +----------------------------------------+-----------------------------------------+-------------------------------------------+-------------------------------------------------+---------------------------------------------------+-----------------------------------------------------+-----------------------------------------------------------------------+--------------------------------------------------------------------+
 | **URI options**                        | **Test 1\:**                            | **Test 2\:**                              | **Test 3\:**                                    | **Test 4\:**                                      | **Soft Fail Test\:**                                | **Malicious Server Test 1\:**                                         | **Malicious Server Test 2\: No OCSP Responder + server w/ Must-**  |


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1712
See for the motivation behind the change: https://jira.mongodb.org/browse/DRIVERS-1311