### PR TITLE
configureFailPoint is mutually exclusive with useMultipleMongoses

### DIFF
--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -229,6 +229,11 @@ ensure that ``configureFailPoint`` commands do not appear in the list of logged
 commands, either by manually filtering it from the list of observed commands or
 by using a different MongoClient to execute ``configureFailPoint``.
 
+Note, similar to the ``tests.failPoint`` field described in the `Transactions
+Spec Test format </source/transactions/tests/README.rst#test-format>`_ tests
+with ``useMultipleMongoses: true`` will not contain a ``configureFailPoint``
+operation.
+
 wait
 ''''
 


### PR DESCRIPTION
Per this discussion: https://github.com/mongodb/mongo-c-driver/pull/648/commits/91c4e4c55a5378825a70428580382b9c9bf727b7?file-filters%5B%5D=.c#r448526630