### PR TITLE
minor: fix wording error in maxConnecting requirement

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -549,7 +549,7 @@ If the list is exhausted, the total number of `Connections <#connection>`_ is
 less than maxPoolSize, and pendingConnectionCount < maxConnecting, the pool MUST
 create a `Connection`_, establish it, mark it as "in use" and return it. If
 totalConnectionCount == maxPoolSize or pendingConnectionCount == maxConnecting,
-then the pool MUST wait to service the request until either both of those
+then the pool MUST wait to service the request until neither of those two
 conditions are met or until a `Connection`_ becomes available, re-entering the
 checkOut loop in either case. This waiting MUST NOT prevent `Connections
 <#connection>`_ from being checked into the pool. Additionally, the Pool MUST


### PR DESCRIPTION
The `checkOut` section currently states that the pool should wait until "either \[totalConnectionCount == maxPoolSize or pendingConnectionCount == maxConnecting\] are met or until a Connection becomes available" before re-entering the queue after being blocked on maxConnecting. This should instead state that the pool should wait until _neither_ of those are true or until a Connection becomes available, since otherwise it couldn't create a new connection after re-entering the loop.