### PR TITLE
DRIVERS-1603 Serverless drivers testing spec

### DIFF
--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -61,6 +61,15 @@ Each YAML file has the following keys:
     and "sharded". If this field is omitted, the default is all topologies (i.e.
     ``["single", "replicaset", "sharded"]``).
 
+  - ``serverlessMode``: Optional string, only applicable to "sharded"
+    topologies. Whether or not the test should be run on serverless instances
+    imitating sharded clusters. Valid modes are "requireServerless",
+    "forbidServerless", and "allowServerless". If "requireServerless", the test
+    MUST only be run on serverless instances. If "forbidServerless", the test
+    MUST only be run on actual sharded deployments. If omitted or
+    "allowServerless", the test can be run on either serverless instances or on
+    real sharded deployments.
+
 - ``collection_name`` (optional): The collection to use for testing.
 
 - ``database_name`` (optional): The database to use for testing.

--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -64,9 +64,8 @@ Each YAML file has the following keys:
   - ``serverless``: (optional) Whether or not the test should be run on
     serverless instances imitating sharded clusters. Valid values are "require",
     "forbid", and "allow". If "require", the test MUST only be run on serverless
-    instances. If "forbid", the test MUST only be run on actual sharded
-    deployments. If omitted or "allow", the test can be run on either serverless
-    instances or on real sharded deployments.
+    instances. If "forbid", the test MUST NOT be run on Serverless instances. If
+    omitted or "allow", this option has no effect.
 
 - ``collection_name`` (optional): The collection to use for testing.
 

--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -61,14 +61,13 @@ Each YAML file has the following keys:
     and "sharded". If this field is omitted, the default is all topologies (i.e.
     ``["single", "replicaset", "sharded"]``).
 
-  - ``serverlessMode``: Optional string, only applicable to "sharded"
-    topologies. Whether or not the test should be run on serverless instances
-    imitating sharded clusters. Valid modes are "requireServerless",
-    "forbidServerless", and "allowServerless". If "requireServerless", the test
-    MUST only be run on serverless instances. If "forbidServerless", the test
-    MUST only be run on actual sharded deployments. If omitted or
-    "allowServerless", the test can be run on either serverless instances or on
-    real sharded deployments.
+  - ``serverlessMode``: (optional) Whether or not the test should be run on
+    serverless instances imitating sharded clusters. Valid modes are
+    "requireServerless", "forbidServerless", and "allowServerless". If
+    "requireServerless", the test MUST only be run on serverless instances. If
+    "forbidServerless", the test MUST only be run on actual sharded
+    deployments. If omitted or "allowServerless", the test can be run on either
+    serverless instances or on real sharded deployments.
 
 - ``collection_name`` (optional): The collection to use for testing.
 

--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -61,13 +61,12 @@ Each YAML file has the following keys:
     and "sharded". If this field is omitted, the default is all topologies (i.e.
     ``["single", "replicaset", "sharded"]``).
 
-  - ``serverlessMode``: (optional) Whether or not the test should be run on
-    serverless instances imitating sharded clusters. Valid modes are
-    "requireServerless", "forbidServerless", and "allowServerless". If
-    "requireServerless", the test MUST only be run on serverless instances. If
-    "forbidServerless", the test MUST only be run on actual sharded
-    deployments. If omitted or "allowServerless", the test can be run on either
-    serverless instances or on real sharded deployments.
+  - ``serverless``: (optional) Whether or not the test should be run on
+    Serverless instances imitating sharded clusters. Valid values are "require",
+    "forbid", and "allow". If "require", the test MUST only be run on Serverless
+    instances. If "forbid", the test MUST only be run on actual sharded
+    deployments. If omitted or "allow", the test can be run on either Serverless
+    instances or on real sharded deployments.
 
 - ``collection_name`` (optional): The collection to use for testing.
 

--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -62,10 +62,10 @@ Each YAML file has the following keys:
     ``["single", "replicaset", "sharded"]``).
 
   - ``serverless``: (optional) Whether or not the test should be run on
-    Serverless instances imitating sharded clusters. Valid values are "require",
-    "forbid", and "allow". If "require", the test MUST only be run on Serverless
+    serverless instances imitating sharded clusters. Valid values are "require",
+    "forbid", and "allow". If "require", the test MUST only be run on serverless
     instances. If "forbid", the test MUST only be run on actual sharded
-    deployments. If omitted or "allow", the test can be run on either Serverless
+    deployments. If omitted or "allow", the test can be run on either serverless
     instances or on real sharded deployments.
 
 - ``collection_name`` (optional): The collection to use for testing.

--- a/source/crud/tests/unified/aggregate.json
+++ b/source/crud/tests/unified/aggregate.json
@@ -1,0 +1,189 @@
+{
+  "description": "aggregate",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "edc-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "edc-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        },
+        {
+          "_id": 5,
+          "x": 55
+        },
+        {
+          "_id": 6,
+          "x": 66
+        },
+        {
+          "_id": 7,
+          "x": 77
+        },
+        {
+          "_id": 8,
+          "x": 88
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "aggregate with multiple batches works",
+      "operations": [
+        {
+          "name": "aggregate",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ],
+            "batchSize": 2
+          },
+          "object": "collection0",
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            },
+            {
+              "_id": 6,
+              "x": 66
+            },
+            {
+              "_id": 7,
+              "x": 77
+            },
+            {
+              "_id": 8,
+              "x": 88
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ],
+                  "cursor": {
+                    "batchSize": 2
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$exists": true
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2
+                },
+                "commandName": "getMore",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$exists": true
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2
+                },
+                "commandName": "getMore",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$exists": true
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2
+                },
+                "commandName": "getMore",
+                "databaseName": "edc-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/aggregate.json
+++ b/source/crud/tests/unified/aggregate.json
@@ -15,7 +15,7 @@
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "edc-tests"
+        "databaseName": "aggregate-tests"
       }
     },
     {
@@ -29,7 +29,7 @@
   "initialData": [
     {
       "collectionName": "coll0",
-      "databaseName": "edc-tests",
+      "databaseName": "aggregate-tests",
       "documents": [
         {
           "_id": 1,
@@ -139,7 +139,7 @@
                   }
                 },
                 "commandName": "aggregate",
-                "databaseName": "edc-tests"
+                "databaseName": "aggregate-tests"
               }
             },
             {
@@ -152,7 +152,7 @@
                   "batchSize": 2
                 },
                 "commandName": "getMore",
-                "databaseName": "edc-tests"
+                "databaseName": "aggregate-tests"
               }
             },
             {
@@ -165,7 +165,7 @@
                   "batchSize": 2
                 },
                 "commandName": "getMore",
