### PR TITLE
SPEC-1412 Clarify Connection creation wording and terminology

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -475,7 +475,7 @@ non-perished available `Connection <#connection>`_ is found or the list of
 available `Connections <#connection>`_ is exhausted. If no `Connections
 <#connection>`_ are available and the total number of `Connections
 <#connection>`_ is less than maxPoolSize, the pool MUST create and return a new
-`Connection <#connection>`_.
+established `Connection <#connection>`_.
 
 If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -329,14 +329,13 @@ The SDAM specification defines `when
 <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#connection-pool-creation>`_
 the driver should create connection pools.
 
-Once a pool is created, if minPoolSize is set, the pool MUST
-immediately begin being "populated" with enough `Connections
-<#connection>`_ such that totalConnections >= minPoolSize. The Pool
-MUST be "populated" in a non-blocking manner, such as via the use of a
-background thread or asynchronous I/O. See `Populating the Pool with a
-Connection
-<#populating-the-pool-with-a-connection-internal-implementation>`_ for
-more details.
+Once a pool is created, if minPoolSize is set, the pool MUST immediately begin
+being "populated" with enough `Connections <#connection>`_ such that
+totalConnections >= minPoolSize. The Pool MUST be "populated" in a non-blocking
+manner, such as via the use of a background thread or asynchronous I/O. See
+`Populating the Pool with a Connection
+<#populating-the-pool-with-a-connection-internal-implementation>`_ for more
+details.
 
 .. code::
 
@@ -442,17 +441,16 @@ Populating the Pool with a Connection (Internal Implementation)
 ---------------------------------------------------------------
 
 "Populating" the pool involves creating and establishing a `Connection
-<#connection>`_ that will not immediately be checked out and will
-instead be marked as "available" and kept in the pool. This type of
-`Connection <#connection>`_ is created to ensure minPoolSize and is
-distinct from from the type that is created, established, and
-immediately checked out in checkOut. See `Checking Out a Connection
-<#populating-the-pool-with-a-connection-internal-implementation>`_ for
-more information on that type of `Connection <#connection>`_ creation.
+<#connection>`_ that will not immediately be checked out and will instead be
+marked as "available" and kept in the pool. This type of `Connection
+<#connection>`_ is created to ensure minPoolSize and is distinct from from the
+type that is created, established, and immediately checked out in checkOut. See
+`Checking Out a Connection
+<#populating-the-pool-with-a-connection-internal-implementation>`_ for more
+information on that type of `Connection <#connection>`_ creation.
 
-Populating the pool MUST NOT block any application threads. For
-example, it could be performed on a background thread or via the use
-of non-blocking I/O.
+Populating the pool MUST NOT block any application threads. For example, it
+could be performed on a background thread or via the use of non-blocking I/O.
 
 .. code::
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -235,10 +235,10 @@ A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A ``C
 WaitQueue
 ---------
 
-A concept that represents pending requests for Connections. When a thread requests a ``Connection`` from a Pool, the thread enters the Pool's WaitQueue. A thread stays in the WaitQueue until it either receives a ``Connection`` or times out. A WaitQueue has the following traits:
+A concept that represents pending requests for ``Connections``. When a thread requests a ``Connection`` from a Pool, the thread enters the Pool's WaitQueue. A thread stays in the WaitQueue until it either receives a ``Connection`` or times out. A WaitQueue has the following traits:
 
 -  **Thread-Safe**: When multiple threads attempt to enter or exit a WaitQueue, they do so in a thread-safe manner.
--  **Ordered/Fair**: When connections are made available, they are issued out to threads in the order that the threads entered the WaitQueue.
+-  **Ordered/Fair**: When ``Connections`` are made available, they are issued out to threads in the order that the threads entered the WaitQueue.
 -  **Timeout aggressively:** If **waitQueueTimeoutMS** is set, members of a WaitQueue MUST timeout if they are enqueued for longer than waitQueueTimeoutMS. Members of a WaitQueue MUST timeout aggressively, and MUST leave the WaitQueue immediately upon timeout.
 
 The implementation details of a WaitQueue are left to the driver.
@@ -258,10 +258,10 @@ A driver-defined entity that encapsulates all non-monitoring Connections associa
 -  **Emit Events:** A Pool MUST emit pool events when dictated by this spec (see `Connection Pool Monitoring <#connection-pool-monitoring>`__). Users MUST be able to subscribe to emitted events in a manner idiomatic to their language and driver.
 -  **Closeable:** A Pool MUST be able to be manually closed. When a Pool is closed, the following behaviors change:
 
-   -  Checking in a ``Connection`` to the Pool automatically closes the Connection
+   -  Checking in a ``Connection`` to the Pool automatically closes the ``Connection``
    -  Attempting to check out a ``Connection`` from the Pool results in an Error
 
--  **Capped:** a pool is capped if **maxPoolSize** is set to a non-zero value. If a pool is capped, then its total number of Connections (including available and in use) MUST NOT exceed **maxPoolSize**
+-  **Capped:** a pool is capped if **maxPoolSize** is set to a non-zero value. If a pool is capped, then its total number of ``Connections`` (including available and in use) MUST NOT exceed **maxPoolSize**
 
 .. code:: typescript
 
@@ -329,7 +329,7 @@ immediately begin populating enough ``Connections`` such that
 totalConnections >= minPoolSize. These ``Connections`` MUST be
 populated in a non-blocking manner, such as via the use of a
 background thread or asynchronous I/O. See `Populating the Pool with a
-Connection <#deprecated-options>`_ for more details.
+Connection <##populating-the-pool-with-a-connection-internal-implementation>`_ for more details.
 
 .. code::
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -10,7 +10,7 @@ Connection Monitoring and Pooling
 :Type: Standards
 :Minimum Server Version: N/A
 :Last Modified: June 11, 2019
-:Version: 1.1.0
+:Version: 1.2.0
 
 .. contents::
 
@@ -895,5 +895,9 @@ Exhaust Cursors may require changes to how we close `Connections <#connection>`_
 
 Change log
 ==========
+:2020-09-03: Clarify Connection states and definition. Require the use of a
+             background thread and/or async I/O. Add tests to ensure
+             ConnectionReadyEvents are fired after ConnectionCreatedEvents.
 
-:2019-06-06: Add "connectionError" as a valid reason for ConnectionCheckOutFailedEvent
+:2019-06-06: Add "connectionError" as a valid reason for
+             ConnectionCheckOutFailedEvent

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -31,13 +31,13 @@ Connection
 ~~~~~~~~~~~~~~
 
 A Connection (when linked) refers to the ``Connection`` type defined
-in this specification. It does not refer to an actual TCP/IP
-connection to an Endpoint. A ``Connection`` will attempt to create and
-wrap such a connection over the course of its existence, but it is not
+in this specification. It does not refer to an actual TCP connection
+to an Endpoint. A ``Connection`` will attempt to create and wrap such
+a TCP connection over the course of its existence, but it is not
 equivalent to one nor does it wrap an active one at all times.
 
 For the purposes of testing, a mocked ``Connection`` type could be used
-with the pool that never actually creates a TCP/IP connection or
+with the pool that never actually creates a TCP connection or
 performs any I/O.
 
 Endpoint
