### PR TITLE
SPEC-1753 Rate limit new connection creations (maxConnecting)

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -406,8 +406,8 @@ performs no I/O.
 .. code::
 
     connection = new Connection()
-    increment total connection count
-    increment pending connection count
+    increment totalConnectionCount
+    increment pendingConnectionCount
     set connection state to "pending"
     emit ConnectionCreatedEvent
     return connection
@@ -453,12 +453,12 @@ ConnectionCounts in any way and MUST NOT emit a ConnectionClosedEvent.
     set connection state to "closed"
 
     if original state is "available":
-      decrement available connection count
+      decrement availableConnectionCount
     else if original state is "pending":
-      decrement pending connection count
+      decrement pendingConnectionCount
 
     if original state != "unmanaged":
-      decrement total connection count
+      decrement totalConnectionCount
       emit ConnectionClosedEvent
 
     # The following can happen at a later time (i.e. in background
@@ -475,7 +475,7 @@ available `Connections <#connection>`_.
 
 .. code::
 
-   increment available connection count
+   increment availableConnectionCount
    set connection state to "available"
    add connection to availableConnections
 
@@ -596,14 +596,14 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
     if connection state is "pending":
       try:
         establish connection
-        decrement pending connection count
+        decrement pendingConnectionCount
       except connection establishment error:
         emit ConnectionCheckOutFailedEvent(reason="error")
-        decrement total connection count
-        decrement pending connection count
+        decrement totalConnectionCount
+        decrement pendingConnectionCount
         throw
     else:
-        decrement available connection count
+        decrement availableConnectionCount
     set connection state to "in use"
     emit ConnectionCheckedOutEvent
     return connection
@@ -660,14 +660,14 @@ monitoring threads.
 
    wait until pendingConnectionCount < maxConnecting
    connection = new Connection()
-   increment pending connection count
+   increment pendingConnectionCount
    try:
      connect connection via TCP / TLS
      set connection state to "unmanaged"
-     decrement pending connection count
+     decrement pendingConnectionCount
      return connection
    except error:
-     decrement pending connection count
+     decrement pendingConnectionCount
      throw error
 
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -528,7 +528,7 @@ are met or until a `Connection <#connection>`_ becomes available, re-entering
 the checkOut loop once it finishes waiting. This waiting MUST NOT block other
 threads from checking in `Connections <#connection>`_ to the pool. Threads that
 are waiting on the maxConnecting requirement to be met MUST receive the newly
-available `Connections <#connection>`_ in order that they entered the WaitQueue. 
+available `Connections <#connection>`_ in order that they entered the WaitQueue.
 
 If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -566,12 +566,12 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
               close connection
               connection = Null
         else if totalConnectionCount < maxPoolSize:
-          if numConnecting < maxConnecting:
+          if pendingConnectionCount < maxConnecting:
             connection = create connection
           else:
             # this waiting MUST NOT prevent other threads from checking Connections
             # back in to the pool.
-            wait until numConnecting < maxConnecting or a connection is available
+            wait until pendingConnectionCount < maxConnecting or a connection is available
             continue
           
     except pool is closed:
@@ -587,7 +587,7 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
     # If there is no background thread, the pool MUST ensure that
     # there are at least minPoolSize total connections.
     # This MUST be done in a non-blocking manner
-    while totalConnectionCount < minPoolSize and numConnecting < maxConnecting:
+    while totalConnectionCount < minPoolSize and pendingConnectionCount < maxConnecting:
       populate the pool with a connection
 
     # If the Connection has not been established yet (TCP, TLS,
@@ -600,6 +600,7 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
       except connection establishment error:
         emit ConnectionCheckOutFailedEvent(reason="error")
         decrement total connection count
+        decrement pending connection count
         throw
     else:
         decrement available connection count

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -695,6 +695,9 @@ monitoring the state of all available `Connections <#connection>`_. This backgro
 thread SHOULD
 
 -  Populate `Connections <#connection>`_ to ensure that the pool always satisfies **minPoolSize**
+    - The background thread SHOULD just go back to sleep instead of waiting for
+      pendingConnectionCount to become less than maxConnecting when satisfying
+      minPoolSize.
 -  Remove and close perished available `Connections <#connection>`_.
 
 withConnection

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -595,12 +595,12 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
     if connection state is "pending":
       try:
         establish connection
-        decrement pendingConnectionCount
       except connection establishment error:
         emit ConnectionCheckOutFailedEvent(reason="error")
         decrement totalConnectionCount
-        decrement pendingConnectionCount
         throw
+      finally:
+        decrement pendingConnectionCount
     else:
         decrement availableConnectionCount
     set connection state to "in use"

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -526,11 +526,10 @@ maxConnecting, then the thread MUST wait until either both of those conditions
 are met or until a `Connection <#connection>`_ becomes available, re-entering
 the checkOut loop once it finishes waiting. This waiting MUST NOT block other
 threads from checking in `Connections <#connection>`_ to the pool. Threads that
-are waiting on the maxConnecting requirement to be met MUST receive the newly
-available `Connections <#connection>`_ in order that they entered the
-WaitQueue. For drivers that implement the WaitQueue via a fair semaphore, a
-second semaphore may be required to implement this waiting. Waiting on this
-semaphore SHOULD be limited by the WaitQueueTimeout, if the driver supports one.
+are waiting MUST be notified in order that they entered the WaitQueue. For
+drivers that implement the WaitQueue via a fair semaphore, a second semaphore
+may be required to implement this. Waiting on this second semaphore SHOULD be
+limited by the WaitQueueTimeout, if the driver supports one.
 
 If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 
@@ -586,7 +585,7 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
     # If there is no background thread, the pool MUST ensure that
     # there are at least minPoolSize total connections.
     # This MUST be done in a non-blocking manner
-    while totalConnectionCount < minPoolSize and pendingConnectionCount < maxConnecting:
+    while totalConnectionCount < minPoolSize:
       populate the pool with a connection
 
     # If the Connection has not been established yet (TCP, TLS,

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -547,7 +547,7 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
 "in use", and the pool's availableConnectionCount MUST be decremented.
 
 maxConnecting Implementation Note
-*********************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For drivers that implement the WaitQueue via a fair semaphore, a second
 semaphore may be required to implement the waiting a thread needs to do if

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -278,6 +278,9 @@ has the following properties:
        */
       generation: number;
     