-                "databaseName": "edc-tests"
+                "databaseName": "aggregate-tests"
               }
             },
             {
@@ -178,7 +178,7 @@
                   "batchSize": 2
                 },
                 "commandName": "getMore",
-                "databaseName": "edc-tests"
+                "databaseName": "aggregate-tests"
               }
             }
           ]

--- a/source/crud/tests/unified/aggregate.yml
+++ b/source/crud/tests/unified/aggregate.yml
@@ -10,7 +10,7 @@ createEntities:
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: &database0Name edc-tests
+      databaseName: &database0Name aggregate-tests
   - collection:
       id: &collection0 collection0
       database: *database0

--- a/source/crud/tests/unified/aggregate.yml
+++ b/source/crud/tests/unified/aggregate.yml
@@ -1,0 +1,79 @@
+description: "aggregate"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true # ensure cursors pin to a single server
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name edc-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+      - { _id: 4, x: 44 }
+      - { _id: 5, x: 55 }
+      - { _id: 6, x: 66 }
+      - { _id: 7, x: 77 }
+      - { _id: 8, x: 88 }
+
+tests:
+  - description: "aggregate with multiple batches works"
+    operations:
+      - name: aggregate
+        arguments:
+          pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+          batchSize: 2
+        object: *collection0
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
+          - { _id: 7, x: 77 }
+          - { _id: 8, x: 88 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: [ { $match: { _id: { $gt: 1 } }} ]
+                cursor: { batchSize: 2 }
+              commandName: aggregate
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$exists: true }
+                collection: *collection0Name
+                batchSize: 2
+              commandName: getMore
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$exists: true }
+                collection: *collection0Name
+                batchSize: 2
+              commandName: getMore
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$exists: true }
+                collection: *collection0Name
+                batchSize: 2
+              commandName: getMore
+              databaseName: *database0Name
+

