### PR TITLE
DRIVERS-1483 PoolClearedErrors must be retried

### DIFF
--- a/source/retryable-reads/retryable-reads.rst
+++ b/source/retryable-reads/retryable-reads.rst
@@ -79,8 +79,9 @@ SocketException                 9001
   listed above, but with an error message containing the substring "not
   master" or "node is recovering"
 
-- a ``PoolClearedError`` as `defined in the CMAP specification
-  <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-errors>`__.
+- a `PoolClearedError`_
+
+  .. _PoolClearedError: ../connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-errors
 
 MongoClient Configuration 
 --------------------------

--- a/source/retryable-reads/retryable-reads.rst
+++ b/source/retryable-reads/retryable-reads.rst
@@ -384,11 +384,10 @@ and reflects the flow described above.
       return executeCommand(server, command);
     } catch (NetworkException originalError) {
       updateTopologyDescriptionForNetworkError(server, originalError);
-      return executeRetry(command, session, originalError);
     } catch (NotMasterException originalError) {
       updateTopologyDescriptionForNotMasterError(server, originalError);
-      return executeRetry(command, session, originalError);
     }
+    return executeRetry(command, session, originalError);
   }
   
   /**

--- a/source/retryable-reads/retryable-reads.rst
+++ b/source/retryable-reads/retryable-reads.rst
@@ -3,7 +3,7 @@ Retryable Reads
 ===============
 
 :Spec Title: Retryable Reads
-:Spec Version: 1.1
+:Spec Version: 1.2
 :Author: Vincent Kam 
 :Lead: Bernie Hackett
 :Advisory Group: Shane Harvey, Scott L’Hommedieu, Jeremy Mikola
@@ -11,7 +11,7 @@ Retryable Reads
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: 2019-05-29
+:Last Modified: 2021-03-24
    
 .. contents::
 
@@ -78,6 +78,9 @@ SocketException                 9001
 - a server error response without an error code or one different from those
   listed above, but with an error message containing the substring "not
   master" or "node is recovering"
+
+- a ``PoolClearedError`` as `defined in the CMAP specification
+  <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-errors>`__.
 
 MongoClient Configuration 
 --------------------------
@@ -356,15 +359,23 @@ and reflects the flow described above.
     /* Allow ServerSelectionException to propagate to our caller, which
      * can then assume that no attempts were made. */
     server = selectServer();
-    connection = server.getConnection()   
+
+    /* PoolClearedException indicates the operation did not even attempt to
+     * create a connection, let alone execute the operation. This means we
+     * are always safe to attempt a retry. We do not need to update SDAM,
+     * since whatever error caused the pool to be cleared will do so itself. */
+    try {
+      connection = server.getConnection()
+    } catch (PoolClearedException poolClearedError) {
+      return executeRetry(command, session, poolClearedError);
+    }
   
     /* If the server does not support retryable reads or if the session in a
      * transaction execute the read as if retryable reads are not enabled. */
     if ( !isRetryableReadsSupported(connection) || session.inTransaction()) {
       return executeCommand(connection, command);
     }
-  
-  
+
     /* NetworkException and NotMasterException are both retryable errors. If
      * caught, remember the exception, update SDAM accordingly, and proceed with
      * retrying the operation. */
@@ -372,10 +383,19 @@ and reflects the flow described above.
       return executeCommand(server, command);
     } catch (NetworkException originalError) {
       updateTopologyDescriptionForNetworkError(server, originalError);
+      return executeRetry(command, session, originalError);
     } catch (NotMasterException originalError) {
       updateTopologyDescriptionForNotMasterError(server, originalError);
+      return executeRetry(command, session, originalError);
     }
+  }
   