+      // Any of the following connection counts may be computed rather than
+      // actually stored on the pool.
+
       /**
        *  An integer expressing how many total Connections
        *  ("pending" + "available" + "in use") the pool currently has

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -527,9 +527,9 @@ a `Connection`_ becomes available, re-entering the checkOut loop once it
 finishes waiting. This waiting MUST NOT block other threads from checking in a
 `Connection`_ to the pool. Threads that are waiting MUST be notified in order
 that they entered the WaitQueue. For drivers that implement the WaitQueue via a
-fair semaphore, a second semaphore may be required to implement this. Waiting on
-this second semaphore SHOULD be limited by the WaitQueueTimeout, if the driver
-supports one.
+fair semaphore, a condition variable may also be required to implement
+this. Waiting on the conditional variable SHOULD be limited by the
+WaitQueueTimeout, if the driver supports one.
 
 If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -9,8 +9,8 @@ Connection Monitoring and Pooling
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: June 11, 2019
-:Version: 1.2.0
+:Last Modified: September 24, 2020
+:Version: 1.3.0
 
 .. contents::
 
@@ -1010,6 +1010,8 @@ Exhaust Cursors may require changes to how we close `Connections <#connection>`_
 
 Change log
 ==========
+:2020-09-24: Introduce maxConnecting requirement, Unmanaged Connections
+
 :2020-09-03: Clarify Connection states and definition. Require the use of a
              background thread and/or async I/O. Add tests to ensure
              ConnectionReadyEvents are fired after ConnectionCreatedEvents.

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -988,19 +988,10 @@ Reference Implementations
 Future Development
 ==================
 
-SDAM
-~~~~
-
-This specification does not dictate how SDAM Monitoring connections are managed. SDAM specifies that “A monitor SHOULD NOT use the client's regular Connection pool”. Some possible solutions for this include:
-
--  Having each Endpoint representation in the driver create and manage a separate dedicated `Connection <#connection>`_ for monitoring purposes
--  Having each Endpoint representation in the driver maintain a separate pool of maxPoolSize 1 for monitoring purposes.
--  Having each Pool maintain a dedicated `Connection <#connection>`_ for monitoring purposes, with an API to expose that Connection.
-
 Advanced Pooling Behaviors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This spec does not address any advanced pooling behaviors like predictive pooling, aggressive `Connection <#connection>`_ creation, or handling high request volume. Future work may address this.
+This spec does not address all advanced pooling behaviors like predictive pooling or aggressive `Connection <#connection>`_ creation. Future work may address this.
 
 Add support for OP_MSG exhaustAllowed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -39,6 +39,23 @@ one nor does it wrap an active one at all times.
 For the purposes of testing, a mocked ``Connection`` type could be used with the
 pool that never actually creates a TCP connection or performs any I/O.
 
+Unmanaged Connection
+~~~~~~~~~~~~~~~~~~~~
+
+An "Unmanaged Connection" refers to a `Connection <#connection>`_ created by the
+pool that does not count towards any connection count, may not be checked in to
+the pool, and causes no monitoring events to be emitted over the course of its
+existence. It does contain a generation, an ID, and an established TCP
+connection, though no steps of the authentication process or the MongoDB
+handshake are performed as part of setting up that TCP connection.
+
+The same restrictions that apply to the creation of normal pooled `Connections
+<#connection>`_ apply to "Unmanaged Connections", and pendingConnectionCount is
+incremented while the underlying TCP connection of an "Unmanaged Connection" is
+being set up.
+
+"Unmanaged Connections" MUST be created and used by SDAM monitoring threads.
+
 Endpoint
 ~~~~~~~~
 
@@ -176,6 +193,8 @@ A driver-defined wrapper around a single TCP connection to an Endpoint. A `Conne
 -  **Single Track:** A `Connection`_ MUST limit itself to one request / response at a time. A `Connection`_ MUST NOT multiplex/pipeline requests to an Endpoint.
 -  **Monotonically Increasing ID:** A `Connection`_ MUST have an ID number associated with it. `Connection`_ IDs within a Pool MUST be assigned in order of creation, starting at 1 and increasing by 1 for each new Connection.
 -  **Valid Connection:** A connection MUST NOT be checked out of the pool until it has successfully and fully completed a MongoDB Handshake and Authentication as specified in the `Handshake <https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst>`__, `OP_COMPRESSED <https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.rst>`__, and `Authentication <https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst>`__ specifications.
+
+   -  Note: `Unmanaged Connections <#unmanaged-connection>`_ do not perform any parts of the MongoDB Handshake or Authentication when created.
 -  **Perishable**: it is possible for a `Connection`_ to become **Perished**. A `Connection`_ is considered perished if any of the following are true:
 
    -  **Stale:** The `Connection`_ 's generation does not match the generation of the parent pool
@@ -220,6 +239,9 @@ A driver-defined wrapper around a single TCP connection to an Endpoint. A `Conne
        *   - "in use":        The Connection has been established, checked out from the pool, and has yet
        *                      to be checked back in. Contributes to totalConnectionCount.
        *
+       *   - "unmanaged":     The Connection was created and established via createUnmanagedConnection
+       *                      and has yet to be closed. Does not contribute to any connection counts.
+       *
        *   - "closed":        The Connection has had its socket closed and cannot be used for any future
        *                      operations. Does not contribute to any connection counts.
        *
@@ -227,7 +249,7 @@ A driver-defined wrapper around a single TCP connection to an Endpoint. A `Conne
        * in this specification. It is not required that drivers
        * actually include this field in their implementations of Connection.
        */
-      state: "pending" | "available" | "in use" | "closed";
+      state: "pending" | "available" | "in use" | "unmanaged" | "closed";
     }
 
 WaitQueue
@@ -291,7 +313,7 @@ has the following properties:
       availableConnectionCount: number;
 
       /**
-       *  An integer expressiong how many Connections are currently
+       *  An integer expressing how many Connections are currently
        *  being established.
        */
       pendingConnectionCount: number;
@@ -315,6 +337,13 @@ has the following properties:
        *  Closes the pool, preventing the pool from creating and returning new Connections
        */
       close(): void;
+
+      /**
+       * Returns a newly established "unmanaged" Connection.
+       *
+       * This Connection MUST NOT be checked in to the pool.
+       */
+      createUnmanagedConnection(): Connection;
     }
 
 .. _connection-pool-behaviors-1:
@@ -409,22 +438,29 @@ Closing a Connection (Internal Implementation)
 ----------------------------------------------
 
 When a `Connection <#connection>`_ is closed, it MUST first be marked as "closed",
-removing it from being counted as "available" or "in use". One that is
+removing it from being counted as "available" or "in use". Once that is
 complete, the `Connection <#connection>`_ can perform whatever teardown is
 necessary to close its underlying socket. The Driver SHOULD perform this
 teardown in a non-blocking manner, such as via the use of a background
 thread or async I/O.
 
+If the `Connection <#connection>`_ being closed is an `Unmanaged Connection
+<#unmanaged-connection>`_, then closing it MUST NOT modify any of the
+ConnectionCounts in any way and MUST NOT emit a ConnectionClosedEvent.
+
 .. code::
 
     original state = connection state
     set connection state to "closed"
-    decrement total connection count
+
     if original state is "available":
       decrement available connection count
     else if original state is "pending":
       decrement pending connection count
-    emit ConnectionClosedEvent
+
+    if original state != "unmanaged":
+      decrement total connection count
+      emit ConnectionClosedEvent
 
     # The following can happen at a later time (i.e. in background
     # thread) or via non-blocking I/O.
@@ -509,6 +545,14 @@ addition, the Pool MUST NOT block other threads from checking out
 
 Before a given `Connection <#connection>`_ is returned from checkOut, it must be marked as
 "in use", and the pool's availableConnectionCount MUST be decremented.
+
+maxConnecting Implementation Note
+*********************************
+
+For drivers that implement the WaitQueue via a fair semaphore, a second
+semaphore may be required to implement the waiting a thread needs to do if
+pendingConnectionCount == maxConnecting at the time of checkOut. Waiting on this
+semaphore SHOULD be limited by the WaitQueueTimeout, if the driver supports one.
 
 .. code::
 
@@ -597,6 +641,39 @@ Clearing a Connection Pool
 --------------------------
 
 A Pool MUST have a method of clearing all `Connections <#connection>`_ when instructed. Rather than iterating through every `Connection <#connection>`_, this method should simply increment the generation of the Pool, implicitly marking all current `Connections <#connection>`_ as stale. The checkOut and checkIn algorithms will handle clearing out stale `Connections <#connection>`_. If a user is subscribed to Connection Monitoring events, a PoolClearedEvent MUST be emitted after incrementing the generation.
+
+Creating an Unmanaged Connection
+--------------------------------
+
+A Pool MUST have a method for creating an `Unmanaged Connection
+<#unmanaged-connection>`_. This method MUST connect the underlying TCP socket of
+the returned `Connection <#connection>`_, but it MUST NOT perform any steps of
+the authentication process or the MongoDB handshake as part of that. The
+returned `Connection <#connection>`_ MUST be marked as "unmanaged" and MUST NOT
+be allowed to be checked back into the Pool.
+
+This method MUST NOT emit any monitoring events under any circumstances.
+
+This method MUST wait until pendingConnectionCount < maxConnecting before
+proceeding with creating an `Unmanaged Connection <#unmanaged-connection>`_.
+
+This method is used to create the `Connections <#connection>`_ used by SDAM
+monitoring threads.
+
+.. code::
+
+   wait until pendingConnectionCount < maxConnecting
+   connection = new Connection()
+   increment pending connection count
+   try:
+     connect connection via TCP / TLS
+     set connection state to "unmanaged"
+     decrement pending connection count
+     return connection
+   except error:
+     decrement pending connection count
+     throw error
+
 
 Forking
 -------

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -528,7 +528,10 @@ are met or until a `Connection <#connection>`_ becomes available, re-entering
 the checkOut loop once it finishes waiting. This waiting MUST NOT block other
 threads from checking in `Connections <#connection>`_ to the pool. Threads that
 are waiting on the maxConnecting requirement to be met MUST receive the newly
-available `Connections <#connection>`_ in order that they entered the WaitQueue.
+available `Connections <#connection>`_ in order that they entered the
+WaitQueue. For drivers that implement the WaitQueue via a fair semaphore, a
+second semaphore may be required to implement this waiting. Waiting on this
+semaphore SHOULD be limited by the WaitQueueTimeout, if the driver supports one.
 
 If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 
@@ -545,14 +548,6 @@ addition, the Pool MUST NOT block other threads from checking out
 
 Before a given `Connection <#connection>`_ is returned from checkOut, it must be marked as
 "in use", and the pool's availableConnectionCount MUST be decremented.
-
-maxConnecting Implementation Note
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For drivers that implement the WaitQueue via a fair semaphore, a second
-semaphore may be required to implement the waiting a thread needs to do if
-pendingConnectionCount == maxConnecting at the time of checkOut. Waiting on this
-semaphore SHOULD be limited by the WaitQueueTimeout, if the driver supports one.
 
 .. code::
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -503,33 +503,33 @@ I/O.
 Checking Out a Connection
 -------------------------
 
-A Pool MUST have a method of allowing the driver to check out a `Connection
-<#connection>`_. Checking out a `Connection <#connection>`_ involves entering
-the WaitQueue, waiting to be granted access to the list of available
-connections, and finding or creating a `Connection <#connection>`_ to be
-returned. If the thread times out in the WaitQueue, an error is thrown.
+A Pool MUST have a method of allowing the driver to check out a `Connection`_.
+Checking out a `Connection`_ involves entering the WaitQueue, waiting to be
+granted access to the list of available connections, and finding or creating a
+`Connection`_ to be returned. If the thread times out in the WaitQueue, an error
+is thrown.
 
 Once reaching the front of the WaitQueue, a thread begins iterating over the
 list of available `Connections <#connection>`_, searching for a non-perished one
-to be returned. If a perished `Connection <#connection>`_ is encountered, such a
-`Connection <#connection>`_ MUST be closed (as described in `Closing a
-Connection <#closing-a-connection-internal-implementation>`_) and the iteration
-of available `Connections <#connection>`_ MUST continue until either a
-non-perished available `Connection <#connection>`_ is found or the list of
-available `Connections <#connection>`_ is exhausted.
+to be returned. If a perished `Connection`_ is encountered, such a `Connection`_
+MUST be closed (as described in `Closing a Connection
+<#closing-a-connection-internal-implementation>`_) and the iteration of
+available `Connections <#connection>`_ MUST continue until either a non-perished
+available `Connection`_ is found or the list of available `Connections
+<#connection>`_ is exhausted.
 
 If the list is exhausted, the total number of `Connections <#connection>`_ is
 less than maxPoolSize, and pendingConnectionCount < maxConnecting, the pool MUST