--- a/source/crud/tests/unified/estimatedDocumentCount.json
+++ b/source/crud/tests/unified/estimatedDocumentCount.json
@@ -1,6 +1,6 @@
 {
   "description": "estimatedDocumentCount",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.3",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/estimatedDocumentCount.json
+++ b/source/crud/tests/unified/estimatedDocumentCount.json
@@ -61,7 +61,8 @@
       "description": "estimatedDocumentCount uses $collStats on 4.9.0 or greater",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.9.0"
+          "minServerVersion": "4.9.0",
+          "serverlessMode": "forbidServerless"
         }
       ],
       "operations": [
@@ -107,7 +108,8 @@
       "description": "estimatedDocumentCount with maxTimeMS on 4.9.0 or greater",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.9.0"
+          "minServerVersion": "4.9.0",
+          "serverlessMode": "forbidServerless"
         }
       ],
       "operations": [
@@ -157,7 +159,8 @@
       "description": "estimatedDocumentCount on non-existent collection on 4.9.0 or greater",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.9.0"
+          "minServerVersion": "4.9.0",
+          "serverlessMode": "forbidServerless"
         }
       ],
       "operations": [
@@ -203,7 +206,8 @@
       "description": "estimatedDocumentCount errors correctly on 4.9.0 or greater--command error",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.9.0"
+          "minServerVersion": "4.9.0",
+          "serverlessMode": "forbidServerless"
         }
       ],
       "operations": [
@@ -270,7 +274,8 @@
       "description": "estimatedDocumentCount errors correctly on 4.9.0 or greater--socket error",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.9.0"
+          "minServerVersion": "4.9.0",
+          "serverlessMode": "forbidServerless"
         }
       ],
       "operations": [

--- a/source/crud/tests/unified/estimatedDocumentCount.json
+++ b/source/crud/tests/unified/estimatedDocumentCount.json
@@ -62,7 +62,7 @@
       "runOnRequirements": [
         {
           "minServerVersion": "4.9.0",
-          "serverlessMode": "forbidServerless"
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -109,7 +109,7 @@
       "runOnRequirements": [
         {
           "minServerVersion": "4.9.0",
-          "serverlessMode": "forbidServerless"
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -160,7 +160,7 @@
       "runOnRequirements": [
         {
           "minServerVersion": "4.9.0",
-          "serverlessMode": "forbidServerless"
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -207,7 +207,7 @@
       "runOnRequirements": [
         {
           "minServerVersion": "4.9.0",
-          "serverlessMode": "forbidServerless"
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -275,7 +275,7 @@
       "runOnRequirements": [
         {
           "minServerVersion": "4.9.0",
-          "serverlessMode": "forbidServerless"
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/source/crud/tests/unified/estimatedDocumentCount.yml
+++ b/source/crud/tests/unified/estimatedDocumentCount.yml
@@ -34,6 +34,7 @@ tests:
   - description: "estimatedDocumentCount uses $collStats on 4.9.0 or greater"
     runOnRequirements:
       - minServerVersion: "4.9.0"
+        serverlessMode: forbidServerless
     operations:
       - name: estimatedDocumentCount
         object: *collection0
@@ -53,6 +54,7 @@ tests:
   - description: "estimatedDocumentCount with maxTimeMS on 4.9.0 or greater"
     runOnRequirements:
       - minServerVersion: "4.9.0"
+        serverlessMode: forbidServerless
     operations:
       - name: estimatedDocumentCount
         object: *collection0
@@ -75,6 +77,7 @@ tests:
   - description: "estimatedDocumentCount on non-existent collection on 4.9.0 or greater"
     runOnRequirements:
       - minServerVersion: "4.9.0"
+        serverlessMode: forbidServerless
     operations:
       - name: estimatedDocumentCount
         object: *collection1
@@ -94,6 +97,7 @@ tests:
   - description: "estimatedDocumentCount errors correctly on 4.9.0 or greater--command error"
     runOnRequirements:
       - minServerVersion: "4.9.0"
+        serverlessMode: forbidServerless
     operations:
       - name: failPoint
         object: testRunner
@@ -124,6 +128,7 @@ tests:
   - description: "estimatedDocumentCount errors correctly on 4.9.0 or greater--socket error"
     runOnRequirements:
       - minServerVersion: "4.9.0"
+        serverlessMode: forbidServerless
     operations:
       - name: failPoint
         object: testRunner

--- a/source/crud/tests/unified/estimatedDocumentCount.yml
+++ b/source/crud/tests/unified/estimatedDocumentCount.yml
@@ -34,7 +34,7 @@ tests:
   - description: "estimatedDocumentCount uses $collStats on 4.9.0 or greater"
     runOnRequirements:
       - minServerVersion: "4.9.0"
-        serverlessMode: forbidServerless
+        serverless: forbid
     operations:
       - name: estimatedDocumentCount
         object: *collection0
@@ -54,7 +54,7 @@ tests:
   - description: "estimatedDocumentCount with maxTimeMS on 4.9.0 or greater"
     runOnRequirements:
       - minServerVersion: "4.9.0"
-        serverlessMode: forbidServerless
+        serverless: forbid
     operations:
       - name: estimatedDocumentCount
         object: *collection0
@@ -77,7 +77,7 @@ tests:
   - description: "estimatedDocumentCount on non-existent collection on 4.9.0 or greater"
     runOnRequirements:
       - minServerVersion: "4.9.0"
-        serverlessMode: forbidServerless
+        serverless: forbid
     operations:
       - name: estimatedDocumentCount
         object: *collection1
@@ -97,7 +97,7 @@ tests:
   - description: "estimatedDocumentCount errors correctly on 4.9.0 or greater--command error"
     runOnRequirements:
       - minServerVersion: "4.9.0"
-        serverlessMode: forbidServerless
+        serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -128,7 +128,7 @@ tests:
   - description: "estimatedDocumentCount errors correctly on 4.9.0 or greater--socket error"
     runOnRequirements:
       - minServerVersion: "4.9.0"
-        serverlessMode: forbidServerless
+        serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/source/crud/tests/unified/estimatedDocumentCount.yml
+++ b/source/crud/tests/unified/estimatedDocumentCount.yml
@@ -1,6 +1,6 @@
 description: "estimatedDocumentCount"
 
-schemaVersion: "1.0"
+schemaVersion: "1.3"
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/find.json
+++ b/source/crud/tests/unified/find.json
@@ -1,0 +1,178 @@
+{
+  "description": "find",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "edc-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "edc-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        },
+        {
+          "_id": 2,
+          "x": 22
+        },
+        {
+          "_id": 3,
+          "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        },
+        {
+          "_id": 5,
+          "x": 55
+        },
+        {
+          "_id": 6,
+          "x": 66
+        },
+        {
+          "_id": 7,
+          "x": 77
+        },
+        {
+          "_id": 8,
+          "x": 88
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "find with multiple batches works",
+      "operations": [
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "batchSize": 2
+          },
+          "object": "collection0",
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            },
+            {
+              "_id": 6,
+              "x": 66
+            },
+            {
+              "_id": 7,
+              "x": 77
+            },
+            {
+              "_id": 8,
+              "x": 88
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {
+                    "_id": {
+                      "$gt": 1
+                    }
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$exists": true
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2
+                },
+                "commandName": "getMore",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$exists": true
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2
+                },
+                "commandName": "getMore",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$exists": true
+                  },
+                  "collection": "coll0",
+                  "batchSize": 2
+                },
+                "commandName": "getMore",
+                "databaseName": "edc-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/find.json
+++ b/source/crud/tests/unified/find.json
@@ -15,7 +15,7 @@
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "edc-tests"
+        "databaseName": "find-tests"
       }
     },
     {
@@ -29,7 +29,7 @@
   "initialData": [
     {
       "collectionName": "coll0",
-      "databaseName": "edc-tests",
+      "databaseName": "find-tests",
       "documents": [
         {
           "_id": 1,
@@ -128,7 +128,7 @@
                   }
                 },
                 "commandName": "find",
-                "databaseName": "edc-tests"
+                "databaseName": "find-tests"
               }
             },
             {
@@ -141,7 +141,7 @@
                   "batchSize": 2
                 },
                 "commandName": "getMore",
-                "databaseName": "edc-tests"
+                "databaseName": "find-tests"
               }
             },
             {
@@ -154,7 +154,7 @@
                   "batchSize": 2
                 },
                 "commandName": "getMore",
-                "databaseName": "edc-tests"
+                "databaseName": "find-tests"
               }
             },
             {
@@ -167,7 +167,7 @@
                   "batchSize": 2
                 },
                 "commandName": "getMore",
-                "databaseName": "edc-tests"
+                "databaseName": "find-tests"
               }
             }
           ]

--- a/source/crud/tests/unified/find.yml
+++ b/source/crud/tests/unified/find.yml
@@ -1,0 +1,78 @@
+description: "find"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true # ensure cursors pin to a single server
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name edc-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+      - { _id: 4, x: 44 }
+      - { _id: 5, x: 55 }
+      - { _id: 6, x: 66 }
+      - { _id: 7, x: 77 }
+      - { _id: 8, x: 88 }
+
+tests:
+  - description: "find with multiple batches works"
+    operations:
+      - name: find
+        arguments:
+          filter: { _id: { $gt: 1 } }
+          batchSize: 2
+        object: *collection0
+        expectResult:
+          - { _id: 2, x: 22 }
+          - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
+          - { _id: 7, x: 77 }
+          - { _id: 8, x: 88 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: { $gt: 1 } }
+              commandName: find
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$exists: true }
+                collection: *collection0Name
+                batchSize: 2
+              commandName: getMore
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$exists: true }
+                collection: *collection0Name
+                batchSize: 2
+              commandName: getMore
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                getMore: { $$exists: true }
+                collection: *collection0Name
+                batchSize: 2
+              commandName: getMore
+              databaseName: *database0Name
+

--- a/source/crud/tests/unified/find.yml
+++ b/source/crud/tests/unified/find.yml
@@ -10,7 +10,7 @@ createEntities:
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: &database0Name edc-tests
+      databaseName: &database0Name find-tests
   - collection:
       id: &collection0 collection0
       database: *database0

