### PR TITLE
DRIVERS-1647: Add appName to fail point at pool-create-min-size-error

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -116,6 +116,8 @@ the addition of the following fields to each test:
 - ``failPoint``: optional, a document containing a ``configureFailPoint``
   command to run against the endpoint being used for the test.
 
+- ``poolOptions.appName`` (optional): appName attribute to be set in connections, which will be affected by the fail point.
+
 Spec Test Match Function
 ========================
 

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.json
@@ -4,7 +4,7 @@
   "description": "error during minPoolSize population clears pool",
   "runOn": [
     {
-      "minServerVersion": "4.2.0"
+      "minServerVersion": "4.9.0"
     }
   ],
   "failPoint": {
@@ -16,11 +16,13 @@
       "failCommands": [
         "isMaster"
       ],
+      "appName": "poolCreateMinSizeErrorTest",
       "closeConnection": true
     }
   },
   "poolOptions": {
-    "minPoolSize": 1
+    "minPoolSize": 1,
+    "appName": "poolCreateMinSizeErrorTest"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.yml
@@ -3,8 +3,8 @@ style: integration
 description: error during minPoolSize population clears pool
 runOn:
   -
-    # required for blockConnection in fail point
-    minServerVersion: "4.2.0"
+    # required for appName in fail point
+    minServerVersion: "4.9.0"
 failPoint:
   configureFailPoint: failCommand
   # high amount to ensure not interfered with by monitor checks.
@@ -12,8 +12,10 @@ failPoint:
   data:
     failCommands: ["isMaster"]
     closeConnection: true
+    appName: "poolCreateMinSizeErrorTest"
 poolOptions:
   minPoolSize: 1
+  appName: "poolCreateMinSizeErrorTest"
 operations:
   - name: ready
   - name: waitForEvent


### PR DESCRIPTION
[DRIVERS-1647](https://jira.mongodb.org/browse/DRIVERS-1647)
Updating pool-create-min-size-error test to include appName in the fail point.