### PR TITLE
Use unsetOrMatches assertion for md5 field in GridFS tests

### DIFF
--- a/source/unified-test-format/tests/valid-pass/poc-gridfs.json
+++ b/source/unified-test-format/tests/valid-pass/poc-gridfs.json
@@ -240,7 +240,9 @@
               "uploadDate": {
                 "$$type": "date"
               },
-              "md5": "283d4fea5dded59cf837d3047328f5af",
+              "md5": {
+                "$$unsetOrMatches": "283d4fea5dded59cf837d3047328f5af"
+              },
               "filename": "filename"
             }
           ]

--- a/source/unified-test-format/tests/valid-pass/poc-gridfs.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-gridfs.yml
@@ -133,7 +133,8 @@ tests:
             length: 5
             chunkSize: 4
             uploadDate: { $$type: date }
-            md5: "283d4fea5dded59cf837d3047328f5af"
+            # The md5 field is deprecated so some drivers do not calculate it when uploading files.
+            md5: { $$unsetOrMatches: "283d4fea5dded59cf837d3047328f5af" }
             filename: filename
       - name: find
         object: *bucket0_chunks_collection


### PR DESCRIPTION
Verified that the Go test runner passes with this change.