### PR TITLE
Add timeout to RTT test

### DIFF
--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -435,7 +435,7 @@ Run the following test(s) on MongoDB 4.4+.
        that the `Server Description Equality`_ rule means that
        ServerDescriptionChangedEvents will not be published. This test may
        need to use a driver specific helper to obtain the latest RTT instead.
-       If the RTT does not exceed 250ms after one minute, consider the test
+       If the RTT does not exceed 250ms after 10 seconds, consider the test
        failed.
 
     #. Disable the failpoint::

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -435,6 +435,8 @@ Run the following test(s) on MongoDB 4.4+.
        that the `Server Description Equality`_ rule means that
        ServerDescriptionChangedEvents will not be published. This test may
        need to use a driver specific helper to obtain the latest RTT instead.
+       If the RTT does not exceed 250ms after one minute, consider the test
+       failed.
 
     #. Disable the failpoint::
 


### PR DESCRIPTION
Add an arbitrary timeout to the RTT prose test.

Per this comment https://github.com/mongodb/mongo-c-driver/pull/648/commits/91c4e4c55a5378825a70428580382b9c9bf727b7?file-filters%5B%5D=.c#r448552242