### PR TITLE
DRIVERS-1594 Only run db.aggregate Versioned API test on 4.9

### DIFF
--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -140,7 +140,63 @@
       ]
     },
     {
-      "description": "aggregate on database appends declared API version",
+      "description": "aggregate on database appends declared API version on servers before 4.9.0",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.8.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "adminDatabase",
+          "arguments": {
+            "pipeline": [
+              {
+                "$listLocalSessions": {}
+              },
+              {
+                "$limit": 1
+              }
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": 1,
+                  "pipeline": [
+                    {
+                      "$listLocalSessions": {}
+                    },
+                    {
+                      "$limit": 1
+                    }
+                  ],
+                  "apiVersion": "1",
+                  "apiStrict": true,
+                  "apiDeprecationErrors": {
+                    "$$unsetOrMatches": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "aggregate on database appends declared API version on 4.9.0 or greater",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9.0"
+        }
+      ],
       "operations": [
         {
           "name": "aggregate",

--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -140,58 +140,7 @@
       ]
     },
     {
-      "description": "aggregate on database appends declared API version on servers before 4.9.0",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "4.8.99"
-        }
-      ],
-      "operations": [
-        {
-          "name": "aggregate",
-          "object": "adminDatabase",
-          "arguments": {
-            "pipeline": [
-              {
-                "$listLocalSessions": {}
-              },
-              {
-                "$limit": 1
-              }
-            ]
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "aggregate": 1,
-                  "pipeline": [
-                    {
-                      "$listLocalSessions": {}
-                    },
-                    {
-                      "$limit": 1
-                    }
-                  ],
-                  "apiVersion": "1",
-                  "apiStrict": true,
-                  "apiDeprecationErrors": {
-                    "$$unsetOrMatches": false
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "aggregate on database appends declared API version on 4.9.0 or greater",
+      "description": "aggregate on database appends declared API version",
       "runOnRequirements": [
         {
           "minServerVersion": "4.9.0"

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -61,7 +61,28 @@ tests:
                 pipeline: *pipeline
                 <<: *expectedApiVersion
 
-  - description: "aggregate on database appends declared API version"
+  - description: "aggregate on database appends declared API version on servers before 4.9.0"
+    runOnRequirements:
+      - maxServerVersion: "4.8.99"
+    operations:
+      - name: aggregate
+        object: *adminDatabase
+        arguments:
+          pipeline: &pipeline
+            - $listLocalSessions: {}
+            - $limit: 1
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: 1
+                pipeline: *pipeline
+                <<: *expectedApiVersion
+
+  - description: "aggregate on database appends declared API version on 4.9.0 or greater"
+    runOnRequirements:
+      - minServerVersion: "4.9.0"
     operations:
       - name: aggregate
         object: *adminDatabase

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -61,26 +61,7 @@ tests:
                 pipeline: *pipeline
                 <<: *expectedApiVersion
 
-  - description: "aggregate on database appends declared API version on servers before 4.9.0"
-    runOnRequirements:
-      - maxServerVersion: "4.8.99"
-    operations:
-      - name: aggregate
-        object: *adminDatabase
-        arguments:
-          pipeline: &pipeline
-            - $listLocalSessions: {}
-            - $limit: 1
-    expectEvents:
-      - client: *client
-        events:
-          - commandStartedEvent:
-              command:
-                aggregate: 1
-                pipeline: *pipeline
-                <<: *expectedApiVersion
-
-  - description: "aggregate on database appends declared API version on 4.9.0 or greater"
+  - description: "aggregate on database appends declared API version"
     runOnRequirements:
       - minServerVersion: "4.9.0"
     operations:


### PR DESCRIPTION
DRIVERS-1594

This follows the work done by @benjirewis in #898 to expect a strict error when running `db.aggregate`. This is only true for 4.9 and newer, so this PR splits the test into two tests for 4.7 and 4.9.