@@ -91,7 +91,7 @@ Drivers that implement a Connection Pool MUST support the following ConnectionPo
 
     interface ConnectionPoolOptions {
       /**
-       *  The maximum number of connections that may be associated
+       *  The maximum number of Connections that may be associated
        *  with a pool at a given time. This includes in use and
        *  available connections.
        *  If specified, MUST be an integer >= 0.
@@ -101,7 +101,7 @@ Drivers that implement a Connection Pool MUST support the following ConnectionPo
       maxPoolSize?: number;
 
       /**
-       *  The minimum number of connections that MUST exist at any moment
+       *  The minimum number of Connections that MUST exist at any moment
        *  in a single connection pool.
        *  If specified, MUST be an integer >= 0. If maxPoolSize is > 0
        *  then minPoolSize must be <= maxPoolSize
@@ -110,7 +110,7 @@ Drivers that implement a Connection Pool MUST support the following ConnectionPo
       minPoolSize?: number;
 
       /**
-       *  The maximum amount of time a connection should remain idle
+       *  The maximum amount of time a Connection should remain idle
        *  in the connection pool before being marked idle.
        *  If specified, MUST be a number >= 0.
        *  A value of 0 means there is no limit.
@@ -151,7 +151,7 @@ The following ConnectionPoolOptions are considered deprecated. They MUST NOT be 
     interface ConnectionPoolOptions {
       /**
        *  The maximum number of threads that can simultaneously wait
-       *  for a connection to become available.
+       *  for a Connection to become available.
        */
       waitQueueSize?: number;
 
@@ -169,7 +169,8 @@ Connection Pool Members
 Connection
 ----------
 
-A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A `Connection <#connection>`_ has the following properties:
+A driver-defined wrapper around a single TCP connection to an
+Endpoint. A `Connection <#connection>`_ has the following properties:
 
 -  **Single Endpoint:** A `Connection <#connection>`_ MUST be associated with a single Endpoint. A `Connection <#connection>`_ MUST NOT be associated with multiple Endpoints.
 -  **Single Lifetime:** A `Connection <#connection>`_ MUST NOT be used after it is closed.
@@ -177,11 +178,15 @@ A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A `Co
 -  **Single Track:** A `Connection <#connection>`_ MUST limit itself to one request / response at a time. A `Connection <#connection>`_ MUST NOT multiplex/pipeline requests to an Endpoint.
 -  **Monotonically Increasing ID:** A `Connection <#connection>`_ MUST have an ID number associated with it. `Connection <#connection>`_ IDs within a Pool MUST be assigned in order of creation, starting at 1 and increasing by 1 for each new Connection.
 -  **Valid Connection:** A connection MUST NOT be checked out of the pool until it has successfully and fully completed a MongoDB Handshake and Authentication as specified in the `Handshake <https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst>`__, `OP_COMPRESSED <https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.rst>`__, and `Authentication <https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst>`__ specifications.
--  **Perishable**: it is possible for a connection to become **Perished**. A connection is considered perished if any of the following are true:
+-  **Perishable**: it is possible for a `Connection <#connection>`_ to become **Perished**. A `Connection <#connection>`_ is considered perished if any of the following are true:
 
-   -  **Stale:** The connection's generation does not match the generation of the parent pool
-   -  **Idle:** The connection is currently "available" and has been for longer than **maxIdleTimeMS**.
-   -  **Errored:** The connection has experienced an error that indicates the connection is no longer recommended for use. Examples include, but are not limited to:
+   - **Stale:** The `Connection <#connection>`_ 's generation does not
+      match the generation of the parent pool
+   - **Idle:** The `Connection <#connection>`_ is currently
+      "available" and has been for longer than **maxIdleTimeMS**.
+   - **Errored:** The `Connection <#connection>`_ has experienced an
+      error that indicates it is no longer recommended for
+      use. Examples include, but are not limited to:
 
       -  Network Error
       -  Network Timeout
@@ -193,18 +198,18 @@ A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A `Co
 
     interface Connection {
       /**
-       *  An id number associated with the connection
+       *  An id number associated with the Connection
        */
       id: number;
 
       /**
-       *  The address of the pool that owns this connection
+       *  The address of the pool that owns this Connection
        */
       address: string;
 
       /**
        *  An integer representing the “generation” of the pool
-       *  when this connection was created
+       *  when this Connection was created
        */
       generation: number;
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -445,9 +445,8 @@ Populating the Pool with a Connection (Internal Implementation)
 marked as "available" and kept in the pool. This type of `Connection
 <#connection>`_ is created to ensure minPoolSize and is distinct from from the
 type that is created, established, and immediately checked out in checkOut. See
-`Checking Out a Connection
-<#populating-the-pool-with-a-connection-internal-implementation>`_ for more
-information on that type of `Connection <#connection>`_ creation.
+`Checking Out a Connection <#checking-out-a-connection>`_ for more information on
+that type of `Connection <#connection>`_ creation.
 
 Populating the pool MUST NOT block any application threads. For example, it
 could be performed on a background thread or via the use of non-blocking I/O.

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -790,6 +790,17 @@ Why is waitQueueTimeoutMS optional for some drivers?
 
 We are anticipating eventually introducing a single client-side timeout mechanism, making us hesitant to introduce another granular timeout control. Therefore, if a driver/language already has an idiomatic way to implement their timeouts, they should leverage that mechanism over implementing waitQueueTimeoutMS.
 
+Why must ensuring minPoolSize require the use of a background thread or async I/O?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Without the use of a background thread, minPoolSize is ensured during
+checkOut. ``Connections`` may not be checked into the pool before
+being established however, so establishment also happens during
+checkOut. If it were done in a blocking fashion, the first operations
+after a clearing of the pool would experience unacceptably high
+latency, especially for larger values of minPoolSize. Thus,
+minPoolSize either needs to be ensured via a background thread (which
+is acceptable to block) or via the usage of non-blocking (async) I/O.
 
 Backwards Compatibility
 =======================

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -413,10 +413,11 @@ thread or async I/O.
 
 .. code::
 
-    decrement total connection count
-    if connection state is "available":
-      decrement available connection count
+    original state = connection state
     set connection state to "closed"
+    decrement total connection count
+    if original state is "available":
+      decrement available connection count
     emit ConnectionClosedEvent
 
     # The following can happen at a later time (i.e. in background

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -249,7 +249,9 @@ Example implementations include:
 Connection Pool
 ---------------
 
-A driver-defined entity that encapsulates all non-monitoring Connections associated with a single Endpoint. The pool has the following properties:
+A driver-defined entity that encapsulates all non-monitoring
+`Connections <#connection>`_ associated with a single Endpoint. The pool
+has the following properties:
 
 -  **Thread Safe:** All Pool behaviors MUST be thread safe.
 -  **Not Fork-Safe:** A Pool is explicitly not fork-safe. If a Pool detects that is it being used by a forked process, it MUST immediately clear itself and update its pid

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -330,12 +330,13 @@ The SDAM specification defines `when
 the driver should create connection pools.
 
 Once a pool is created, if minPoolSize is set, the pool MUST immediately begin
-being "populated" with enough `Connections <#connection>`_ such that
-totalConnections >= minPoolSize. The Pool MUST be "populated" in a non-blocking
-manner, such as via the use of a background thread or asynchronous I/O. See
-`Populating the Pool with a Connection
+being `populated
+<#populating-the-pool-with-a-connection-internal-implementation>`_ with enough
+`Connections <#connection>`_ such that totalConnections >= minPoolSize. This
+MUST be done in a non-blocking manner, such as via the use of a background
+thread or asynchronous I/O. See `Populating the Pool with a Connection
 <#populating-the-pool-with-a-connection-internal-implementation>`_ for more
-details.
+details on the steps involved.
 
 .. code::
 
@@ -440,16 +441,14 @@ available `Connections <#connection>`_.
 Populating the Pool with a Connection (Internal Implementation)
 ---------------------------------------------------------------
 
-"Populating" the pool involves creating and establishing a `Connection
-<#connection>`_ that will not immediately be checked out and will instead be
-marked as "available" and kept in the pool. This type of `Connection
-<#connection>`_ is created to ensure minPoolSize and is distinct from from the
-type that is created, established, and immediately checked out in checkOut. See
-`Checking Out a Connection <#checking-out-a-connection>`_ for more information on
-that type of `Connection <#connection>`_ creation.
+"Populating" the pool involves preemptively creating and establishing a
+`Connection <#connection>`_ which is marked as "available" for use in future
+operations. This process is used to help ensure the number of established
+connections managed by the pool is at least minPoolSize.
 
 Populating the pool MUST NOT block any application threads. For example, it
-could be performed on a background thread or via the use of non-blocking I/O.
+could be performed on a background thread or via the use of non-blocking/async
+I/O.
 
 .. code::
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -30,11 +30,11 @@ Definitions
 Connection
 ~~~~~~~~~~~~~~
 
-A Connection (when linked) refers to the ``Connection`` type defined in this
-specification. It does not refer to an actual TCP connection to an Endpoint. A
-``Connection`` will attempt to create and wrap such a TCP connection over the
-course of its existence, but it is not equivalent to one nor does it wrap an
-active one at all times.
+A Connection (when linked) refers to the ``Connection`` type defined in the
+`Connection Pool Members`_ section of this specification. It does not refer to an actual TCP
+connection to an Endpoint. A ``Connection`` will attempt to create and wrap such
+a TCP connection over the course of its existence, but it is not equivalent to
+one nor does it wrap an active one at all times.
 
 For the purposes of testing, a mocked ``Connection`` type could be used with the
 pool that never actually creates a TCP connection or performs any I/O.
@@ -168,20 +168,19 @@ Connection Pool Members
 Connection
 ----------
 
-A driver-defined wrapper around a single TCP connection to an
-Endpoint. A `Connection <#connection>`_ has the following properties:
+A driver-defined wrapper around a single TCP connection to an Endpoint. A `Connection`_ has the following properties:
 
--  **Single Endpoint:** A `Connection <#connection>`_ MUST be associated with a single Endpoint. A `Connection <#connection>`_ MUST NOT be associated with multiple Endpoints.
--  **Single Lifetime:** A `Connection <#connection>`_ MUST NOT be used after it is closed.
--  **Single Owner:** A `Connection <#connection>`_ MUST belong to exactly one Pool, and MUST NOT be shared across multiple pools
--  **Single Track:** A `Connection <#connection>`_ MUST limit itself to one request / response at a time. A `Connection <#connection>`_ MUST NOT multiplex/pipeline requests to an Endpoint.
--  **Monotonically Increasing ID:** A `Connection <#connection>`_ MUST have an ID number associated with it. `Connection <#connection>`_ IDs within a Pool MUST be assigned in order of creation, starting at 1 and increasing by 1 for each new Connection.
+-  **Single Endpoint:** A `Connection`_ MUST be associated with a single Endpoint. A `Connection`_ MUST NOT be associated with multiple Endpoints.
+-  **Single Lifetime:** A `Connection`_ MUST NOT be used after it is closed.
+-  **Single Owner:** A `Connection`_ MUST belong to exactly one Pool, and MUST NOT be shared across multiple pools
+-  **Single Track:** A `Connection`_ MUST limit itself to one request / response at a time. A `Connection`_ MUST NOT multiplex/pipeline requests to an Endpoint.
+-  **Monotonically Increasing ID:** A `Connection`_ MUST have an ID number associated with it. `Connection`_ IDs within a Pool MUST be assigned in order of creation, starting at 1 and increasing by 1 for each new Connection.
 -  **Valid Connection:** A connection MUST NOT be checked out of the pool until it has successfully and fully completed a MongoDB Handshake and Authentication as specified in the `Handshake <https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst>`__, `OP_COMPRESSED <https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.rst>`__, and `Authentication <https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst>`__ specifications.
--  **Perishable**: it is possible for a `Connection <#connection>`_ to become **Perished**. A `Connection <#connection>`_ is considered perished if any of the following are true:
+-  **Perishable**: it is possible for a `Connection`_ to become **Perished**. A `Connection`_ is considered perished if any of the following are true:
 
-   - **Stale:** The `Connection <#connection>`_ 's generation does not match the generation of the parent pool
-   - **Idle:** The `Connection <#connection>`_ is currently "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
-   - **Errored:** The `Connection <#connection>`_ has experienced an error that indicates it is no longer recommended for use. Examples include, but are not limited to:
+   -  **Stale:** The `Connection`_ 's generation does not match the generation of the parent pool
+   -  **Idle:** The `Connection`_ is currently "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
+   -  **Errored:** The `Connection`_ has experienced an error that indicates it is no longer recommended for use. Examples include, but are not limited to:
 
       -  Network Error
       -  Network Timeout

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -528,7 +528,8 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
       leave wait queue
 
     # If the Connection has not been established yet (TCP, TLS,
-    # handshake, compression, and auth), it must be before it is returned.
+    # handshake, compression, and auth), it must be established
+    # before it is returned.
     # This MUST NOT block other threads from acquiring connections.
     if connection state is "pending":
       try:

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -838,21 +838,19 @@ Why is waitQueueTimeoutMS optional for some drivers?
 
 We are anticipating eventually introducing a single client-side timeout mechanism, making us hesitant to introduce another granular timeout control. Therefore, if a driver/language already has an idiomatic way to implement their timeouts, they should leverage that mechanism over implementing waitQueueTimeoutMS.
 
-Why must ensuring minPoolSize require the use of a background thread or async I/O?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Why must populating the pool require the use of a background thread or async I/O?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Without the use of a background thread, minPoolSize is ensured during
-checkOut. `Connections <#connection>`_ may not be checked into the pool before
-being established, however, so establishment also happens during
-checkOut. If `Connection <#connection>`_ establishment were done in a blocking
-fashion, the first operations after a clearing of the pool would
-experience unacceptably high latency, especially for larger values of
-minPoolSize. Thus, minPoolSize either needs to be ensured via a
-background thread (which is acceptable to block) or via the usage of
-non-blocking (async) I/O.
+Without the use of a background thread, the pool is `populated
+<#populating-the-pool-with-a-connection-internal-implementation>`_ with enough
+connections to satisfy minPoolSize during checkOut. `Connections <#connection>`_
+are established as part of populating the pool though, so if `Connection
+<#connection>`_ establishment were done in a blocking fashion, the first
+operations after a clearing of the pool would experience unacceptably high
+latency, especially for larger values of minPoolSize. Thus, populating the pool
+must occur on a background thread (which is acceptable to block) or via the
+usage of non-blocking (async) I/O.
 
-Why must closing a connection be non-blocking?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Because idle and perished `Connections <#connection>`_ are cleaned up as part of
 checkOut, performing blocking I/O while closing such `Connections <#connection>`_

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -851,6 +851,8 @@ latency, especially for larger values of minPoolSize. Thus, populating the pool
 must occur on a background thread (which is acceptable to block) or via the
 usage of non-blocking (async) I/O.
 
+Why should closing a connection be non-blocking?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Because idle and perished `Connections <#connection>`_ are cleaned up as part of
 checkOut, performing blocking I/O while closing such `Connections <#connection>`_

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -482,7 +482,9 @@ If the pool is closed, any attempt to check out a `Connection <#connection>`_ MU
 If minPoolSize is set, the `Connection <#connection>`_ Pool MUST always have at
 least minPoolSize total `Connections <#connection>`_. If the pool does not
 implement a background thread, the checkOut method is responsible for
-ensuring this requirement.
+`populating the pool
+<#populating-the-pool-with-a-connection-internal-implementation>`_ with enough
+`Connections <#connection>`_ such that this requirement is met.
 
 A `Connection <#connection>`_ MUST NOT be checked out until it is established. In
 addition, the Pool MUST NOT block other threads from checking out

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -179,13 +179,9 @@ Endpoint. A `Connection <#connection>`_ has the following properties:
 -  **Valid Connection:** A connection MUST NOT be checked out of the pool until it has successfully and fully completed a MongoDB Handshake and Authentication as specified in the `Handshake <https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst>`__, `OP_COMPRESSED <https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.rst>`__, and `Authentication <https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst>`__ specifications.
 -  **Perishable**: it is possible for a `Connection <#connection>`_ to become **Perished**. A `Connection <#connection>`_ is considered perished if any of the following are true:
 
-   - **Stale:** The `Connection <#connection>`_ 's generation does not
-     match the generation of the parent pool
-   - **Idle:** The `Connection <#connection>`_ is currently
-     "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
-   - **Errored:** The `Connection <#connection>`_ has experienced an
-     error that indicates it is no longer recommended for
-     use. Examples include, but are not limited to:
+   - **Stale:** The `Connection <#connection>`_ 's generation does not match the generation of the parent pool
+   - **Idle:** The `Connection <#connection>`_ is currently "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
+   - **Errored:** The `Connection <#connection>`_ has experienced an error that indicates it is no longer recommended for use. Examples include, but are not limited to:
 
       -  Network Error
       -  Network Timeout

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -331,11 +331,13 @@ The SDAM specification defines `when
 the driver should create connection pools.
 
 Once a pool is created, if minPoolSize is set, the pool MUST
-immediately begin populating enough `Connections <#connection>`_ such that
-totalConnections >= minPoolSize. These `Connections <#connection>`_ MUST be
-populated in a non-blocking manner, such as via the use of a
+immediately begin being "populated" with enough `Connections
+<#connection>`_ such that totalConnections >= minPoolSize. The Pool
+MUST be "populated" in a non-blocking manner, such as via the use of a
 background thread or asynchronous I/O. See `Populating the Pool with a
-Connection <#populating-the-pool-with-a-connection-internal-implementation>`_ for more details.
+Connection
+<#populating-the-pool-with-a-connection-internal-implementation>`_ for
+more details.
 
 .. code::
 
@@ -439,13 +441,18 @@ available `Connections <#connection>`_.
 Populating the Pool with a Connection (Internal Implementation)
 ---------------------------------------------------------------
 
-If minPoolSize is set, the pool MUST ensure that it always has at
-least minPoolSize total `Connections <#connection>`_. In order to achieve this, it
-needs to be able to create `Connections <#connection>`_ that begin as "available"
-instead of "in use" (i.e. "populate the pool"). Performing this
-process MUST NOT block any application threads. For example, it could
-be performed on a background thread or via the use of non-blocking
-I/O.
+"Populating" the pool involves creating and establishing a `Connection
+<#connection>`_ that will not immediately be checked out and will
+instead be marked as "available" and kept in the pool. This type of
+`Connection <#connection>`_ is created to ensure minPoolSize and is
+distinct from from the type that is created, established, and
+immediately checked out in checkOut. See `Checking Out a Connection
+<#populating-the-pool-with-a-connection-internal-implementation>`_ for
+more information on that type of `Connection <#connection>`_ creation.
+
+Populating the pool MUST NOT block any application threads. For
+example, it could be performed on a background thread or via the use
+of non-blocking I/O.
 
 .. code::
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -27,18 +27,17 @@ The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL N
 Definitions
 ===========
 
-``Connection``
+Connection
 ~~~~~~~~~~~~~~
 
-A ``Connection`` (when code-formatted) refers to the ``Connection``
-type defined in this specification. It does not refer to an actual
-TCP/IP connection to an Endpoint. A ``Connection`` will attempt to
-create and wrap such a connection over the course of its existence,
-but it is not equivalent to one nor does it wrap an active one at all
-times.
+A Connection (when linked) refers to the ``Connection`` type defined
+in this specification. It does not refer to an actual TCP/IP
+connection to an Endpoint. A ``Connection`` will attempt to create and
+wrap such a connection over the course of its existence, but it is not
+equivalent to one nor does it wrap an active one at all times.
 
-For the purposes of testing, a mocked ``Connection`` type could be
-used with the pool that never actually creates a TCP/IP connection or
+For the purposes of testing, a mocked ``Connection`` type could be used
+with the pool that never actually creates a TCP/IP connection or
 performs any I/O.
 
 Endpoint
@@ -170,13 +169,13 @@ Connection Pool Members
 Connection
 ----------
 
-A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A ``Connection`` has the following properties:
+A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A `Connection <#connection>`_ has the following properties:
 
--  **Single Endpoint:** A ``Connection`` MUST be associated with a single Endpoint. A ``Connection`` MUST NOT be associated with multiple Endpoints.
--  **Single Lifetime:** A ``Connection`` MUST NOT be used after it is closed.
--  **Single Owner:** A ``Connection`` MUST belong to exactly one Pool, and MUST NOT be shared across multiple pools
--  **Single Track:** A ``Connection`` MUST limit itself to one request / response at a time. A ``Connection`` MUST NOT multiplex/pipeline requests to an Endpoint.
--  **Monotonically Increasing ID:** A ``Connection`` MUST have an ID number associated with it. ``Connection`` IDs within a Pool MUST be assigned in order of creation, starting at 1 and increasing by 1 for each new Connection.
+-  **Single Endpoint:** A `Connection <#connection>`_ MUST be associated with a single Endpoint. A `Connection <#connection>`_ MUST NOT be associated with multiple Endpoints.
+-  **Single Lifetime:** A `Connection <#connection>`_ MUST NOT be used after it is closed.
+-  **Single Owner:** A `Connection <#connection>`_ MUST belong to exactly one Pool, and MUST NOT be shared across multiple pools
+-  **Single Track:** A `Connection <#connection>`_ MUST limit itself to one request / response at a time. A `Connection <#connection>`_ MUST NOT multiplex/pipeline requests to an Endpoint.
+-  **Monotonically Increasing ID:** A `Connection <#connection>`_ MUST have an ID number associated with it. `Connection <#connection>`_ IDs within a Pool MUST be assigned in order of creation, starting at 1 and increasing by 1 for each new Connection.
 -  **Valid Connection:** A connection MUST NOT be checked out of the pool until it has successfully and fully completed a MongoDB Handshake and Authentication as specified in the `Handshake <https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst>`__, `OP_COMPRESSED <https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.rst>`__, and `Authentication <https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst>`__ specifications.
 -  **Perishable**: it is possible for a connection to become **Perished**. A connection is considered perished if any of the following are true:
 
@@ -235,10 +234,10 @@ A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A ``C
 WaitQueue
 ---------
 
-A concept that represents pending requests for ``Connections``. When a thread requests a ``Connection`` from a Pool, the thread enters the Pool's WaitQueue. A thread stays in the WaitQueue until it either receives a ``Connection`` or times out. A WaitQueue has the following traits:
+A concept that represents pending requests for `Connections <#connection>`_. When a thread requests a `Connection <#connection>`_ from a Pool, the thread enters the Pool's WaitQueue. A thread stays in the WaitQueue until it either receives a `Connection <#connection>`_ or times out. A WaitQueue has the following traits:
 
 -  **Thread-Safe**: When multiple threads attempt to enter or exit a WaitQueue, they do so in a thread-safe manner.
--  **Ordered/Fair**: When ``Connections`` are made available, they are issued out to threads in the order that the threads entered the WaitQueue.
+-  **Ordered/Fair**: When `Connections <#connection>`_ are made available, they are issued out to threads in the order that the threads entered the WaitQueue.
 -  **Timeout aggressively:** If **waitQueueTimeoutMS** is set, members of a WaitQueue MUST timeout if they are enqueued for longer than waitQueueTimeoutMS. Members of a WaitQueue MUST timeout aggressively, and MUST leave the WaitQueue immediately upon timeout.
 
 The implementation details of a WaitQueue are left to the driver.
@@ -258,10 +257,10 @@ A driver-defined entity that encapsulates all non-monitoring Connections associa
 -  **Emit Events:** A Pool MUST emit pool events when dictated by this spec (see `Connection Pool Monitoring <#connection-pool-monitoring>`__). Users MUST be able to subscribe to emitted events in a manner idiomatic to their language and driver.
 -  **Closeable:** A Pool MUST be able to be manually closed. When a Pool is closed, the following behaviors change:
 
-   -  Checking in a ``Connection`` to the Pool automatically closes the ``Connection``
-   -  Attempting to check out a ``Connection`` from the Pool results in an Error
+   -  Checking in a `Connection <#connection>`_ to the Pool automatically closes the `Connection <#connection>`_
+   -  Attempting to check out a `Connection <#connection>`_ from the Pool results in an Error
 
--  **Capped:** a pool is capped if **maxPoolSize** is set to a non-zero value. If a pool is capped, then its total number of ``Connections`` (including available and in use) MUST NOT exceed **maxPoolSize**
+-  **Capped:** a pool is capped if **maxPoolSize** is set to a non-zero value. If a pool is capped, then its total number of `Connections <#connection>`_ (including available and in use) MUST NOT exceed **maxPoolSize**
 
 .. code:: typescript
 
@@ -325,11 +324,11 @@ The SDAM specification defines `when
 the driver should create connection pools.
 
 Once a pool is created, if minPoolSize is set, the pool MUST
-immediately begin populating enough ``Connections`` such that
-totalConnections >= minPoolSize. These ``Connections`` MUST be
+immediately begin populating enough `Connections <#connection>`_ such that
+totalConnections >= minPoolSize. These `Connections <#connection>`_ MUST be
 populated in a non-blocking manner, such as via the use of a
 background thread or asynchronous I/O. See `Populating the Pool with a
-Connection <##populating-the-pool-with-a-connection-internal-implementation>`_ for more details.
+Connection <#populating-the-pool-with-a-connection-internal-implementation>`_ for more details.
 
 .. code::
 
@@ -345,10 +344,10 @@ Connection <##populating-the-pool-with-a-connection-internal-implementation>`_ f
 Closing a Connection Pool
 -------------------------
 
-When a pool is closed, it MUST first close all available ``Connections`` in that pool. This results in the following behavior changes:
+When a pool is closed, it MUST first close all available `Connections <#connection>`_ in that pool. This results in the following behavior changes:
 
--  In use ``Connections`` MUST be closed when they are checked in to the closed pool.
--  Attempting to check out a ``Connection`` MUST result in an error.
+-  In use `Connections <#connection>`_ MUST be closed when they are checked in to the closed pool.
+-  Attempting to check out a `Connection <#connection>`_ MUST result in an error.
 
 .. code::
 
@@ -360,8 +359,8 @@ When a pool is closed, it MUST first close all available ``Connections`` in that
 Creating a Connection (Internal Implementation)
 -----------------------------------------------
 
-When creating a ``Connection``, the initial ``Connection`` is in an
-“unestablished” state. This only creates a “virtual” ``Connection``, and
+When creating a `Connection <#connection>`_, the initial `Connection <#connection>`_ is in an
+“unestablished” state. This only creates a “virtual” `Connection <#connection>`_, and
 performs no I/O. 
 
 .. code::
@@ -375,7 +374,7 @@ performs no I/O.
 Establishing a Connection (Internal Implementation)
 ---------------------------------------------------
 
-Before a ``Connection`` can be marked as either "available" or "in use", it
+Before a `Connection <#connection>`_ can be marked as either "available" or "in use", it
 must be established. This process involves performing the initial
 handshake, handling OP_COMPRESSED, and performing authentication.
 
@@ -396,9 +395,9 @@ handshake, handling OP_COMPRESSED, and performing authentication.
 Closing a Connection (Internal Implementation)
 ----------------------------------------------
 
-When a ``Connection`` is closed, it MUST first be marked as "closed",
+When a `Connection <#connection>`_ is closed, it MUST first be marked as "closed",
 removing it from being counted as "available" or "in use". One that is
-complete, the ``Connection`` can perform whatever teardown is
+complete, the `Connection <#connection>`_ can perform whatever teardown is
 necessary to close its underlying socket. The Driver MUST perform this
 teardown in a non-blocking manner, such as via the use of a background
 thread or async I/O.
@@ -418,10 +417,10 @@ thread or async I/O.
 Marking a Connection as Available (Internal Implementation)
 -----------------------------------------------------------
 
-A ``Connection`` is "available" if it is able to be checked out. A
-``Connection`` MUST NOT be marked as "available" until it has been
+A `Connection <#connection>`_ is "available" if it is able to be checked out. A
+`Connection <#connection>`_ MUST NOT be marked as "available" until it has been
 established. The pool MUST keep track of the number of currently
-available ``Connections``.
+available `Connections <#connection>`_.
 
 .. code::
 
@@ -434,8 +433,8 @@ Populating the Pool with a Connection (Internal Implementation)
 ---------------------------------------------------------------
 
 If minPoolSize is set, the pool MUST ensure that it always has at
-least minPoolSize total ``Connections``. In order to achieve this, it
-needs to be able to create ``Connections`` that begin as "available"
+least minPoolSize total `Connections <#connection>`_. In order to achieve this, it
+needs to be able to create `Connections <#connection>`_ that begin as "available"
 instead of "in use" (i.e. "populate the pool"). Performing this
 process MUST NOT block any application threads. For example, it could
 be performed on a background thread or via the use of non-blocking
@@ -451,29 +450,29 @@ I/O.
 Checking Out a Connection
 -------------------------
 
-A Pool MUST have a method of allowing the driver to check out a ``Connection``. Checking out a ``Connection`` involves entering the WaitQueue and waiting for a ``Connection`` to become available. If the thread times out in the WaitQueue, an error is thrown.
+A Pool MUST have a method of allowing the driver to check out a `Connection <#connection>`_. Checking out a `Connection <#connection>`_ involves entering the WaitQueue and waiting for a `Connection <#connection>`_ to become available. If the thread times out in the WaitQueue, an error is thrown.
 
-If, in the process of iterating available ``Connections`` in the pool
-by the checkOut method, a perished ``Connection`` is encountered, such
-a ``Connection`` MUST be closed and the iteration of available
-``Connections`` MUST continue until either a non-perished available
-``Connection`` is found or the list of available ``Connections`` is
-exhausted. If no ``Connections`` are available and the total number of
-``Connections`` is less than maxPoolSize, the pool MUST create and
-return a new ``Connection``.
+If, in the process of iterating available `Connections <#connection>`_ in the pool
+by the checkOut method, a perished `Connection <#connection>`_ is encountered, such
+a `Connection <#connection>`_ MUST be closed and the iteration of available
+`Connections <#connection>`_ MUST continue until either a non-perished available
+`Connection <#connection>`_ is found or the list of available `Connections <#connection>`_ is
+exhausted. If no `Connections <#connection>`_ are available and the total number of
+`Connections <#connection>`_ is less than maxPoolSize, the pool MUST create and
+return a new `Connection <#connection>`_.
 
-If the pool is closed, any attempt to check out a ``Connection`` MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
+If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 
-If minPoolSize is set, the ``Connection`` Pool MUST always have at
-least minPoolSize total ``Connections``. If the pool does not
+If minPoolSize is set, the `Connection <#connection>`_ Pool MUST always have at
+least minPoolSize total `Connections <#connection>`_. If the pool does not
 implement a background thread, the checkOut method is responsible for
 ensuring this requirement.
 
-A ``Connection`` MUST NOT be checked out until it is established. In
+A `Connection <#connection>`_ MUST NOT be checked out until it is established. In
 addition, the Pool MUST NOT block other threads from checking out
-``Connections`` while establishing a ``Connection``.
+`Connections <#connection>`_ while establishing a `Connection <#connection>`_.
 
-Before a given ``Connection`` is returned from checkOut, it must be marked as
+Before a given `Connection <#connection>`_ is returned from checkOut, it must be marked as
 "in use", and the pool's availableConnectionCount MUST be decremented.
 
 .. code::
@@ -530,16 +529,16 @@ Checking In a Connection
 ------------------------
 
 A Pool MUST have a method of allowing the driver to check in a
-``Connection``. The driver MUST NOT be allowed to check in a
-``Connection`` to a Pool that did not create that ``Connection``, and
+`Connection <#connection>`_. The driver MUST NOT be allowed to check in a
+`Connection <#connection>`_ to a Pool that did not create that `Connection <#connection>`_, and
 MUST throw an Error if this is attempted.
 
-When the ``Connection`` is checked in, it is closed if any of the following are true:
+When the `Connection <#connection>`_ is checked in, it is closed if any of the following are true:
 
--  The ``Connection`` is perished.
+-  The `Connection <#connection>`_ is perished.
 -  The pool has been closed.
 
-Otherwise, the ``Connection`` is marked as available.
+Otherwise, the `Connection <#connection>`_ is marked as available.
 
 .. code::
 
@@ -552,17 +551,17 @@ Otherwise, the ``Connection`` is marked as available.
 Clearing a Connection Pool
 --------------------------
 
-A Pool MUST have a method of clearing all ``Connections`` when instructed. Rather than iterating through every ``Connection``, this method should simply increment the generation of the Pool, implicitly marking all current ``Connections`` as stale. The checkOut and checkIn algorithms will handle clearing out stale ``Connections``. If a user is subscribed to Connection Monitoring events, a PoolClearedEvent MUST be emitted after incrementing the generation.
+A Pool MUST have a method of clearing all `Connections <#connection>`_ when instructed. Rather than iterating through every `Connection <#connection>`_, this method should simply increment the generation of the Pool, implicitly marking all current `Connections <#connection>`_ as stale. The checkOut and checkIn algorithms will handle clearing out stale `Connections <#connection>`_. If a user is subscribed to Connection Monitoring events, a PoolClearedEvent MUST be emitted after incrementing the generation.
 
 Forking
 -------
 
-A ``Connection`` is explicitly not fork-safe. The proper behavior in the case of a fork is to ResetAfterFork by:
+A `Connection <#connection>`_ is explicitly not fork-safe. The proper behavior in the case of a fork is to ResetAfterFork by:
 
 -  clear all Connection Pools in the child process
--  closing all ``Connections`` in the child-process.
+-  closing all `Connections <#connection>`_ in the child-process.
 
-Drivers that support forking MUST document that ``Connections`` to an Endpoint are not fork-safe, and document the proper way to ResetAfterFork in the driver.
+Drivers that support forking MUST document that `Connections <#connection>`_ to an Endpoint are not fork-safe, and document the proper way to ResetAfterFork in the driver.
 
 Drivers MAY aggressively ResetAfterFork if the driver detects it has been forked.
 
@@ -575,16 +574,16 @@ Background Thread
 ^^^^^^^^^^^^^^^^^
 
 A Pool SHOULD have a background Thread that is responsible for
-monitoring the state of all available ``Connections``. This background
+monitoring the state of all available `Connections <#connection>`_. This background
 thread SHOULD
 
--  Populate ``Connections`` to ensure that the pool always satisfies **minPoolSize**
--  Remove and close perished available ``Connections``.
+-  Populate `Connections <#connection>`_ to ensure that the pool always satisfies **minPoolSize**
+-  Remove and close perished available `Connections <#connection>`_.
 
 withConnection
 ^^^^^^^^^^^^^^
 
-A Pool SHOULD implement a scoped resource management mechanism idiomatic to their language to prevent ``Connections`` from not being checked in. Examples include `Python's "with" statement <https://docs.python.org/3/whatsnew/2.6.html#pep-343-the-with-statement>`__ and `C#'s "using" statement <https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement>`__. If implemented, drivers SHOULD use this method as the default method of checking out and checking in ``Connections``.
+A Pool SHOULD implement a scoped resource management mechanism idiomatic to their language to prevent `Connections <#connection>`_ from not being checked in. Examples include `Python's "with" statement <https://docs.python.org/3/whatsnew/2.6.html#pep-343-the-with-statement>`__ and `C#'s "using" statement <https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/using-statement>`__. If implemented, drivers SHOULD use this method as the default method of checking out and checking in `Connections <#connection>`_.
 
 .. _connection-pool-monitoring-1:
 
@@ -797,17 +796,17 @@ Why do we have separate ConnectionCreated and ConnectionReady events, but only o
 
 ConnectionCreated and ConnectionReady each involve different state changes in the pool.
 
--  ConnectionCreated adds a new “unestablished” ``Connection``, meaning the totalConnectionCount increases by one
--  ConnectionReady establishes that the ``Connection`` is ready for use, meaning the availableConnectionCount increases by one
+-  ConnectionCreated adds a new “unestablished” `Connection <#connection>`_, meaning the totalConnectionCount increases by one
+-  ConnectionReady establishes that the `Connection <#connection>`_ is ready for use, meaning the availableConnectionCount increases by one
 
-ConnectionClosed indicates that the ``Connection`` is no longer a member of the pool, decrementing totalConnectionCount and potentially availableConnectionCount. After this point, the ``Connection`` is no longer a part of the pool. Further hypothetical events would not indicate a change to the state of the pool, so they are not specified here.
+ConnectionClosed indicates that the `Connection <#connection>`_ is no longer a member of the pool, decrementing totalConnectionCount and potentially availableConnectionCount. After this point, the `Connection <#connection>`_ is no longer a part of the pool. Further hypothetical events would not indicate a change to the state of the pool, so they are not specified here.
 
 Why are waitQueueSize and waitQueueMultiple deprecated?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These options were originally only implemented in three drivers (Java, C#, and Python), and provided little value. While these fields would allow for faster diagnosis of issues in the connection pool, they would not actually prevent an error from occurring. 
 
-Additionally, these options have the effect of prioritizing older requests over newer requests, which is not necessarily the behavior that users want. They can also result in cases where queue access oscillates back and forth between full and not full. If a driver has a full waitQueue, then all requests for ``Connections`` will be rejected. If the client is continually spammed with requests, you could wind up with a scenario where as soon as the waitQueue is no longer full, it is immediately filled. It is not a favorable situation to be in, partially b/c it violates the fairness guarantee that the waitQueue normally provides. 
+Additionally, these options have the effect of prioritizing older requests over newer requests, which is not necessarily the behavior that users want. They can also result in cases where queue access oscillates back and forth between full and not full. If a driver has a full waitQueue, then all requests for `Connections <#connection>`_ will be rejected. If the client is continually spammed with requests, you could wind up with a scenario where as soon as the waitQueue is no longer full, it is immediately filled. It is not a favorable situation to be in, partially b/c it violates the fairness guarantee that the waitQueue normally provides. 
 
 Because of these issues, it does not make sense to `go against driver mantras and provide an additional knob <../../README.rst#>`__. We may eventually pursue an alternative configurations to address wait queue size in `Advanced Pooling Behaviors <#advanced-pooling-behaviors>`__.
 
@@ -822,9 +821,9 @@ Why must ensuring minPoolSize require the use of a background thread or async I/
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Without the use of a background thread, minPoolSize is ensured during
-checkOut. ``Connections`` may not be checked into the pool before
+checkOut. `Connections <#connection>`_ may not be checked into the pool before
 being established, however, so establishment also happens during
-checkOut. If ``Connection`` establishment were done in a blocking
+checkOut. If `Connection <#connection>`_ establishment were done in a blocking
 fashion, the first operations after a clearing of the pool would
 experience unacceptably high latency, especially for larger values of
 minPoolSize. Thus, minPoolSize either needs to be ensured via a
@@ -834,10 +833,10 @@ non-blocking (async) I/O.
 Why must closing a connection be non-blocking?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Because idle and perished ``Connections`` are cleaned up as part of
-checkOut, performing blocking I/O while closing such ``Connections``
+Because idle and perished `Connections <#connection>`_ are cleaned up as part of
+checkOut, performing blocking I/O while closing such `Connections <#connection>`_
 would block application threads, introducing unnecessary latency. Once
-a ``Connection`` is marked as "closed", it will not be checked out
+a `Connection <#connection>`_ is marked as "closed", it will not be checked out
 again, so ensuring the socket is torn down does not need to happen
 immediately and can happen at a later time, either via async I/O or a
 background thread. 
@@ -862,19 +861,19 @@ SDAM
 
 This specification does not dictate how SDAM Monitoring connections are managed. SDAM specifies that “A monitor SHOULD NOT use the client's regular Connection pool”. Some possible solutions for this include:
 
--  Having each Endpoint representation in the driver create and manage a separate dedicated ``Connection`` for monitoring purposes
+-  Having each Endpoint representation in the driver create and manage a separate dedicated `Connection <#connection>`_ for monitoring purposes
 -  Having each Endpoint representation in the driver maintain a separate pool of maxPoolSize 1 for monitoring purposes.
--  Having each Pool maintain a dedicated ``Connection`` for monitoring purposes, with an API to expose that Connection.
+-  Having each Pool maintain a dedicated `Connection <#connection>`_ for monitoring purposes, with an API to expose that Connection.
 
 Advanced Pooling Behaviors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This spec does not address any advanced pooling behaviors like predictive pooling, aggressive ``Connection`` creation, or handling high request volume. Future work may address this.
+This spec does not address any advanced pooling behaviors like predictive pooling, aggressive `Connection <#connection>`_ creation, or handling high request volume. Future work may address this.
 
 Add support for OP_MSG exhaustAllowed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Exhaust Cursors may require changes to how we close ``Connections`` in the future, specifically to add a way to close and remove from its pool a ``Connection`` which has unread exhaust messages.
+Exhaust Cursors may require changes to how we close `Connections <#connection>`_ in the future, specifically to add a way to close and remove from its pool a `Connection <#connection>`_ which has unread exhaust messages.
 
 
 Change log

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -30,15 +30,14 @@ Definitions
 Connection
 ~~~~~~~~~~~~~~
 
-A Connection (when linked) refers to the ``Connection`` type defined
-in this specification. It does not refer to an actual TCP connection
-to an Endpoint. A ``Connection`` will attempt to create and wrap such
-a TCP connection over the course of its existence, but it is not
-equivalent to one nor does it wrap an active one at all times.
+A Connection (when linked) refers to the ``Connection`` type defined in this
+specification. It does not refer to an actual TCP connection to an Endpoint. A
+``Connection`` will attempt to create and wrap such a TCP connection over the
+course of its existence, but it is not equivalent to one nor does it wrap an
+active one at all times.
 
-For the purposes of testing, a mocked ``Connection`` type could be used
-with the pool that never actually creates a TCP connection or
-performs any I/O.
+For the purposes of testing, a mocked ``Connection`` type could be used with the
+pool that never actually creates a TCP connection or performs any I/O.
 
 Endpoint
 ~~~~~~~~

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -180,12 +180,12 @@ Endpoint. A `Connection <#connection>`_ has the following properties:
 -  **Perishable**: it is possible for a `Connection <#connection>`_ to become **Perished**. A `Connection <#connection>`_ is considered perished if any of the following are true:
 
    - **Stale:** The `Connection <#connection>`_ 's generation does not
-      match the generation of the parent pool
+     match the generation of the parent pool
    - **Idle:** The `Connection <#connection>`_ is currently
-      "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
+     "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
    - **Errored:** The `Connection <#connection>`_ has experienced an
-      error that indicates it is no longer recommended for
-      use. Examples include, but are not limited to:
+     error that indicates it is no longer recommended for
+     use. Examples include, but are not limited to:
 
       -  Network Error
       -  Network Timeout

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -467,14 +467,16 @@ Checking Out a Connection
 
 A Pool MUST have a method of allowing the driver to check out a `Connection <#connection>`_. Checking out a `Connection <#connection>`_ involves entering the WaitQueue and waiting for a `Connection <#connection>`_ to become available. If the thread times out in the WaitQueue, an error is thrown.
 
-If, in the process of iterating available `Connections <#connection>`_ in the pool
-by the checkOut method, a perished `Connection <#connection>`_ is encountered, such
-a `Connection <#connection>`_ MUST be closed and the iteration of available
-`Connections <#connection>`_ MUST continue until either a non-perished available
-`Connection <#connection>`_ is found or the list of available `Connections <#connection>`_ is
-exhausted. If no `Connections <#connection>`_ are available and the total number of
-`Connections <#connection>`_ is less than maxPoolSize, the pool MUST create and
-return a new `Connection <#connection>`_.
+If, in the process of iterating available `Connections <#connection>`_ in the
+pool by the checkOut method, a perished `Connection <#connection>`_ is
+encountered, such a `Connection <#connection>`_ MUST be closed (as described in
+`Closing a Connection <#closing-a-connection-internal-implementation>`_) and the
+iteration of available `Connections <#connection>`_ MUST continue until either a
+non-perished available `Connection <#connection>`_ is found or the list of
+available `Connections <#connection>`_ is exhausted. If no `Connections
+<#connection>`_ are available and the total number of `Connections
+<#connection>`_ is less than maxPoolSize, the pool MUST create and return a new
+`Connection <#connection>`_.
 
 If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -183,7 +183,7 @@ Endpoint. A `Connection <#connection>`_ has the following properties:
    - **Stale:** The `Connection <#connection>`_ 's generation does not
       match the generation of the parent pool
    - **Idle:** The `Connection <#connection>`_ is currently
-      "available" and has been for longer than **maxIdleTimeMS**.
+      "available" (as defined below) and has been for longer than **maxIdleTimeMS**.
    - **Errored:** The `Connection <#connection>`_ has experienced an
       error that indicates it is no longer recommended for
       use. Examples include, but are not limited to:

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -552,7 +552,9 @@ A Pool MUST have a method of allowing the driver to check in a
 `Connection <#connection>`_ to a Pool that did not create that `Connection <#connection>`_, and
 MUST throw an Error if this is attempted.
 
-When the `Connection <#connection>`_ is checked in, it is closed if any of the following are true:
+When the `Connection <#connection>`_ is checked in, it MUST be `closed
+<#closing-a-connection-internal-implementation>`_ if any of the following are
+true:
 
 -  The `Connection <#connection>`_ is perished.
 -  The pool has been closed.

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -156,13 +156,13 @@ Connection Pool Members
 Connection
 ----------
 
-A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A Connection has the following properties:
+A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A ``Connection`` has the following properties:
 
--  **Single Endpoint:** A Connection MUST be associated with a single Endpoint. A Connection MUST NOT be associated with multiple Endpoints.
--  **Single Lifetime:** A Connection MUST NOT be used after it is closed.
--  **Single Owner:** A Connection MUST belong to exactly one Pool, and MUST NOT be shared across multiple pools
--  **Single Track:** A Connection MUST limit itself to one request / response at a time. A Connection MUST NOT multiplex/pipeline requests to an Endpoint.
--  **Monotonically Increasing ID:** A Connection MUST have an ID number associated with it. Connection IDs within a Pool MUST be assigned in order of creation, starting at 1 and increasing by 1 for each new Connection.
+-  **Single Endpoint:** A ``Connection`` MUST be associated with a single Endpoint. A ``Connection`` MUST NOT be associated with multiple Endpoints.
+-  **Single Lifetime:** A ``Connection`` MUST NOT be used after it is closed.
+-  **Single Owner:** A ``Connection`` MUST belong to exactly one Pool, and MUST NOT be shared across multiple pools
+-  **Single Track:** A ``Connection`` MUST limit itself to one request / response at a time. A ``Connection`` MUST NOT multiplex/pipeline requests to an Endpoint.
+-  **Monotonically Increasing ID:** A ``Connection`` MUST have an ID number associated with it. ``Connection`` IDs within a Pool MUST be assigned in order of creation, starting at 1 and increasing by 1 for each new Connection.
 -  **Valid Connection:** A connection MUST NOT be checked out of the pool until it has successfully and fully completed a MongoDB Handshake and Authentication as specified in the `Handshake <https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst>`__, `OP_COMPRESSED <https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.rst>`__, and `Authentication <https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst>`__ specifications.
 -  **Perishable**: it is possible for a connection to become **Perished**. A connection is considered perished if any of the following are true:
 
@@ -221,7 +221,7 @@ A driver-defined wrapper around a single TCP/IP connection to an Endpoint. A Con
 WaitQueue
 ---------
 
-A concept that represents pending requests for Connections. When a thread requests a Connection from a Pool, the thread enters the Pool's WaitQueue. A thread stays in the WaitQueue until it either receives a Connection or times out. A WaitQueue has the following traits:
+A concept that represents pending requests for Connections. When a thread requests a ``Connection`` from a Pool, the thread enters the Pool's WaitQueue. A thread stays in the WaitQueue until it either receives a ``Connection`` or times out. A WaitQueue has the following traits:
 
 -  **Thread-Safe**: When multiple threads attempt to enter or exit a WaitQueue, they do so in a thread-safe manner.
 -  **Ordered/Fair**: When connections are made available, they are issued out to threads in the order that the threads entered the WaitQueue.
@@ -244,8 +244,8 @@ A driver-defined entity that encapsulates all non-monitoring Connections associa
 -  **Emit Events:** A Pool MUST emit pool events when dictated by this spec (see `Connection Pool Monitoring <#connection-pool-monitoring>`__). Users MUST be able to subscribe to emitted events in a manner idiomatic to their language and driver.
 -  **Closeable:** A Pool MUST be able to be manually closed. When a Pool is closed, the following behaviors change:
 
-   -  Checking in a Connection to the Pool automatically closes the Connection
-   -  Attempting to check out a Connection from the Pool results in an Error
+   -  Checking in a ``Connection`` to the Pool automatically closes the Connection
+   -  Attempting to check out a ``Connection`` from the Pool results in an Error
 
 -  **Capped:** a pool is capped if **maxPoolSize** is set to a non-zero value. If a pool is capped, then its total number of Connections (including available and in use) MUST NOT exceed **maxPoolSize**
 
@@ -333,7 +333,7 @@ Closing a Connection Pool
 When a pool is closed, it MUST first close all available Connections in that pool. This results in the following behavior changes:
 
 -  In use Connections MUST be closed when they are checked in to the closed pool.
--  Attempting to check out a Connection MUST result in an error.
+-  Attempting to check out a ``Connection`` MUST result in an error.
 
 .. code::
 
@@ -345,7 +345,7 @@ When a pool is closed, it MUST first close all available Connections in that poo
 Creating a Connection (Internal Implementation)
 -----------------------------------------------
 
-When creating a Connection, the initial Connection is in an
+When creating a Connection, the initial ``Connection`` is in an
 “unestablished” state. This only creates a “virtual” Connection, and
 performs no I/O. 
 
@@ -360,7 +360,7 @@ performs no I/O.
 Establishing a Connection (Internal Implementation)
 ---------------------------------------------------
 
-Before a Connection can be marked as "available", it must be
+Before a ``Connection`` can be marked as "available", it must be
 “established”. This process involves performing the initial handshake,
 handling OP_COMPRESSED, and performing authentication.
 
@@ -381,9 +381,9 @@ handling OP_COMPRESSED, and performing authentication.
 Closing a Connection (Internal Implementation)
 ----------------------------------------------
 
-When a Connection is closed, it MUST first be marked as "closed",
+When a ``Connection`` is closed, it MUST first be marked as "closed",
 removing it from being counted as "available" or "in use". One that is
-complete, the Connection can perform whatever teardown is necessary to
+complete, the ``Connection`` can perform whatever teardown is necessary to
 close the socket. The Driver MUST perform this teardown in a
 non-blocking manner, such as via the use of a background thread or
 async I/O.
@@ -403,8 +403,8 @@ async I/O.
 Marking a Connection as Available (Internal Implementation)
 -----------------------------------------------------------
 
-A Connection is "available" if it is able to be checked out. A
-Connection MUST NOT be marked as "available" until it has been
+A ``Connection`` is "available" if it is able to be checked out. A
+``Connection`` MUST NOT be marked as "available" until it has been
 established. The pool MUST keep track of the number of currently
 available Connections.
 
@@ -433,23 +433,23 @@ background thread or perform the I/O in a non-blocking manner.
 Checking Out a Connection
 -------------------------
 
-A Pool MUST have a method of allowing the driver to check out a Connection. Checking out a Connection involves entering the WaitQueue, and waiting for a Connection to become available. If the thread times out in the WaitQueue, an error is thrown.
+A Pool MUST have a method of allowing the driver to check out a Connection. Checking out a ``Connection`` involves entering the WaitQueue, and waiting for a ``Connection`` to become available. If the thread times out in the WaitQueue, an error is thrown.
 
-If, in the process of iterating available Connections in the pool by the checkOut method, a perished Connection is encountered, such a Connection MUST be closed and the iteration of available Connections MUST continue until either a non-perished available Connection is found or the list of available Connections is exhausted. If no Connections are available and the total number of Connections is less than maxPoolSize, the pool MUST create and return a new Connection.
+If, in the process of iterating available Connections in the pool by the checkOut method, a perished ``Connection`` is encountered, such a ``Connection`` MUST be closed and the iteration of available Connections MUST continue until either a non-perished available ``Connection`` is found or the list of available Connections is exhausted. If no Connections are available and the total number of Connections is less than maxPoolSize, the pool MUST create and return a new Connection.
 
-If the pool is closed, any attempt to check out a Connection MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
+If the pool is closed, any attempt to check out a ``Connection`` MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 
-If minPoolSize is set, the Connection Pool MUST always have at least
+If minPoolSize is set, the ``Connection`` Pool MUST always have at least
 minPoolSize total Connections. If the pool does not implement a
 background thread, the checkOut method is responsible for ensuring
 this requirement.
 
-A Connection MUST NOT be checked out until it is "established". In
+A ``Connection`` MUST NOT be checked out until it is "established". In
 addition, the Pool MUST NOT block other threads from checking out
 Connections while establishing a Connection.
 
 Before returning a Connection, it must be marked as "in use". This
-MUST decrement the pool's available Connection count.
+MUST decrement the pool's available ``Connection`` count.
 
 .. code::
 
@@ -504,14 +504,14 @@ MUST decrement the pool's available Connection count.
 Checking In a Connection
 ------------------------
 
-A Pool MUST have a method of allowing the driver to check in a Connection. The driver MUST NOT be allowed to check in a Connection to a Pool that did not create that Connection, and MUST throw an Error if this is attempted.
+A Pool MUST have a method of allowing the driver to check in a Connection. The driver MUST NOT be allowed to check in a ``Connection`` to a Pool that did not create that Connection, and MUST throw an Error if this is attempted.
 
-When the Connection is checked in, it is closed if any of the following are true:
+When the ``Connection`` is checked in, it is closed if any of the following are true:
 
--  The Connection is perished.
+-  The ``Connection`` is perished.
 -  The pool has been closed.
 
-Otherwise, the Connection is marked as available.
+Otherwise, the ``Connection`` is marked as available.
 
 .. code::
 
@@ -524,12 +524,12 @@ Otherwise, the Connection is marked as available.
 Clearing a Connection Pool
 --------------------------
 
-A Pool MUST have a method of clearing all Connections when instructed. Rather than iterating through every Connection, this method should simply increment the generation of the Pool, implicitly marking all current Connections as stale. The checkOut and checkIn algorithms will handle clearing out stale Connections. If a user is subscribed to Connection Monitoring events, a PoolClearedEvent MUST be emitted after incrementing the generation.
+A Pool MUST have a method of clearing all Connections when instructed. Rather than iterating through every Connection, this method should simply increment the generation of the Pool, implicitly marking all current Connections as stale. The checkOut and checkIn algorithms will handle clearing out stale Connections. If a user is subscribed to ``Connection`` Monitoring events, a PoolClearedEvent MUST be emitted after incrementing the generation.
 
 Forking
 -------
 
-A Connection is explicitly not fork-safe. The proper behavior in the case of a fork is to ResetAfterFork by:
+A ``Connection`` is explicitly not fork-safe. The proper behavior in the case of a fork is to ResetAfterFork by:
 
 -  clear all Connection Pools in the child process
 -  closing all Connections in the child-process.
@@ -770,16 +770,16 @@ Why do we have separate ConnectionCreated and ConnectionReady events, but only o
 ConnectionCreated and ConnectionReady each involve different state changes in the pool.
 
 -  ConnectionCreated adds a new “unestablished” Connection, meaning the totalConnectionCount increases by one
--  ConnectionReady establishes that the Connection is ready for use, meaning the availableConnectionCount increases by one
+-  ConnectionReady establishes that the ``Connection`` is ready for use, meaning the availableConnectionCount increases by one
 
-ConnectionClosed indicates that the Connection is no longer a member of the pool, decrementing totalConnectionCount and potentially availableConnectionCount. After this point, the Connection is no longer a part of the pool. Further hypothetical events would not indicate a change to the state of the pool, so they are not specified here.
+ConnectionClosed indicates that the ``Connection`` is no longer a member of the pool, decrementing totalConnectionCount and potentially availableConnectionCount. After this point, the ``Connection`` is no longer a part of the pool. Further hypothetical events would not indicate a change to the state of the pool, so they are not specified here.
 
 Why are waitQueueSize and waitQueueMultiple deprecated?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 These options were originally only implemented in three drivers (Java, C#, and Python), and provided little value. While these fields would allow for faster diagnosis of issues in the connection pool, they would not actually prevent an error from occurring. 
 
-Additionally, these options have the effect of prioritizing older requests over newer requests, which is not necessarily the behavior that users want. They can also result in cases where queue access oscillates back and forth between full and not full. If a driver has a full waitQueue, then all requests for Connections will be rejected. If the client is continually spammed with requests, you could wind up with a scenario where as soon as the waitQueue is no longer full, it is immediately filled. It is not a favorable situation to be in, partially b/c it violates the fairness guarantee that the waitQueue normally provides. 
+Additionally, these options have the effect of prioritizing older requests over newer requests, which is not necessarily the behavior that users want. They can also result in cases where queue access oscillates back and forth between full and not full. If a driver has a full waitQueue, then all requests for ``Connections`` will be rejected. If the client is continually spammed with requests, you could wind up with a scenario where as soon as the waitQueue is no longer full, it is immediately filled. It is not a favorable situation to be in, partially b/c it violates the fairness guarantee that the waitQueue normally provides. 
 
 Because of these issues, it does not make sense to `go against driver mantras and provide an additional knob <../../README.rst#>`__. We may eventually pursue an alternative configurations to address wait queue size in `Advanced Pooling Behaviors <#advanced-pooling-behaviors>`__.
 
@@ -811,19 +811,19 @@ SDAM
 
 This specification does not dictate how SDAM Monitoring connections are managed. SDAM specifies that “A monitor SHOULD NOT use the client's regular Connection pool”. Some possible solutions for this include:
 
--  Having each Endpoint representation in the driver create and manage a separate dedicated Connection for monitoring purposes
+-  Having each Endpoint representation in the driver create and manage a separate dedicated ``Connection`` for monitoring purposes
 -  Having each Endpoint representation in the driver maintain a separate pool of maxPoolSize 1 for monitoring purposes.
--  Having each Pool maintain a dedicated Connection for monitoring purposes, with an API to expose that Connection.
+-  Having each Pool maintain a dedicated ``Connection`` for monitoring purposes, with an API to expose that Connection.
 
 Advanced Pooling Behaviors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This spec does not address any advanced pooling behaviors like predictive pooling, aggressive Connection creation, or handling high request volume. Future work may address this.
+This spec does not address any advanced pooling behaviors like predictive pooling, aggressive ``Connection`` creation, or handling high request volume. Future work may address this.
 
 Add support for OP_MSG exhaustAllowed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Exhaust Cursors may require changes to how we close Connections in the future, specifically to add a way to close and remove from its pool a Connection which has unread exhaust messages.
+Exhaust Cursors may require changes to how we close ``Connections`` in the future, specifically to add a way to close and remove from its pool a ``Connection`` which has unread exhaust messages.
 
 
 Change log

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -407,7 +407,7 @@ Closing a Connection (Internal Implementation)
 When a `Connection <#connection>`_ is closed, it MUST first be marked as "closed",
 removing it from being counted as "available" or "in use". One that is
 complete, the `Connection <#connection>`_ can perform whatever teardown is
-necessary to close its underlying socket. The Driver MUST perform this
+necessary to close its underlying socket. The Driver SHOULD perform this
 teardown in a non-blocking manner, such as via the use of a background
 thread or async I/O.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -474,8 +474,8 @@ iteration of available `Connections <#connection>`_ MUST continue until either a
 non-perished available `Connection <#connection>`_ is found or the list of
 available `Connections <#connection>`_ is exhausted. If no `Connections
 <#connection>`_ are available and the total number of `Connections
-<#connection>`_ is less than maxPoolSize, the pool MUST create and return a new
-established `Connection <#connection>`_.
+<#connection>`_ is less than maxPoolSize, the pool MUST create a `Connection
+<#connection>`_, establish it, mark it as "in use" and return it.
 
 If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 
@@ -537,8 +537,8 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
         emit ConnectionCheckOutFailedEvent(reason="error")
         decrement total connection count
         throw
-
-    decrement available connection count
+    else:
+        decrement available connection count
     set connection state to "in use"
     emit ConnectionCheckedOutEvent
     return connection

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-connection.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-connection.json
@@ -13,14 +13,22 @@
       "address": 42
     },
     {
+      "type": "ConnectionCreated",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
       "type": "ConnectionCheckedOut",
       "connectionId": 1,
       "address": 42
     }
   ],
   "ignore": [
-    "ConnectionPoolCreated",
-    "ConnectionCreated",
-    "ConnectionReady"
+    "ConnectionPoolCreated"
   ]
 }

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-connection.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-connection.yml
@@ -6,10 +6,14 @@ operations:
 events:
   - type: ConnectionCheckOutStarted
     address: 42
