### PR TITLE
fix: add missing tests for atomic operators in update/replace

### DIFF
--- a/source/crud/tests/v1/write/bulkWrite-collation.json
+++ b/source/crud/tests/v1/write/bulkWrite-collation.json
@@ -138,8 +138,10 @@
                   "x": "ping"
                 },
                 "replacement": {
-                  "_id": 6,
-                  "x": "ping"
+                  "$set": {
+                    "_id": 6,
+                    "x": "ping"
+                  }
                 },
                 "upsert": true,
                 "collation": {

--- a/source/crud/tests/v1/write/bulkWrite-collation.yml
+++ b/source/crud/tests/v1/write/bulkWrite-collation.yml
@@ -71,7 +71,7 @@ tests:
                         name: "replaceOne"
                         arguments:
                             filter: { x: "ping" }
-                            replacement: { _id: 6, x: "ping" }
+                            replacement: { $set: { _id: 6, x: "ping" } }
                             upsert: true
                             collation: { locale: "en_US", strength: 3 }
                     -

--- a/source/crud/tests/v1/write/findOneAndReplace.json
+++ b/source/crud/tests/v1/write/findOneAndReplace.json
@@ -268,6 +268,49 @@
           ]
         }
       }
+    },
+    {
+      "description": "FindOneAndReplace require no atomic operators in replacement document",
+      "operation": {
+        "name": "findOneAndReplace",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "replacement": {
+            "$set": {
+              "x": 44
+            }
+          },
+          "projection": {
+            "x": 1,
+            "_id": 0
+          },
+          "returnDocument": "After",
+          "sort": {
+            "x": 1
+          }
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/crud/tests/v1/write/findOneAndReplace.yml
+++ b/source/crud/tests/v1/write/findOneAndReplace.yml
@@ -9,7 +9,7 @@ tests:
         operation:
             name: findOneAndReplace
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 replacement: {x: 32}
                 projection: {x: 1, _id: 0}
@@ -27,7 +27,7 @@ tests:
         operation:
             name: findOneAndReplace
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
                 replacement: {x: 32}
                 projection: {x: 1, _id: 0}
@@ -106,6 +106,24 @@ tests:
 
         outcome:
             result: null
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}
+    -
+        description: "FindOneAndReplace require no atomic operators in replacement document"
+        operation:
+            name: findOneAndReplace
+            arguments:
+                filter: { _id: 4 }
+                replacement: { $set: { x: 44 } }
+                projection: { x: 1, _id: 0 }
+                returnDocument: After
+                sort: { x: 1 }
+
+        outcome:
+            error: true
             collection:
                 data:
                     - {_id: 1, x: 11}

--- a/source/crud/tests/v1/write/findOneAndUpdate.json
+++ b/source/crud/tests/v1/write/findOneAndUpdate.json
@@ -374,6 +374,48 @@
           ]
         }
       }
+    },
+    {
+      "description": "FindOneAndUpdate require atomic operators for update document",
+      "operation": {
+        "name": "findOneAndUpdate",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "update": {
+            "x": 1
+          },
+          "projection": {
+            "x": 1,
+            "_id": 0
+          },
+          "returnDocument": "After",
+          "sort": {
+            "x": 1
+          },
+          "upsert": true
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/crud/tests/v1/write/findOneAndUpdate.yml
+++ b/source/crud/tests/v1/write/findOneAndUpdate.yml
@@ -9,9 +9,9 @@ tests:
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -28,9 +28,9 @@ tests:
         operation:
             name: findOneAndUpdate
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -49,7 +49,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 2}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -67,7 +67,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 2}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -86,7 +86,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
@@ -104,7 +104,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 # Omit the sort option as it has no effect when no documents
@@ -127,7 +127,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -146,7 +146,7 @@ tests:
             name: findOneAndUpdate
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 projection: {x: 1, _id: 0}
                 returnDocument: After
@@ -161,3 +161,22 @@ tests:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
                     - {_id: 4, x: 1}
+    -
+        description: "FindOneAndUpdate require atomic operators for update document"
+        operation:
+            name: findOneAndUpdate
+            arguments:
+                filter: { _id: 4 }
+                update: { x: 1 }
+                projection: { x: 1, _id: 0 }
+                returnDocument: After
+                sort: { x: 1 }
+                upsert: true
+
+        outcome:
+            error: true
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}

