### PR TITLE
command_name is not an operations field

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -96,8 +96,6 @@ Each YAML file has the following keys:
 
     - ``collectionOptions``: |txn|
 
-    - ``command_name``: |txn|
-
     - ``arguments``: |txn|
 
     - ``result``: |txn|


### PR DESCRIPTION
This might have been copypasta, but AFAIK `command_name` only exists within a command expectation. It was never a field for documents in `operations`.