### PR TITLE
Run killAllSessions in unified tests if the test started a transaction

### DIFF
--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -2236,8 +2236,8 @@ Clear the entity map for this test. For each ClientSession in the entity map,
 the test runner MUST end the session (e.g. call
 `endSession <../sessions/driver-sessions.rst#endsession>`_).
 
-If the test failed or started a transaction, the test runner MUST terminate
-any open transactions (see: `Terminating Open Transactions`_).
+If the test started a transaction, the test runner MUST terminate any open
+transactions (see: `Terminating Open Transactions`_).
 
 Proceed to the subsequent test.
 

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -2236,8 +2236,8 @@ Clear the entity map for this test. For each ClientSession in the entity map,
 the test runner MUST end the session (e.g. call
 `endSession <../sessions/driver-sessions.rst#endsession>`_).
 
-If the test failed, the test runner MUST terminate any open transactions (see:
-`Terminating Open Transactions`_).
+If the test failed or started a transaction, the test runner MUST terminate
+any open transactions (see: `Terminating Open Transactions`_).
 
 Proceed to the subsequent test.
 


### PR DESCRIPTION
This [test](https://github.com/mongodb/specifications/blob/23fb6262f3688fee52b0e284216d42fe472fdd97/source/unified-test-format/tests/valid-pass/poc-transactions-mongos-pin-auto.yml#L119) causes future tests to hang when doing operations against the same database/collection because the `abortTransaction` command fails server-side so the transaction is left open. Drivers ignore these errors, though, so the test still passes. There was some discussion about this in the original PR and the resolution was that this is a PHP-only issue because MongoClient/session pool instances are persisted across tests, but this will affect all test runners.

After discussing with @ShaneHarvey, we decided the simplest solution is to terminate open transactions if a test fails or starts a transaction.