### PR TITLE
DRIVERS-1505 Update versioned api database aggregate strict test

### DIFF
--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -154,6 +154,11 @@
                 "$limit": 1
               }
             ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "stage $listLocalSessions is not allowed with 'apiStrict: true' in API Version 1",
+            "errorCodeName": "APIStrictError"
           }
         }
       ],

--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -156,8 +156,6 @@
             ]
           },
           "expectError": {
-            "isError": true,
-            "errorContains": "stage $listLocalSessions is not allowed with 'apiStrict: true' in API Version 1",
             "errorCodeName": "APIStrictError"
           }
         }

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -69,6 +69,10 @@ tests:
           pipeline: &pipeline
             - $listLocalSessions: {}
             - $limit: 1
+        expectError:
+          isError: true
+          errorContains: "stage $listLocalSessions is not allowed with 'apiStrict: true' in API Version 1"
+          errorCodeName: "APIStrictError"
     expectEvents:
       - client: *client
         events:

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -70,8 +70,6 @@ tests:
             - $listLocalSessions: {}
             - $limit: 1
         expectError:
-          isError: true
-          errorContains: "stage $listLocalSessions is not allowed with 'apiStrict: true' in API Version 1"
           errorCodeName: "APIStrictError"
     expectEvents:
       - client: *client


### PR DESCRIPTION
[DRIVERS-1505](https://jira.mongodb.org/browse/DRIVERS-1505)

In the `crud-api-version-1-strict` spec test, a $listLocalSessions stage is used in an aggregate test case. That stage was [excluded](https://docs.google.com/document/d/10heZ18gZQw3x4MFPaTcY1Pwb0XCW7aSsEX5-cSe-nvs/edit#heading=h.wl7sg62rrat1) from api version 1, so the test fails with an API strict error.

Updates the test to expect this error.