### PR TITLE
DRIVERS-828 Update spec changelog and schema-1.2

### DIFF
--- a/source/unified-test-format/schema-1.2.json
+++ b/source/unified-test-format/schema-1.2.json
@@ -89,6 +89,33 @@
               "minItems": 1,
               "items": { "type": "string" }
             },
+            "storeEventsAsEntities": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "PoolCreatedEvent",
+                    "PoolReadyEvent",
+                    "PoolClearedEvent",
+                    "PoolClosedEvent",
+                    "ConnectionCreatedEvent",
+                    "ConnectionReadyEvent",
+                    "ConnectionClosedEvent",
+                    "ConnectionCheckOutStartedEvent",
+                    "ConnectionCheckOutFailedEvent",
+                    "ConnectionCheckedOutEvent",
+                    "ConnectionCheckedInEvent",
+                    "CommandStartedEvent",
+                    "CommandSucceededEvent",
+                    "CommandFailedEvent"
+                  ]
+                }
+              }
+            },
             "serverApi": { "$ref":  "#/definitions/serverApi" }
           }
         },

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -1,4 +1,4 @@
-SCHEMA=../schema-1.1.json
+SCHEMA=../schema-1.2.json
 
 .PHONY: all invalid valid-fail valid-pass versioned-api HAS_AJV
 

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-minProperties.json
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-minProperties.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-storeEventsAsEntities-minProperties",
+  "schemaVersion": "1.2",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "storeEventsAsEntities": {}
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-minProperties.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-minProperties.yml
@@ -1,0 +1,12 @@
+description: "entity-client-storeEventsAsEntities-minProperties"
+
+schemaVersion: "1.2"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      storeEventsAsEntities: {}
+
+tests:
+  - description: "foo"
+    operations: []

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-enum.json
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-enum.json
@@ -1,0 +1,22 @@
+{
+  "description": "entity-client-storeEventsAsEntities-property-enum",
+  "schemaVersion": "1.2",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "storeEventsAsEntities": {
+          "events": [
+            "foo"
+          ]
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-enum.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-enum.yml
@@ -1,0 +1,13 @@
+description: "entity-client-storeEventsAsEntities-property-enum"
+
+schemaVersion: "1.2"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      storeEventsAsEntities:
+        events: ["foo"]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-minItems.json
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-minItems.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-storeEventsAsEntities-property-minItems",
+  "schemaVersion": "1.2",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "storeEventsAsEntities": {
+          "events": []
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-minItems.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-minItems.yml
@@ -1,0 +1,13 @@
+description: "entity-client-storeEventsAsEntities-property-minItems"
+
+schemaVersion: "1.2"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      storeEventsAsEntities:
+        events: []
+
+tests:
+  - description: "foo"
+    operations: []

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-type.json
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-type.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-storeEventsAsEntities-property-type",
+  "schemaVersion": "1.2",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "storeEventsAsEntities": {
+          "events": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-type.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-property-type.yml
@@ -1,0 +1,13 @@
+description: "entity-client-storeEventsAsEntities-property-type"
+
+schemaVersion: "1.2"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      storeEventsAsEntities:
+        events: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-type.json
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-storeEventsAsEntities-type",
+  "schemaVersion": "1.2",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "storeEventsAsEntities": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-type.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-storeEventsAsEntities-type.yml
@@ -1,0 +1,12 @@
+description: "entity-client-storeEventsAsEntities-type"
+
+schemaVersion: "1.2"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      storeEventsAsEntities: 0
+
+tests:
+  - description: "foo"
+    operations: []

--- a/source/unified-test-format/tests/valid-fail/entity-client-storeEventsAsEntity-conflict_with_client_id.json
+++ b/source/unified-test-format/tests/valid-fail/entity-client-storeEventsAsEntity-conflict_with_client_id.json
@@ -1,0 +1,25 @@
+{
+  "description": "entity-client-storeEventsAsEntity-conflict_with_client_id",
+  "schemaVersion": "1.2",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "storeEventsAsEntities": {
+          "client0": [
+            "PoolCreatedEvent",
+            "PoolReadyEvent",
+            "PoolClearedEvent",
+            "PoolClosedEvent"
+          ]
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/valid-fail/entity-client-storeEventsAsEntity-conflict_with_client_id.yml
+++ b/source/unified-test-format/tests/valid-fail/entity-client-storeEventsAsEntity-conflict_with_client_id.yml
@@ -1,0 +1,15 @@
+description: "entity-client-storeEventsAsEntity-conflict_with_client_id"
+
+schemaVersion: "1.2"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      storeEventsAsEntities:
+        # Using the client ID here will ensure that test runners also detect
+        # conflicts with the same entity being defined
+        client0: ["PoolCreatedEvent", "PoolReadyEvent", "PoolClearedEvent", "PoolClosedEvent"]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/source/unified-test-format/tests/valid-fail/entity-client-storeEventsAsEntity-conflict_with_existing_id.json
+++ b/source/unified-test-format/tests/valid-fail/entity-client-storeEventsAsEntity-conflict_with_existing_id.json
@@ -1,0 +1,37 @@
+{
+  "description": "entity-client-storeEventsAsEntity-conflict_with_existing_id",
+  "schemaVersion": "1.2",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "storeEventsAsEntities": {
+          "events": [
+            "PoolCreatedEvent",
+            "PoolReadyEvent",
+            "PoolClearedEvent",
+            "PoolClosedEvent"
+          ]
+        }
+      }
+    },
+    {
+      "client": {
+        "id": "client1",
+        "storeEventsAsEntities": {
+          "events": [
+            "CommandStartedEvent",
+            "CommandSucceededEvent",
+            "CommandFailedEvent"
+          ]
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/valid-fail/entity-client-storeEventsAsEntity-conflict_with_existing_id.yml
+++ b/source/unified-test-format/tests/valid-fail/entity-client-storeEventsAsEntity-conflict_with_existing_id.yml
@@ -1,0 +1,18 @@
+description: "entity-client-storeEventsAsEntity-conflict_with_existing_id"
+
+schemaVersion: "1.2"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      storeEventsAsEntities:
+        events: ["PoolCreatedEvent", "PoolReadyEvent", "PoolClearedEvent", "PoolClosedEvent"]
+  - client:
+      id: &client1 client1
+      storeEventsAsEntities:
+        # This should conflict with storeEventsAsEntities for client0
+        events: ["CommandStartedEvent", "CommandSucceededEvent", "CommandFailedEvent"]
+
+tests:
+  - description: "foo"
+    operations: []

--- a/source/unified-test-format/tests/valid-pass/entity-client-storeEventsAsEntity.json
+++ b/source/unified-test-format/tests/valid-pass/entity-client-storeEventsAsEntity.json
@@ -1,0 +1,64 @@
+{
+  "description": "entity-client-storeEventsAsEntity",
+  "schemaVersion": "1.2",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "storeEventsAsEntities": {
+          "events": [
+            "CommandStartedEvent",
+            "CommandSucceededEvent",
+            "CommandFailedEvent"
+          ]
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "storeEventsAsEntity captures events",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/valid-pass/entity-client-storeEventsAsEntity.yml
+++ b/source/unified-test-format/tests/valid-pass/entity-client-storeEventsAsEntity.yml
@@ -1,0 +1,35 @@
+description: "entity-client-storeEventsAsEntity"
+
+schemaVersion: "1.2"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      storeEventsAsEntities:
+        # Note: this test does not assert that the events are actually saved to
+        # this entity since there is presently no assertion syntax to do so.
+        events: ["CommandStartedEvent", "CommandSucceededEvent", "CommandFailedEvent"]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+  - description: "storeEventsAsEntity captures events"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+        expectResult:
+          - { _id: 1, x: 11 }

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3,13 +3,13 @@ Unified Test Format
 ===================
 
 :Spec Title: Unified Test Format
-:Spec Version: 1.1.1
+:Spec Version: 1.2.0
 :Author: Jeremy Mikola
 :Advisors: Prashant Mital, Isabel Atkinson, Thomas Reggi
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2020-12-23
+:Last Modified: 2021-03-01
 
 .. contents::
 
@@ -2922,6 +2922,9 @@ spec changes developed in parallel or during the same release cycle.
 
 Change Log
 ==========
+
+:2021-03-01: Added ``storeEventsAsEntities`` option for client entities and
+             ``loop`` operation, which is needed for Atlas Driver Testing.
 
 :2020-12-23: Clarify how JSON schema is renamed for new minor versions.
 


### PR DESCRIPTION
2ce041277c07b2f67b0dff73f1b04fa7e10f2af8 (#903) missed updating the spec version and changelog for storeEventsAsEntities and loop. Additionally, storeEventsAsEntities required a schema update and corresponding tests.