### PR TITLE
Skip deprecation errors test when requireApiVersion is true

### DIFF
--- a/source/versioned-api/tests/test-commands-deprecation-errors.json
+++ b/source/versioned-api/tests/test-commands-deprecation-errors.json
@@ -6,7 +6,8 @@
       "minServerVersion": "4.7",
       "serverParameters": {
         "enableTestCommands": true,
-        "acceptAPIVersion2": true
+        "acceptAPIVersion2": true,
+        "requireApiVersion": false
       }
     }
   ],

--- a/source/versioned-api/tests/test-commands-deprecation-errors.yml
+++ b/source/versioned-api/tests/test-commands-deprecation-errors.yml
@@ -7,6 +7,7 @@ runOnRequirements:
     serverParameters:
       enableTestCommands: true
       acceptAPIVersion2: true
+      requireApiVersion: false
 
 createEntities:
   - client:


### PR DESCRIPTION
The `test-commands-deprecation-errors` test should skip when requireApiVersion is true since it uses `runCommand` without setting an `apiVersion` (this issue [was also discovered](https://github.com/mongodb/specifications/pull/887) for other `runCommand` tests).  When requireApiVersion is true for `test-commands-deprecation-errors`, commands are sent to the server for test setup that lack a `ServerAPIVersion` and the server errors incorrectly before the `runCommand` is sent.

Skips the test when `requireApiVersion` is true.