### PR TITLE
SPEC-1768 add a metadataClient for CSFLE

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -336,7 +336,8 @@ it is set to an internal ``MongoClient``. If ``bypassAutomaticEncryption=true``,
 the option is ignored since ``listCollections`` is only run during automatic
 encryption.
 
-If neither are passed, they are set to the same internal ``MongoClient``.
+The ``keyVaultClient`` and ``metadataClient`` MUST be set to the same internal
+``MongoClient`` if neither are passed in and ``bypassAutomaticEncryption=false``.
 
 The internal ``MongoClient`` MUST be configured with the same options as the
 parent ``MongoClient`` with the ``AutoEncryptionOpts`` excluded.
@@ -350,6 +351,7 @@ The following pseudo-code describes the configuration behavior:
       internalClientOpts = copy(clientOpts)
       internalClientOpts.autoEncryptionOpts = None
       client.internalClient = MongoClient (internalClientOpts)
+      return client.internalClient
 
    def configureAutoEncryptionClients (client, clientOpts):
       if clientOpts.autoEncryptionOpts.keyVaultClient != None:

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -345,6 +345,7 @@ parent ``MongoClient`` with the ``AutoEncryptionOpts`` excluded.
 The following pseudo-code describes the configuration behavior:
 
 .. code::
+
    def getOrCreateInternalClient (client, clientOpts):
       if client.internalClient != None:
          return client.internalClient

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -249,7 +249,6 @@ MongoClient Changes
       schemaMap: Optional<Map<String, Document>>; // Maps namespace to a local schema
       bypassAutoEncryption: Optional<Boolean>; // Default false.
       extraOptions: Optional<Map<String, Value>>;
-      metadataClient: Optional<MongoClient>;
    }
 
 A MongoClient can be configured to automatically encrypt collection

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -332,6 +332,11 @@ The following pseudo-code describes the configuration behavior for the three ``M
       else:
          client.metadataClient = getOrCreateInternalClient (client, clientOpts)
 
+Configuring the internal ``MongoClient`` MUST match the parent ``MongoClient``,
+except ``minPoolSize`` is set to ``0`` and ``AutoEncryptionOpts`` is omitted.
+This includes copying the options and host information from the URI, and other
+non-URI configuration (monitoring callbacks, versioned API, etc.).
+
 Drivers MUST document that an additional ``MongoClient`` may be created, using
 the following as a template:
 
@@ -343,8 +348,8 @@ the following as a template:
    - ``AutoEncryptionOpts.bypassAutomaticEncryption`` is ``false``.
 
    If an internal ``MongoClient`` is created, it is configured with the same
-   options as the parent ``MongoClient`` except ``minPoolSize=0`` and
-   ``AutoEncryptionOpts`` is omitted.
+   options as the parent ``MongoClient`` except ``minPoolSize`` is set to ``0``
+   and ``AutoEncryptionOpts`` is omitted.
 
 See `What's the deal with metadataClient, keyVaultClient, and the internal client?`_
 

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1430,13 +1430,17 @@ options, instead of a client object.
 Can the metadataClient serve as the internal client when no keyVaultClient is set?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Technically yes, but it adds complexity to the API without a clear benefit.
+No, it was decided against since it adds complexity to the API without a clear
+benefit.
 
 The ``metadataClient`` and ``keyVaultClient`` currently serve separate distinct
 purposes from the user's perspective.
 
 The ``keyVaultClient`` fetches keys from the key vault collection.
 The ``metadataClient`` runs ``listCollections`` to check for remote schemas.
+
+The behavior is that if a ``metadataClient`` is set, but a ``keyVaultClient``
+is not set, an internal client will be created to serve as the ``keyVaultClient``.
 
 Future work
 ===========

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -11,7 +11,7 @@ Client Side Encryption
 :Type: Standards
 :Minimum Server Version: 4.2
 :Last Modified: October 19, 2020
-:Version: 1.2.0
+:Version: 1.3.0
 
 .. contents::
 

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -239,7 +239,7 @@ MongoClient Changes
       private Optional<MongoClient> mongocryptd_client; // Client to mongocryptd.
       private MongoClient keyvault_client; // Client used to run find on the key vault collection. This is either an external MongoClient, the parent MongoClient, or internal_client.
       private MongoClient metadata_client; // Client used to run listCollections. This is either the parent MongoClient or internal_client.
