### PR TITLE
Use unsetOrMatches operator in bulk write command expectations

### DIFF
--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -301,6 +301,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -353,7 +359,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -396,6 +405,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -972,6 +984,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -1027,7 +1042,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1077,6 +1095,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -116,7 +116,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -128,7 +131,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -140,7 +146,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "countDocuments appends declared API version"
@@ -362,7 +371,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "updateMany appends declared API version"
@@ -379,7 +391,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
 
   - description: "updateOne appends declared API version"
@@ -396,5 +411,8 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion

--- a/source/versioned-api/tests/crud-api-version-1.json
+++ b/source/versioned-api/tests/crud-api-version-1.json
@@ -298,6 +298,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],
@@ -350,7 +356,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -393,6 +402,9 @@
                       "u": {
                         "_id": 4,
                         "x": 44
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
                       },
                       "upsert": true
                     }
@@ -997,6 +1009,9 @@
                         "_id": 4,
                         "x": 44
                       },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
                       "upsert": true
                     }
                   ],
@@ -1052,7 +1067,10 @@
                           "x": 1
                         }
                       },
-                      "multi": true
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
                     }
                   ],
                   "apiVersion": "1",
@@ -1102,6 +1120,12 @@
                         "$inc": {
                           "x": 1
                         }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
                       }
                     }
                   ],

--- a/source/versioned-api/tests/crud-api-version-1.yml
+++ b/source/versioned-api/tests/crud-api-version-1.yml
@@ -116,7 +116,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -128,7 +131,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
@@ -140,7 +146,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "countDocuments appends declared API version"
@@ -370,7 +379,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 4 }, u: { _id: 4, x: 44 }, upsert: true }
+                  - q: { _id: 4 }
+                    u: { _id: 4, x: 44 }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: true
                 <<: *expectedApiVersion
 
   - description: "updateMany appends declared API version"
@@ -387,7 +399,10 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: { $gt: 1 } }, u: { $inc: { x: 1 } }, multi: true }
+                  - q: { _id: { $gt: 1 } }
+                    u: { $inc: { x: 1 } }
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion
 
   - description: "updateOne appends declared API version"
@@ -404,5 +419,8 @@ tests:
               command:
                 update: *collectionName
                 updates:
-                  - { q: { _id: 2 }, u: { $inc: { x: 1 } } }
+                  - q: { _id: 2 }
+                    u: { $inc: { x: 1 } }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
                 <<: *expectedApiVersion


### PR DESCRIPTION
The PHP driver adds the `multi` and `upsert` fields with default values, which causes the versioned API spec tests to fail due to the fields not being expected. This PR uses the `$$unsetOrMatches` operator to make the command expectations more forgiving.