+  /**
+   * Executes the second attempt of a retryable read after a retryable error
+   * was encountered. On failure, this may return the original error, depending
+   * on the type of the new error encountered.
+   */
+  function executeRetry(command, session, originalError) {
     /* If we cannot select a server, do not proceed with retrying and
      * throw the original error. The caller can then infer that an attempt was
      * made and failed. */
@@ -656,6 +676,8 @@ degraded performance can simply disable ``retryableReads``.
 
 Changelog 
 ==========
+
+2021-03-23: Require that PoolClearedErrors are retried
 
 2019-06-07: Mention $merge stage for aggregate alongside $out
 

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -171,7 +171,7 @@ PoolClearedError Retryability Test
 This test will be used to ensure drivers properly retry after encountering PoolClearedErrors.
 This test MUST be implemented by any driver that implements the CMAP specification.
 
-1. Create a client with directConnection=true and maxPoolSize=1.
+1. Create a client with directConnection=true, maxPoolSize=1, and retryReads=true.
 
 2. Enable the following failpoint::
 
@@ -192,8 +192,8 @@ This test MUST be implemented by any driver that implements the CMAP specificati
 
 5. Via CMAP monitoring, assert that the first check out succeeds.
 
-6. Via CMAP monitoring, assert that the second check out fails with a
-   ``PoolClearedError``.
+6. Via CMAP monitoring, assert that the second check out fails due to a
+   connection error.
 
 7. Disable the failpoint.
 

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -171,7 +171,8 @@ PoolClearedError Retryability Test
 This test will be used to ensure drivers properly retry after encountering PoolClearedErrors.
 This test MUST be implemented by any driver that implements the CMAP specification.
 
-1. Create a client with directConnection=true, maxPoolSize=1, and retryReads=true.
+1. Create a client with maxPoolSize=1 and retryReads=true. If testing against a
+   sharded deployment, be sure to connect to only a single mongos.
 
 2. Enable the following failpoint::
 

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -193,10 +193,15 @@ This test MUST be implemented by any driver that implements the CMAP specificati
 
 5. Via CMAP monitoring, assert that the first check out succeeds.
 
-6. Via CMAP monitoring, assert that the second check out fails due to a
+6. Via CMAP monitoring, assert that a PoolClearedEvent is then emitted.
+
+7. Via CMAP monitoring, assert that the second check out then fails due to a
    connection error.
 
-7. Disable the failpoint.
+8. Via Command Monitoring, assert that exactly three ``find`` CommandStartedEvents
+   were observed in total.
+
+9. Disable the failpoint.
 
 
 Changelog

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -244,7 +244,6 @@ The RetryableWriteError label might be added to an error in a variety of ways:
   true on the client performing the relevant operation:
 
   - a server error response with any the following codes:
-
     .. list-table::
         :header-rows: 1
 

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -453,8 +453,8 @@ Consider the following pseudo-code:
      * values will be derived from the implicit or explicit session object. */
     retryableCommand = addTransactionIdToCommand(command, session);
 
-    /* If the error has a RetryableWriteError label, remember the exception,
-     * update SDAM accordingly, and proceed with retrying the operation.
+    /* If the error has a RetryableWriteError label, remember the exception
+     * and proceed with retrying the operation.
      *
      * IllegalOperation (code 20) with errmsg starting with "Transaction
      * numbers" MUST be re-raised with an actionable error message. */

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -453,9 +453,8 @@ Consider the following pseudo-code:
      * values will be derived from the implicit or explicit session object. */
     retryableCommand = addTransactionIdToCommand(command, session);
 
-    /* NetworkException and NotMasterException are both retryable errors. If
-     * caught, remember the exception, update SDAM accordingly, and proceed with
-     * retrying the operation.
+    /* If the error has a RetryableWriteError label, remember the exception,
+     * update SDAM accordingly, and proceed with retrying the operation.
      *
      * IllegalOperation (code 20) with errmsg starting with "Transaction
      * numbers" MUST be re-raised with an actionable error message. */
@@ -505,10 +504,10 @@ Consider the following pseudo-code:
     }
   }
 
-``handleError`` in the above psuedocode refers to the function defined in the
-`Error handling psuedocode`_ section of the SDAM specification.
+``handleError`` in the above pseudocode refers to the function defined in the
+`Error handling pseudocode`_ section of the SDAM specification.
 
-.. _Error handling psuedocode: ../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#error-handling-psuedocode
+.. _Error handling pseudocode: ../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#error-handling-pseudocode
 
 When retrying a write command, drivers MUST resend the command with the same
 transaction ID. Drivers MUST NOT resend the original wire protocol message if

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -226,10 +226,12 @@ The RetryableWriteError label might be added to an error in a variety of ways:
   label to that error if the MongoClient performing the operation has the
   retryWrites configuration option set to true.
 
