### PR TITLE
include rationale for CSFLE cmds to mongocryptd on unencrypted colls

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1459,12 +1459,13 @@ safeguard. A collection may not have encrypted fields, but a command on the
 collection may could have sensitive data as part of the command arguments. For
 example:
 
-```
-db.publicData.aggregate([
-    {$lookup: {from: "privateData", localField: "_id", foreignField: "_id", as: "privateData"}},
-    {$match: {"privateData.ssn": "123-45-6789"}},
-])
-```
+.. code::
+
+   db.publicData.aggregate([
+      {$lookup: {from: "privateData", localField: "_id", foreignField: "_id", as: "privateData"}},
+      {$match: {"privateData.ssn": "123-45-6789"}},
+   ])
+
 
 The ``publicData`` collection does not have encrypted fields, but the
 ``privateData`` collection does. mongocryptd rejects an aggregate with

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1449,7 +1449,7 @@ decryption. ``listCollections`` is not run when ``bypassAutoEncryption`` is
 ``true``, making a metadataClient unnecessary.
 
 Why are commands sent to mongocryptd on collections without encrypted fields?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------------------------------------------------
 
 If a ``MongoClient`` is configured with automatic encryption, all commands on
 collections listed as ``AUTOENCRYPT`` in `libmongocrypt: Auto Encryption


### PR DESCRIPTION
Not urgent – but I wanted to capture this rationale somewhere.