-create a `Connection <#connection>`_, establish it, mark it as "in use" and
-return it. If totalConnectionCount == maxPoolSize or pendingConnectionCount ==
-maxConnecting, then the thread MUST wait until either both of those conditions
-are met or until a `Connection <#connection>`_ becomes available, re-entering
-the checkOut loop once it finishes waiting. This waiting MUST NOT block other
-threads from checking in `Connections <#connection>`_ to the pool. Threads that
-are waiting MUST be notified in order that they entered the WaitQueue. For
-drivers that implement the WaitQueue via a fair semaphore, a second semaphore
-may be required to implement this. Waiting on this second semaphore SHOULD be
-limited by the WaitQueueTimeout, if the driver supports one.
+create a `Connection`_, establish it, mark it as "in use" and return it. If
+totalConnectionCount == maxPoolSize or pendingConnectionCount == maxConnecting,
+then the thread MUST wait until either both of those conditions are met or until
+a `Connection`_ becomes available, re-entering the checkOut loop once it
+finishes waiting. This waiting MUST NOT block other threads from checking in a
+`Connection`_ to the pool. Threads that are waiting MUST be notified in order
+that they entered the WaitQueue. For drivers that implement the WaitQueue via a
+fair semaphore, a second semaphore may be required to implement this. Waiting on
+this second semaphore SHOULD be limited by the WaitQueueTimeout, if the driver
+supports one.
 
 If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -43,16 +43,16 @@ Unmanaged Connection
 ~~~~~~~~~~~~~~~~~~~~
 
 An "Unmanaged Connection" refers to a `Connection <#connection>`_ created by the
-pool that does not count towards any connection count, may not be checked in to
+pool that does not contribute to any connection count, may not be checked in to
 the pool, and causes no monitoring events to be emitted over the course of its
 existence. It does contain a generation, an ID, and an established TCP
 connection, though no steps of the authentication process or the MongoDB
 handshake are performed as part of setting up that TCP connection.
 
-The same restrictions that apply to the creation of normal pooled `Connections
-<#connection>`_ apply to "Unmanaged Connections", and pendingConnectionCount is
-incremented while the underlying TCP connection of an "Unmanaged Connection" is
-being set up.
+The same establishment restrictions that apply to the creation of normal pooled
+`Connections <#connection>`_ apply to "Unmanaged Connections" too
+(e.g. maxConnecting), and pendingConnectionCount is incremented while the
+underlying TCP connection of an "Unmanaged Connection" is still being set up.
 
 "Unmanaged Connections" MUST be created and used by SDAM monitoring threads.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -528,7 +528,7 @@ finishes waiting. This waiting MUST NOT block other threads from checking in a
 `Connection`_ to the pool. Threads that are waiting MUST be notified in order
 that they entered the WaitQueue. For drivers that implement the WaitQueue via a
 fair semaphore, a condition variable may also be required to implement
-this. Waiting on the conditional variable SHOULD be limited by the
+this. Waiting on the condition variable SHOULD be limited by the
 WaitQueueTimeout, if the driver supports one.
 
 If the pool is closed, any attempt to check out a `Connection <#connection>`_ MUST throw an Error, and any items in the waitQueue MUST be removed from the waitQueue and throw an Error.

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -427,7 +427,6 @@ handshake, handling OP_COMPRESSED, and performing authentication.
       handle OP_COMPRESSED
       perform connection authentication
       emit ConnectionReadyEvent
-      decrement pending connection count
       return connection
     except error:
       close connection
@@ -597,6 +596,7 @@ Before a given `Connection <#connection>`_ is returned from checkOut, it must be
     if connection state is "pending":
       try:
         establish connection
