### PR TITLE
Add top level unsetOrMatches to insertMany operation

### DIFF
--- a/source/unified-test-format/tests/valid-pass/poc-retryable-writes.json
+++ b/source/unified-test-format/tests/valid-pass/poc-retryable-writes.json
@@ -297,13 +297,15 @@
             "ordered": true
           },
           "expectResult": {
-            "insertedCount": {
-              "$$unsetOrMatches": 2
-            },
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 3,
-                "1": 4
+            "$$unsetOrMatches": {
+              "insertedCount": {
+                "$$unsetOrMatches": 2
+              },
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 3,
+                  "1": 4
+                }
               }
             }
           }

--- a/source/unified-test-format/tests/valid-pass/poc-retryable-writes.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-retryable-writes.yml
@@ -141,8 +141,7 @@ tests:
             - { _id: 4, x: 44 }
           ordered: true
         expectResult:
-          insertedCount: { $$unsetOrMatches: 2 }
-          insertedIds: { $$unsetOrMatches: { 0: 3, 1: 4 } }
+          { $$unsetOrMatches: { insertedCount: { $$unsetOrMatches: 2 } }, insertedIds: { $$unsetOrMatches: { 0: 3, 1: 4 } } }
     outcome:
       - collectionName: *collectionName
         databaseName: *databaseName


### PR DESCRIPTION
The .NET driver does not return a result for the insertOne and insertMany methods, which is allowed in the CRUD spec (as all fields of the result are optional). To reflect this, we need to add a top-level `$$unsetOrMatches` to the expected result for such operations.