-- When a CMAP-compliant driver encounters a ``PoolClearedError`` during
+- When a CMAP-compliant driver encounters a `PoolClearedError`_ during
   connection check out, it MUST add a RetryableWriteError label to that error if
   the MongoClient performing the operation has the retryWrites configuration
   option set to true.
+
+  .. _PoolClearedError: ../connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-errors
 
 - For server versions 4.4 and newer, the server will add a RetryableWriteError
   label to errors or server responses that it considers retryable before

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -238,44 +238,45 @@ The RetryableWriteError label might be added to an error in a variety of ways:
   NOT add a RetryableWriteError label to any error derived from a 4.4+ server
   response (i.e. any error that is not a network error).
 
-- When receiving a command result with an error from a pre-4.4 server that
+- When receiving a command result with an error code from a pre-4.4 server that
   supports retryable writes, the driver MUST add a RetryableWriteError label to
-  errors that meet the following criteria if the retryWrites option is set to
-  true on the client performing the relevant operation:
+  the resulting error/exception if the result contains any the following server
+  error codes and the retryWrites option is set to true on the client performing
+  the relevant operation:
 
-  - a server error response with any the following codes:
-    .. list-table::
-        :header-rows: 1
+  .. list-table::
+      :header-rows: 1
 
-        * - Error Name
-        - Error Code
-        * - InterruptedAtShutdown
-        - 11600
-        * - InterruptedDueToReplStateChange
-        - 11602
-        * - NotMaster
-        - 10107
-        * - NotMasterNoSlaveOk
-        - 13435
-        * - NotMasterOrSecondary
-        - 13436
-        * - PrimarySteppedDown
-        - 189
-        * - ShutdownInProgress
-        - 91
-        * - HostNotFound
-        - 7
-        * - HostUnreachable
-        - 6
-        * - NetworkTimeout
-        - 89
-        * - SocketException
-        - 9001
-        * - ExceededTimeLimit
-        - 262
+      * - Error Name
+      - Error Code
+      * - InterruptedAtShutdown
+      - 11600
+      * - InterruptedDueToReplStateChange
+      - 11602
+      * - NotMaster
+      - 10107
+      * - NotMasterNoSlaveOk
+      - 13435
+      * - NotMasterOrSecondary
+      - 13436
+      * - PrimarySteppedDown
+      - 189
+      * - ShutdownInProgress
+      - 91
+      * - HostNotFound
+      - 7
+      * - HostUnreachable
+      - 6
+      * - NetworkTimeout
+      - 89
+      * - SocketException
+      - 9001
+      * - ExceededTimeLimit
+      - 262
 
-  - a server response with a write concern error response containing any of the
-    previously listed codes
+  A RetryableWriteError label MUST also be added to errors/exceptions derived
+  from server responses that have a write concern error containing any of the
+  previously listed codes.
 
   The criteria for retryable errors is similar to the discussion in the SDAM
   spec's section on `Error Handling`_, but includes additional error codes. See

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -246,33 +246,33 @@ The RetryableWriteError label might be added to an error in a variety of ways:
   - a server error response with any the following codes:
 
     .. list-table::
-        :header-rows: 1
+      :header-rows: 1
 
-        * - Error Name
+      * - Error Name
         - Error Code
-        * - InterruptedAtShutdown
+      * - InterruptedAtShutdown
         - 11600
-        * - InterruptedDueToReplStateChange
+      * - InterruptedDueToReplStateChange
         - 11602
-        * - NotMaster
+      * - NotMaster
         - 10107
-        * - NotMasterNoSlaveOk
+      * - NotMasterNoSlaveOk
         - 13435
-        * - NotMasterOrSecondary
+      * - NotMasterOrSecondary
         - 13436
-        * - PrimarySteppedDown
+      * - PrimarySteppedDown
         - 189
-        * - ShutdownInProgress
+      * - ShutdownInProgress
         - 91
-        * - HostNotFound
+      * - HostNotFound
         - 7
-        * - HostUnreachable
+      * - HostUnreachable
         - 6
-        * - NetworkTimeout
+      * - NetworkTimeout
         - 89
-        * - SocketException
+      * - SocketException
         - 9001