+        decrement pending connection count
       except connection establishment error:
         emit ConnectionCheckOutFailedEvent(reason="error")
         decrement total connection count

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
@@ -10,7 +10,7 @@
   "failPoint": {
     "configureFailPoint": "failCommand",
     "mode": {
-      "times": 3
+      "times": 10
     },
     "data": {
       "failCommands": [

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
@@ -10,7 +10,7 @@
   "failPoint": {
     "configureFailPoint": "failCommand",
     "mode": {
-      "times": 20
+      "times": 50
     },
     "data": {
       "failCommands": [

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
@@ -10,7 +10,7 @@
   "failPoint": {
     "configureFailPoint": "failCommand",
     "mode": {
-      "times": 10
+      "times": 20
     },
     "data": {
       "failCommands": [

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
@@ -1,0 +1,104 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "maxConnecting is enforced",
+  "runOn": [
+    {
+      "minServerVersion": "4.4.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 3
+    },
+    "data": {
+      "failCommands": [
+        "isMaster"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 750
+    }
+  },
+  "poolOptions": {
+    "maxPoolSize": 10,
+    "waitQueueTimeoutMS": 5000
+  },
+  "operations": [
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "wait",
+      "thread": "thread2",
+      "ms": 100
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "wait",
+      "thread": "thread3",
+      "ms": 100
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 3
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCreated",
+      "address": 42,
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42,
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCheckOutStarted",
+    "ConnectionCheckedIn",
+    "ConnectionCheckedOut",
+    "ConnectionClosed",
+    "ConnectionPoolCreated"
+  ]
+}

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
@@ -7,7 +7,8 @@ runOn:
     minServerVersion: "4.4.0"
 failPoint:
   configureFailPoint: failCommand
-  mode: { times: 3 }
+  # high amount to ensure not interfered with by monitor checks.
+  mode: { times: 10 }
   data:
     failCommands: ["isMaster"]
     closeConnection: false

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
@@ -1,0 +1,73 @@
+version: 1
+style: integration
+description: maxConnecting is enforced
+runOn:
+  # required for blockConnection in fail point
+  minServerVersion: "4.4.0"
+failPoint:
+  configureFailPoint: failCommand
+  mode: { times: 3 }
+  data:
+    failCommands: ["isMaster"]
+    closeConnection: false
+    blockConnection: true
+    blockTimeMS: 750
+poolOptions:
+  maxPoolSize: 10
+  waitQueueTimeoutMS: 5000
+operations:
+  # start creating a Connection. This will take a while
+  # due to the fail point.
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+  # Start 2 new threads that wait for a little then try
+  # to check out connections. Only one thread should
+  # start creating a Connection and the other one should be
+  # waiting for pendingConnectionCount to be less than maxConnecting,
+  # only starting once thread1 finishes creating its Connection.
+  - name: start
+    target: thread2
+  - name: wait
+    thread: thread2
+    ms: 100
+  - name: checkOut
+    thread: thread2
+  - name: start
+    target: thread3
+  - name: wait
+    thread: thread3
+    ms: 100
+  - name: checkOut
+    thread: thread3
+  # wait until all Connections have been created.
+  - name: waitForEvent
+    event: ConnectionReadyEvent
+    count: 3
+events:
+  # thread1 creates its connection
+  - type: ConnectionCreated
+    address: 42
+    connectionId: 1
+  # either thread2 or thread3 creates its connection
+  # the other thread is stuck waiting for maxConnecting to come down
+  - type: ConnectionCreated
+    address: 42
+  # thread1 finishes establishing its connection, freeing
+  # up the blocked thread to start establishing
+  - type: ConnectionReady
+    address: 42
+    connectionId: 1
+  - type: ConnectionCreated
+    address: 42
+  # the remaining two Connections finish establishing
+  - type: ConnectionReady
+    address: 42
+  - type: ConnectionReady
+    address: 42
+ignore:
+  - ConnectionCheckedIn
+  - ConnectionCheckedOut
+  - ConnectionClosed
+  - ConnectionPoolCreated

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
@@ -8,7 +8,7 @@ runOn:
 failPoint:
   configureFailPoint: failCommand
   # high amount to ensure not interfered with by monitor checks.
-  mode: { times: 10 }
+  mode: { times: 20 }
   data:
     failCommands: ["isMaster"]
     closeConnection: false

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
@@ -8,7 +8,7 @@ runOn:
 failPoint:
   configureFailPoint: failCommand
   # high amount to ensure not interfered with by monitor checks.
-  mode: { times: 20 }
+  mode: { times: 50 }
   data:
     failCommands: ["isMaster"]
     closeConnection: false

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
@@ -2,8 +2,9 @@ version: 1
 style: integration
 description: maxConnecting is enforced
 runOn:
-  # required for blockConnection in fail point
-  minServerVersion: "4.4.0"
+  -
+    # required for blockConnection in fail point
+    minServerVersion: "4.4.0"
 failPoint:
   configureFailPoint: failCommand
   mode: { times: 3 }
@@ -43,7 +44,7 @@ operations:
     thread: thread3
   # wait until all Connections have been created.
   - name: waitForEvent
-    event: ConnectionReadyEvent
+    event: ConnectionReady
     count: 3
 events:
   # thread1 creates its connection
@@ -67,6 +68,7 @@ events:
   - type: ConnectionReady
     address: 42
 ignore:
+  - ConnectionCheckOutStarted
   - ConnectionCheckedIn
   - ConnectionCheckedOut
   - ConnectionClosed

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.json
@@ -1,0 +1,111 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "waiting on maxConnecting is limited by WaitQueueTimeoutMS",
+  "runOn": [
+    {
+      "minServerVersion": "4.4.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 20
+    },
+    "data": {
+      "failCommands": [
+        "isMaster"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 750
+    }
+  },
+  "poolOptions": {
+    "maxPoolSize": 10,
+    "waitQueueTimeoutMS": 50
+  },
+  "operations": [
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 2
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
+    },
+    {
+      "name": "waitForThread",
+      "target": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionReady",
+      "count": 2
+    }
+  ],
+  "error": {
+    "type": "WaitQueueTimeoutError",
+    "message": "Timed out while checking out a connection from connection pool"
+  },
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "timeout",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    },
+    {
+      "type": "ConnectionReady",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionCheckedIn",
+    "ConnectionCheckedOut",
+    "ConnectionClosed",
+    "ConnectionPoolCreated"
+  ]
+}

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.json
@@ -63,11 +63,6 @@
     {
       "name": "waitForThread",
       "target": "thread3"
-    },
-    {
-      "name": "waitForEvent",
-      "event": "ConnectionReady",
-      "count": 2
     }
   ],
   "error": {
@@ -90,14 +85,6 @@
     {
       "type": "ConnectionCheckOutFailed",
       "reason": "timeout",
-      "address": 42
-    },
-    {
-      "type": "ConnectionReady",
-      "address": 42
-    },
-    {
-      "type": "ConnectionReady",
       "address": 42
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.json
@@ -10,7 +10,7 @@
   "failPoint": {
     "configureFailPoint": "failCommand",
     "mode": {
-      "times": 20
+      "times": 50
     },
     "data": {
       "failCommands": [

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
@@ -16,10 +16,9 @@ failPoint:
     blockTimeMS: 750
 poolOptions:
   maxPoolSize: 10
-  # waitQueueTimeoutMS is not supposed to limit the time it takes to
-  # establish a connection, but given that the option will soon be deprecated anyways,
-  # drivers may skip this test if their implementation of waitQueueTimeoutMS does
-  # include establishment time.
+  # Drivers that limit connection establishment by waitQueueTimeoutMS may skip
+  # this test. While waitQueueTimeoutMS is technically not supposed to limit establishment time,
+  # it will soon be deprecated, so it is easier for those drivers to just skip this test.
   waitQueueTimeoutMS: 50
 operations:
   # start creating two connections simultaneously.

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
@@ -43,9 +43,6 @@ operations:
   # rejoin thread3, should experience error
   - name: waitForThread
     target: thread3
-  - name: waitForEvent
-    event: ConnectionReady
-    count: 2
 error:
   type: WaitQueueTimeoutError
   message: Timed out while checking out a connection from connection pool
@@ -58,10 +55,6 @@ events:
     address: 42
   - type: ConnectionCheckOutFailed
     reason: timeout
-    address: 42
-  - type: ConnectionReady
-    address: 42
-  - type: ConnectionReady
     address: 42
 ignore:
   - ConnectionCreated

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
@@ -1,0 +1,71 @@
+version: 1
+style: integration
+description: waiting on maxConnecting is limited by WaitQueueTimeoutMS
+runOn:
+  -
+    # required for blockConnection in fail point
+    minServerVersion: "4.4.0"
+failPoint:
+  configureFailPoint: failCommand
+  # high amount to ensure not interfered with by monitor checks.
+  mode: { times: 20 }
+  data:
+    failCommands: ["isMaster"]
+    closeConnection: false
+    blockConnection: true
+    blockTimeMS: 750
+poolOptions:
+  maxPoolSize: 10
+  waitQueueTimeoutMS: 50
+operations:
+  # start creating two connections simultaneously.
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+  - name: start
+    target: thread2
+  - name: checkOut
+    thread: thread2
+  # wait for other two threads to start establishing
+  - name: waitForEvent
+    event: ConnectionCreated
+    count: 2
+  # start a third thread that will be blocked waiting for
+  # one of the other two to finish
+  - name: start
+    target: thread3
+  - name: checkOut
+    thread: thread3
+  - name: waitForEvent
+    event: ConnectionCheckOutFailed
+    count: 1
+  # rejoin thread3, should experience error
+  - name: waitForThread
+    target: thread3
+  - name: waitForEvent
+    event: ConnectionReady
+    count: 2
+error:
+  type: WaitQueueTimeoutError
+  message: Timed out while checking out a connection from connection pool
+events:
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutStarted
+    address: 42
+  - type: ConnectionCheckOutFailed
+    reason: timeout
+    address: 42
+  - type: ConnectionReady
+    address: 42
+  - type: ConnectionReady
+    address: 42
+ignore:
+  - ConnectionCreated
+  - ConnectionCheckedIn
+  - ConnectionCheckedOut
+  - ConnectionClosed
+  - ConnectionPoolCreated

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
@@ -16,6 +16,10 @@ failPoint:
     blockTimeMS: 750
 poolOptions:
   maxPoolSize: 10
+  # waitQueueTimeoutMS is not supposed to limit the time it takes to
+  # establish a connection, but given that the option will soon be deprecated anyways,
+  # drivers may skip this test if their implementation of waitQueueTimeoutMS does
+  # include establishment time.
   waitQueueTimeoutMS: 50
 operations:
   # start creating two connections simultaneously.

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
@@ -8,7 +8,7 @@ runOn:
 failPoint:
   configureFailPoint: failCommand
   # high amount to ensure not interfered with by monitor checks.
-  mode: { times: 20 }
+  mode: { times: 50 }
   data:
     failCommands: ["isMaster"]
     closeConnection: false

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
@@ -10,7 +10,7 @@
   "failPoint": {
     "configureFailPoint": "failCommand",
     "mode": {
-      "times": 3
+      "times": 10
     },
     "data": {
       "failCommands": [

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
@@ -1,0 +1,145 @@
+{
+  "version": 1,
+  "style": "integration",
+  "description": "threads blocked by maxConnecting check out returned connections",
+  "runOn": [
+    {
+      "minServerVersion": "4.4.0"
+    }
+  ],
+  "failPoint": {
+    "configureFailPoint": "failCommand",
+    "mode": {
+      "times": 3
+    },
+    "data": {
+      "failCommands": [
+        "isMaster"
+      ],
+      "closeConnection": false,
+      "blockConnection": true,
+      "blockTimeMS": 750
+    }
+  },
+  "poolOptions": {
+    "maxPoolSize": 10,
+    "waitQueueTimeoutMS": 5000
+  },
+  "operations": [
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1",
+      "label": "conn0"
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "waitForEvent",
+      "thread": "thread2",
+      "event": "ConnectionCheckedOut",
+      "count": 1
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "waitForEvent",
+      "thread": "thread3",
+      "event": "ConnectionCheckedOut",
+      "count": 1
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "start",
+      "target": "thread4"
+    },
+    {
+      "name": "waitForEvent",
+      "thread": "thread4",
+      "event": "ConnectionCreated",
+      "count": 3
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread4"
+    },
+    {
+      "name": "waitForEvent",
+      "thread": "thread1",
+      "event": "ConnectionCreated",
+      "count": 3
+    },
+    {
+      "name": "wait",
+      "thread": "thread1",
+      "ms": 100
+    },
+    {
+      "name": "checkIn",
+      "thread": "thread1",
+      "connection": "conn0"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCheckedOut",
+      "count": 4
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCreated",
+      "address": 42,
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1,
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionClosed",
+    "ConnectionReady",
+    "ConnectionPoolCreated",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
@@ -10,7 +10,7 @@
   "failPoint": {
     "configureFailPoint": "failCommand",
     "mode": {
-      "times": 20
+      "times": 50
     },
     "data": {
       "failCommands": [

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
@@ -10,7 +10,7 @@
   "failPoint": {
     "configureFailPoint": "failCommand",
     "mode": {
-      "times": 10
+      "times": 20
     },
     "data": {
       "failCommands": [

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
@@ -27,23 +27,20 @@
   },
   "operations": [
     {
+      "name": "checkOut",
+      "label": "conn0"
+    },
+    {
       "name": "start",
       "target": "thread1"
     },
     {
       "name": "checkOut",
-      "thread": "thread1",
-      "label": "conn0"
+      "thread": "thread1"
     },
     {
       "name": "start",
       "target": "thread2"
-    },
-    {
-      "name": "waitForEvent",
-      "thread": "thread2",
-      "event": "ConnectionCheckedOut",
-      "count": 1
     },
     {
       "name": "checkOut",
@@ -54,43 +51,20 @@
       "target": "thread3"
     },
     {
-      "name": "waitForEvent",
-      "thread": "thread3",
-      "event": "ConnectionCheckedOut",
-      "count": 1
-    },
-    {
       "name": "checkOut",
       "thread": "thread3"
     },
     {
-      "name": "start",
-      "target": "thread4"
-    },
-    {
       "name": "waitForEvent",
-      "thread": "thread4",
-      "event": "ConnectionCreated",
-      "count": 3
-    },
-    {
-      "name": "checkOut",
-      "thread": "thread4"
-    },
-    {
-      "name": "waitForEvent",
-      "thread": "thread1",
-      "event": "ConnectionCreated",
-      "count": 3
+      "event": "ConnectionCheckOutStarted",
+      "count": 4
     },
     {
       "name": "wait",
-      "thread": "thread1",
       "ms": 100
     },
     {
       "name": "checkIn",
-      "thread": "thread1",
       "connection": "conn0"
     },
     {

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
@@ -7,7 +7,8 @@ runOn:
     minServerVersion: "4.4.0"
 failPoint:
   configureFailPoint: failCommand
-  mode: { times: 3 }
+  # high amount to ensure not interfered with by monitor checks.
+  mode: { times: 10 }
   data:
     failCommands: ["isMaster"]
     closeConnection: false

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
@@ -17,84 +17,61 @@ poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
 operations:
-  # start a thread, check out a connection, and
-  # hold it until the other threads are blocked
-  # on maxConnecting.
+  # check out a connection and hold on to it.
+  - name: checkOut
+    label: conn0
+  # then start three threads that all attempt to check out. Two threads
+  # will fill maxConnecting, and the other should be waiting either for
+  # the other two to finish or for the main thread to check its connection
+  # back in.
   - name: start
     target: thread1
   - name: checkOut
     thread: thread1
-    label: conn0
-  # Start 2 new threads that wait for thread1 to check
-  # out its connection before attempting to check out their own.
-  # This fills maxConnecting for the next 750ms.
   - name: start
     target: thread2
-  - name: waitForEvent
-    thread: thread2
-    event: ConnectionCheckedOut
-    count: 1
   - name: checkOut
     thread: thread2
   - name: start
     target: thread3
-  - name: waitForEvent
-    thread: thread3
-    event: ConnectionCheckedOut
-    count: 1
   - name: checkOut
     thread: thread3
-  # start a new thread that waits for the previous two threads to
-  # start creating their connections, then try to check out a
-  # new Connection. This thread should be blocked on maxConnecting.
-  - name: start
-    target: thread4
+  # wait for all three to start checking out and a little longer
+  # for the establishments to begin.
   - name: waitForEvent
-    thread: thread4
-    event: ConnectionCreated
-    count: 3
-  - name: checkOut
-    thread: thread4
-  # In the thread that is holding the original Connection, wait
-  # for thread2 and thread3 to start creating their Connection,
-  # wait for a little longer, then check back in the Connection
-  # its been holding. thread4 should now check this Connection
-  # out without attempting to create a new Connection.
-  - name: waitForEvent
-    thread: thread1
-    event: ConnectionCreated
-    count: 3
+    event: ConnectionCheckOutStarted
+    count: 4
   - name: wait
-    thread: thread1
     ms: 100
+  # check original connection back in, so the thread that isn't
+  # currently establishing will become unblocked. Then wait for
+  # all threads to complete.
   - name: checkIn
-    thread: thread1
     connection: conn0
-  # wait until all threads have finished checking out.
   - name: waitForEvent
     event: ConnectionCheckedOut
     count: 4
 events:
-  # thread1 checking out a Connection and holding it
+  # main thread checking out a Connection and holding it
   - type: ConnectionCreated
     address: 42
     connectionId: 1
   - type: ConnectionCheckedOut
     address: 42
-  # threads 2 and 3 creating their Connections
+  # two threads creating their Connections
   - type: ConnectionCreated
     address: 42
   - type: ConnectionCreated
     address: 42
-  # thread1 checking its Connection back in
+  # main thread checking its Connection back in
   - type: ConnectionCheckedIn
     connectionId: 1
     address: 42
-  # thread4 checking out the returned Connection
+  # remaining thread checking out the returned Connection
   - type: ConnectionCheckedOut
     connectionId: 1
     address: 42
-  # threads 2 and 3 finishing Connection establishment
+  # first two threads finishing Connection establishment
   - type: ConnectionCheckedOut
     address: 42
   - type: ConnectionCheckedOut

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
@@ -8,7 +8,7 @@ runOn:
 failPoint:
   configureFailPoint: failCommand
   # high amount to ensure not interfered with by monitor checks.
-  mode: { times: 10 }
+  mode: { times: 20 }
   data:
     failCommands: ["isMaster"]
     closeConnection: false

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
@@ -1,0 +1,102 @@
+version: 1
+style: integration
+description: threads blocked by maxConnecting check out returned connections
+runOn:
+  # required for blockConnection in fail point
+  minServerVersion: "4.4.0"
+failPoint:
+  configureFailPoint: failCommand
+  mode: { times: 3 }
+  data:
+    failCommands: ["isMaster"]
+    closeConnection: false
+    blockConnection: true
+    blockTimeMS: 750
+poolOptions:
+  maxPoolSize: 10
+  waitQueueTimeoutMS: 5000
+operations:
+  # start a thread, check out a connection, and
+  # hold it until the other threads are blocked
+  # on maxConnecting.
+  - name: start
+    target: thread1
+  - name: checkOut
+    thread: thread1
+    label: conn0
+  # Start 2 new threads that wait for thread1 to check
+  # out its connection before attempting to check out their own. 
+  # This fills maxConnecting for the next 750ms.
+  - name: start
+    target: thread2
+  - name: waitForEvent
+    thread: thread2
+    count: 1
+  - name: checkOut
+    thread: thread2
+  - name: start
+    target: thread3
+  - name: waitForEvent
+    thread: thread3
+    count: 1
+  - name: checkOut
+    thread: thread3
+  # start a new thread that waits for the previous two threads to
+  # start creating their connections, then try to check out a
+  # new Connection. This thread should be blocked on maxConnecting.
+  - name: start
+    target: thread4
+  - name: waitForEvent
+    thread: thread4
+    event: ConnectionCreated
+    count: 3
+  - name: checkOut
+    thread: thread4
+  # In the thread that is holding the original Connection, wait
+  # for thread2 and thread3 to start creating their Connection,
+  # wait for a little longer, then check back in the Connection
+  # its been holding. thread4 should now check this Connection
+  # out without attempting to create a new Connection.
+  - name: waitForEvent
+    thread: thread1
+    event: ConnectionCreated
+    count: 3
+  - name: wait
+    thread: thread1
+    ms: 100
+  - name: checkIn
+    thread: thread1
+    connection: conn0
+  # wait until all threads have finished checking out.
+  - name: waitForEvent
+    event: ConnectionCheckedOut
+    count: 4
+events:
+  # thread1 checking out a Connection and holding it
+  - type: ConnectionCreated
+    address: 42
+    connectionId: 1
+  - type: ConnectionCheckedOut
+    address: 42
+  # threads 2 and 3 creating their Connections
+  - type: ConnectionCreated
+    address: 42
+  - type: ConnectionCreated
+    address: 42
+  # thread1 checking its Connection back in
+  - type: ConnectionCheckedIn
+    connectionId: 1
+    address: 42
+  # thread4 checking out the returned Connection
+  - type: ConnectionCheckedOut
+    connectionId: 1
+    address: 42
+  # threads 2 and 3 finishing Connection establishment
+  - type: ConnectionCheckedOut
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+ignore:
+  - ConnectionClosed
+  - ConnectionReady
+  - ConnectionPoolCreated

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
@@ -26,7 +26,7 @@ operations:
     thread: thread1
     label: conn0
   # Start 2 new threads that wait for thread1 to check
-  # out its connection before attempting to check out their own. 
+  # out its connection before attempting to check out their own.
   # This fills maxConnecting for the next 750ms.
   - name: start
     target: thread2

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
@@ -8,7 +8,7 @@ runOn:
 failPoint:
   configureFailPoint: failCommand
   # high amount to ensure not interfered with by monitor checks.
-  mode: { times: 20 }
+  mode: { times: 50 }
   data:
     failCommands: ["isMaster"]
     closeConnection: false

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
@@ -2,8 +2,9 @@ version: 1
 style: integration
 description: threads blocked by maxConnecting check out returned connections
 runOn:
-  # required for blockConnection in fail point
-  minServerVersion: "4.4.0"
+  -
+    # required for blockConnection in fail point
+    minServerVersion: "4.4.0"
 failPoint:
   configureFailPoint: failCommand
   mode: { times: 3 }
@@ -31,6 +32,7 @@ operations:
     target: thread2
   - name: waitForEvent
     thread: thread2
+    event: ConnectionCheckedOut
     count: 1
   - name: checkOut
     thread: thread2
@@ -38,6 +40,7 @@ operations:
     target: thread3
   - name: waitForEvent
     thread: thread3
+    event: ConnectionCheckedOut
     count: 1
   - name: checkOut
     thread: thread3
@@ -100,3 +103,4 @@ ignore:
   - ConnectionClosed
   - ConnectionReady
   - ConnectionPoolCreated
+  - ConnectionCheckOutStarted

--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -145,10 +145,11 @@ but the decision is left to the implementer.
 Servers are monitored with dedicated sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`A monitor SHOULD NOT use the client's regular connection pool`_
-to acquire a socket;
-it uses a dedicated socket that does not count toward the pool's
-maximum size.
+If the client contains a CMAP spec-compliant connection pool, a monitor MUST use
+the pool to create "Unmanaged Connection"s for use in monitoring. Otherwise, `A
+monitor SHOULD NOT use the client's regular connection pool`_ to acquire a
+socket; it uses a dedicated socket that does not count toward the pool's maximum
+size.
 
 Drivers MUST NOT authenticate on sockets used for monitoring nor include
 SCRAM mechanism negotiation (i.e. ``saslSupportedMechs``), as doing so would
@@ -908,8 +909,8 @@ Thus both operations SHOULD use connectTimeoutMS, since that is the value
 users supply to help the client guess if a server is down,
 based on users' knowledge of expected latencies on their networks.
 
-A monitor SHOULD NOT use the client's regular connection pool
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+A monitor SHOULD NOT use the client's regular connection pool (non-CMAP)
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 If a multi-threaded driver's connection pool enforces a maximum size
 and monitors use sockets from the pool,
@@ -924,6 +925,10 @@ The latter is more complex than it is worth.
 Since this rule is justified for drivers that enforce a maximum pool size,
 this spec recommends that all drivers follow the same rule
 for the sake of consistency.
+
+For drivers that implement their connection pool as specified in CMAP,
+"Unmanaged Connections", which do not compete with regular pooled connections,
+MUST be used.
 
 Monitors MUST use a dedicated connection for RTT commands
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -1082,6 +1087,9 @@ awaitable isMaster heartbeat in the new protocol.
 
 Changelog
 ---------
+
+- 2020-09-24 Require the use of createUnmanagedConnection for monitoring
+  connections where possible.
 
 - 2020-06-11 Support connectTimeoutMS=0 in streaming heartbeat protocol.
 

--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -145,11 +145,10 @@ but the decision is left to the implementer.
 Servers are monitored with dedicated sockets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If the client contains a CMAP spec-compliant connection pool, a monitor MUST use
-the pool to create "Unmanaged Connection"s for use in monitoring. Otherwise, `A
-monitor SHOULD NOT use the client's regular connection pool`_ to acquire a
-socket; it uses a dedicated socket that does not count toward the pool's maximum
-size.
+`A monitor SHOULD NOT use the client's regular connection pool`_
+to acquire a socket;
+it uses a dedicated socket that does not count toward the pool's
+maximum size.
 
 Drivers MUST NOT authenticate on sockets used for monitoring nor include
 SCRAM mechanism negotiation (i.e. ``saslSupportedMechs``), as doing so would
@@ -909,8 +908,8 @@ Thus both operations SHOULD use connectTimeoutMS, since that is the value
 users supply to help the client guess if a server is down,
 based on users' knowledge of expected latencies on their networks.
 
-A monitor SHOULD NOT use the client's regular connection pool (non-CMAP)
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+A monitor SHOULD NOT use the client's regular connection pool
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 If a multi-threaded driver's connection pool enforces a maximum size
 and monitors use sockets from the pool,
@@ -925,10 +924,6 @@ The latter is more complex than it is worth.
 Since this rule is justified for drivers that enforce a maximum pool size,
 this spec recommends that all drivers follow the same rule
 for the sake of consistency.
-
-For drivers that implement their connection pool as specified in CMAP,
-"Unmanaged Connections", which do not compete with regular pooled connections,
-MUST be used.
 
 Monitors MUST use a dedicated connection for RTT commands
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''
@@ -1087,9 +1082,6 @@ awaitable isMaster heartbeat in the new protocol.
 
 Changelog
 ---------
-
-- 2020-09-24 Require the use of createUnmanagedConnection for monitoring
-  connections where possible.
 
 - 2020-06-11 Support connectTimeoutMS=0 in streaming heartbeat protocol.
 


### PR DESCRIPTION
SPEC-1753

This PR updates the CMAP spec to require that drivers limit the number of concurrently establishing connections.