### PR TITLE
DRIVERS-1595 Verify that abortTransaction does not include Versioned API options

### DIFF
--- a/source/versioned-api/tests/transaction-handling.json
+++ b/source/versioned-api/tests/transaction-handling.json
@@ -382,7 +382,138 @@
           ]
         }
       ]
+    },
+    {
+      "description": "abortTransaction does not include an API version",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session",
+            "document": {
+              "_id": 6,
+              "x": 66
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 6
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session",
+            "document": {
+              "_id": 7,
+              "x": 77
+            }
+          },
+          "expectResult": {
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 7
+              }
+            }
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 6,
+                      "x": 66
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "startTransaction": true,
+                  "apiVersion": "1",
+                  "apiStrict": {
+                    "$$unsetOrMatches": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "test",
+                  "documents": [
+                    {
+                      "_id": 7,
+                      "x": 77
+                    }
+                  ],
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "abortTransaction": 1,
+                  "lsid": {
+                    "$$sessionLsid": "session"
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }
-

--- a/source/versioned-api/tests/transaction-handling.yml
+++ b/source/versioned-api/tests/transaction-handling.yml
@@ -137,4 +137,44 @@ tests:
                 commitTransaction: 1
                 lsid: { $$sessionLsid: *session }
                 <<: *noApiVersion
-
+  - description: "abortTransaction does not include an API version"
+    runOnRequirements:
+      - topologies: [ replicaset, sharded-replicaset ]
+    operations:
+      - name: startTransaction
+        object: *session
+      - name: insertOne
+        object: *collection
+        arguments:
+          session: *session
+          document: { _id: 6, x: 66 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 6 } } }
+      - name: insertOne
+        object: *collection
+        arguments:
+          session: *session
+          document: { _id: 7, x: 77 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 7 } } }
+      - name: abortTransaction
+        object: *session
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 6, x: 66 } ]
+                lsid: { $$sessionLsid: *session }
+                startTransaction: true
+                <<: *expectedApiVersion
+          - commandStartedEvent:
+              command:
+                insert: *collectionName
+                documents: [ { _id: 7, x: 77 } ]
+                lsid: { $$sessionLsid: *session }
+                <<: *noApiVersion
+          - commandStartedEvent:
+              command:
+                abortTransaction: 1
+                lsid: { $$sessionLsid: *session }
+                <<: *noApiVersion


### PR DESCRIPTION
DRIVERS-1595

Verified the test locally, but it's almost an exact copy of the `commitTransaction` test above so I skipped the evergreen patch build.