### PR TITLE
SPEC-1774 support AWS temp creds in CSFLE

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1513,6 +1513,7 @@ Changelog
 =========
 
 +------------+------------------------------------------------------------+
+| 2021-01-22 | Add sessionToken option to 'aws' KMS provider              |
 | 2020-12-12 | Add metadataClient option and internal client              |
 | 2020-10-19 | Add 'azure' and 'gcp' KMS providers                        |
 | 2019-10-11 | Add 'endpoint' to AWS masterkey                            |

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -364,7 +364,8 @@ to authenticate.
 
    aws: {
       accessKeyId: String,
-      secretAccessKey: String
+      secretAccessKey: String,
+      sessionToken: Optional<String> // Required for temporary AWS credentials.
    }
 
    azure: {

--- a/source/client-side-encryption/etc/test-templates/awsTemporary.yml.template
+++ b/source/client-side-encryption/etc/test-templates/awsTemporary.yml.template
@@ -1,0 +1,57 @@
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+
+data: []
+json_schema: {{schema()}}
+key_vault_data: [{{key()}}]
+
+tests:
+  - description: "Insert a document with auto encryption using the AWS provider with temporary credentials"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          awsTemporary: {}
+    operations:
+      - name: insertOne
+        arguments:
+          document: &doc0 { _id: 1, encrypted_string: "string0" }
+    expectations:
+    # Auto encryption will request the collection info.
+    - command_started_event:
+        command:
+          listCollections: 1
+          filter:
+            name: *collection_name
+        command_name: listCollections
+    # Then key is fetched from the key vault.
+    - command_started_event:
+        command:
+          find: datakeys
+          filter: { $or: [ { _id: { $in: [ {{key()["_id"]}} ] } }, { keyAltNames: { $in: [] } } ] }
+          $db: keyvault
+        command_name: find
+    - command_started_event:
+        command:
+          insert: *collection_name
+          documents:
+            - &doc0_encrypted { _id: 1, encrypted_string: {{ciphertext("string0", field="encrypted_string")}} }
+          ordered: true
+        command_name: insert
+    outcome:
+      collection:
+        # Outcome is checked using a separate MongoClient without auto encryption.
+        data:
+          - *doc0_encrypted
+  - description: "Insert with invalid temporary credentials"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          awsTemporaryNoSessionToken: {}
+    operations:
+      - name: insertOne
+        arguments:
+          document: *doc0
+        result:
+          errorContains: "security token"

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -147,7 +147,32 @@ Then for each element in ``tests``:
 
 #. Create a **new** MongoClient using ``clientOptions``.
 
-   #. If ``autoEncryptOpts`` includes ``aws``, ``azure``, and/or ``gcp`` as a KMS provider, pass in credentials from the environment.
+   #. If ``autoEncryptOpts`` includes ``aws``, ``awsTemporary``, ``awsTemporaryNoSessionToken``, ``azure``, and/or ``gcp`` as a KMS provider, pass in credentials from the environment.
+      - ``awsTemporary``, and ``awsTemporaryNoSessionToken`` require temporary AWS credentials. These can be retrieved using the csfle `set-temp-creds.sh <https://github.com/mongodb-labs/drivers-evergreen-tools/tree/master/.evergreen/csfle>`_ script.
+      - ``aws``, ``awsTemporary``, and ``awsTemporaryNoSessionToken`` are mutually exclusive.
+      - The following is a full KMS providers map for reference:
+
+        .. code:: javascript
+
+           {
+              "aws": {
+                 "accessKeyId": <set from environment>,
+                 "secretAccessKey": <set from environment>
+                 "sessionToken": <set from environment>
+              },
+              "azure": {
+                 "tenantId": <set from environment>,
+                 "clientId": <set from environment>,
+                 "clientSecret": <set from environment>,
+              },
+                 "gcp": {
+                 "email": <set from environment>,
+                 "privateKey": <set from environment>,
+              }
+              "local": { "key": <base64 decoding of LOCAL_MASTERKEY> }
+           }
+
+
    #. If ``autoEncryptOpts`` does not include ``keyVaultNamespace``, default it to ``keyvault.datakeys``.
 
 #. For each element in ``operations``:

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -147,33 +147,72 @@ Then for each element in ``tests``:
 
 #. Create a **new** MongoClient using ``clientOptions``.
 
-   #. If ``autoEncryptOpts`` includes ``aws``, ``awsTemporary``, ``awsTemporaryNoSessionToken``, ``azure``, and/or ``gcp`` as a KMS provider, pass in credentials from the environment.
-      - ``awsTemporary``, and ``awsTemporaryNoSessionToken`` require temporary AWS credentials. These can be retrieved using the csfle `set-temp-creds.sh <https://github.com/mongodb-labs/drivers-evergreen-tools/tree/master/.evergreen/csfle>`_ script.
-      - ``aws``, ``awsTemporary``, and ``awsTemporaryNoSessionToken`` are mutually exclusive.
-      - The following is a full KMS providers map for reference:
+   #. If ``autoEncryptOpts`` includes ``aws``, ``awsTemporary``, ``awsTemporaryNoSessionToken``,
+      ``azure``, and/or ``gcp`` as a KMS provider, pass in credentials from the environment.
+
+      - ``awsTemporary``, and ``awsTemporaryNoSessionToken`` require temporary
+        AWS credentials. These can be retrieved using the csfle `set-temp-creds.sh
+        <https://github.com/mongodb-labs/drivers-evergreen-tools/tree/master/.evergreen/csfle>`_
+        script.
+
+      - ``aws``, ``awsTemporary``, and ``awsTemporaryNoSessionToken`` are
+        mutually exclusive.
+
+        ``aws`` should be substituted with:
 
         .. code:: javascript
 
-           {
-              "aws": {
-                 "accessKeyId": <set from environment>,
-                 "secretAccessKey": <set from environment>
-                 "sessionToken": <set from environment>
-              },
-              "azure": {
-                 "tenantId": <set from environment>,
-                 "clientId": <set from environment>,
-                 "clientSecret": <set from environment>,
-              },
-                 "gcp": {
-                 "email": <set from environment>,
-                 "privateKey": <set from environment>,
-              }
-              "local": { "key": <base64 decoding of LOCAL_MASTERKEY> }
+           "aws": {
+                "accessKeyId": <set from environment>,
+                "secretAccessKey": <set from environment>
            }
 
+        ``awsTemporary`` should be substituted with:
 
-   #. If ``autoEncryptOpts`` does not include ``keyVaultNamespace``, default it to ``keyvault.datakeys``.
+        .. code:: javascript
+
+           "aws": {
+                "accessKeyId": <set from environment>,
+                "secretAccessKey": <set from environment>
+                "sessionToken": <set from environment>
+           }
+
+        ``awsTemporaryNoSessionToken`` should be substituted with:
+
+        .. code:: javascript
+
+           "aws": {
+               "accessKeyId": <set from environment>,
+               "secretAccessKey": <set from environment>
+           }
+
+        ``gcp`` should be substituted with:
+
+        .. code:: javascript
+
+           "gcp": {
+               "email": <set from environment>,
+               "privateKey": <set from environment>,
+           }
+
+        ``azure`` should be substituted with:
+
+        .. code:: javascript
+
+           "azure": {
+               "tenantId": <set from environment>,
+               "clientId": <set from environment>,
+               "clientSecret": <set from environment>,
+           }
+
+        ``local`` should be substituted with:
+
+        .. code:: javascript
+
+           "local": { "key": <base64 decoding of LOCAL_MASTERKEY> }
+
+   #. If ``autoEncryptOpts`` does not include ``keyVaultNamespace``, default it
+      to ``keyvault.datakeys``.
 
 #. For each element in ``operations``:
 

--- a/source/client-side-encryption/tests/awsTemporary.json
+++ b/source/client-side-encryption/tests/awsTemporary.json
@@ -202,7 +202,7 @@
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {
-            "awsTemporary": {}
+            "awsTemporaryNoSessionToken": {}
           }
         }
       },
