### PR TITLE
Use 10s timeout for SDAM waitForEvent operation

### DIFF
--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -257,6 +257,9 @@ PoolClearedEvent to be published::
 Note that "count" includes events that were published while running previous
 operations.
 
+If the "waitForEvent" operation is not satisfied after 10 seconds, the
+operation is considered an error.
+
 ServerMarkedUnknownEvent
 ````````````````````````
 


### PR DESCRIPTION
Per this discussion: https://github.com/mongodb/mongo-c-driver/pull/648/commits/91c4e4c55a5378825a70428580382b9c9bf727b7?file-filters%5B%5D=.c#r448520715