### PR TITLE
DRIVERS-1561 Remove skipReason on edc versioned API test

### DIFF
--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -608,7 +608,6 @@
     },
     {
       "description": "estimatedDocumentCount appends declared API version",
-      "skipReason": "DRIVERS-1561 collStats is not in API version 1",
       "operations": [
         {
           "name": "estimatedDocumentCount",

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -225,7 +225,6 @@ tests:
                 <<: *expectedApiVersion
 
   - description: "estimatedDocumentCount appends declared API version"
-    skipReason: "DRIVERS-1561 collStats is not in API version 1"
     operations:
       - name: estimatedDocumentCount
         object: *collection


### PR DESCRIPTION
[DRIVERS-1561](https://jira.mongodb.org/browse/DRIVERS-1561)

Removes skipReason on estimatedDocumentCount test for versioned API. This test was being skipped because the $collStats aggregate pipeline stage was not a part of API version 1, but it was just added in [SERVER-54470](https://jira.mongodb.org/browse/SERVER-54470).