### PR TITLE
SPEC-1780 Fix typos in estimatedDocumentCount spec and tests

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -672,8 +672,10 @@ As documented above, the only supported option is maxTimeMS::
   ]
 
 Similar to the count command, the estimated count of documents is returned
-in the ``n`` field. Drivers can assume that the first field of the first batch
-returned from the cursor contains the ``n`` field.
+in the ``n`` field. Implementations can assume that the document containing
+the single result of the aggregation pipeline is contained in the first batch of
+the server's reply to the aggregate command. It is not necessary to execute a getMore
+operation to ensure that the result is available.
 
 In the event this aggregation is run against a non-existent namespace, a NamespaceNotFound(26)
 error will be returned during execution. Drivers MUST interpret the server error code 26 as

--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -672,7 +672,8 @@ As documented above, the only supported option is maxTimeMS::
   ]
 
 Similar to the count command, the estimated count of documents is returned
-in the ``n`` field.
+in the ``n`` field. Drivers can assume that the first field of the first batch
+returned from the cursor contains the ``n`` field.
 
 In the event this aggregation is run against a non-existent namespace, a NamespaceNotFound(26)
 error will be returned during execution. Drivers MUST interpret the server error code 26 as

--- a/source/crud/tests/unified/estimatedDocumentCount.json
+++ b/source/crud/tests/unified/estimatedDocumentCount.json
@@ -10,7 +10,8 @@
                 ],
                 "uriOptions": {
                     "retryReads": false
-                }
+                },
+                "useMultipleMongoses": false
             }
         },
         {

--- a/source/crud/tests/unified/estimatedDocumentCount.yml
+++ b/source/crud/tests/unified/estimatedDocumentCount.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.0"
 createEntities:
   - client:
       id: &client0 client0
+      useMultipleMongoses: false # Avoid setting fail points with multiple mongoses
       uriOptions: { retryReads: false } # Avoid retrying fail points with closeConnection
       observeEvents: [ commandStartedEvent ]
   - database:

--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -596,7 +596,12 @@
     },
     {
       "description": "estimatedDocumentCount appends declared API version",
-      "skipReason": "DRIVERS-1437 count was removed from API version 1",
+      "skipReason": "DRIVERS-1561 collStats is not in API version 1",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9.0"
+        }
+      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",
@@ -611,7 +616,22 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "count": "test",
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$collStats": {
+                        "count": {}
+                      }
+                    },
+                    {
+                      "$group": {
+                        "_id": 1,
+                        "n": {
+                          "$sum": "$count"
+                        }
+                      }
+                    }
+                  ],
                   "apiVersion": "1",
                   "apiStrict": true,
                   "apiDeprecationErrors": {

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -216,7 +216,9 @@ tests:
                 <<: *expectedApiVersion
 
   - description: "estimatedDocumentCount appends declared API version"
-    skipReason: "DRIVERS-1437 count was removed from API version 1"
+    skipReason: "DRIVERS-1561 collStats is not in API version 1"
+    runOnRequirements:
+      - minServerVersion: "4.9.0" # $collStats is not used in estimatedDocumentCount on < 4.9
     operations:
       - name: estimatedDocumentCount
         object: *collection
@@ -226,7 +228,10 @@ tests:
         events:
           - commandStartedEvent:
               command:
-                count: *collectionName
+                aggregate: *collectionName
+                pipeline: &pipeline
+                  - $collStats: { count: {} }
+                  - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
   - description: "find command with declared API version appends to the command, but getMore does not"


### PR DESCRIPTION
Adds a line clarifying an assumption drivers can make about the result of an aggregate with $collStats.

Disables multiple mongoses on the recently added spec tests for estimatedDocumentCount so that failpoints work as expected on sharded topologies.