### PR TITLE
SPEC-1548 Allow 0 for min/max pool size and fully test cmap URI options

### DIFF
--- a/source/uri-options/tests/connection-pool-options.json
+++ b/source/uri-options/tests/connection-pool-options.json
@@ -2,13 +2,15 @@
   "tests": [
     {
       "description": "Valid connection pool options are parsed correctly",
-      "uri": "mongodb://example.com/?maxIdleTimeMS=50000",
+      "uri": "mongodb://example.com/?maxIdleTimeMS=50000&maxPoolSize=5&minPoolSize=3",
       "valid": true,
       "warning": false,
       "hosts": null,
       "auth": null,
       "options": {
-        "maxIdleTimeMS": 50000
+        "maxIdleTimeMS": 50000,
+        "maxPoolSize": 5,
+        "minPoolSize": 3
       }
     },
     {
@@ -28,6 +30,28 @@
       "hosts": null,
       "auth": null,
       "options": {}
+    },
+    {
+      "description": "maxPoolSize=0 does not error",
+      "uri": "mongodb://example.com/?maxPoolSize=0",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "maxPoolSize": 0
+      }
+    },
+    {
+      "description": "minPoolSize=0 does not error",
+      "uri": "mongodb://example.com/?minPoolSize=0",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "minPoolSize": 0
+      }
     }
   ]
 }

--- a/source/uri-options/tests/connection-pool-options.yml
+++ b/source/uri-options/tests/connection-pool-options.yml
@@ -1,13 +1,15 @@
 tests:
     -
         description: "Valid connection pool options are parsed correctly"
-        uri: "mongodb://example.com/?maxIdleTimeMS=50000"
+        uri: "mongodb://example.com/?maxIdleTimeMS=50000&maxPoolSize=5&minPoolSize=3"
         valid: true
         warning: false
         hosts: ~
         auth: ~
         options:
             maxIdleTimeMS: 50000
+            maxPoolSize: 5
+            minPoolSize: 3
     -
         description: "Non-numeric maxIdleTimeMS causes a warning"
         uri: "mongodb://example.com/?maxIdleTimeMS=invalid"
@@ -24,3 +26,23 @@ tests:
         hosts: ~
         auth: ~
         options: {}
+
+    -
+      description: "maxPoolSize=0 does not error"
+      uri: "mongodb://example.com/?maxPoolSize=0"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          maxPoolSize: 0
+
+    -
+      description: "minPoolSize=0 does not error"
+      uri: "mongodb://example.com/?minPoolSize=0"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          minPoolSize: 0 

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -194,10 +194,10 @@ pertaining to URI options apply here.
      - The maximum replication lag, in wall clock time, that a secondary can suffer and still be eligible for server selection
 
    * - minPoolSize
-     - positive integer
+     - non-negative integer
      - defined in the `Connection Pooling spec`_
      - required for drivers with connection pools
-     - The maximum number of clients or connections able to be created by a pool at a given time
+     - The number of connections the driver should create and main in the pool even when no operations are occurring 
 
    * - readConcernLevel
      - any string (`to allow for forwards compatibility with the server <https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#unknown-levels-and-additional-options-for-string-based-readconcerns>`_)

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -182,7 +182,7 @@ pertaining to URI options apply here.
      - The amount of time a connection can be idle before it's closed
 
    * - maxPoolSize
-     - positive integer
+     - non-negative integer; 0 means no maximum
      - defined in the `Connection Pooling spec`_
      - required for drivers with connection pools
      - The maximum number of clients or connections able to be created by a pool at a given time

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -185,7 +185,7 @@ pertaining to URI options apply here.
      - non-negative integer; 0 means no maximum
      - defined in the `Connection Pooling spec`_
      - required for drivers with connection pools
-     - The maximum number of clients or connections able to be created by a pool at a given time
+     - The maximum number of clients or connections able to be created by a pool at a given time. This count includes connections which are currently checked out.
 
    * - maxStalenessSeconds
      - -1 (no max staleness check) or integer >= 90
@@ -197,7 +197,7 @@ pertaining to URI options apply here.
      - non-negative integer
      - defined in the `Connection Pooling spec`_
      - required for drivers with connection pools
-     - The number of connections the driver should create and main in the pool even when no operations are occurring 
+     - The number of connections the driver should create and maintain in the pool even when no operations are occurring. This count includes connections which are currently checked out. 
 
    * - readConcernLevel
      - any string (`to allow for forwards compatibility with the server <https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#unknown-levels-and-additional-options-for-string-based-readconcerns>`_)


### PR DESCRIPTION
Since this bug happened due to the CMAP options being added without sufficient tests, I added specific tests for both minPoolSize and maxPoolSize to the comprehensive test of CMAP URI options well as for the specific values of 0.