### PR TITLE
SPEC-1582 Parse $uuid fields as Binary subtype 4

### DIFF
--- a/source/bson-corpus/tests/binary.json
+++ b/source/bson-corpus/tests/binary.json
@@ -42,6 +42,7 @@
         {
             "description": "subtype 0x04 UUID",
             "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}",
             "degenerate_extjson": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}"
         },
         {
@@ -88,10 +89,6 @@
         }
     ],
     "parseErrors": [
-        {
-            "description": "$uuid missing hyphens",
-            "string": "{\"x\" : { \"$uuid\" : \"73ffd26444b34c6990e8e7d1dfc035d4\"}}"
-        },
         {
             "description": "$uuid wrong type",
             "string": "{\"x\" : { \"$uuid\" : { \"data\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}}"

--- a/source/bson-corpus/tests/binary.json
+++ b/source/bson-corpus/tests/binary.json
@@ -37,7 +37,8 @@
         {
             "description": "subtype 0x04",
             "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}"
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}",
+            "degenerate_extjson": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}"
         },
         {
             "description": "subtype 0x05",

--- a/source/bson-corpus/tests/binary.json
+++ b/source/bson-corpus/tests/binary.json
@@ -37,7 +37,11 @@
         {
             "description": "subtype 0x04",
             "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
-            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"04\"}}}"
+        },
+        {
+            "description": "subtype 0x04 UUID",
+            "canonical_bson": "1D000000057800100000000473FFD26444B34C6990E8E7D1DFC035D400",
             "degenerate_extjson": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}"
         },
         {
@@ -81,6 +85,20 @@
         {
             "description": "subtype 0x02 length negative one",
             "bson": "130000000578000600000002FFFFFFFFFFFF00"
+        }
+    ],
+    "parseErrors": [
+        {
+            "description": "$uuid missing hyphens",
+            "string": "{\"x\" : { \"$uuid\" : \"73ffd26444b34c6990e8e7d1dfc035d4\"}}"
+        },
+        {
+            "description": "$uuid wrong type",
+            "string": "{\"x\" : { \"$uuid\" : { \"data\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}}"
+        },
+        {
+            "description": "$uuid invalid value",
+            "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-90e8-e7d1dfc035d4\"}}"
         }
     ]
 }

--- a/source/extended-json.rst
+++ b/source/extended-json.rst
@@ -526,9 +526,6 @@ for readability)::
      "Double": {
          "$numberDouble": "42.42"
      },
-     "SpecialFloat": {
-         "$numberDouble": "NaN"
-     },
      "Decimal": {
          "$numberDecimal": "1234.5"
      },
@@ -587,7 +584,6 @@ for readability)::
      },
      "True": true,
      "False": false,
-
      "DBRef": {
          "$ref": "collection",
          "$id": {
@@ -609,6 +605,7 @@ for readability)::
      },
      "Null": null
   }
+
 
 Relaxed Extended JSON Example
 -----------------------------
@@ -930,6 +927,11 @@ v2.1.0
 
 * Added support for parsing ``$uuid`` fields as BSON Binary subtype 4.
 
+* Changed the example to using the MongoDB Python Driver. It previously
+  used the MongoDB Java Driver. The new example excludes the following
+  BSON types that are unsupported in Python - ``Symbol``, ``SpecialFloat``,
+  ``DBPointer`` and ``Undefined``. Transformations for these types are
+  now only documented in the `Conversion table`_.
 
 v2.0.0
 ------


### PR DESCRIPTION
POC'ing this with PyMongo uncovered an issue - `$uuid` is also how UUIDs were represented in PyMongo's legacy extJSON format so  this might result in a backward-breaking change in the Python driver.

Also, there is no mention in this spec whether extJSON parsers should offer configuration options that allow the user to set UuidRepresentation (https://github.com/mongodb/specifications/blob/master/source/uuid.rst) and accordingly decode UUID fields (I'd guess that UNSPECIFIED would decode as Binary subtype 4, any other representation would decode as native UUID; on the generation/encoding side we'd need to decide whether native UUIDs will be encoded as subtype 4 or 3).