--- a/source/crud/tests/v1/write/replaceOne-collation.yml
+++ b/source/crud/tests/v1/write/replaceOne-collation.yml
@@ -9,9 +9,9 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {x: 'PING'}
-                replacement: {_id: 2, x: 'pong'}
-                collation: {locale: 'en_US', strength: 2} # https://docs.mongodb.com/master/reference/collation/#collation-document
+                filter: { x: 'PING' }
+                replacement: { _id: 2, x: 'pong' }
+                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/master/reference/collation/#collation-document
 
         outcome:
             result:

--- a/source/crud/tests/v1/write/replaceOne.json
+++ b/source/crud/tests/v1/write/replaceOne.json
@@ -200,6 +200,43 @@
           ]
         }
       }
+    },
+    {
+      "description": "ReplaceOne require no atomic operators in replacement document",
+      "operation": {
+        "name": "replaceOne",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "replacement": {
+            "$set": {
+              "_id": 4,
+              "x": 1
+            }
+          },
+          "upsert": true
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/crud/tests/v1/write/replaceOne.yml
+++ b/source/crud/tests/v1/write/replaceOne.yml
@@ -10,9 +10,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: 
-                    _id: {$gt: 1}
-                replacement: {x: 111}
+                filter: { _id: {$gt: 1} }
+                replacement: { x: 111 }
 
         outcome:
             result:
@@ -26,8 +25,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 1}
-                replacement: {_id: 1, x: 111}
+                filter: { _id: 1 }
+                replacement: { _id: 1, x: 111 }
 
         outcome:
             result:
@@ -44,8 +43,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {_id: 4, x: 1}
+                filter: { _id: 4 }
+                replacement: { _id: 4, x: 1 }
 
         outcome:
             result:
@@ -62,8 +61,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {x: 1}
+                filter: { _id: 4 }
+                replacement: { x: 1 }
                 upsert: true
 
         outcome:
@@ -84,8 +83,8 @@ tests:
         operation:
             name: "replaceOne"
             arguments:
-                filter: {_id: 4}
-                replacement: {_id: 4, x: 1}
+                filter: { _id: 4 }
+                replacement: { _id: 4, x: 1 }
                 upsert: true
 
         outcome:
@@ -100,3 +99,18 @@ tests:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
                     - {_id: 4, x: 1}
+    -
+        description: "ReplaceOne require no atomic operators in replacement document"
+        operation:
+            name: "replaceOne"
+            arguments:
+                filter: { _id: 4 }
+                replacement: { $set: { _id: 4, x: 1 } }
+                upsert: true
+        outcome:
+            error: true
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}

--- a/source/crud/tests/v1/write/updateOne.json
+++ b/source/crud/tests/v1/write/updateOne.json
@@ -162,6 +162,40 @@
           ]
         }
       }
+    },
+    {
+      "description": "UpdateOne require atomic operators in update document",
+      "operation": {
+        "name": "updateOne",
+        "arguments": {
+          "filter": {
+            "_id": 4
+          },
+          "update": {
+            "x": 1
+          },
+          "upsert": true
+        }
+      },
+      "outcome": {
+        "error": true,
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      }
     }
   ]
 }

--- a/source/crud/tests/v1/write/updateOne.yml
+++ b/source/crud/tests/v1/write/updateOne.yml
@@ -10,9 +10,9 @@ tests:
         operation:
             name: "updateOne"
             arguments:
-                filter: 
+                filter:
                     _id: {$gt: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -28,7 +28,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 1}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -47,7 +47,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
 
         outcome:
@@ -66,7 +66,7 @@ tests:
             name: "updateOne"
             arguments:
                 filter: {_id: 4}
-                update: 
+                update:
                     $inc: {x: 1}
                 upsert: true
 
@@ -82,3 +82,18 @@ tests:
                     - {_id: 2, x: 22}
                     - {_id: 3, x: 33}
                     - {_id: 4, x: 1}
+    -
+        description: "UpdateOne require atomic operators in update document"
+        operation:
+            name: "updateOne"
+            arguments:
+                filter: { _id: 4 }
+                update: { x: 1 }
+                upsert: true
+        outcome:
+            error: true
+            collection:
+                data:
+                    - {_id: 1, x: 11}
+                    - {_id: 2, x: 22}
+                    - {_id: 3, x: 33}


### PR DESCRIPTION
There were some missing test cases in our test coverage around requiring or restricting atomic operators in update and replace operations. This patch also includes tests to verify that errors are thrown when the required atomic conditions are not set

SPEC-1710