### PR TITLE
Use 4.9 as minServerVersion for versioned API tests

### DIFF
--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7"
+      "minServerVersion": "4.9"
     }
   ],
   "createEntities": [
@@ -609,11 +609,6 @@
     {
       "description": "estimatedDocumentCount appends declared API version",
       "skipReason": "DRIVERS-1561 collStats is not in API version 1",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -3,7 +3,7 @@ description: "CRUD Api Version 1 (strict)"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
 
 createEntities:
   - client:
@@ -226,8 +226,6 @@ tests:
 
   - description: "estimatedDocumentCount appends declared API version"
     skipReason: "DRIVERS-1561 collStats is not in API version 1"
-    runOnRequirements:
-      - minServerVersion: "4.9.0" # $collStats is not used in estimatedDocumentCount on < 4.9
     operations:
       - name: estimatedDocumentCount
         object: *collection

--- a/source/versioned-api/tests/crud-api-version-1.json
+++ b/source/versioned-api/tests/crud-api-version-1.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7"
+      "minServerVersion": "4.9"
     }
   ],
   "createEntities": [
@@ -599,46 +599,7 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount appends declared API version on less than 4.9.0",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "4.8.99"
-        }
-      ],
-      "operations": [
-        {
-          "name": "estimatedDocumentCount",
-          "object": "collection",
-          "arguments": {}
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "count": "test",
-                  "apiVersion": "1",
-                  "apiStrict": {
-                    "$$unsetOrMatches": false
-                  },
-                  "apiDeprecationErrors": true
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
       "description": "estimatedDocumentCount appends declared API version on 4.9.0 or greater",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.9.0"
-        }
-      ],
       "operations": [
         {
           "name": "estimatedDocumentCount",

--- a/source/versioned-api/tests/crud-api-version-1.yml
+++ b/source/versioned-api/tests/crud-api-version-1.yml
@@ -3,7 +3,7 @@ description: "CRUD Api Version 1"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
 
 createEntities:
   - client:
@@ -218,24 +218,7 @@ tests:
                 key: x
                 <<: *expectedApiVersion
 
-  - description: "estimatedDocumentCount appends declared API version on less than 4.9.0"
-    runOnRequirements:
-      - maxServerVersion: "4.8.99"
-    operations:
-      - name: estimatedDocumentCount
-        object: *collection
-        arguments: {}
-    expectEvents:
-      - client: *client
-        events:
-          - commandStartedEvent:
-              command:
-                count: *collectionName
-                <<: *expectedApiVersion
-
   - description: "estimatedDocumentCount appends declared API version on 4.9.0 or greater"
-    runOnRequirements:
-      - minServerVersion: "4.9.0"
     operations:
       - name: estimatedDocumentCount
         object: *collection

--- a/source/versioned-api/tests/runcommand-helper-no-api-version-declared.json
+++ b/source/versioned-api/tests/runcommand-helper-no-api-version-declared.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "serverParameters": {
         "requireApiVersion": false
       }

--- a/source/versioned-api/tests/runcommand-helper-no-api-version-declared.yml
+++ b/source/versioned-api/tests/runcommand-helper-no-api-version-declared.yml
@@ -3,7 +3,7 @@ description: "RunCommand helper: No API version declared"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
     serverParameters:
       requireApiVersion: false
 

--- a/source/versioned-api/tests/test-commands-deprecation-errors.json
+++ b/source/versioned-api/tests/test-commands-deprecation-errors.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true,
         "acceptAPIVersion2": true,

--- a/source/versioned-api/tests/test-commands-deprecation-errors.yml
+++ b/source/versioned-api/tests/test-commands-deprecation-errors.yml
@@ -3,7 +3,7 @@ description: "Test commands: deprecation errors"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
     serverParameters:
       enableTestCommands: true
       acceptAPIVersion2: true

--- a/source/versioned-api/tests/test-commands-strict-mode.json
+++ b/source/versioned-api/tests/test-commands-strict-mode.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true
       }

--- a/source/versioned-api/tests/test-commands-strict-mode.yml
+++ b/source/versioned-api/tests/test-commands-strict-mode.yml
@@ -3,7 +3,7 @@ description: "Test commands: strict mode"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
     serverParameters:
       enableTestCommands: true
 

--- a/source/versioned-api/tests/transaction-handling.json
+++ b/source/versioned-api/tests/transaction-handling.json
@@ -3,7 +3,7 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.7",
+      "minServerVersion": "4.9",
       "topologies": [
         "replicaset",
         "sharded-replicaset"

--- a/source/versioned-api/tests/transaction-handling.yml
+++ b/source/versioned-api/tests/transaction-handling.yml
@@ -3,7 +3,7 @@ description: "Transaction handling"
 schemaVersion: "1.1"
 
 runOnRequirements:
-  - minServerVersion: "4.7"
+  - minServerVersion: "4.9"
     topologies: [ replicaset, sharded-replicaset ]
 
 createEntities:


### PR DESCRIPTION
After some discussion on whether versioned API tests should even run on 4.7, we've come to the conclusion that there's no point testing 4.7 as it was mainly an internal test release. This PR changes the `minServerVersion` requirement for all tests to 4.9 and drops testing `estimatedDocumentCount` with the `count` command on 4.7.