-        * - ExceededTimeLimit
+      * - ExceededTimeLimit
         - 262
 
   - a server response with a write concern error response containing any of the

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -495,10 +495,9 @@ Consider the following pseudo-code:
      * propagate. */
     try {
       return executeCommand(server, retryableCommand);
+    } catch (DriverException ignoredError) {
+      throw originalError;
     } catch (Exception secondError) {
-      if (secondError instanceof DriverException) {
-        throw originalError;
-      }
       handleError(secondError);
       throw secondError;
     }

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -238,45 +238,45 @@ The RetryableWriteError label might be added to an error in a variety of ways:
   NOT add a RetryableWriteError label to any error derived from a 4.4+ server
   response (i.e. any error that is not a network error).
 
-- When receiving a command result with an error code from a pre-4.4 server that
+- When receiving a command result with an error from a pre-4.4 server that
   supports retryable writes, the driver MUST add a RetryableWriteError label to
-  the resulting error/exception if the result contains any the following server
-  error codes and the retryWrites option is set to true on the client performing
-  the relevant operation:
+  errors that meet the following criteria if the retryWrites option is set to
+  true on the client performing the relevant operation:
 
-.. list-table::
-    :header-rows: 1
+  - a server error response with any the following codes:
 
-    * - Error Name
-    - Error Code
-    * - InterruptedAtShutdown
-    - 11600
-    * - InterruptedDueToReplStateChange
-    - 11602
-    * - NotMaster
-    - 10107
-    * - NotMasterNoSlaveOk
-    - 13435
-    * - NotMasterOrSecondary
-    - 13436
-    * - PrimarySteppedDown
-    - 189
-    * - ShutdownInProgress
-    - 91
-    * - HostNotFound
-    - 7
-    * - HostUnreachable
-    - 6
-    * - NetworkTimeout
-    - 89
-    * - SocketException
-    - 9001
-    * - ExceededTimeLimit
-    - 262
+    .. list-table::
+        :header-rows: 1
 
-  A RetryableWriteError label MUST also be added to errors/exceptions derived
-  from server responses that have a write concern error containing any of the
-  previously listed codes.
+        * - Error Name
+        - Error Code
+        * - InterruptedAtShutdown
+        - 11600
+        * - InterruptedDueToReplStateChange
+        - 11602
+        * - NotMaster
+        - 10107
+        * - NotMasterNoSlaveOk
+        - 13435
+        * - NotMasterOrSecondary
+        - 13436
+        * - PrimarySteppedDown
+        - 189
+        * - ShutdownInProgress
+        - 91
+        * - HostNotFound
+        - 7
+        * - HostUnreachable
+        - 6
+        * - NetworkTimeout
+        - 89
+        * - SocketException
+        - 9001
+        * - ExceededTimeLimit
+        - 262
+
+  - a server response with a write concern error response containing any of the
+    previously listed codes
 
   The criteria for retryable errors is similar to the discussion in the SDAM
   spec's section on `Error Handling`_, but includes additional error codes. See

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -244,35 +244,35 @@ The RetryableWriteError label might be added to an error in a variety of ways:
   error codes and the retryWrites option is set to true on the client performing
   the relevant operation:
 
-  .. list-table::
-      :header-rows: 1
+.. list-table::
+    :header-rows: 1
 
-      * - Error Name
-      - Error Code
-      * - InterruptedAtShutdown
-      - 11600
-      * - InterruptedDueToReplStateChange
-      - 11602
-      * - NotMaster
-      - 10107
-      * - NotMasterNoSlaveOk
-      - 13435
-      * - NotMasterOrSecondary
-      - 13436
-      * - PrimarySteppedDown
-      - 189
-      * - ShutdownInProgress
-      - 91
-      * - HostNotFound
-      - 7
-      * - HostUnreachable
-      - 6
-      * - NetworkTimeout
-      - 89
-      * - SocketException
-      - 9001
-      * - ExceededTimeLimit
-      - 262
+    * - Error Name
+    - Error Code
+    * - InterruptedAtShutdown
+    - 11600
+    * - InterruptedDueToReplStateChange
+    - 11602
+    * - NotMaster
+    - 10107
+    * - NotMasterNoSlaveOk
+    - 13435
+    * - NotMasterOrSecondary
+    - 13436
+    * - PrimarySteppedDown
+    - 189
+    * - ShutdownInProgress
+    - 91
+    * - HostNotFound
+    - 7
+    * - HostUnreachable
+    - 6
+    * - NetworkTimeout
+    - 89
+    * - SocketException
+    - 9001
+    * - ExceededTimeLimit
+    - 262
 
   A RetryableWriteError label MUST also be added to errors/exceptions derived
   from server responses that have a write concern error containing any of the

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -217,7 +217,7 @@ In a server error response with a writeConcernError field the top level document
 or the writeConcernError document may contain the RetryableWriteError error label.
 
 RetryableWriteError Labels
