### PR TITLE
SPEC-1767 Fix race in CMAP test 'maxConnecting is enforced'

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -152,11 +152,10 @@ For each YAML file with ``style: unit``:
   - If ``poolOptions`` is specified, use those options to initialize both pools
   - The returned pool must have an ``address`` set as a string value.
 
-- Execute each ``operation`` in ``operations``
+- Process each ``operation`` in ``operations`` (on the main thread)
 
-  - If a ``thread`` is specified, execute in that corresponding thread. Otherwise, execute in the main thread.
+  - If a ``thread`` is specified, the main thread MUST schedule the operation to execute in the corresponding thread. Otherwise, execute the operation directly in the main thread.
 
-- Wait for the main thread to finish executing all of its operations
 - If ``error`` is presented
 
   - Assert that an actual error ``actualError`` was thrown by the main thread

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
@@ -31,30 +31,29 @@
       "target": "thread1"
     },
     {
-      "name": "checkOut",
-      "thread": "thread1"
-    },
-    {
       "name": "start",
       "target": "thread2"
-    },
-    {
-      "name": "wait",
-      "thread": "thread2",
-      "ms": 100
-    },
-    {
-      "name": "checkOut",
-      "thread": "thread2"
     },
     {
       "name": "start",
       "target": "thread3"
     },
     {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 1
+    },
+    {
       "name": "wait",
-      "thread": "thread3",
       "ms": 100
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
     },
     {
       "name": "checkOut",

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
@@ -33,7 +33,7 @@ operations:
   - name: waitForEvent
     event: ConnectionCreated
     count: 1
-  # wait some more time to ensure thread1's Connection is ready first
+  # wait some more time to ensure thread1 has begun establishing a Connection
   - name: wait
     ms: 100
   # start 2 check out requests. Only one thread should

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
@@ -18,29 +18,30 @@ poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
 operations:
-  # start creating a Connection. This will take a while
-  # due to the fail point.
+  # start 3 threads
   - name: start
     target: thread1
+  - name: start
+    target: thread2
+  - name: start
+    target: thread3
+  # start creating a Connection. This will take a while
+  # due to the fail point.
   - name: checkOut
     thread: thread1
-  # Start 2 new threads that wait for a little then try
-  # to check out connections. Only one thread should
+  # wait for thread1 to actually start creating a Connection
+  - name: waitForEvent
+    event: ConnectionCreated
+    count: 1
+  # wait some more time to ensure thread1's Connection is ready first
+  - name: wait
+    ms: 100
+  # start 2 check out requests. Only one thread should
   # start creating a Connection and the other one should be
   # waiting for pendingConnectionCount to be less than maxConnecting,
   # only starting once thread1 finishes creating its Connection.
-  - name: start
-    target: thread2
-  - name: wait
-    thread: thread2
-    ms: 100
   - name: checkOut
     thread: thread2
-  - name: start
-    target: thread3
-  - name: wait
-    thread: thread3
-    ms: 100
   - name: checkOut
     thread: thread3
   # wait until all Connections have been created.


### PR DESCRIPTION
Tested in python here: https://evergreen.mongodb.com/version/5fc6afbdd1fe0771a322eaec
And a second time for good measure: https://evergreen.mongodb.com/version/5fc6edb032f417146256a3aa