### PR TITLE
Revert addition of "single" topology type to dirty sessions test

### DIFF
--- a/source/sessions/tests/dirty-session-errors.json
+++ b/source/sessions/tests/dirty-session-errors.json
@@ -3,8 +3,7 @@
     {
       "minServerVersion": "4.0",
       "topology": [
-        "replicaset",
-        "single"
+        "replicaset"
       ]
     },
     {

--- a/source/sessions/tests/dirty-session-errors.yml
+++ b/source/sessions/tests/dirty-session-errors.yml
@@ -1,6 +1,6 @@
 runOn:
   - minServerVersion: "4.0"
-    topology: ["replicaset", "single"]
+    topology: ["replicaset"]
   - minServerVersion: "4.1.8"
     topology: ["sharded"]
 


### PR DESCRIPTION
The tests assume that the server supports retryable writes,
and even though standalones support sessions, they don't actually
support retryable writes (which require an oplog)

DRIVERS-1230