-      private Optional<MongoClient> internal_client; // An internal MongoClient. An internal MongoClient. Created if no external keyVaultClient was set, or if a metadataClient is needed
+      private Optional<MongoClient> internal_client; // An internal MongoClient. Created if no external keyVaultClient was set, or if a metadataClient is needed
    }
 
    class AutoEncryptionOpts {
@@ -1443,8 +1443,9 @@ security risk.
 Why is the metadataClient not needed if bypassAutoEncryption=true
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Because automatic decryption does not require the JSON schema.
-``listCollections`` is not run during automatic encryption.
+JSON schema data is only needed for automatic encryption but not for automatic
+decryption. ``listCollections`` is not run when ``bypassAutoEncryption`` is
+``true``, making a metadataClient unnecessary.
 
 Future work
 ===========

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -237,7 +237,7 @@ MongoClient Changes
       // Implementation details.
       private mongocrypt_t libmongocrypt_handle; // Handle to libmongocrypt.
       private Optional<MongoClient> mongocryptd_client; // Client to mongocryptd.
-      private MongoClient keyvault_client; // Client used to run find on the key vault collection. This is either an external MongoClient or internal_client.
+      private MongoClient keyvault_client; // Client used to run find on the key vault collection. This is either an external MongoClient, the parent MongoClient, or internal_client.
       private MongoClient metadata_client; // Client used to run listCollections. This is either the parent MongoClient or internal_client.
       private Optional<MongoClient> internal_client; // An internal MongoClient. Created if no external keyVaultClient and/or metadataClient was set.
    }

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -297,7 +297,7 @@ keyVaultClient can be used to route data key queries to a separate
 MongoDB cluster.
 
 If a ``keyVaultClient`` is not passed, and the parent ``MongoClient`` is
-configured with a non-zero ``maxPoolSize``, the ``keyVaultClient`` is set to an
+configured with a limited ``maxPoolSize``, the ``keyVaultClient`` is set to an
 internal ``MongoClient``. See `keyVaultClient, metadataClient, and the internal
 MongoClient`_ for configuration behavior.
 
@@ -1397,8 +1397,8 @@ has a remote schema. This uses the ``metadataClient``.
 - a ``find`` against the key vault collection to fetch keys. This uses the
 ``keyVaultClient``.
 
-Why not reuse the parent MongoClient when maxPoolSize is non-zero?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Why not reuse the parent MongoClient when maxPoolSize is limited?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 These operations MUST NOT reuse the same connection pool as the parent
 ``MongoClient`` configured with automatic encryption to avoid possible deadlock

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -239,7 +239,7 @@ MongoClient Changes
       private Optional<MongoClient> mongocryptd_client; // Client to mongocryptd.
       private MongoClient keyvault_client; // Client used to run find on the key vault collection. This is either an external MongoClient, the parent MongoClient, or internal_client.
       private MongoClient metadata_client; // Client used to run listCollections. This is either the parent MongoClient or internal_client.
