### PR TITLE
SPEC-1764 Test that monitors wait minHeartbeatFrequencyMS between failed server checks

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -196,16 +196,16 @@ This test requires MongoDB 4.9.0+.
          data: {
              failCommands: ["isMaster"],
              errorCode: 1234,
-             appName: "SDAMSleepTest"
+             appName: "SDAMMinHeartbeatFrequencyTest"
          }
      }
 
-2. Create a client with directConnection=true, appName="SDAMSleepTest", and
-   serverSelectionTimeoutMS=unlimited.
+2. Create a client with directConnection=true, appName="SDAMMinHeartbeatFrequencyTest", and
+   serverSelectionTimeoutMS=10000.
 
 3. Start a timer.
 
-4. Execute a ``ping`` command with unlimited ServerSelectionTimeoutMS.
+4. Execute a ``ping`` command.
 
 5. Stop the timer. Assert that the ``ping`` took between 4.5 seconds and 6.5
    seconds to complete.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -178,3 +178,34 @@ Attempt a write to a collection.
 
 Outcome: Verify that the write succeeded or failed depending on existing
 driver behavior with respect to the starting topology.
+
+Monitors sleep at least minHeartbeatFreqencyMS between checks
+-------------------------------------------------------------
+
+This test will be used to ensure monitors sleep for an appropriate amount of
+time between failed server checks so as to not flood the server with new
+connection creations.
+
+This test requires MongoDB 4.9.0+.
+
+1. Enable the following failpoint::
+
+     {
+         configureFailPoint: "failCommand",
+         mode: { times: 10 },
+         data: {
+             failCommands: ["isMaster"],
+             errorCode: 1234,
+             appName: "SDAMSleepTest"
+         }
+     }
+
+2. Create a client with directConnection=true, appName="SDAMSleepTest", and
+   serverSelectionTimeoutMS=unlimited.
+
+3. Start a timer.
+
+4. Execute a ``ping`` command with unlimited ServerSelectionTimeoutMS.
+
+5. Stop the timer. Assert that the ``ping`` took between 4.5 seconds and 6.5
+   seconds to complete.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -192,7 +192,7 @@ This test requires MongoDB 4.9.0+.
 
      {
          configureFailPoint: "failCommand",
-         mode: { times: 10 },
+         mode: { times: 5 },
          data: {
              failCommands: ["isMaster"],
              errorCode: 1234,
@@ -201,11 +201,11 @@ This test requires MongoDB 4.9.0+.
      }
 
 2. Create a client with directConnection=true, appName="SDAMMinHeartbeatFrequencyTest", and
-   serverSelectionTimeoutMS=10000.
+   serverSelectionTimeoutMS=5000.
 
 3. Start a timer.
 
 4. Execute a ``ping`` command.
 
-5. Stop the timer. Assert that the ``ping`` took between 4.5 seconds and 6.5
+5. Stop the timer. Assert that the ``ping`` took between 2 seconds and 3.5
    seconds to complete.


### PR DESCRIPTION
SPEC-1764

This PR adds a prose integration test to the SDAM spec to ensure that monitors wait at least 500ms between server checks even when a thread in server selection is requesting immediate checks.