-==========================
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The RetryableWriteError label might be added to an error in a variety of ways:
 
@@ -275,8 +275,8 @@ The RetryableWriteError label might be added to an error in a variety of ways:
         * - ExceededTimeLimit
         - 262
 
-   - a server response with a write concern error response containing any of the
-     previously listed codes
+  - a server response with a write concern error response containing any of the
+    previously listed codes
 
   The criteria for retryable errors is similar to the discussion in the SDAM
   spec's section on `Error Handling`_, but includes additional error codes. See

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -331,8 +331,8 @@ and sharded clusters.
    test MUST be implemented by any driver that implements the CMAP
    specification.
 
-   1. Create a client with directConnection=true, maxPoolSize=1, and
-      retryWrites=true.
+   1. Create a client with maxPoolSize=1 and retryWrites=true. If testing
+      against a sharded deployment, be sure to connect to only a single mongos.
 
    2. Enable the following failpoint::
 

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -327,10 +327,45 @@ and sharded clusters.
    in use MAY skip this test for sharded clusters, since ``mongos`` does not report
    this information in its ``serverStatus`` response.
 
+#. Test that drivers properly retry after encountering PoolClearedErrors. This
+   test MUST be implemented by any driver that implements the CMAP
+   specification.
+
+   1. Create a client with directConnection=true, maxPoolSize=1, and
+      retryWrites=true.
+
+   2. Enable the following failpoint::
+
+       {
+           configureFailPoint: "failCommand",
+           mode: { times: 1 },
+           data: {
+               failCommands: ["insert"],
+               errorCode: 91,
+               blockConnection: true,
+               blockTimeMS: 1000
+           }
+       }
+
+   3. Start two threads and attempt to perform an ``insertOne`` simultaneously on both.
+
+   4. Verify that both ``insertOne`` attempts succeed.
+
+   5. Via CMAP monitoring, assert that the first check out succeeds.
+
+   6. Via CMAP monitoring, assert that the second check out fails due to a
+      connection error.
+
+   7. Disable the failpoint.
+
+
 Changelog
 =========
 
-:2019-10-21: Add ``errorLabelsContain`` and ``errorLabelsContain`` fields to ``result``
+:2021-03-24: Add prose test verifying ``PoolClearedErrors`` are retried.
+
+:2019-10-21: Add ``errorLabelsContain`` and ``errorLabelsContain`` fields to
+             ``result``
 
 :2019-08-07: Add Prose Tests section
 

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -353,10 +353,15 @@ and sharded clusters.
 
    5. Via CMAP monitoring, assert that the first check out succeeds.
 
-   6. Via CMAP monitoring, assert that the second check out fails due to a
+   6. Via CMAP monitoring, assert that a PoolClearedEvent is then emitted.
+
+   7. Via CMAP monitoring, assert that the second check out then fails due to a
       connection error.
 
-   7. Disable the failpoint.
+   8. Via Command Monitoring, assert that exactly three ``insert``
+      CommandStartedEvents were observed in total.
+
+   9. Disable the failpoint.
 
 
 Changelog


### PR DESCRIPTION
DRIVERS-1483

This PR updates the language of the retryability specifications to require that [`PoolClearedErrors`](https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-errors) are retried. This PR also adds a prose test to each spec so drivers can confirm they conform to the requirement correctly.

POC implementation in Rust: https://github.com/patrickfreed/mongo-rust-driver/commit/2ed7132e9cd936ca071ffdc7f072036150fc7115

This is the final spec change in the Avoiding Connection Storms project (DRIVERS-781)
