### PR TITLE
DRIVERS-1627: Note driver-related features for 4.4 wire version

### DIFF
--- a/source/wireversion-featurelist.rst
+++ b/source/wireversion-featurelist.rst
@@ -63,9 +63,9 @@ Server Wire version and Feature List
    * - 4.4
      - 9
      - | Streaming protocol for SDAM
-     - | ResumableChangeStreamError error label
-     - | findAndModify "hint" option
-     - | createIndexes "commitQuorum" option
+       | ResumableChangeStreamError error label
+       | findAndModify "hint" option
+       | createIndexes "commitQuorum" option
 
    * - 5.0
      - 12

--- a/source/wireversion-featurelist.rst
+++ b/source/wireversion-featurelist.rst
@@ -62,7 +62,10 @@ Server Wire version and Feature List
 
    * - 4.4
      - 9
-     - | Resumable initial sync
+     - | Streaming protocol for SDAM
+     - | ResumableChangeStreamError error label
+     - | findAndModify "hint" option
+     - | createIndexes "commitQuorum" option
 
    * - 5.0
      - 12


### PR DESCRIPTION
http://jira.mongodb.org/browse/DRIVERS-1627

This revises #943.

[Resumable Initial Sync](https://docs.mongodb.com/manual/release-notes/4.4/#resumable-initial-sync) was indeed a 4.4 feature, but I don't think it pertained to drivers. This change replaces it with a list of driver features I came across by quickly grepping through our specs and wire version checks in PHPLIB. I may be missing some, but I think this makes the entry more relevant to driver developers.