--- a/source/crud/tests/v2/db-aggregate.json
+++ b/source/crud/tests/v2/db-aggregate.json
@@ -1,7 +1,8 @@
 {
   "runOn": [
     {
-      "minServerVersion": "3.6.0"
+      "minServerVersion": "3.6.0",
+      "serverlessMode": "forbidServerless"
     }
   ],
   "database_name": "admin",

--- a/source/crud/tests/v2/db-aggregate.json
+++ b/source/crud/tests/v2/db-aggregate.json
@@ -2,7 +2,7 @@
   "runOn": [
     {
       "minServerVersion": "3.6.0",
-      "serverlessMode": "forbidServerless"
+      "serverless": "forbid"
     }
   ],
   "database_name": "admin",

--- a/source/crud/tests/v2/db-aggregate.yml
+++ b/source/crud/tests/v2/db-aggregate.yml
@@ -1,7 +1,7 @@
 runOn:
     -
         minServerVersion: "3.6.0"
-        serverlessMode: "forbidServerless"
+        serverless: "forbid"
 
 database_name: &database_name "admin"
 

--- a/source/crud/tests/v2/db-aggregate.yml
+++ b/source/crud/tests/v2/db-aggregate.yml
@@ -1,7 +1,7 @@
 runOn:
     -
         minServerVersion: "3.6.0"
-        serverless: "forbid"
+        serverless: "forbid" # serverless does not support $listLocalSessions or $currentOp
 
 database_name: &database_name "admin"
 

--- a/source/crud/tests/v2/db-aggregate.yml
+++ b/source/crud/tests/v2/db-aggregate.yml
@@ -1,6 +1,7 @@
 runOn:
     -
         minServerVersion: "3.6.0"
+        serverlessMode: "forbidServerless"
 
 database_name: &database_name "admin"
 

--- a/source/serverless-testing/tests/README.rst
+++ b/source/serverless-testing/tests/README.rst
@@ -1,0 +1,112 @@
+================
+Serverless Tests
+================
+
+.. contents::
+
+----
+
+Introduction
+============
+
+This file describes a subset of existing spec tests as well as some new prose
+tests that drivers MUST use to assert compatibility with Serverless.
+
+Test Configuration
+==================
+
+These tests MUST be run against a live Serverless instance on Atlas. A new
+Serverless instance MUST be created each time the test suite is run, and it MUST
+be deleted once the tests have completed, regardless of their outcome. The
+`serverless directory in the drivers-evergreen-tools repository`_ contains
+scripts for creating and deleting Serverless instances, and the ``config.yml``
+contains an example evergreen configuration that uses them to run the tests.
+
+.. _serverless directory in the drivers-evergreen-tools repository: https://github.com/mongodb-labs/drivers-evergreen-tools/tree/master/.evergreen/serverless
+
+All tests MUST be run with wire protocol compression and authentication
+enabled. Additionally, Serverless requires the usage of the versioned API, so
+the tests MUST be run with a server API version specified.
+
+Required Variables
+~~~~~~~~~~~~~~~~~~
+
+Managing the Serverless instances and connecting to them requires a few
+variables to be specified. These are confidential and MUST be specified as
+private Evergreen variables or used only in private Evergreen projects.
+
+- ``${SERVERLESS_DRIVERS_GROUP}``: Contains the group ID of the Atlas group
+   dedicated to drivers testing of Serverless.
+
+- ``${SERVERLESS_API_PUBLIC_KEY}``: The public key required to use the Atlas API
+  for provisioning of Serverless instances.
+
+- ``${SERVERLESS_API_PRIVATE_KEY}``: The public key required to use the Atlas
+  API for provisioning of Serverless instances.
+
+- ``${SERVERLESS_ATLAS_USER}``: the SCRAM username used to authenticate to any
+  Serverless instance created in the drivers testing Atlas group.
+
+- ``${SERVERLESS_ATLAS_PASSWORD}``: the SCRAM password used to authenticate to
+  any Serverless instance created in the drivers testing Atlas group.
+
+
+Existing Spec Tests
+===================
+
+Tests defined in the following specifications MUST be included in a driver's
+serverless testing suite, including prose tests:
+- CRUD, including the v1, v2, and unified tests
+- Sessions
+- Versioned API
+
+In the future, this list will be expanded to include a greater portion of the
+tests once the Serverless proxy has more robust failCommand support.
+
+Note that the formats for the JSON/YAML tests of these specifications were
+updated to include a new ``runOnRequirement`` specifically for serverless
+testing, so make sure to update the affected test runners to support this
+requirement and then sync the tests.
+
+The Serverless proxy presents itself as a mongos, so any test meant to run
+against sharded clusters will be executed by the runners, with the exception of
+the tests affected by the previously mentioned ``runOnRequirement``.
+
+Prose Tests
+===========
+
+The following tests MUST be implemented to fully test compatibility with
+Serverless.
+
+#. Test that the driver properly constructs and issues a `killCursors
+   <https://docs.mongodb.com/manual/reference/command/killCursors/>`_ command to
+   the Serverless proxy. For this test, configure an APM listener on a client
+   and execute a query on a collection that will leave a cursor open on the
+   server (e.g. specify ``batchSize=2`` for a query that would match 3+
+   documents). Drivers MAY iterate the cursor if necessary to execute the
+   initial ``find`` command but MUST NOT iterate further to avoid executing a
+   ``getMore``.
+
+   Observe the CommandSucceededEvent event for the ``find`` command and extract
+   the cursor's ID and namespace from the response document's ``cursor.id`` and
+   ``cursor.ns`` fields, respectively. Destroy the cursor object and observe
+   a CommandStartedEvent and CommandSucceededEvent for the ``killCursors``
+   command. Assert that the cursor ID and target namespace in the outgoing
+   command match the values from the ``find`` command's CommandSucceededEvent.
+   When matching the namespace, note that the ``killCursors`` field will contain
+   the collection name and the database may be inferred from either the ``$db``
+   field or accessed via the CommandStartedEvent directly. Finally, assert that
+   the ``killCursors`` CommandSucceededEvent indicates that the expected cursor
+   was killed in the ``cursorsKilled`` field.
+
+#. Repeat test 1 on a cursor that is still left open after both the initial
+   ``find`` and a single ``getMore`` (e.g. specify ``batchSize=1`` for a query
+   that would match 3+ documents).
+
+Other Tests
+===========
+
+Any other existing tests for cursor behavior that a driver may have implemented
+independently of any spec requirements SHOULD also be included in the driver's
+Serverless testing suite. Note that ChangeStreams are not supported by the
+proxy, so tests for them cannot be included.

--- a/source/serverless-testing/tests/README.rst
+++ b/source/serverless-testing/tests/README.rst
@@ -33,7 +33,9 @@ Required Variables
 
 Managing the Serverless instances and connecting to them requires a few
 variables to be specified. These are confidential and MUST be specified as
-private Evergreen variables or used only in private Evergreen projects.
+private Evergreen variables or used only in private Evergreen projects. If using
+a public Evergreen project, xtrace MUST be disabled when using these variables
+to help prevent accidental leaks.
 
 - ``${SERVERLESS_DRIVERS_GROUP}``: Contains the group ID of the Atlas group
    dedicated to drivers testing of Serverless.

--- a/source/serverless-testing/tests/README.rst
+++ b/source/serverless-testing/tests/README.rst
@@ -37,20 +37,20 @@ private Evergreen variables or used only in private Evergreen projects. If using
 a public Evergreen project, xtrace MUST be disabled when using these variables
 to help prevent accidental leaks.
 
-- ``$SERVERLESS_DRIVERS_GROUP``: Contains the ID of the Atlas group dedicated to
-   drivers testing of Serverless.
+- ``${SERVERLESS_DRIVERS_GROUP}``: Contains the ID of the Atlas group dedicated
+  to drivers testing of Serverless.
 
-- ``$SERVERLESS_API_PUBLIC_KEY``: The public key required to use the Atlas API
+- ``${SERVERLESS_API_PUBLIC_KEY}``: The public key required to use the Atlas API
   for provisioning of Serverless instances.
 
-- ``$SERVERLESS_API_PRIVATE_KEY``: The public key required to use the Atlas API
-  for provisioning of Serverless instances.
+- ``${SERVERLESS_API_PRIVATE_KE}Y``: The public key required to use the Atlas
+  API for provisioning of Serverless instances.
 
-- ``$SERVERLESS_ATLAS_USER``: the SCRAM username used to authenticate to any
+- ``${SERVERLESS_ATLAS_USER``: }the SCRAM username used to authenticate to any
   Serverless instance created in the drivers testing Atlas group.
 
-- ``$SERVERLESS_ATLAS_PASSWORD``: the SCRAM password used to authenticate to any
-  Serverless instance created in the drivers testing Atlas group.
+- ``${SERVERLESS_ATLAS_PASSWORD}``: the SCRAM password used to authenticate to
+  any Serverless instance created in the drivers testing Atlas group.
 
 
 Existing Spec Tests

--- a/source/serverless-testing/tests/README.rst
+++ b/source/serverless-testing/tests/README.rst
@@ -32,10 +32,10 @@ Required Variables
 ~~~~~~~~~~~~~~~~~~
 
 Managing the Serverless instances and connecting to them requires a few
-variables to be specified. These are confidential and MUST be specified as
-private Evergreen variables or used only in private Evergreen projects. If using
-a public Evergreen project, xtrace MUST be disabled when using these variables
-to help prevent accidental leaks.
+variables to be specified. The variables marked "private" are confidential and
+MUST be specified as private Evergreen variables or used only in private
+Evergreen projects. If using a public Evergreen project, xtrace MUST be disabled
+when using these variables to help prevent accidental leaks.
 
 - ``${SERVERLESS_DRIVERS_GROUP}``: Contains the ID of the Atlas group dedicated
   to drivers testing of Serverless.
@@ -43,14 +43,16 @@ to help prevent accidental leaks.
 - ``${SERVERLESS_API_PUBLIC_KEY}``: The public key required to use the Atlas API
   for provisioning of Serverless instances.
 
-- ``${SERVERLESS_API_PRIVATE_KE}Y``: The public key required to use the Atlas
-  API for provisioning of Serverless instances.
+- ``${SERVERLESS_API_PRIVATE_KEY}``: (private) The private key required to use
+  the Atlas API for provisioning of Serverless instances.
 
-- ``${SERVERLESS_ATLAS_USER``: }the SCRAM username used to authenticate to any
-  Serverless instance created in the drivers testing Atlas group.
+- ``${SERVERLESS_ATLAS_USER}``: (private) The SCRAM username used to
+  authenticate to any Serverless instance created in the drivers testing Atlas
+  group.
 
-- ``${SERVERLESS_ATLAS_PASSWORD}``: the SCRAM password used to authenticate to
-  any Serverless instance created in the drivers testing Atlas group.
+- ``${SERVERLESS_ATLAS_PASSWORD}``: (private) The SCRAM password used to
+  authenticate to any Serverless instance created in the drivers testing Atlas
+  group.
 
 
 Existing Spec Tests

--- a/source/serverless-testing/tests/README.rst
+++ b/source/serverless-testing/tests/README.rst
@@ -37,20 +37,20 @@ private Evergreen variables or used only in private Evergreen projects. If using
 a public Evergreen project, xtrace MUST be disabled when using these variables
 to help prevent accidental leaks.
 
-- ``${SERVERLESS_DRIVERS_GROUP}``: Contains the group ID of the Atlas group
-   dedicated to drivers testing of Serverless.
+- ``$SERVERLESS_DRIVERS_GROUP``: Contains the ID of the Atlas group dedicated to
+   drivers testing of Serverless.
 
-- ``${SERVERLESS_API_PUBLIC_KEY}``: The public key required to use the Atlas API
+- ``$SERVERLESS_API_PUBLIC_KEY``: The public key required to use the Atlas API
   for provisioning of Serverless instances.
 
-- ``${SERVERLESS_API_PRIVATE_KEY}``: The public key required to use the Atlas
-  API for provisioning of Serverless instances.
+- ``$SERVERLESS_API_PRIVATE_KEY``: The public key required to use the Atlas API
+  for provisioning of Serverless instances.
 
-- ``${SERVERLESS_ATLAS_USER}``: the SCRAM username used to authenticate to any
+- ``$SERVERLESS_ATLAS_USER``: the SCRAM username used to authenticate to any
   Serverless instance created in the drivers testing Atlas group.
 
-- ``${SERVERLESS_ATLAS_PASSWORD}``: the SCRAM password used to authenticate to
-  any Serverless instance created in the drivers testing Atlas group.
+- ``$SERVERLESS_ATLAS_PASSWORD``: the SCRAM password used to authenticate to any
+  Serverless instance created in the drivers testing Atlas group.
 
 
 Existing Spec Tests
@@ -58,6 +58,7 @@ Existing Spec Tests
 
 Tests defined in the following specifications MUST be included in a driver's
 serverless testing suite, including prose tests:
+
 - CRUD, including the v1, v2, and unified tests
 
 In the future, this list will be expanded to include a greater portion of the

--- a/source/serverless-testing/tests/README.rst
+++ b/source/serverless-testing/tests/README.rst
@@ -59,8 +59,6 @@ Existing Spec Tests
 Tests defined in the following specifications MUST be included in a driver's
 serverless testing suite, including prose tests:
 - CRUD, including the v1, v2, and unified tests
-- Sessions
-- Versioned API
 
 In the future, this list will be expanded to include a greater portion of the
 tests once the Serverless proxy has more robust failCommand support.

--- a/source/serverless-testing/tests/README.rst
+++ b/source/serverless-testing/tests/README.rst
@@ -9,8 +9,8 @@ Serverless Tests
 Introduction
 ============
 
-This file describes a subset of existing spec tests as well as some new prose
-tests that drivers MUST use to assert compatibility with Serverless.
+This file describes a subset of existing tests that drivers MUST use to assert
+compatibility with Serverless.
 
 Test Configuration
 ==================
@@ -74,37 +74,6 @@ requirement and then sync the tests.
 The Serverless proxy presents itself as a mongos, so any test meant to run
 against sharded clusters will be executed by the runners, with the exception of
 the tests affected by the previously mentioned ``runOnRequirement``.
-
-Prose Tests
-===========
-
-The following tests MUST be implemented to fully test compatibility with
-Serverless.
-
-#. Test that the driver properly constructs and issues a `killCursors
-   <https://docs.mongodb.com/manual/reference/command/killCursors/>`_ command to
-   the Serverless proxy. For this test, configure an APM listener on a client
-   and execute a query on a collection that will leave a cursor open on the
-   server (e.g. specify ``batchSize=2`` for a query that would match 3+
-   documents). Drivers MAY iterate the cursor if necessary to execute the
-   initial ``find`` command but MUST NOT iterate further to avoid executing a
-   ``getMore``.
-
-   Observe the CommandSucceededEvent event for the ``find`` command and extract
-   the cursor's ID and namespace from the response document's ``cursor.id`` and
-   ``cursor.ns`` fields, respectively. Destroy the cursor object and observe
-   a CommandStartedEvent and CommandSucceededEvent for the ``killCursors``
-   command. Assert that the cursor ID and target namespace in the outgoing
-   command match the values from the ``find`` command's CommandSucceededEvent.
-   When matching the namespace, note that the ``killCursors`` field will contain
-   the collection name and the database may be inferred from either the ``$db``
-   field or accessed via the CommandStartedEvent directly. Finally, assert that
-   the ``killCursors`` CommandSucceededEvent indicates that the expected cursor
-   was killed in the ``cursorsKilled`` field.
-
-#. Repeat test 1 on a cursor that is still left open after both the initial
-   ``find`` and a single ``getMore`` (e.g. specify ``batchSize=1`` for a query
-   that would match 3+ documents).
 
 Other Tests
 ===========

--- a/source/serverless-testing/tests/README.rst
+++ b/source/serverless-testing/tests/README.rst
@@ -10,48 +10,48 @@ Introduction
 ============
 
 This file describes a subset of existing tests that drivers MUST use to assert
-compatibility with Serverless.
+compatibility with serverless MongoDB.
 
 Test Configuration
 ==================
 
-These tests MUST be run against a live Serverless instance on Atlas. A new
-Serverless instance MUST be created each time the test suite is run, and it MUST
+These tests MUST be run against a live serverless instance on Atlas. A new
+serverless instance MUST be created each time the test suite is run, and it MUST
 be deleted once the tests have completed, regardless of their outcome. The
 `serverless directory in the drivers-evergreen-tools repository`_ contains
-scripts for creating and deleting Serverless instances, and the ``config.yml``
+scripts for creating and deleting serverless instances, and the ``config.yml``
 contains an example evergreen configuration that uses them to run the tests.
 
 .. _serverless directory in the drivers-evergreen-tools repository: https://github.com/mongodb-labs/drivers-evergreen-tools/tree/master/.evergreen/serverless
 
 All tests MUST be run with wire protocol compression and authentication
-enabled. Additionally, Serverless requires the usage of the versioned API, so
+enabled. Additionally, serverless requires the usage of the versioned API, so
 the tests MUST be run with a server API version specified.
 
 Required Variables
 ~~~~~~~~~~~~~~~~~~
 
-Managing the Serverless instances and connecting to them requires a few
+Managing the serverless instances and connecting to them requires a few
 variables to be specified. The variables marked "private" are confidential and
 MUST be specified as private Evergreen variables or used only in private
 Evergreen projects. If using a public Evergreen project, xtrace MUST be disabled
 when using these variables to help prevent accidental leaks.
 
 - ``${SERVERLESS_DRIVERS_GROUP}``: Contains the ID of the Atlas group dedicated
-  to drivers testing of Serverless.
+  to drivers testing of serverless MongoDB.
 
 - ``${SERVERLESS_API_PUBLIC_KEY}``: The public key required to use the Atlas API
-  for provisioning of Serverless instances.
+  for provisioning of serverless instances.
 
 - ``${SERVERLESS_API_PRIVATE_KEY}``: (private) The private key required to use
-  the Atlas API for provisioning of Serverless instances.
+  the Atlas API for provisioning of serverless instances.
 
 - ``${SERVERLESS_ATLAS_USER}``: (private) The SCRAM username used to
-  authenticate to any Serverless instance created in the drivers testing Atlas
+  authenticate to any serverless instance created in the drivers testing Atlas
   group.
 
 - ``${SERVERLESS_ATLAS_PASSWORD}``: (private) The SCRAM password used to
-  authenticate to any Serverless instance created in the drivers testing Atlas
+  authenticate to any serverless instance created in the drivers testing Atlas
   group.
 
 
@@ -64,14 +64,14 @@ serverless testing suite, including prose tests:
 - CRUD, including the v1, v2, and unified tests
 
 In the future, this list will be expanded to include a greater portion of the
-tests once the Serverless proxy has more robust failCommand support.
+tests once the serverless proxy has more robust failCommand support.
 
 Note that the formats for the JSON/YAML tests of these specifications were
 updated to include a new ``runOnRequirement`` specifically for serverless
 testing, so make sure to update the affected test runners to support this
 requirement and then sync the tests.
 
-The Serverless proxy presents itself as a mongos, so any test meant to run
+The serverless proxy presents itself as a mongos, so any test meant to run
 against sharded clusters will be executed by the runners, with the exception of
 the tests affected by the previously mentioned ``runOnRequirement``.
 
@@ -80,5 +80,5 @@ Other Tests
 
 Any other existing tests for cursor behavior that a driver may have implemented
 independently of any spec requirements SHOULD also be included in the driver's
-Serverless testing suite. Note that ChangeStreams are not supported by the
+serverless testing suite. Note that ChangeStreams are not supported by the
 proxy, so tests for them cannot be included.

--- a/source/unified-test-format/schema-1.3.json
+++ b/source/unified-test-format/schema-1.3.json
@@ -55,6 +55,10 @@
             "enum": ["single", "replicaset", "sharded", "sharded-replicaset"]
           }
         },
