### PR TITLE
DRIVERS-1649 acceptAPIVersion2 -> acceptApiVersion2

### DIFF
--- a/source/versioned-api/tests/README.rst
+++ b/source/versioned-api/tests/README.rst
@@ -12,7 +12,7 @@ Notes
 This directory contains tests for the Versioned API specification. They are
 implemented in the `Unified Test Format <../../unified-test-format/unified-test-format.rst>`__,
 and require schema version 1.1. Note that to run these tests, the server must be
-started with both ``enableTestCommands`` and ``acceptAPIVersion2`` parameters
+started with both ``enableTestCommands`` and ``acceptApiVersion2`` parameters
 set to true.
 
 Testing with required API version

--- a/source/versioned-api/tests/test-commands-deprecation-errors.json
+++ b/source/versioned-api/tests/test-commands-deprecation-errors.json
@@ -6,7 +6,7 @@
       "minServerVersion": "4.9",
       "serverParameters": {
         "enableTestCommands": true,
-        "acceptAPIVersion2": true,
+        "acceptApiVersion2": true,
         "requireApiVersion": false
       }
     }

--- a/source/versioned-api/tests/test-commands-deprecation-errors.yml
+++ b/source/versioned-api/tests/test-commands-deprecation-errors.yml
@@ -6,7 +6,7 @@ runOnRequirements:
   - minServerVersion: "4.9"
     serverParameters:
       enableTestCommands: true
-      acceptAPIVersion2: true
+      acceptApiVersion2: true
       requireApiVersion: false
 
 createEntities:

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -286,4 +286,4 @@ versioned API. This is not covered in this specification.
 
 Change Log
 ==========
-* 2020-04-10: Replaced usages of ``acceptAPIVersion2`` with `acceptApiVersion2``.
+* 2021-04-10: Replaced usages of ``acceptAPIVersion2`` with `acceptApiVersion2``.

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -3,7 +3,7 @@ Versioned API For Drivers
 =========================
 
 :Spec Title: Versioned API For Drivers
-:Spec Version: 1.0.0
+:Spec Version: 1.0.1
 :Author: Andreas Braun
 :Advisors: Jeff Yemin, A. Jesse Jiryu Davis, Patrick Freed, Oleg Pudeyev
 :Status: Accepted

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -286,4 +286,4 @@ versioned API. This is not covered in this specification.
 
 Change Log
 ==========
-* 2021-04-10: Replaced usages of ``acceptAPIVersion2`` with `acceptApiVersion2``.
+* 2021-04-10: Replaced usages of ``acceptAPIVersion2`` with ``acceptApiVersion2``.

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -9,7 +9,7 @@ Versioned API For Drivers
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2020-12-01
+:Last Modified: 2021-04-10
 
 .. contents::
 
@@ -286,3 +286,4 @@ versioned API. This is not covered in this specification.
 
 Change Log
 ==========
+* 2020-04-10: Replaced usages of ``acceptAPIVersion2`` with `acceptApiVersion2``.


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1649

The server renamed this parameter.