@@ -216,7 +216,7 @@
             }
           },
           "result": {
-            "errorContains": "LMAO"
+            "errorContains": "security token"
           }
         }
       ]

--- a/source/client-side-encryption/tests/awsTemporary.json
+++ b/source/client-side-encryption/tests/awsTemporary.json
@@ -1,0 +1,225 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "json_schema": {
+    "properties": {
+      "encrypted_w_altname": {
+        "encrypt": {
+          "keyId": "/altname",
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      },
+      "random": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+        }
+      },
+      "encrypted_string_equivalent": {
+        "encrypt": {
+          "keyId": [
+            {
+              "$binary": {
+                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                "subType": "04"
+              }
+            }
+          ],
+          "bsonType": "string",
+          "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        }
+      }
+    },
+    "bsonType": "object"
+  },
+  "key_vault_data": [
+    {
+      "status": 1,
+      "_id": {
+        "$binary": {
+          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+          "subType": "04"
+        }
+      },
+      "masterKey": {
+        "provider": "aws",
+        "key": "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        "region": "us-east-1"
+      },
+      "updateDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyMaterial": {
+        "$binary": {
+          "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO",
+          "subType": "00"
+        }
+      },
+      "creationDate": {
+        "$date": {
+          "$numberLong": "1552949630483"
+        }
+      },
+      "keyAltNames": [
+        "altname",
+        "another_altname"
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Insert a document with auto encryption using the AWS provider with temporary credentials",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "awsTemporary": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "default"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$binary": {
+                            "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                            "subType": "04"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault"
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default",
+              "documents": [
+                {
+                  "_id": 1,
+                  "encrypted_string": {
+                    "$binary": {
+                      "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                      "subType": "06"
+                    }
+                  }
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1,
+              "encrypted_string": {
+                "$binary": {
+                  "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                  "subType": "06"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "Insert with invalid temporary credentials",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "awsTemporary": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encrypted_string": "string0"
+            }
+          },
+          "result": {
+            "errorContains": "LMAO"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/client-side-encryption/tests/awsTemporary.yml
+++ b/source/client-side-encryption/tests/awsTemporary.yml
@@ -1,0 +1,57 @@
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+
+data: []
+json_schema: {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+key_vault_data: [{'status': 1, '_id': {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}, 'masterKey': {'provider': 'aws', 'key': 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0', 'region': 'us-east-1'}, 'updateDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyMaterial': {'$binary': {'base64': 'AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO', 'subType': '00'}}, 'creationDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyAltNames': ['altname', 'another_altname']}]
+
+tests:
+  - description: "Insert a document with auto encryption using the AWS provider with temporary credentials"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          awsTemporary: {}
+    operations:
+      - name: insertOne
+        arguments:
+          document: &doc0 { _id: 1, encrypted_string: "string0" }
+    expectations:
+    # Auto encryption will request the collection info.
+    - command_started_event:
+        command:
+          listCollections: 1
+          filter:
+            name: *collection_name
+        command_name: listCollections
+    # Then key is fetched from the key vault.
+    - command_started_event:
+        command:
+          find: datakeys
+          filter: { $or: [ { _id: { $in: [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] } }, { keyAltNames: { $in: [] } } ] }
+          $db: keyvault
+        command_name: find
+    - command_started_event:
+        command:
+          insert: *collection_name
+          documents:
+            - &doc0_encrypted { _id: 1, encrypted_string: {'$binary': {'base64': 'AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==', 'subType': '06'}} }
+          ordered: true
+        command_name: insert
+    outcome:
+      collection:
+        # Outcome is checked using a separate MongoClient without auto encryption.
+        data:
+          - *doc0_encrypted
+  - description: "Insert with invalid temporary credentials"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          awsTemporary: {}
+    operations:
+      - name: insertOne
+        arguments:
+          document: *doc0
+        result:
+          errorContains: "LMAO"

--- a/source/client-side-encryption/tests/awsTemporary.yml
+++ b/source/client-side-encryption/tests/awsTemporary.yml
@@ -48,10 +48,10 @@ tests:
     clientOptions:
       autoEncryptOpts:
         kmsProviders:
-          awsTemporary: {}
+          awsTemporaryNoSessionToken: {}
     operations:
       - name: insertOne
         arguments:
           document: *doc0
         result:
-          errorContains: "LMAO"
+          errorContains: "security token"


### PR DESCRIPTION
Adds integration tests for creating and passing temporary AWS credentials to authenticate KMS requests for CSFLE.

Drivers can obtain AWS temporary credentials with a new `set-temp-creds.sh` script included in drivers-evergreen-tools: https://github.com/mongodb-labs/drivers-evergreen-tools/pull/136 By default, the temporary credentials expire after 12 hours.

POC of the new tests running in Evergreen in libmongoc: https://github.com/mongodb/mongo-c-driver/pull/725

Tests require libmongocrypt 1.2.0: https://github.com/mongodb/libmongocrypt/releases/tag/1.2.0