### PR TITLE
Document that the abortTransaction command accepts recoveryToken

### DIFF
--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -763,7 +763,8 @@ The abortTransaction server command has the following format:
         lsid : { id : <UUID> },
         txnNumber : <Int64>,
         autocommit : false,
-        writeConcern : {...}
+        writeConcern : {...},
+        recoveryToken : {...}
     }
 
 Both commands MUST be sent to the admin database.


### PR DESCRIPTION
Minor change to document that the abortTransaction command accepts recoveryToken. The spec already mandates this and has tests to verify the behavior. 

Motivation: In [SERVER-53811](https://jira.mongodb.org/browse/SERVER-53811), the server asked me to explain which command args drivers use for commit and abort. I was planning to share this section of the spec but was surprised to see recoveryToken was not present in the abortTransaction example.