+        "serverlessMode": {
+          "type": "string",
+          "enum": ["requireServerless", "forbidServerless", "allowServerless"]
+        },
         "serverParameters": {
           "type": "object",
           "minProperties": 1

--- a/source/unified-test-format/schema-1.3.json
+++ b/source/unified-test-format/schema-1.3.json
@@ -55,9 +55,9 @@
             "enum": ["single", "replicaset", "sharded", "sharded-replicaset"]
           }
         },
-        "serverlessMode": {
+        "serverless": {
           "type": "string",
-          "enum": ["requireServerless", "forbidServerless", "allowServerless"]
+          "enum": ["require", "forbid", "allow"]
         },
         "serverParameters": {
           "type": "object",

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -1,4 +1,4 @@
-SCHEMA=../schema-1.2.json
+SCHEMA=../schema-1.3.json
 
 .PHONY: all invalid valid-fail valid-pass versioned-api HAS_AJV
 

--- a/source/unified-test-format/tests/valid-pass/poc-crud.json
+++ b/source/unified-test-format/tests/valid-pass/poc-crud.json
@@ -1,6 +1,6 @@
 {
   "description": "poc-crud",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.3",
   "createEntities": [
     {
       "client": {

--- a/source/unified-test-format/tests/valid-pass/poc-crud.json
+++ b/source/unified-test-format/tests/valid-pass/poc-crud.json
@@ -406,7 +406,8 @@
       "description": "Aggregate with $listLocalSessions",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0"
+          "minServerVersion": "3.6.0",
+          "serverlessMode": "forbidServerless"
         }
       ],
       "operations": [

--- a/source/unified-test-format/tests/valid-pass/poc-crud.json
+++ b/source/unified-test-format/tests/valid-pass/poc-crud.json
@@ -407,7 +407,7 @@
       "runOnRequirements": [
         {
           "minServerVersion": "3.6.0",
-          "serverlessMode": "forbidServerless"
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/source/unified-test-format/tests/valid-pass/poc-crud.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-crud.yml
@@ -1,6 +1,6 @@
 description: "poc-crud"
 
-schemaVersion: "1.0"
+schemaVersion: "1.3"
 
 createEntities:
   - client:

--- a/source/unified-test-format/tests/valid-pass/poc-crud.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-crud.yml
@@ -170,6 +170,7 @@ tests:
   - description: "Aggregate with $listLocalSessions"
     runOnRequirements:
       - minServerVersion: "3.6.0"
+        serverlessMode: forbidServerless
     operations:
       - name: aggregate
         object: *database1

--- a/source/unified-test-format/tests/valid-pass/poc-crud.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-crud.yml
@@ -170,7 +170,7 @@ tests:
   - description: "Aggregate with $listLocalSessions"
     runOnRequirements:
       - minServerVersion: "3.6.0"
-        serverlessMode: forbidServerless
+        serverless: forbid
     operations:
       - name: aggregate
         object: *database1

--- a/source/unified-test-format/tests/valid-pass/poc-crud.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-crud.yml
@@ -170,7 +170,7 @@ tests:
   - description: "Aggregate with $listLocalSessions"
     runOnRequirements:
       - minServerVersion: "3.6.0"
-        serverless: forbid
+        serverless: forbid # serverless does not support $listLocalSessions
     operations:
       - name: aggregate
         object: *database1

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -369,13 +369,12 @@ The structure of this object is as follows:
   "sharded" topology, test runners MUST accept any type of sharded cluster (i.e.
   "sharded" implies "sharded-replicaset", but not vice versa).
 
-- ``serverlessMode``: Optional string. Whether or not the test should be run on
-  serverless instances imitating sharded clusters. Valid modes are
-  "requireServerless", "forbidServerless", and "allowServerless". If
-  "requireServerless", the test MUST only be run on serverless instances. If
-  "forbidServerless", the test MUST only be run on actual sharded
-  deployments. If omitted or "allowServerless", the test can be run on either
-  serverless instances or on real sharded deployments.
+- ``serverless``: Optional string. Whether or not the test should be run on
+  Serverless instances imitating sharded clusters. Valid values are "require",
+  "forbid", and "allow". If "require", the test MUST only be run on Serverless
+  instances. If "forbid", the test MUST only be run on actual sharded
+  deployments. If omitted or "allow", the test can be run on either Serverless
+  instances or on real sharded deployments.
 
 - ``serverParameters``: Optional object of server parameters to check against.
   To check server parameters, drivers send a

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3,7 +3,7 @@ Unified Test Format
 ===================
 
 :Spec Title: Unified Test Format
-:Spec Version: 1.2.4
+:Spec Version: 1.3.0
 :Author: Jeremy Mikola
 :Advisors: Prashant Mital, Isabel Atkinson, Thomas Reggi
 :Status: Accepted
@@ -368,6 +368,15 @@ The structure of this object is as follows:
   in `Determining if a Sharded Cluster Uses Replica Sets`_. When matching a
   "sharded" topology, test runners MUST accept any type of sharded cluster (i.e.
   "sharded" implies "sharded-replicaset", but not vice versa).
+
+- ``serverlessMode``: Optional string, only applicable to "sharded" and
+  "sharded-replicaset" topologies. Whether or not the test should be run on
+  serverless instances imitating sharded clusters. Valid modes are
+  "requireServerless", "forbidServerless", and "allowServerless". If
+  "requireServerless", the test MUST only be run on serverless instances. If
+  "forbidServerless", the test MUST only be run on actual sharded
+  deployments. If omitted or "allowServerless", the test can be run on either
+  serverless instances or on real sharded deployments.
 
 - ``serverParameters``: Optional object of server parameters to check against.
   To check server parameters, drivers send a

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -372,9 +372,8 @@ The structure of this object is as follows:
 - ``serverless``: Optional string. Whether or not the test should be run on
   serverless instances imitating sharded clusters. Valid values are "require",
   "forbid", and "allow". If "require", the test MUST only be run on serverless
-  instances. If "forbid", the test MUST only be run on actual sharded
-  deployments. If omitted or "allow", the test can be run on either serverless
-  instances or on real sharded deployments.
+  instances. If "forbid", the test MUST NOT be run on Serverless instances. If
+  omitted or "allow", this option has no effect.
 
 - ``serverParameters``: Optional object of server parameters to check against.
   To check server parameters, drivers send a

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -370,10 +370,10 @@ The structure of this object is as follows:
   "sharded" implies "sharded-replicaset", but not vice versa).
 
 - ``serverless``: Optional string. Whether or not the test should be run on
-  Serverless instances imitating sharded clusters. Valid values are "require",
-  "forbid", and "allow". If "require", the test MUST only be run on Serverless
+  serverless instances imitating sharded clusters. Valid values are "require",
+  "forbid", and "allow". If "require", the test MUST only be run on serverless
   instances. If "forbid", the test MUST only be run on actual sharded
-  deployments. If omitted or "allow", the test can be run on either Serverless
+  deployments. If omitted or "allow", the test can be run on either serverless
   instances or on real sharded deployments.
 
 - ``serverParameters``: Optional object of server parameters to check against.

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -369,8 +369,7 @@ The structure of this object is as follows:
   "sharded" topology, test runners MUST accept any type of sharded cluster (i.e.
   "sharded" implies "sharded-replicaset", but not vice versa).
 
-- ``serverlessMode``: Optional string, only applicable to "sharded" and
-  "sharded-replicaset" topologies. Whether or not the test should be run on
+- ``serverlessMode``: Optional string. Whether or not the test should be run on
   serverless instances imitating sharded clusters. Valid modes are
   "requireServerless", "forbidServerless", and "allowServerless". If
   "requireServerless", the test MUST only be run on serverless instances. If

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -9,7 +9,7 @@ Unified Test Format
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-04-08
+:Last Modified: 2021-04-09
 
 .. contents::
 
@@ -2983,6 +2983,8 @@ spec changes developed in parallel or during the same release cycle.
 
 Change Log
 ==========
+
+:2021-04-09: Introduce ``serverless`` `runOnRequirement`_.
 
 :2021-04-08: List additional error codes that may be ignored when calling
              ``killAllSessions`` and note that the command should not be called

--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -143,7 +143,7 @@
       "description": "aggregate on database appends declared API version",
       "runOnRequirements": [
         {
-          "serverlessMode": "forbidServerless"
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -1,6 +1,6 @@
 {
   "description": "CRUD Api Version 1 (strict)",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.3",
   "runOnRequirements": [
     {
       "minServerVersion": "4.9"

--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -141,6 +141,11 @@
     },
     {
       "description": "aggregate on database appends declared API version",
+      "runOnRequirements": [
+        {
+          "serverlessMode": "forbidServerless"
+        }
+      ],
       "operations": [
         {
           "name": "aggregate",

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -63,7 +63,7 @@ tests:
 
   - description: "aggregate on database appends declared API version"
     runOnRequirements:
-      - serverlessMode: "forbidServerless"
+      - serverless: "forbid"
     operations:
       - name: aggregate
         object: *adminDatabase

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -1,6 +1,6 @@
 description: "CRUD Api Version 1 (strict)"
 
-schemaVersion: "1.1"
+schemaVersion: "1.3"
 
 runOnRequirements:
   - minServerVersion: "4.9"

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -62,6 +62,8 @@ tests:
                 <<: *expectedApiVersion
 
   - description: "aggregate on database appends declared API version"
+    runOnRequirements:
+      - serverlessMode: "forbidServerless"
     operations:
       - name: aggregate
         object: *adminDatabase

--- a/source/versioned-api/tests/crud-api-version-1.json
+++ b/source/versioned-api/tests/crud-api-version-1.json
@@ -143,7 +143,7 @@
       "description": "aggregate on database appends declared API version",
       "runOnRequirements": [
         {
-          "serverlessMode": "forbidServerless"
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/source/versioned-api/tests/crud-api-version-1.json
+++ b/source/versioned-api/tests/crud-api-version-1.json
@@ -1,6 +1,6 @@
 {
   "description": "CRUD Api Version 1",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.3",
   "runOnRequirements": [
     {
       "minServerVersion": "4.9"

--- a/source/versioned-api/tests/crud-api-version-1.json
+++ b/source/versioned-api/tests/crud-api-version-1.json
@@ -141,6 +141,11 @@
     },
     {
       "description": "aggregate on database appends declared API version",
+      "runOnRequirements": [
+        {
+          "serverlessMode": "forbidServerless"
+        }
+      ],
       "operations": [
         {
           "name": "aggregate",

--- a/source/versioned-api/tests/crud-api-version-1.yml
+++ b/source/versioned-api/tests/crud-api-version-1.yml
@@ -65,7 +65,7 @@ tests:
 
   - description: "aggregate on database appends declared API version"
     runOnRequirements:
-      - serverlessMode: forbidServerless
+      - serverless: forbid
     operations:
       - name: aggregate
         object: *adminDatabase

--- a/source/versioned-api/tests/crud-api-version-1.yml
+++ b/source/versioned-api/tests/crud-api-version-1.yml
@@ -64,6 +64,8 @@ tests:
                 <<: *expectedApiVersion
 
   - description: "aggregate on database appends declared API version"
+    runOnRequirements:
+      - serverlessMode: forbidServerless
     operations:
       - name: aggregate
         object: *adminDatabase

--- a/source/versioned-api/tests/crud-api-version-1.yml
+++ b/source/versioned-api/tests/crud-api-version-1.yml
@@ -1,6 +1,6 @@
 description: "CRUD Api Version 1"
 
-schemaVersion: "1.1"
+schemaVersion: "1.3"
 
 runOnRequirements:
   - minServerVersion: "4.9"


### PR DESCRIPTION
[DRIVERS-1603](https://jira.mongodb.org/browse/DRIVERS-1603)

This PR adds a testing-only spec which requires that drivers run a certain set of tests against a live Atlas serverless instance. As part of this, the unified test format was updated to include a Serverless-specific runOnRequirement, and some tests were updated to use it as necessary.

Example patch: https://evergreen.mongodb.com/version/606e3ba332f4171c4c8b406e