### PR TITLE
SPEC-1777 Add more spec tests for invalid relaxed UUIDs

### DIFF
--- a/source/bson-corpus/tests/binary.json
+++ b/source/bson-corpus/tests/binary.json
@@ -94,8 +94,20 @@
             "string": "{\"x\" : { \"$uuid\" : { \"data\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4\"}}}"
         },
         {
-            "description": "$uuid invalid value",
+            "description": "$uuid invalid value--too short",
             "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-90e8-e7d1dfc035d4\"}}"
+        },
+        {
+            "description": "$uuid invalid value--too long",
+            "string": "{\"x\" : { \"$uuid\" : \"73ffd264-44b3-4c69-90e8-e7d1dfc035d4-789e4\"}}"
+        },
+        {
+            "description": "$uuid invalid value--misplaced hyphens",
+            "string": "{\"x\" : { \"$uuid\" : \"73ff-d26444b-34c6-990e8e-7d1dfc035d4\"}}"
+        },
+        {
+            "description": "$uuid invalid value--too many hyphens",
+            "string": "{\"x\" : { \"$uuid\" : \"----d264-44b3-4--9-90e8-e7d1dfc0----\"}}"
         }
     ]
 }


### PR DESCRIPTION
[SPEC-1777](https://jira.mongodb.org/browse/SPEC-1777)

[DRIVERS-848](https://jira.mongodb.org/browse/DRIVERS-848) adds support for parsing a new, relaxed $uuid extended JSON representation of binary subtype 4. This change requires drivers to validate passed in UUIDs to make sure they conform to RFC 4122 standards.

The current spec tests only have one invalid UUID case. The Go driver had to add more test coverage for invalid UUIDs, so it would probably be a good idea to add these to spec tests.