### PR TITLE
SPEC-1715 add additional timestamp test for not 2^32-1

### DIFF
--- a/source/bson-corpus/tests/timestamp.json
+++ b/source/bson-corpus/tests/timestamp.json
@@ -18,6 +18,11 @@
             "description": "Timestamp with high-order bit set on both seconds and increment",
             "canonical_bson": "10000000116100FFFFFFFFFFFFFFFF00",
             "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 4294967295, \"i\" :  4294967295} } }"
+        },
+        {
+            "description": "Timestamp with high-order bit set: (4000000000, 4000000000)",
+            "canonical_bson": "1000000011610000286BEE00286BEE00", 
+            "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 4000000000, \"i\" :  4000000000} } }"
         }
     ],
     "decodeErrors": [

--- a/source/bson-corpus/tests/timestamp.json
+++ b/source/bson-corpus/tests/timestamp.json
@@ -20,7 +20,7 @@
             "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 4294967295, \"i\" :  4294967295} } }"
         },
         {
-            "description": "Timestamp with high-order bit set: (4000000000, 4000000000)",
+            "description": "Timestamp with high-order bit set on both seconds and increment (not UINT32_MAX)",
             "canonical_bson": "1000000011610000286BEE00286BEE00", 
             "canonical_extjson": "{\"a\" : {\"$timestamp\" : {\"t\" : 4000000000, \"i\" :  4000000000} } }"
         }


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1715

If the 64 bit number 2^32-1 is not stored in an unsigned number, it will wrap around to -1, which is a special value. I added another test that has the high-order bit set that doesn't yield a special value on error.