### PR TITLE
SPEC-1781 Expect success for operations without expectError and expectResult

### DIFF
--- a/source/unified-test-format/tests/valid-fail/operation-failure.json
+++ b/source/unified-test-format/tests/valid-fail/operation-failure.json
@@ -1,0 +1,56 @@
+{
+  "description": "operation-failure",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "operation-failure"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Unsupported command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "unsupportedCommand",
+            "command": {
+              "unsupportedCommand": 1
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "Unsupported query operator",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "$unsupportedQueryOperator": 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/valid-fail/operation-failure.yml
+++ b/source/unified-test-format/tests/valid-fail/operation-failure.yml
@@ -1,0 +1,31 @@
+description: "operation-failure"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: operation-failure
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: coll0
+
+tests:
+  - description: "Unsupported command"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments:
+          commandName: unsupportedCommand
+          command: { unsupportedCommand: 1 }
+
+  - description: "Unsupported query operator"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { $unsupportedQueryOperator: 1 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/SPEC-1781

As a valid-fail test, this will ensure test runners expect operations to succeed by default even if they have no result assertions.