-      private Optional<MongoClient> internal_client; // An internal MongoClient. Created if no external keyVaultClient and/or metadataClient was set.
+      private Optional<MongoClient> internal_client; // An internal MongoClient. An internal MongoClient. Created if no external keyVaultClient was set, or if a metadataClient is needed
    }
 
    class AutoEncryptionOpts {

--- a/source/client-side-encryption/etc/test-templates/aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/aggregate.yml.template
@@ -30,13 +30,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -83,13 +76,6 @@ tests:
             cursor: {}
           command_name: aggregate
       # Needs to fetch key when decrypting results
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/azureKMS.yml.template
+++ b/source/client-side-encryption/etc/test-templates/azureKMS.yml.template
@@ -25,13 +25,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/source/client-side-encryption/etc/test-templates/basic.yml.template
+++ b/source/client-side-encryption/etc/test-templates/basic.yml.template
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -81,13 +74,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/bulk.yml.template
+++ b/source/client-side-encryption/etc/test-templates/bulk.yml.template
@@ -39,13 +39,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/count.yml.template
+++ b/source/client-side-encryption/etc/test-templates/count.yml.template
@@ -28,13 +28,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/countDocuments.yml.template
+++ b/source/client-side-encryption/etc/test-templates/countDocuments.yml.template
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/delete.yml.template
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -75,13 +68,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/distinct.yml.template
+++ b/source/client-side-encryption/etc/test-templates/distinct.yml.template
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/explain.yml.template
+++ b/source/client-side-encryption/etc/test-templates/explain.yml.template
@@ -33,13 +33,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/find.yml.template
+++ b/source/client-side-encryption/etc/test-templates/find.yml.template
@@ -30,13 +30,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -77,13 +70,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/findOneAndDelete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/findOneAndDelete.yml.template
@@ -28,13 +28,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/findOneAndReplace.yml.template
+++ b/source/client-side-encryption/etc/test-templates/findOneAndReplace.yml.template
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/findOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/findOneAndUpdate.yml.template
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/gcpKMS.yml.template
+++ b/source/client-side-encryption/etc/test-templates/gcpKMS.yml.template
@@ -25,13 +25,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/source/client-side-encryption/etc/test-templates/getMore.yml.template
+++ b/source/client-side-encryption/etc/test-templates/getMore.yml.template
@@ -38,13 +38,6 @@ tests:
             find: *collection_name
             batchSize: 2
           command_name: find
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/insert.yml.template
+++ b/source/client-side-encryption/etc/test-templates/insert.yml.template
@@ -25,13 +25,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -70,13 +63,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/source/client-side-encryption/etc/test-templates/keyAltName.yml.template
+++ b/source/client-side-encryption/etc/test-templates/keyAltName.yml.template
@@ -25,13 +25,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/localKMS.yml.template
+++ b/source/client-side-encryption/etc/test-templates/localKMS.yml.template
@@ -26,13 +26,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/source/client-side-encryption/etc/test-templates/localSchema.yml.template
+++ b/source/client-side-encryption/etc/test-templates/localSchema.yml.template
@@ -25,13 +25,6 @@ tests:
           filter: { _id: 1 }
         result: [*doc0]
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/missingKey.yml.template
+++ b/source/client-side-encryption/etc/test-templates/missingKey.yml.template
@@ -32,13 +32,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "different"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/replaceOne.yml.template
+++ b/source/client-side-encryption/etc/test-templates/replaceOne.yml.template
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/types.yml.template
+++ b/source/client-side-encryption/etc/test-templates/types.yml.template
@@ -27,13 +27,6 @@ tests:
           filter: { _id: 1 }
         result: *doc0
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -75,13 +68,6 @@ tests:
           filter: { _id: 1 }
         result: *doc1
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -123,13 +109,6 @@ tests:
           filter: { _id: 1 }
         result: *doc2
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -197,13 +176,6 @@ tests:
           filter: { _id: 1 }
         result: *doc6
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -245,13 +217,6 @@ tests:
           filter: { _id: 1 }
         result: *doc7
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -319,13 +284,6 @@ tests:
           filter: { _id: 1 }
         result: *doc10
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -367,13 +325,6 @@ tests:
           filter: { _id: 1 }
         result: *doc11
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -415,13 +366,6 @@ tests:
           filter: { _id: 1 }
         result: *doc13
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/updateMany.yml.template
+++ b/source/client-side-encryption/etc/test-templates/updateMany.yml.template
@@ -32,13 +32,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/updateOne.yml.template
+++ b/source/client-side-encryption/etc/test-templates/updateOne.yml.template
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -880,6 +880,8 @@ Case 4
 
 Case 5
 ``````
+Drivers that do not support an unlimited maximum pool size MUST skip this test.
+
 - MaxPoolSize: 0
 - AutoEncryptionOpts:
    - bypassAutoEncryption=false
@@ -895,6 +897,8 @@ Case 5
 
 Case 6
 ``````
+Drivers that do not support an unlimited maximum pool size MUST skip this test.
+
 - MaxPoolSize: 0
 - AutoEncryptionOpts:
    - bypassAutoEncryption=false
@@ -910,6 +914,8 @@ Case 6
 
 Case 7
 ``````
+Drivers that do not support an unlimited maximum pool size MUST skip this test.
+
 - MaxPoolSize: 0
 - AutoEncryptionOpts:
    - bypassAutoEncryption=true
@@ -923,6 +929,8 @@ Case 7
 
 Case 8
 ``````
+Drivers that do not support an unlimited maximum pool size MUST skip this test.
+
 - MaxPoolSize: 0
 - AutoEncryptionOpts:
    - bypassAutoEncryption=true

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -795,7 +795,6 @@ Create a ``ClientEncryption`` object, named ``client_encryption`` configured wit
 - ``keyVaultClient``=``client_test``
 - ``keyVaultNamespace``="keyvault.datakeys"
 - ``kmsProviders``=``{ "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }``
-- ``readConcern=majority`` and ``writeConcern=majority``
 
 Use ``client_encryption`` to encrypt the value "string0" with ``algorithm``="AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic" and ``keyAltName``="local". Store the result in a variable named ``ciphertext``.
 
@@ -808,16 +807,17 @@ Each test must assert the number of unique ``MongoClient``s created. This can be
 Running a test case
 ```````````````````
 - Create a ``MongoClient`` named ``client_encrypted`` configured as follows:
-   - ``AutoEncrytionOpts.keyVaultNamespace="keyvault.datakeys"``
-   - ``AutoEncrytionOpts.kmsProviders``=``{ "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }``
+   - Set ``AutoEncryptionOpts``:
+      - ``keyVaultNamespace="keyvault.datakeys"``
+      - ``kmsProviders``=``{ "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }``
+      - Append ``TestCase.AutoEncryptionOpts`` (defined below)
    - Capture command started events.
    - Set ``maxPoolSize=TestCase.MaxPoolSize``
-   - Append ``TestCase.AutoEncryptionOpts`` (defined below)
 - If the testcase sets ``AutoEncryptionOpts.bypassAutoEncryption=true``:
-   - Use ``client_test`` to insert ``{ "_id": 0, "encrypted": <ciphertext> }``.
+   - Use ``client_test`` to insert ``{ "_id": 0, "encrypted": <ciphertext> }`` into ``db.coll``.
 - Otherwise:
    - Use ``client_encrypted`` to insert ``{ "_id": 0, "encrypted": "string0" }``.
-- Run a ``findOne`` operation, with the filter ``{ "_id": 0 }``.
+- Use ``client_encrypted`` to run a ``findOne`` operation on ``db.coll``, with the filter ``{ "_id": 0 }``.
 - Expect the result to be ``{ "_id": 0, "encrypted": "string0" }``.
 - Check captured events against ``TestCase.Expectations``.
 - Check the number of unique ``MongoClient``s created is equal to ``TestCase.ExpectedNumberOfClients``.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -860,8 +860,8 @@ Case 3
 - Expectations:
    - Expect ``client_encrypted`` to have captured three ``CommandStartedEvent``:
       - an insert on "db".
-      - a find on "keyvault".
       - a find on "db"
+      - a find on "keyvault".
 - ExpectedNumberOfClients: 2
 
 Case 4
@@ -923,8 +923,8 @@ Drivers that do not support an unlimited maximum pool size MUST skip this test.
 - Expectations:
    - Expect ``client_encrypted`` to have captured three ``CommandStartedEvent``:
       - an insert on "db".
-      - a find on "keyvault".
       - a find on "db"
+      - a find on "keyvault".
 - ExpectedNumberOfClients: 1
 
 Case 8

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -779,12 +779,14 @@ There are multiple parameterized test cases. Before each test case, perform the 
 Setup
 `````
 
-Create two ``MongoClient``s with ``maxPoolSize=1``, ``readConcern=majority`` and ``writeConcern=majority``:
-- ``client_test`` for test operations
-- ``client_keyvault`` to use as a ``keyVaultClient``. Capture command started events.
+Create a ``MongoClient`` for setup operations named ``client_test``.
+
+Create a ``MongoClient`` for key vault operations with ``maxPoolSize=1`` named ``client_keyvault``. Capture command started events.
 
 Using ``client_test``, drop the collections ``keyvault.datakeys`` and ``db.coll``.
-Insert the document `external/external-key.json <../external/external-key.json>`_ into ``keyvault.datakeys``.
+
+Insert the document `external/external-key.json <../external/external-key.json>`_ into ``keyvault.datakeys`` with majority write concern.
+
 Create a collection ``db.coll`` configured with a JSON schema `external/external-schema.json <../external/external-schema.json>`_ as the validator, like so:
 
 .. code:: typescript

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -774,6 +774,10 @@ The following tests that setting ``bypassAutoEncryption=true`` really does bypas
 Deadlock tests
 ~~~~~~~~~~~~~~
 
+.. _Connection Monitoring and Pooling: /source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+
+The following tests only apply to drivers that have implemented a connection pool (see the `Connection Monitoring and Pooling`_ specification).
+
 There are multiple parameterized test cases. Before each test case, perform the setup.
 
 Setup

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -774,9 +774,7 @@ The following tests that setting ``bypassAutoEncryption=true`` really does bypas
 Deadlock tests
 ~~~~~~~~~~~~~~
 
-There are several test cases. Before each test case, perform the setup.
-
-Drivers that do not support ``maxPoolSize`` may skip the warning/error cases.
+There are multiple parameterized test cases. Before each test case, perform the setup.
 
 Setup
 `````
@@ -798,6 +796,7 @@ Create a ``ClientEncryption`` object, named ``client_encryption`` configured wit
 - ``keyVaultClient``=``client_test``
 - ``keyVaultNamespace``="keyvault.datakeys"
 - ``kmsProviders``=``{ "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }``
+- ``readConcern=majority`` and ``writeConcern=majority``
 
 Use ``client_encryption`` to encrypt the value "string0" with ``algorithm``="AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic" and ``keyAltName``="local". Store the result in a variable named ``ciphertext``.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -861,7 +861,6 @@ Case 3
    - keyVaultClient=unset
 - Expectations:
    - Expect ``client_encrypted`` to have captured three ``CommandStartedEvent``:
-      - an insert on "db".
       - a find on "db"
       - a find on "keyvault".
 - ExpectedNumberOfClients: 2
@@ -874,7 +873,6 @@ Case 4
    - keyVaultClient=client_keyvault
 - Expectations:
    - Expect ``client_encrypted`` to have captured two ``CommandStartedEvent``:
-      - an insert on "db".
       - a find on "db"
    - Expect ``client_keyvault`` to have captured one ``CommandStartedEvent``:
       - a find on "keyvault".
@@ -924,7 +922,6 @@ Drivers that do not support an unlimited maximum pool size MUST skip this test.
    - keyVaultClient=unset
 - Expectations:
    - Expect ``client_encrypted`` to have captured three ``CommandStartedEvent``:
-      - an insert on "db".
       - a find on "db"
       - a find on "keyvault".
 - ExpectedNumberOfClients: 1
@@ -939,7 +936,6 @@ Drivers that do not support an unlimited maximum pool size MUST skip this test.
    - keyVaultClient=client_keyvault
 - Expectations:
    - Expect ``client_encrypted`` to have captured two ``CommandStartedEvent``:
-      - an insert on "db".
       - a find on "db"
    - Expect ``client_keyvault`` to have captured one ``CommandStartedEvent``:
       - a find on "keyvault".

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -822,6 +822,7 @@ Running a test case
 - Check captured events against ``TestCase.Expectations``.
 
 (Drivers with a thread-unsafe ``MongoClient`` MUST skip the following steps)
+
 - Run the following sequence of operations 10 times concurrently (e.g. in 10 separate threads), indexed by ``i``.
    - Use ``client_encrypted`` to insert ``{ "_id": ``i``, "encrypted": "string0" }``.
    - Run a ``findOne`` operation, with the filter ``{ "_id": ``i`` }``.

--- a/source/client-side-encryption/tests/aggregate.json
+++ b/source/client-side-encryption/tests/aggregate.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -271,18 +259,6 @@
               "cursor": {}
             },
             "command_name": "aggregate"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
           }
         },
         {

--- a/source/client-side-encryption/tests/aggregate.yml
+++ b/source/client-side-encryption/tests/aggregate.yml
@@ -30,13 +30,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -83,13 +76,6 @@ tests:
             cursor: {}
           command_name: aggregate
       # Needs to fetch key when decrypting results
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/azureKMS.json
+++ b/source/client-side-encryption/tests/azureKMS.json
@@ -142,18 +142,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/azureKMS.yml
+++ b/source/client-side-encryption/tests/azureKMS.yml
@@ -25,13 +25,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/source/client-side-encryption/tests/basic.json
+++ b/source/client-side-encryption/tests/basic.json
@@ -147,18 +147,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -279,18 +267,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/source/client-side-encryption/tests/basic.yml
+++ b/source/client-side-encryption/tests/basic.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -81,13 +74,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/source/client-side-encryption/tests/bulk.json
+++ b/source/client-side-encryption/tests/bulk.json
@@ -181,18 +181,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/bulk.yml
+++ b/source/client-side-encryption/tests/bulk.yml
@@ -39,13 +39,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/count.json
+++ b/source/client-side-encryption/tests/count.json
@@ -152,18 +152,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/count.yml
+++ b/source/client-side-encryption/tests/count.yml
@@ -28,13 +28,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/countDocuments.json
+++ b/source/client-side-encryption/tests/countDocuments.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/countDocuments.yml
+++ b/source/client-side-encryption/tests/countDocuments.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/delete.json
+++ b/source/client-side-encryption/tests/delete.json
@@ -154,18 +154,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -272,18 +260,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/source/client-side-encryption/tests/delete.yml
+++ b/source/client-side-encryption/tests/delete.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -75,13 +68,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/source/client-side-encryption/tests/distinct.json
+++ b/source/client-side-encryption/tests/distinct.json
@@ -164,18 +164,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/distinct.yml
+++ b/source/client-side-encryption/tests/distinct.yml
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/explain.json
+++ b/source/client-side-encryption/tests/explain.json
@@ -158,18 +158,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/explain.yml
+++ b/source/client-side-encryption/tests/explain.yml
@@ -33,13 +33,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/find.json
+++ b/source/client-side-encryption/tests/find.json
@@ -163,18 +163,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -298,18 +286,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/source/client-side-encryption/tests/find.yml
+++ b/source/client-side-encryption/tests/find.yml
@@ -30,13 +30,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -77,13 +70,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/source/client-side-encryption/tests/findOneAndDelete.json
+++ b/source/client-side-encryption/tests/findOneAndDelete.json
@@ -151,18 +151,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/findOneAndDelete.yml
+++ b/source/client-side-encryption/tests/findOneAndDelete.yml
@@ -28,13 +28,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/findOneAndReplace.json
+++ b/source/client-side-encryption/tests/findOneAndReplace.json
@@ -150,18 +150,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/findOneAndReplace.yml
+++ b/source/client-side-encryption/tests/findOneAndReplace.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/findOneAndUpdate.json
+++ b/source/client-side-encryption/tests/findOneAndUpdate.json
@@ -152,18 +152,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/findOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/findOneAndUpdate.yml
@@ -29,13 +29,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/gcpKMS.json
+++ b/source/client-side-encryption/tests/gcpKMS.json
@@ -144,18 +144,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/gcpKMS.yml
+++ b/source/client-side-encryption/tests/gcpKMS.yml
@@ -25,13 +25,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/source/client-side-encryption/tests/getMore.json
+++ b/source/client-side-encryption/tests/getMore.json
@@ -182,18 +182,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/getMore.yml
+++ b/source/client-side-encryption/tests/getMore.yml
@@ -38,13 +38,6 @@ tests:
             find: *collection_name
             batchSize: 2
           command_name: find
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/insert.json
+++ b/source/client-side-encryption/tests/insert.json
@@ -134,18 +134,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -254,18 +242,6 @@
               "filter": {
                 "name": "default"
               }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
             },
             "command_name": "listCollections"
           }

--- a/source/client-side-encryption/tests/insert.yml
+++ b/source/client-side-encryption/tests/insert.yml
@@ -25,13 +25,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -70,13 +63,6 @@ tests:
             listCollections: 1
             filter:
               name: *collection_name
-          command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
           command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:

--- a/source/client-side-encryption/tests/keyAltName.json
+++ b/source/client-side-encryption/tests/keyAltName.json
@@ -134,18 +134,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/keyAltName.yml
+++ b/source/client-side-encryption/tests/keyAltName.yml
@@ -25,13 +25,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/localKMS.json
+++ b/source/client-side-encryption/tests/localKMS.json
@@ -117,18 +117,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/localKMS.yml
+++ b/source/client-side-encryption/tests/localKMS.yml
@@ -26,13 +26,6 @@ tests:
           filter:
             name: *collection_name
         command_name: listCollections
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: "datakeys"
-          $db: keyvault
-        command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:
         command:

--- a/source/client-side-encryption/tests/localSchema.json
+++ b/source/client-side-encryption/tests/localSchema.json
@@ -139,18 +139,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/localSchema.yml
+++ b/source/client-side-encryption/tests/localSchema.yml
@@ -25,13 +25,6 @@ tests:
           filter: { _id: 1 }
         result: [*doc0]
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/missingKey.json
+++ b/source/client-side-encryption/tests/missingKey.json
@@ -143,18 +143,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "different"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "different",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/missingKey.yml
+++ b/source/client-side-encryption/tests/missingKey.yml
@@ -32,13 +32,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "different"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/replaceOne.json
+++ b/source/client-side-encryption/tests/replaceOne.json
@@ -151,18 +151,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/replaceOne.yml
+++ b/source/client-side-encryption/tests/replaceOne.yml
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/types.json
+++ b/source/client-side-encryption/tests/types.json
@@ -106,18 +106,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -257,18 +245,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -405,18 +381,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {
@@ -659,18 +623,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -807,18 +759,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {
@@ -1060,18 +1000,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -1217,18 +1145,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [
@@ -1369,18 +1285,6 @@
         }
       ],
       "expectations": [
-        {
-          "command_started_event": {
-            "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
         {
           "command_started_event": {
             "command": {

--- a/source/client-side-encryption/tests/types.yml
+++ b/source/client-side-encryption/tests/types.yml
@@ -27,13 +27,6 @@ tests:
           filter: { _id: 1 }
         result: *doc0
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -75,13 +68,6 @@ tests:
           filter: { _id: 1 }
         result: *doc1
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -123,13 +109,6 @@ tests:
           filter: { _id: 1 }
         result: *doc2
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -197,13 +176,6 @@ tests:
           filter: { _id: 1 }
         result: *doc6
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -245,13 +217,6 @@ tests:
           filter: { _id: 1 }
         result: *doc7
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -319,13 +284,6 @@ tests:
           filter: { _id: 1 }
         result: *doc10
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -367,13 +325,6 @@ tests:
           filter: { _id: 1 }
         result: *doc11
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:
@@ -415,13 +366,6 @@ tests:
           filter: { _id: 1 }
         result: *doc13
     expectations:
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/updateMany.json
+++ b/source/client-side-encryption/tests/updateMany.json
@@ -167,18 +167,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/updateMany.yml
+++ b/source/client-side-encryption/tests/updateMany.yml
@@ -32,13 +32,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/updateOne.json
+++ b/source/client-side-encryption/tests/updateOne.json
@@ -153,18 +153,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              },
-              "$db": "keyvault"
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/updateOne.yml
+++ b/source/client-side-encryption/tests/updateOne.yml
@@ -31,13 +31,6 @@ tests:
             filter:
               name: *collection_name
           command_name: listCollections
-      - command_started_event:
-          command:
-            listCollections: 1
-            filter:
-              name: "datakeys"
-            $db: keyvault
-          command_name: listCollections
       # Then key is fetched from the key vault.
       - command_started_event:
           command:


### PR DESCRIPTION
Summary of changes:
- Create an internal client when necessary to use as the `metadataClient`, `keyVaultClient`, or both. If both require an internal client, they share one.

The rationale for adding an internal client is that it fixes the issue in the default case (`maxPoolSize=100` by default).

Caveats:
- The internal client does not expose configuration options.

[This branch of mongo-go-driver](https://github.com/mongodb/mongo-go-driver/compare/master...kevinAlbs:spec1768_poc?expand=1) contains a POC implementation and implementation of prose tests.

The command started expectations in spec tests will also be updated to remove `listCollections` commands to the key vault collection (which is a nice side-benefit of this change). I have those changes in a separate PR: https://github.com/mongodb/specifications/pull/892