### PR TITLE
Skip runCommand tests when requireApiVersion is true

### DIFF
--- a/source/versioned-api/tests/runcommand-helper-no-api-version-declared.json
+++ b/source/versioned-api/tests/runcommand-helper-no-api-version-declared.json
@@ -3,7 +3,10 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7"
+      "minServerVersion": "4.7",
+      "serverParameters": {
+        "requireApiVersion": false
+      }
     }
   ],
   "createEntities": [

--- a/source/versioned-api/tests/runcommand-helper-no-api-version-declared.yml
+++ b/source/versioned-api/tests/runcommand-helper-no-api-version-declared.yml
@@ -4,6 +4,8 @@ schemaVersion: "1.1"
 
 runOnRequirements:
   - minServerVersion: "4.7"
+    serverParameters:
+      requireApiVersion: false
 
 createEntities:
   - client:


### PR DESCRIPTION
With requireApiVersion enabled, this test is no longer valid as the test client would always have an API version declared. As per the spec, declaring an API version in a command document for a command helper and declaring a version on the client is invalid and has undefined behaviour.