### PR TITLE
Fix 404 URI for Documentation Style Guidelines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Writing Documents
 -----------------
 
 Write documents using `reStructuredText`_, following the `MongoDB
-Documentation Style Guidelines <http://docs.mongodb.org/manual/meta/style-guide/>`_.
+Documentation Style Guidelines <https://docs.mongodb.com/meta/style-guide/style/>`_.
 
 Store all source documents in the ``source/`` directory.
 

--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Writing Documents
 -----------------
 
 Write documents using `reStructuredText`_, following the `MongoDB
-Documentation Style Guidelines <https://docs.mongodb.com/meta/style-guide/style/>`_.
+Documentation Style Guidelines <https://docs.mongodb.com/meta/style-guide/>`_.
 
 Store all source documents in the ``source/`` directory.
 


### PR DESCRIPTION
This PR is to replace a 404 URI in the README with a current link to MongoDB Style Guidelines.