### PR TITLE
Test intended invalid syntax for expectedEventsForClient

### DIFF
--- a/source/unified-test-format/tests/invalid/expectedEvent-additionalProperties.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-additionalProperties.json
@@ -11,18 +11,13 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
+          "client": "client0",
+          "events": [
             {
-              "client": "client0",
-              "events": [
-                {
-                  "foo": 0
-                }
-              ]
+              "foo": 0
             }
           ]
         }

--- a/source/unified-test-format/tests/invalid/expectedEvent-additionalProperties.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-additionalProperties.yml
@@ -8,10 +8,8 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - foo: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - foo: 0

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandFailedEvent-commandName-type.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandFailedEvent-commandName-type.json
@@ -11,20 +11,15 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
+          "client": "client0",
+          "events": [
             {
-              "client": "client0",
-              "events": [
-                {
-                  "commandFailedEvent": {
-                    "commandName": 0
-                  }
-                }
-              ]
+              "commandFailedEvent": {
+                "commandName": 0
+              }
             }
           ]
         }

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandFailedEvent-commandName-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandFailedEvent-commandName-type.yml
@@ -8,11 +8,9 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - commandFailedEvent:
-                  commandName: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandFailedEvent:
+              commandName: 0

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-additionalProperties.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-additionalProperties.json
@@ -11,20 +11,15 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
+          "client": "client0",
+          "events": [
             {
-              "client": "client0",
-              "events": [
-                {
-                  "commandStartedEvent": {
-                    "foo": 0
-                  }
-                }
-              ]
+              "commandStartedEvent": {
+                "foo": 0
+              }
             }
           ]
         }

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-additionalProperties.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-additionalProperties.yml
@@ -8,11 +8,9 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - commandStartedEvent:
-                  foo: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              foo: 0

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-command-type.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-command-type.json
@@ -11,20 +11,15 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
+          "client": "client0",
+          "events": [
             {
-              "client": "client0",
-              "events": [
-                {
-                  "commandStartedEvent": {
-                    "command": 0
-                  }
-                }
-              ]
+              "commandStartedEvent": {
+                "command": 0
+              }
             }
           ]
         }

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-command-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-command-type.yml
@@ -8,11 +8,9 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - commandStartedEvent:
-                  command: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command: 0

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-commandName-type.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-commandName-type.json
@@ -11,20 +11,15 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
+          "client": "client0",
+          "events": [
             {
-              "client": "client0",
-              "events": [
-                {
-                  "commandStartedEvent": {
-                    "commandName": 0
-                  }
-                }
-              ]
+              "commandStartedEvent": {
+                "commandName": 0
+              }
             }
           ]
         }

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-commandName-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-commandName-type.yml
@@ -8,11 +8,9 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - commandStartedEvent:
-                  commandName: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: 0

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-databaseName-type.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-databaseName-type.json
@@ -11,20 +11,15 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
+          "client": "client0",
+          "events": [
             {
-              "client": "client0",
-              "events": [
-                {
-                  "commandStartedEvent": {
-                    "databaseName": 0
-                  }
-                }
-              ]
+              "commandStartedEvent": {
+                "databaseName": 0
+              }
             }
           ]
         }

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-databaseName-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandStartedEvent-databaseName-type.yml
@@ -8,11 +8,9 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - commandStartedEvent:
-                  databaseName: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: 0

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandSucceededEvent-commandName-type.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandSucceededEvent-commandName-type.json
@@ -11,20 +11,15 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
+          "client": "client0",
+          "events": [
             {
-              "client": "client0",
-              "events": [
-                {
-                  "commandSucceededEvent": {
-                    "commandName": 0
-                  }
-                }
-              ]
+              "commandSucceededEvent": {
+                "commandName": 0
+              }
             }
           ]
         }

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandSucceededEvent-commandName-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandSucceededEvent-commandName-type.yml
@@ -8,11 +8,9 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - commandSucceededEvent:
-                  commandName: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandSucceededEvent:
+              commandName: 0

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandSucceededEvent-reply-type.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandSucceededEvent-reply-type.json
@@ -11,20 +11,15 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
+          "client": "client0",
+          "events": [
             {
-              "client": "client0",
-              "events": [
-                {
-                  "commandSucceededEvent": {
-                    "reply": 0
-                  }
-                }
-              ]
+              "commandSucceededEvent": {
+                "reply": 0
+              }
             }
           ]
         }