+  - type: ConnectionCreated
+    connectionId: 1
+    address: 42
+  - type: ConnectionReady
+    connectionId: 1
+    address: 42
   - type: ConnectionCheckedOut
     connectionId: 1
     address: 42
 ignore:
   - ConnectionPoolCreated
-  - ConnectionCreated
-  - ConnectionReady

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size.json
@@ -12,6 +12,11 @@
       "count": 3
     },
     {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 3
+    },
+    {
       "name": "checkOut"
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size.yml
@@ -7,6 +7,9 @@ operations:
   - name: waitForEvent
     event: ConnectionCreated
     count: 3
+  - name: waitForEvent
+    event: ConnectionReady
+    count: 3
   - name: checkOut
 events:
   - type: ConnectionPoolCreated


### PR DESCRIPTION
SPEC-1412

This PR makes a number of modifications to the CMAP spec to clarify the lifecycle of a `Connection` and the terminology used to describe it. Besides resyncing the tests, this ideally should not require any changes in drivers that currently implement a CMAP-based connection pool.

This originally started out as fixing a minor issue with the wording of "creating a connection" that resulted in ConnectionReady events being fired before ConnectionCreated events according to a literal interpretation of the spec. In fixing this issue, I realized that a solution could not easily be found that worked for both drivers that had a background thread and/or async I/O and for drivers that were single threaded. Seeing as no single-threaded drivers currently implement CMAP or plan to do so, this PR also adds a requirement to the CMAP pool that a background thread and/or async I/O is used. See the comments on SPEC-1412 (and the rationale included in the diff) for details on this part. 

Because this change involved a lot of search-and-replace, the diff is a little ugly. I've highlighted the actual changes here to aid in reviewing:
- Defined `Connection` specifically as a "Connection object" and disambiguated it from a TCP/IP connection
    - `code-formatted` "Connection" everywhere in the spec where it was referenced in this context.
- exhaustively listed the possible "states" that a `Connection` can be in and described them clearly
    - the states: "unestablished", "available", "in use", and "closed"
    - removed references to "readyToUse" and "setting up" a connection, replaced with "established" and "establish(ing)"
- added separate sections for "Populating the Pool with a Connection" and "Marking a Connection as Available"
- Required ensuring minPoolSize and clearing of perished connections to be non-blocking or done by the background thread
- Added test verifying ConnectionReady events are fired after ConnectionCreated events
- Added test verifying connections are established as a part of minPoolSize population