--- a/source/unified-test-format/tests/invalid/expectedEvent-commandSucceededEvent-reply-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-commandSucceededEvent-reply-type.yml
@@ -8,11 +8,9 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - commandSucceededEvent:
-                  reply: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandSucceededEvent:
+              reply: 0

--- a/source/unified-test-format/tests/invalid/expectedEvent-maxProperties.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-maxProperties.json
@@ -11,19 +11,14 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
+          "client": "client0",
+          "events": [
             {
-              "client": "client0",
-              "events": [
-                {
-                  "commandStartedEvent": {},
-                  "commandSucceededEvent": {}
-                }
-              ]
+              "commandStartedEvent": {},
+              "commandSucceededEvent": {}
             }
           ]
         }

--- a/source/unified-test-format/tests/invalid/expectedEvent-maxProperties.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-maxProperties.yml
@@ -8,11 +8,9 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - commandStartedEvent: {}
-                commandSucceededEvent: {}
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: {}
+            commandSucceededEvent: {}

--- a/source/unified-test-format/tests/invalid/expectedEvent-minProperties.json
+++ b/source/unified-test-format/tests/invalid/expectedEvent-minProperties.json
@@ -11,17 +11,12 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
-            {
-              "client": "client0",
-              "events": [
-                {}
-              ]
-            }
+          "client": "client0",
+          "events": [
+            {}
           ]
         }
       ]

--- a/source/unified-test-format/tests/invalid/expectedEvent-minProperties.yml
+++ b/source/unified-test-format/tests/invalid/expectedEvent-minProperties.yml
@@ -8,10 +8,8 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events:
-              - {}
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - {}

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-additionalProperties.json
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-additionalProperties.json
@@ -11,17 +11,12 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
-            {
-              "client": "client0",
-              "events": [],
-              "foo": 0
-            }
-          ]
+          "client": "client0",
+          "events": [],
+          "foo": 0
         }
       ]
     }

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-additionalProperties.yml
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-additionalProperties.yml
@@ -8,10 +8,8 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events: []
-            foo: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events: []
+        foo: 0

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-client-required.json
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-client-required.json
@@ -11,15 +11,10 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
-            {
-              "events": []
-            }
-          ]
+          "events": []
         }
       ]
     }

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-client-required.yml
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-client-required.yml
@@ -8,8 +8,6 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - events: []
+    operations: []
+    expectEvents:
+      - events: []

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-client-type.json
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-client-type.json
@@ -11,16 +11,11 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
-            {
-              "client": 0,
-              "events": []
-            }
-          ]
+          "client": 0,
+          "events": []
         }
       ]
     }

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-client-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-client-type.yml
@@ -8,9 +8,7 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: 0
-            events: []
+    operations: []
+    expectEvents:
+      - client: 0
+        events: []

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-events-items.json
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-events-items.json
@@ -11,17 +11,12 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
-            {
-              "client": "client0",
-              "events": [
-                0
-              ]
-            }
+          "client": "client0",
+          "events": [
+            0
           ]
         }
       ]

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-events-items.yml
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-events-items.yml
@@ -8,9 +8,7 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events: [0]
+    operations: []
+    expectEvents:
+      - client: *client0
+        events: [0]

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-events-required.json
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-events-required.json
@@ -11,15 +11,10 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
-            {
-              "client": "client0"
-            }
-          ]
+          "client": "client0"
         }
       ]
     }

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-events-required.yml
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-events-required.yml
@@ -8,8 +8,6 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
+    operations: []
+    expectEvents:
+      - client: *client0

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-events-type.json
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-events-type.json
@@ -11,16 +11,11 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
+      "operations": [],
+      "expectEvents": [
         {
-          "name": "foo",
-          "object": "client0",
-          "expectEvents": [
-            {
-              "client": "client0",
-              "events": 0
-            }
-          ]
+          "client": "client0",
+          "events": 0
         }
       ]
     }

--- a/source/unified-test-format/tests/invalid/expectedEventsForClient-events-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedEventsForClient-events-type.yml
@@ -8,9 +8,7 @@ createEntities:
 
 tests:
   - description: "foo"
-    operations:
-      - name: "foo"
-        object: *client0
-        expectEvents:
-          - client: *client0
-            events: 0
+    operations: []
+    expectEvents:
+      - client: *client0
+        events: 0


### PR DESCRIPTION
These tests previously nested expectEvents within an operation, which was invalid but meant the intended invalid syntax was never tested.

Note: I'm forgoing a DRIVERS ticket here as drivers don't sync these tests. They are only run from the specification repository's CI.