### PR TITLE
DRIVERS-720 Add unified tests for LB support

### DIFF
--- a/source/load-balancers/tests/README.rst
+++ b/source/load-balancers/tests/README.rst
@@ -1,0 +1,45 @@
+===========================
+Load Balancer Support Tests
+===========================
+
+.. contents::
+
+----
+
+Introduction
+============
+
+This document describes how drivers should create load balanced clusters for
+testing and how tests should be executed for such clusters.
+
+Cluster Setup
+=============
+
+Drivers MUST execute tests against a load balanced sharded cluster with two
+mongos nodes running on localhost ports 27017 and 27018. The shard and config
+servers may run on any free ports. In addition to the sharded cluster, there
+MUST be two TCP load balancers operating in round-robin mode: one fronting
+both mongos nodes and one fronting a single mongos.
+
+When running tests in Evergreen, drivers MUST add a new task to each MongoDB
+5.0+ build variant to test against load balanced clusters. For example, if
+the latest released server version is 5.2, there should be load balanced
+testing tasks for 5.0, 5.2, and ``latest``.
+
+TODO: Once the work for drivers-evergreen-tools is complete, we should add
+notes/links about which config files should be used and the names of the
+environment variables that will be used to pass in the LB URIs.
+
+Tests
+======
+
+The YAML and JSON files in this directory contain platform-independent tests
+written in the `Unified Test Format
+<../unified-test-format/unified-test-format.rst>`_. Drivers MUST run the
+following test suites against a load balanced cluster:
+
+#. All test suites written in the Unified Test Format
+#. Retryable Reads
+#. Retryable Writes
+#. Change Streams
+#. Initial DNS Seedlist Discovery

--- a/source/load-balancers/tests/README.rst
+++ b/source/load-balancers/tests/README.rst
@@ -58,7 +58,7 @@ Tests
 
 The YAML and JSON files in this directory contain platform-independent tests
 written in the `Unified Test Format
-<../unified-test-format/unified-test-format.rst>`_. Drivers MUST run the
+<../../unified-test-format/unified-test-format.rst>`_. Drivers MUST run the
 following test suites against a load balanced cluster:
 
 #. All test suites written in the Unified Test Format

--- a/source/load-balancers/tests/README.rst
+++ b/source/load-balancers/tests/README.rst
@@ -46,6 +46,13 @@ cluster. Drivers MUST use the final URI stored in ``SINGLE_MONGOS_LB_URI``
 test runners (e.g. the internal MongoClient described by the `Unified Test
 Format spec <../../unified-test-format/unified-test-format.rst>`__).
 
+In addition to modifying load balancer URIs, drivers MUST also mock server
+support for returning a ``serviceId`` field in ``hello`` or legacy ``hello``
+command responses when running tests against a load-balanced cluster. This
+can be done by using the value of ``topologyVersion.processId`` to set
+``serviceId``. This MUST be done for all connections established by the test
+runner, including those made by any internal clients.
+
 Tests
 ======
 

--- a/source/load-balancers/tests/README.rst
+++ b/source/load-balancers/tests/README.rst
@@ -12,23 +12,39 @@ Introduction
 This document describes how drivers should create load balanced clusters for
 testing and how tests should be executed for such clusters.
 
-Cluster Setup
-=============
+Testing Requirements
+====================
 
-Drivers MUST execute tests against a load balanced sharded cluster with two
+For each server version that supports load balanced clusters, drivers MUST
+add two Evergreen tasks: one with a sharded cluster with both authentication
+and TLS enabled and one with a sharded cluster with authentication and TLS
+disabled. In each task, the sharded cluster MUST be configured with two
 mongos nodes running on localhost ports 27017 and 27018. The shard and config
-servers may run on any free ports. In addition to the sharded cluster, there
-MUST be two TCP load balancers operating in round-robin mode: one fronting
-both mongos nodes and one fronting a single mongos.
+servers may run on any free ports. Each task MUST also start up two TCP load
+balancers operating in round-robin mode: one fronting both mongos servers and
+one fronting a single mongos.
 
-When running tests in Evergreen, drivers MUST add a new task to each MongoDB
-5.0+ build variant to test against load balanced clusters. For example, if
-the latest released server version is 5.2, there should be load balanced
-testing tasks for 5.0, 5.2, and ``latest``.
+Load Balancer Configuration
+---------------------------
 
-TODO: Once the work for drivers-evergreen-tools is complete, we should add
-notes/links about which config files should be used and the names of the
-environment variables that will be used to pass in the LB URIs.
+Drivers MUST use the ``run-load-balancer.sh`` script in
+``drivers-evergreen-tools`` to start the TCP load balancers for Evergreen
+tasks. This script MUST be run after the backing sharded cluster has already
+been started. The script writes the URIs of the load balancers to a YAML
+expansions file, which can be read by drivers via the ``expansions.update``
+Evergreen command. This will store the URIs into the ``SINGLE_MONGOS_LB_URI``
+and ``MULTI_MONGOS_LB_URI`` environment variables.
+
+Test Runner Configuration
+-------------------------
+
+If the backing sharded cluster is configured with TLS enabled, drivers MUST
+add the relevant TLS options to both ``SINGLE_MONGOS_LB_URI`` and
+``MULTI_MONGOS_LB_URI`` to ensure that test clients can connect to the
+cluster. Drivers MUST use the final URI stored in ``SINGLE_MONGOS_LB_URI``
+(with additional TLS options if required) to configure internal clients for
+test runners (e.g. the internal MongoClient described by the `Unified Test
+Format spec <../unified-test-format/unified-test-format.rst`_).
 
 Tests
 ======

--- a/source/load-balancers/tests/README.rst
+++ b/source/load-balancers/tests/README.rst
@@ -44,7 +44,7 @@ add the relevant TLS options to both ``SINGLE_MONGOS_LB_URI`` and
 cluster. Drivers MUST use the final URI stored in ``SINGLE_MONGOS_LB_URI``
 (with additional TLS options if required) to configure internal clients for
 test runners (e.g. the internal MongoClient described by the `Unified Test
-Format spec <../unified-test-format/unified-test-format.rst`_).
+Format spec <../../unified-test-format/unified-test-format.rst>`__).
 
 Tests
 ======

--- a/source/load-balancers/tests/cursors.json
+++ b/source/load-balancers/tests/cursors.json
@@ -1148,6 +1148,81 @@
           ]
         }
       ]
+    },
+    {
+      "description": "change streams pin to a connection",
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "changeStream0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "aggregate"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "aggregate"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/source/load-balancers/tests/cursors.json
+++ b/source/load-balancers/tests/cursors.json
@@ -1,0 +1,1153 @@
+{
+  "description": "cursors are correctly pinned to connections for load-balanced clusters",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent",
+          "connectionReadyEvent",
+          "connectionClosedEvent",
+          "connectionCheckedOutEvent",
+          "connectionCheckedInEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection1",
+        "database": "database0",
+        "collectionName": "coll1"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection2",
+        "database": "database0",
+        "collectionName": "coll2"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "database0Name",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    },
+    {
+      "collectionName": "coll1",
+      "databaseName": "database0Name",
+      "documents": []
+    },
+    {
+      "collectionName": "coll2",
+      "databaseName": "database0Name",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "no connection is pinned if all documents are returned in the initial batch",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {}
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {}
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are returned when the cursor is drained",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 2
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 3
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "ns": {
+                      "$$type": "string"
+                    },
+                    "nextBatch": {
+                      "$$type": "array"
+                    }
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are returned to the pool when the cursor is closed",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are not returned after an network error during getMore",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 2
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are returned after a network error during a killCursors request",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "killCursors"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connections are not returned to the pool after a non-network error on getMore",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "errorCode": 7
+              }
+            }
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 1
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectResult": {
+            "_id": 2
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectError": {
+            "errorCode": 7
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "batchSize": 2
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": {
+                      "$$type": "long"
+                    },
+                    "firstBatch": {
+                      "$$type": "array"
+                    },
+                    "ns": {
+                      "$$type": "string"
+                    }
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "killCursors"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "aggregate pins the cursor to a connection",
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "batchSize": 2
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "cursor": {
+                    "batchSize": 2
+                  }
+                },
+                "commandName": "aggregate"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "aggregate"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "ns": {
+                      "$$type": "string"
+                    },
+                    "nextBatch": {
+                      "$$type": "array"
+                    }
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listCollections pins the cursor to a connection",
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "cursor": {
+                    "batchSize": 2
+                  }
+                },
+                "commandName": "listCollections",
+                "databaseName": "database0Name"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "listCollections"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": {
+                    "$$type": "string"
+                  }
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "ns": {
+                      "$$type": "string"
+                    },
+                    "nextBatch": {
+                      "$$type": "array"
+                    }
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listIndexes pins the cursor to a connection",
+      "operations": [
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "name": "x_1"
+          }
+        },
+        {
+          "name": "createIndex",
+          "object": "collection0",
+          "arguments": {
+            "keys": {
+              "y": 1
+            },
+            "name": "y_1"
+          }
+        },
+        {
+          "name": "listIndexes",
+          "object": "collection0",
+          "arguments": {
+            "batchSize": 2
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "coll0",
+                  "indexes": [
+                    {
+                      "name": "x_1",
+                      "key": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                },
+                "commandName": "createIndexes"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "createIndexes"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "coll0",
+                  "indexes": [
+                    {
+                      "name": "y_1",
+                      "key": {
+                        "y": 1
+                      }
+                    }
+                  ]
+                },
+                "commandName": "createIndexes"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "createIndexes"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listIndexes": "coll0",
+                  "cursor": {
+                    "batchSize": 2
+                  }
+                },
+                "commandName": "listIndexes",
+                "databaseName": "database0Name"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "listIndexes"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "getMore": {
+                    "$$type": "long"
+                  },
+                  "collection": "coll0"
+                },
+                "commandName": "getMore"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "cursor": {
+                    "id": 0,
+                    "ns": {
+                      "$$type": "string"
+                    },
+                    "nextBatch": {
+                      "$$type": "array"
+                    }
+                  }
+                },
+                "commandName": "getMore"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/load-balancers/tests/cursors.yml
+++ b/source/load-balancers/tests/cursors.yml
@@ -462,3 +462,42 @@ tests:
           # Events for listIndexes and getMore.
           - connectionCheckedOutEvent: {}
           - connectionCheckedInEvent: {}
+
+  - description: change streams pin to a connection
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client0
+          connections: 1
+      - name: close
+        object: *changeStream0
+      - name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client0
+          connections: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: aggregate
+          - commandSucceededEvent:
+              commandName: aggregate
+          - commandStartedEvent:
+              commandName: killCursors
+          - commandSucceededEvent:
+              commandName: killCursors
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for creating the change stream.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          # Events for closing the change stream.
+          - connectionCheckedInEvent: {}

--- a/source/load-balancers/tests/cursors.yml
+++ b/source/load-balancers/tests/cursors.yml
@@ -1,0 +1,464 @@
+description: cursors are correctly pinned to connections for load-balanced clusters
+
+schemaVersion: '1.3'
+
+runOnRequirements:
+  - topologies: [ load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+        - connectionReadyEvent
+        - connectionClosedEvent
+        - connectionCheckedOutEvent
+        - connectionCheckedInEvent
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0Name
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+  - collection:
+      id: &collection1 collection1
+      database: *database0
+      collectionName: &collection1Name coll1
+  - collection:
+      id: &collection2 collection2
+      database: *database0
+      collectionName: &collection2Name coll2
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+      - { _id: 2 }
+      - { _id: 3 }
+  - collectionName: *collection1Name
+    databaseName: *database0Name
+    documents: []
+  - collectionName: *collection2Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: no connection is pinned if all documents are returned in the initial batch
+    operations:
+      - name: createFindCursor
+        object: *collection0
+        arguments:
+          filter: {}
+        saveResultAsEntity: &cursor0 cursor0
+      - &assertConnectionNotPinned
+        name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client0
+          connections: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: {}
+              commandName: find
+          - commandSucceededEvent:
+              reply:
+                cursor:
+                  id: 0
+                  firstBatch: { $$type: array }
+                  ns: { $$type: string }
+              commandName: find
+      - client: *client0
+        eventType: cmap
+        events:
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connections are returned when the cursor is drained
+    operations:
+      - &createAndSaveCursor
+        name: createFindCursor
+        object: *collection0
+        arguments:
+          filter: {}
+          batchSize: 2
+        saveResultAsEntity: &cursor0 cursor0
+      - &assertConnectionPinned
+        name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client0
+          connections: 1
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult: { _id: 1 }
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult: { _id: 2 }
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult: { _id: 3 }
+      - *assertConnectionNotPinned
+      - &closeCursor
+        name: close
+        object: *cursor0
+    expectEvents:
+      - client: *client0
+        events:
+          - &findWithBatchSizeStarted
+            commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: {}
+                batchSize: 2
+              commandName: find
+          - &findWithBatchSizeSucceeded
+            commandSucceededEvent:
+              reply:
+                cursor:
+                  id: { $$type: long }
+                  firstBatch: { $$type: array }
+                  ns: { $$type: string }
+              commandName: find
+          - &getMoreStarted
+            commandStartedEvent:
+              command:
+                getMore: { $$type: long }
+                collection: *collection0Name
+              commandName: getMore
+          - &getMoreSucceeded
+            commandSucceededEvent:
+              reply:
+                cursor:
+                  id: 0
+                  ns: { $$type: string }
+                  nextBatch: { $$type: array }
+              commandName: getMore
+      - client: *client0
+        eventType: cmap
+        events:
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connections are returned to the pool when the cursor is closed
+    operations:
+      - *createAndSaveCursor
+      - *assertConnectionPinned
+      - *closeCursor
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *findWithBatchSizeStarted
+          - *findWithBatchSizeSucceeded
+          - &killCursorsStarted
+            commandStartedEvent:
+              commandName: killCursors
+          - &killCursorsSucceeded
+            commandSucceededEvent:
+              commandName: killCursors
+      - client: *client0
+        eventType: cmap
+        events:
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  # If a network error occurs during a getMore request, the connection must remain pinned. and drivers must not
+  # attempt to send a killCursors command when the cursor is closed because the connection is no longer valid.
+  - description: pinned connections are not returned after an network error during getMore
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ getMore ]
+              closeConnection: true
+      - *createAndSaveCursor
+      - *assertConnectionPinned
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult:
+          _id: 1
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult:
+          _id: 2
+      # Third next() call should perform a getMore.
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectError:
+          # Network errors are considered client-side errors per the unified test format spec.
+          isClientError: true
+      - *assertConnectionPinned
+      - *closeCursor # Execute a close operation to actually release the connection.
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *findWithBatchSizeStarted
+          - *findWithBatchSizeSucceeded
+          - *getMoreStarted
+          - &getMoreFailed
+            commandFailedEvent:
+              commandName: getMore
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events to set the failpoint.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the find command + getMore.
+          - connectionCheckedOutEvent: {}
+          # Events for the close() operation.
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent:
+              reason: error
+
+  - description: pinned connections are returned after a network error during a killCursors request
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ killCursors ]
+              closeConnection: true
+      - *createAndSaveCursor
+      - *assertConnectionPinned
+      - *closeCursor
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *findWithBatchSizeStarted
+          - *findWithBatchSizeSucceeded
+          - *killCursorsStarted
+          - commandFailedEvent:
+              commandName: killCursors
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events to set the failpoint.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the find command + killCursors.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent:
+              reason: error
+
+  - description: pinned connections are not returned to the pool after a non-network error on getMore
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ getMore ]
+              errorCode: &hostNotFoundCode 7 # This is not a state change error code, so it should not cause SDAM changes.
+      - *createAndSaveCursor
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult:
+          _id: 1
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectResult:
+          _id: 2
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectError:
+          errorCode: *hostNotFoundCode
+      - *assertConnectionPinned
+      - *closeCursor
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *findWithBatchSizeStarted
+          - *findWithBatchSizeSucceeded
+          - *getMoreStarted
+          - *getMoreFailed
+          - *killCursorsStarted
+          - *killCursorsSucceeded
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events to set the failpoint.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the find command + getMore + killCursors.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  # Basic tests for cursor-creating commands besides "find". We don't need to replicate the full set of tests defined
+  # above for each such command. Instead, only one test is needed per command to ensure that the pinned connection is
+  # correctly passed down to the server.
+  #
+  # Each test creates a cursor with a small batch size and fully iterates it. Because drivers do not publish CMAP
+  # events when using pinned connections, each test asserts that only one set of ready/checkout/checkin events are
+  # published.
+
+  - description: aggregate pins the cursor to a connection
+    operations:
+      - name: aggregate
+        object: *collection0
+        arguments:
+          pipeline: []
+          batchSize: 2
+      - name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client0
+          connections: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                cursor:
+                  batchSize: 2
+              commandName: aggregate
+          - commandSucceededEvent:
+              commandName: aggregate
+          - *getMoreStarted
+          - *getMoreSucceeded
+      - client: *client0
+        eventType: cmap
+        events:
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: listCollections pins the cursor to a connection
+    operations:
+      - name: listCollections
+        object: *database0
+        arguments:
+          filter: {}
+          batchSize: 2
+      - name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client0
+          connections: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                listCollections: 1
+                cursor:
+                  batchSize: 2
+              commandName: listCollections
+              databaseName: *database0Name
+          - commandSucceededEvent:
+              commandName: listCollections
+          # Write out the event for getMore rather than using the getMoreStarted anchor because the "collection" field
+          # is not equal to *collection0Name as the command is not executed against a collection.
+          - commandStartedEvent:
+              command:
+                getMore: { $$type: long }
+                collection: { $$type: string }
+              commandName: getMore
+          - *getMoreSucceeded
+      - client: *client0
+        eventType: cmap
+        events:
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: listIndexes pins the cursor to a connection
+    operations:
+      # There is an automatic index on _id so we create two more indexes to force multiple batches with batchSize=2.
+      - name: createIndex
+        object: *collection0
+        arguments:
+          keys: &x1IndexSpec { x: 1 }
+          name: &x1IndexName x_1
+      - name: createIndex
+        object: *collection0
+        arguments:
+          keys: &y1IndexSpec { y: 1 }
+          name: &y1IndexName y_1
+      - name: listIndexes
+        object: *collection0
+        arguments:
+          batchSize: 2
+      - name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client0
+          connections: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createIndexes: *collection0Name
+                indexes:
+                  - name: *x1IndexName
+                    key: *x1IndexSpec
+              commandName: createIndexes
+          - commandSucceededEvent:
+              commandName: createIndexes
+          - commandStartedEvent:
+              command:
+                createIndexes: *collection0Name
+                indexes:
+                  - name: *y1IndexName
+                    key: *y1IndexSpec
+              commandName: createIndexes
+          - commandSucceededEvent:
+              commandName: createIndexes
+          - commandStartedEvent:
+              command:
+                listIndexes: *collection0Name
+                cursor:
+                  batchSize: 2
+              commandName: listIndexes
+              databaseName: *database0Name
+          - commandSucceededEvent:
+              commandName: listIndexes
+          - *getMoreStarted
+          - *getMoreSucceeded
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for first createIndexes.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for second createIndexes.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for listIndexes and getMore.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}

--- a/source/load-balancers/tests/event-monitoring.json
+++ b/source/load-balancers/tests/event-monitoring.json
@@ -1,0 +1,184 @@
+{
+  "description": "monitoring events include correct fields",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "uriOptions": {
+          "retryReads": false
+        },
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent",
+          "poolClearedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "database0",
+      "collectionName": "coll0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command started and succeeded events include serviceId",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServiceId": true
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServiceId": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "command failed events include serviceId",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServiceId": true
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServiceId": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "poolClearedEvent events include serviceId",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {}
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServiceId": true
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServiceId": true
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "poolClearedEvent": {
+                "hasServiceId": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/load-balancers/tests/event-monitoring.yml
+++ b/source/load-balancers/tests/event-monitoring.yml
@@ -1,0 +1,99 @@
+description: monitoring events include correct fields
+
+schemaVersion: '1.3'
+
+runOnRequirements:
+  - topologies: [ load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+      uriOptions:
+        retryReads: false
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+        - poolClearedEvent
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents: []
+
+tests:
+  - description: command started and succeeded events include serviceId
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              hasServiceId: true
+          - commandSucceededEvent:
+              commandName: insert
+              hasServiceId: true
+
+  - description: command failed events include serviceId
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { $or: true }
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: find
+              hasServiceId: true
+          - commandFailedEvent:
+              commandName: find
+              hasServiceId: true
+
+  - description: poolClearedEvent events include serviceId
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [find]
+              closeConnection: true
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: find
+              hasServiceId: true
+          - commandFailedEvent:
+              commandName: find
+              hasServiceId: true
+      - client: *client0
+        eventType: cmap
+        events:
+          - poolClearedEvent:
+              hasServiceId: true

--- a/source/load-balancers/tests/lb-connection-establishment.json
+++ b/source/load-balancers/tests/lb-connection-establishment.json
@@ -1,0 +1,58 @@
+{
+  "description": "connection establishment for load-balanced clusters",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "uriOptions": {
+          "loadBalanced": false
+        },
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "operations against load balancers fail if URI contains loadBalanced=false",
+      "skipReason": "servers have not implemented LB support yet so they will not fail the connection handshake in this case",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
+    }
+  ]
+}

--- a/source/load-balancers/tests/lb-connection-establishment.yml
+++ b/source/load-balancers/tests/lb-connection-establishment.yml
@@ -1,0 +1,36 @@
+description: connection establishment for load-balanced clusters
+
+schemaVersion: '1.3'
+
+runOnRequirements:
+  - topologies: [ load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      uriOptions:
+        # Explicitly set loadBalanced to false to override the option from the global URI.
+        loadBalanced: false
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0
+
+tests:
+  - description: operations against load balancers fail if URI contains loadBalanced=false
+    skipReason: servers have not implemented LB support yet so they will not fail the connection handshake in this case
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+        expectError:
+          isClientError: false
+    expectEvents:
+      # No events should be published because the server fails the connection handshake, so the "ping" command is never
+      # sent.
+      - client: *client0
+        events: []

--- a/source/load-balancers/tests/non-lb-connection-establishment.json
+++ b/source/load-balancers/tests/non-lb-connection-establishment.json
@@ -5,7 +5,6 @@
     {
       "topologies": [
         "single",
-        "replicaset",
         "sharded"
       ]
     }
@@ -14,6 +13,7 @@
     {
       "client": {
         "id": "lbTrueClient",
+        "useMultipleMongoses": false,
         "uriOptions": {
           "loadBalanced": true
         }

--- a/source/load-balancers/tests/non-lb-connection-establishment.json
+++ b/source/load-balancers/tests/non-lb-connection-establishment.json
@@ -1,0 +1,92 @@
+{
+  "description": "connection establishment if loadBalanced is specified for non-load balanced clusters",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "single",
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "lbTrueClient",
+        "uriOptions": {
+          "loadBalanced": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "lbTrueDatabase",
+        "client": "lbTrueClient",
+        "databaseName": "lbTrueDb"
+      }
+    },
+    {
+      "client": {
+        "id": "lbFalseClient",
+        "uriOptions": {
+          "loadBalanced": false
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "lbFalseDatabase",
+        "client": "lbFalseClient",
+        "databaseName": "lbFalseDb"
+      }
+    }
+  ],
+  "_yamlAnchors": {
+    "runCommandArguments": [
+      {
+        "arguments": {
+          "commandName": "ping",
+          "command": {
+            "ping": 1
+          }
+        }
+      }
+    ]
+  },
+  "tests": [
+    {
+      "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "lbTrueDatabase",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectError": {
+            "errorContains": "Driver attempted to initialize in load balancing mode, but the server does not support this mode"
+          }
+        }
+      ]
+    },
+    {
+      "description": "operations against non-load balanced clusters succeed if URI contains loadBalanced=false",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "lbFalseDatabase",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/load-balancers/tests/non-lb-connection-establishment.yml
+++ b/source/load-balancers/tests/non-lb-connection-establishment.yml
@@ -3,12 +3,16 @@ description: connection establishment if loadBalanced is specified for non-load 
 schemaVersion: '1.3'
 
 runOnRequirements:
-  # This test should be executed on all topologies except load-balanced.
-  - topologies: [ single, replicaset, sharded ]
+  # Don't run on replica sets because the URI used to configure the clients will contain multiple hosts and the
+  # replicaSet option, which will cause an error when constructing the lbTrueClient entity.
+  - topologies: [ single, sharded ]
 
 createEntities:
   - client:
       id: &lbTrueClient lbTrueClient
+      # Restrict to a single mongos to ensure there are not multiple hosts in the URI, which would conflict with
+      # loadBalanced=true.
+      useMultipleMongoses: false
       uriOptions:
         loadBalanced: true
   - database:

--- a/source/load-balancers/tests/non-lb-connection-establishment.yml
+++ b/source/load-balancers/tests/non-lb-connection-establishment.yml
@@ -1,0 +1,52 @@
+description: connection establishment if loadBalanced is specified for non-load balanced clusters
+
+schemaVersion: '1.3'
+
+runOnRequirements:
+  # This test should be executed on all topologies except load-balanced.
+  - topologies: [ single, replicaset, sharded ]
+
+createEntities:
+  - client:
+      id: &lbTrueClient lbTrueClient
+      uriOptions:
+        loadBalanced: true
+  - database:
+      id: &lbTrueDatabase lbTrueDatabase
+      client: *lbTrueClient
+      databaseName: &lbTrueDatabaseName lbTrueDb
+  - client:
+      id: &lbFalseClient lbFalseClient
+      uriOptions:
+        loadBalanced: false
+  - database:
+      id: &lbFalseDatabase lbFalseDatabase
+      client: *lbFalseClient
+      databaseName: &lbFalseDatabaseName lbFalseDb
+
+_yamlAnchors:
+  runCommandArguments:
+    - &pingArguments
+      arguments:
+        commandName: ping
+        command: { ping: 1 }
+
+tests:
+  # These tests assert that drivers behave correctly if loadBalanced=true/false for non-load balanced clusters. Existing
+  # spec tests should cover the case where loadBalanced is unset.
+
+  # If the server is not configured to be behind a load balancer and the URI contains loadBalanced=true, the driver
+  # should error during the connection handshake because the server's hello response does not contain a serviceId field.
+  - description: operations against non-load balanced clusters fail if URI contains loadBalanced=true
+    operations:
+      - name: runCommand
+        object: *lbTrueDatabase
+        <<: *pingArguments
+        expectError:
+          errorContains: Driver attempted to initialize in load balancing mode, but the server does not support this mode
+
+  - description: operations against non-load balanced clusters succeed if URI contains loadBalanced=false
+    operations:
+      - name: runCommand
+        object: *lbFalseDatabase
+        <<: *pingArguments

--- a/source/load-balancers/tests/sdam-error-handling.json
+++ b/source/load-balancers/tests/sdam-error-handling.json
@@ -96,7 +96,17 @@
     {
       "collectionName": "singleColl",
       "databaseName": "singleDB",
-      "documents": []
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
     },
     {
       "collectionName": "multiColl",
@@ -368,6 +378,127 @@
               "connectionCheckOutFailedEvent": {
                 "reason": "connectionError"
               }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "stale errors are ignored",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "getMore"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "singleColl",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "createFindCursor",
+          "object": "singleColl",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor1"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor0",
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor1"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor1"
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "cursor1",
+          "expectError": {
+            "isClientError": true
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor1"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "singleClient",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
             }
           ]
         }

--- a/source/load-balancers/tests/sdam-error-handling.json
+++ b/source/load-balancers/tests/sdam-error-handling.json
@@ -1,0 +1,377 @@
+{
+  "description": "state change errors are correctly handled",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "observedEvents": [
+      "connectionCreatedEvent",
+      "connectionReadyEvent",
+      "connectionCheckedOutEvent",
+      "connectionCheckOutFailedEvent",
+      "connectionCheckedInEvent",
+      "connectionClosedEvent",
+      "poolClearedEvent"
+    ]
+  },
+  "createEntities": [
+    {
+      "client": {
+        "id": "failPointClient",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "client": {
+        "id": "singleClient",
+        "useMultipleMongoses": false,
+        "uriOptions": {
+          "appname": "lbSDAMErrorTestClient",
+          "retryWrites": false
+        },
+        "observeEvents": [
+          "connectionCreatedEvent",
+          "connectionReadyEvent",
+          "connectionCheckedOutEvent",
+          "connectionCheckOutFailedEvent",
+          "connectionCheckedInEvent",
+          "connectionClosedEvent",
+          "poolClearedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "singleDB",
+        "client": "singleClient",
+        "databaseName": "singleDB"
+      }
+    },
+    {
+      "collection": {
+        "id": "singleColl",
+        "database": "singleDB",
+        "collectionName": "singleColl"
+      }
+    },
+    {
+      "client": {
+        "id": "multiClient",
+        "useMultipleMongoses": true,
+        "uriOptions": {
+          "retryWrites": false
+        },
+        "observeEvents": [
+          "connectionCreatedEvent",
+          "connectionReadyEvent",
+          "connectionCheckedOutEvent",
+          "connectionCheckOutFailedEvent",
+          "connectionCheckedInEvent",
+          "connectionClosedEvent",
+          "poolClearedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "multiDB",
+        "client": "multiClient",
+        "databaseName": "multiDB"
+      }
+    },
+    {
+      "collection": {
+        "id": "multiColl",
+        "database": "multiDB",
+        "collectionName": "multiColl"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "singleColl",
+      "databaseName": "singleDB",
+      "documents": []
+    },
+    {
+      "collectionName": "multiColl",
+      "databaseName": "multiDB",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "only connections for a specific serviceId are closed when pools are cleared",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "multiColl",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "createFindCursor",
+          "object": "multiColl",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor1"
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "close",
+          "object": "cursor1"
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "multiClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "multiColl",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "errorCode": 11600
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "multiColl",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "multiClient",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "stale"
+              }
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "errors during the initial connection hello are ignore",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.9"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "isMaster"
+                ],
+                "closeConnection": true,
+                "appName": "lbSDAMErrorTestClient"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "singleColl",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "singleClient",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionCheckOutFailedEvent": {
+                "reason": "connectionError"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "errors during authentication are processed",
+      "runOnRequirements": [
+        {
+          "auth": true
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "saslContinue"
+                ],
+                "closeConnection": true,
+                "appName": "lbSDAMErrorTestClient"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "singleColl",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "singleClient",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionCheckOutFailedEvent": {
+                "reason": "connectionError"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/load-balancers/tests/sdam-error-handling.yml
+++ b/source/load-balancers/tests/sdam-error-handling.yml
@@ -52,7 +52,10 @@ createEntities:
 initialData:
   - collectionName: *singleCollName
     databaseName: *singleDBName
-    documents: []
+    documents:
+      - _id: 1
+      - _id: 2
+      - _id: 3
   - collectionName: *multiCollName
     databaseName: *multiDBName
     documents:
@@ -196,3 +199,72 @@ tests:
               reason: error
           - connectionCheckOutFailedEvent:
               reason: connectionError
+
+  - description: stale errors are ignored
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *failPointClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 2 }
+            data:
+              failCommands: [getMore]
+              closeConnection: true
+      # Force two connections to be checked out from the pool.
+      - name: createFindCursor
+        object: *singleColl
+        arguments:
+          filter: {}
+          batchSize: 2
+        saveResultAsEntity: &cursor0 cursor0
+      - name: createFindCursor
+        object: *singleColl
+        arguments:
+          filter: {}
+          batchSize: 2
+        saveResultAsEntity: &cursor1 cursor1
+      # Iterate cursor0 three times to force a network error.
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+      - name: iterateUntilDocumentOrError
+        object: *cursor0
+        expectError:
+          isClientError: true
+      - name: close
+        object: *cursor0
+      # Iterate cursor1 three times to force a network error.
+      - name: iterateUntilDocumentOrError
+        object: *cursor1
+      - name: iterateUntilDocumentOrError
+        object: *cursor1
+      - name: iterateUntilDocumentOrError
+        object: *cursor1
+        expectError:
+          isClientError: true
+      - name: close
+        object: *cursor1
+    expectEvents:
+      - client: *singleClient
+        eventType: cmap
+        events:
+          # Events for creating both cursors.
+          - connectionCreatedEvent: {}
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCreatedEvent: {}
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          # Events for iterating and closing the first cursor.  The failed
+          # getMore should cause a poolClearedEvent to be published.
+          - poolClearedEvent: {}
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent: {}
+          # Events for iterating and closing the second cursor. The failed
+          # getMore should not clear the pool because the connection's
+          # generation number is stale.
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent: {}

--- a/source/load-balancers/tests/sdam-error-handling.yml
+++ b/source/load-balancers/tests/sdam-error-handling.yml
@@ -1,0 +1,198 @@
+description: state change errors are correctly handled
+
+schemaVersion: '1.3'
+
+runOnRequirements:
+  - topologies: [ load-balanced ]
+
+_yamlAnchors:
+  observedEvents: &observedEvents
+    - connectionCreatedEvent
+    - connectionReadyEvent
+    - connectionCheckedOutEvent
+    - connectionCheckOutFailedEvent
+    - connectionCheckedInEvent
+    - connectionClosedEvent
+    - poolClearedEvent
+
+createEntities:
+  - client:
+      id: &failPointClient failPointClient
+      useMultipleMongoses: false
+  - client:
+      id: &singleClient singleClient
+      useMultipleMongoses: false
+      uriOptions:
+        appname: &singleClientAppName lbSDAMErrorTestClient
+        retryWrites: false
+      observeEvents: *observedEvents
+  - database:
+      id: &singleDB singleDB
+      client: *singleClient
+      databaseName: &singleDBName singleDB
+  - collection:
+      id: &singleColl singleColl
+      database: *singleDB
+      collectionName: &singleCollName singleColl
+  - client:
+      id: &multiClient multiClient
+      useMultipleMongoses: true
+      uriOptions:
+        retryWrites: false
+      observeEvents: *observedEvents
+  - database:
+      id: &multiDB multiDB
+      client: *multiClient
+      databaseName: &multiDBName multiDB
+  - collection:
+      id: &multiColl multiColl
+      database: *multiDB
+      collectionName: &multiCollName multiColl
+
+initialData:
+  - collectionName: *singleCollName
+    databaseName: *singleDBName
+    documents: []
+  - collectionName: *multiCollName
+    databaseName: *multiDBName
+    documents:
+      - _id: 1
+      - _id: 2
+      - _id: 3
+
+tests:
+  - description: only connections for a specific serviceId are closed when pools are cleared
+    operations:
+      # Create two cursors to force two connections.
+      - name: createFindCursor
+        object: *multiColl
+        arguments:
+          filter: {}
+          batchSize: 2
+        saveResultAsEntity: &cursor0 cursor0
+      - name: createFindCursor
+        object: *multiColl
+        arguments:
+          filter: {}
+          batchSize: 2
+        saveResultAsEntity: &cursor1 cursor1
+      # Close both cursors to return the connections to the pool.
+      - name: close
+        object: *cursor0
+      - name: close
+        object: *cursor1
+      # Fail an operation with a state change error.
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *multiClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [insert]
+              errorCode: &errorCode 11600 # InterruptedAtShutdown
+      - name: insertOne
+        object: *multiColl
+        arguments:
+          document: { x: 1 }
+        expectError:
+          errorCode: *errorCode
+      # Do another operation to ensure the relevant connection has been closed.
+      - name: insertOne
+        object: *multiColl
+        arguments:
+          document: { x: 1 }
+    expectEvents:
+      - client: *multiClient
+        eventType: cmap
+        events:
+          # Create cursors.
+          - connectionCreatedEvent: {}
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCreatedEvent: {}
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          # Close cursors.
+          - connectionCheckedInEvent: {}
+          - connectionCheckedInEvent: {}
+          # Set failpoint.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # First insertOne.
+          - connectionCheckedOutEvent: {}
+          - poolClearedEvent: {}
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent:
+              reason: stale
+          # Second insertOne.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  # This test uses singleClient to ensure that connection attempts are routed
+  # to the same mongos on which the failpoint is set.
+  - description: errors during the initial connection hello are ignore 
+    runOnRequirements:
+      # Server version 4.9+ is needed to set a fail point on the initial
+      # connection handshake with the appName filter due to SERVER-49336.
+      - minServerVersion: '4.9'
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *failPointClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [isMaster]
+              closeConnection: true
+              appName: *singleClientAppName
+      - name: insertOne
+        object: *singleColl
+        arguments:
+          document: { x: 1 }
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *singleClient
+        eventType: cmap
+        events:
+          - connectionCreatedEvent: {}
+          - connectionClosedEvent:
+              reason: error
+          - connectionCheckOutFailedEvent:
+              reason: connectionError
+
+  - description: errors during authentication are processed
+    runOnRequirements:
+      - auth: true
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *failPointClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [saslContinue]
+              closeConnection: true
+              appName: *singleClientAppName
+      - name: insertOne
+        object: *singleColl
+        arguments:
+          document: { x: 1 }
+        expectError:
+          isClientError: true
+    expectEvents:
+      - client: *singleClient
+        eventType: cmap
+        events:
+          - connectionCreatedEvent: {}
+          - poolClearedEvent: {}
+          - connectionClosedEvent:
+              reason: error
+          - connectionCheckOutFailedEvent:
+              reason: connectionError

--- a/source/load-balancers/tests/server-selection.json
+++ b/source/load-balancers/tests/server-selection.json
@@ -1,0 +1,82 @@
+{
+  "description": "server selection for load-balanced clusters",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0",
+        "collectionOptions": {
+          "readPreference": {
+            "mode": "secondaryPreferred"
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "database0Name",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "$readPreference is sent for load-balanced clusters",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {}
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "$readPreference": {
+                    "mode": "secondaryPreferred"
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "database0Name"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/load-balancers/tests/server-selection.yml
+++ b/source/load-balancers/tests/server-selection.yml
@@ -1,0 +1,50 @@
+description: server selection for load-balanced clusters
+
+schemaVersion: '1.3'
+
+runOnRequirements:
+  - topologies: [ load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0Name
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+      collectionOptions:
+        readPreference:
+          # Use secondaryPreferred to ensure that operations can succeed even if the shards are only comprised of one
+          # server.
+          mode: &readPrefMode secondaryPreferred
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: $readPreference is sent for load-balanced clusters
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: {}
+                $readPreference:
+                  mode: *readPrefMode
+              commandName: find
+              databaseName: *database0Name

--- a/source/load-balancers/tests/transactions.json
+++ b/source/load-balancers/tests/transactions.json
@@ -852,18 +852,6 @@
             "client": "client0",
             "connections": 0
           }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session0"
-        },
-        {
-          "name": "assertNumberConnectionsCheckedOut",
-          "object": "testRunner",
-          "arguments": {
-            "client": "client0",
-            "connections": 0
-          }
         }
       ],
       "expectEvents": [
@@ -879,11 +867,6 @@
               "commandStartedEvent": {
                 "commandName": "commitTransaction"
               }
-            },
-            {
-              "commandStartedEvent": {
-                "commandName": "commitTransaction"
-              }
             }
           ]
         },
@@ -893,12 +876,6 @@
           "events": [
             {
               "connectionReadyEvent": {}
-            },
-            {
-              "connectionCheckedOutEvent": {}
-            },
-            {
-              "connectionCheckedInEvent": {}
             },
             {
               "connectionCheckedOutEvent": {}

--- a/source/load-balancers/tests/transactions.json
+++ b/source/load-balancers/tests/transactions.json
@@ -1,0 +1,1599 @@
+{
+  "description": "transactions are correctly pinned to connections for load-balanced clusters",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "observeEvents": [
+          "commandStartedEvent",
+          "connectionReadyEvent",
+          "connectionClosedEvent",
+          "connectionCheckedOutEvent",
+          "connectionCheckedInEvent"
+        ]
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "database0Name",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "documents": [
+      {
+        "_id": 4
+      }
+    ]
+  },
+  "tests": [
+    {
+      "description": "all operations go to the same mongos",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "transaction can be committed multiple times",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is not released after a non-transient CRUD error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 51
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          },
+          "expectError": {
+            "errorCode": 51,
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is not released after a non-transient commit error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction"
+                ],
+                "errorCode": 51
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "expectError": {
+            "errorCode": 51,
+            "errorLabelsOmit": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a non-transient abort error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "errorCode": 51
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient non-network CRUD error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 24
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          },
+          "expectError": {
+            "errorCode": 24,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient network CRUD error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          },
+          "expectError": {
+            "isClientError": true,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient non-network commit error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction"
+                ],
+                "errorCode": 24
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "expectError": {
+            "errorCode": 24,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient network commit error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "commitTransaction"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0",
+          "ignoreResultAndError": true
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient non-network abort error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "errorCode": 24
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released after a transient network abort error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "abortTransaction"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionClosedEvent": {
+                "reason": "error"
+              }
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is released on successful abort",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is returned when a new transaction is started",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "pinned connection is returned when a non-transaction operation uses the session",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "commitTransaction"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "a connection can be shared by a transaction and a cursor",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2,
+            "session": "session0"
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "close",
+          "object": "cursor0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 1
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "assertNumberConnectionsCheckedOut",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "connections": 0
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "killCursors"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "abortTransaction"
+              }
+            }
+          ]
+        },
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/load-balancers/tests/transactions.json
+++ b/source/load-balancers/tests/transactions.json
@@ -69,6 +69,36 @@
   },
   "tests": [
     {
+      "description": "sessions are reused in LB mode",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "assertSameLsidOnLastTwoCommands",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0"
+          }
+        }
+      ]
+    },
+    {
       "description": "all operations go to the same mongos",
       "operations": [
         {

--- a/source/load-balancers/tests/transactions.yml
+++ b/source/load-balancers/tests/transactions.yml
@@ -43,6 +43,19 @@ _yamlAnchors:
       _id: 4
 
 tests:
+  - description: sessions are reused in LB mode
+    operations:
+      - &nonTransactionalInsert
+        name: insertOne
+        object: *collection0
+        arguments:
+          document: { x: 1 }
+      - *nonTransactionalInsert
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+
   - description: all operations go to the same mongos
     operations:
       - &startTransaction

--- a/source/load-balancers/tests/transactions.yml
+++ b/source/load-balancers/tests/transactions.yml
@@ -1,0 +1,585 @@
+description: transactions are correctly pinned to connections for load-balanced clusters
+
+schemaVersion: '1.3'
+
+runOnRequirements:
+  - topologies: [ load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+      observeEvents:
+        # Do not observe commandSucceededEvent or commandFailedEvent because we cannot guarantee success or failure of
+        # commands like commitTransaction and abortTransaction in a multi-mongos load-balanced setup.
+        - commandStartedEvent
+        - connectionReadyEvent
+        - connectionClosedEvent
+        - connectionCheckedOutEvent
+        - connectionCheckedInEvent
+  - session:
+      id: &session0 session0
+      client: *client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0Name
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+      - { _id: 2 }
+      - { _id: 3 }
+
+_yamlAnchors:
+  documents:
+    - &insertDocument
+      _id: 4
+
+tests:
+  - description: all operations go to the same mongos
+    operations:
+      - &startTransaction
+        name: startTransaction
+        object: *session0
+      - &transactionalInsert
+        name: insertOne
+        object: *collection0
+        arguments:
+          document: { x: 1 }
+          session: *session0
+      - &assertConnectionPinned
+        name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client0
+          connections: 1
+      - *transactionalInsert
+      - *transactionalInsert
+      - *transactionalInsert
+      - *transactionalInsert
+      - *transactionalInsert
+      - *assertConnectionPinned
+      - &commitTransaction
+        name: commitTransaction
+        object: *session0
+    expectEvents:
+      - client: *client0
+        events:
+          - &insertStarted
+            commandStartedEvent:
+              commandName: insert
+          - *insertStarted
+          - *insertStarted
+          - *insertStarted
+          - *insertStarted
+          - *insertStarted
+          - &commitStarted
+            commandStartedEvent:
+              commandName: commitTransaction
+      - client: *client0
+        eventType: cmap
+        events:
+          # The connection is never checked back in.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+
+  - description: transaction can be committed multiple times
+    operations:
+      - *startTransaction
+      - *transactionalInsert
+      - *assertConnectionPinned
+      - *commitTransaction
+      - *assertConnectionPinned
+      - *commitTransaction
+      - *commitTransaction
+      - *commitTransaction
+      - *assertConnectionPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *commitStarted
+          - *commitStarted
+          - *commitStarted
+          - *commitStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+
+  - description: pinned connection is not released after a non-transient CRUD error
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              errorCode: &nonTransientErrorCode 51 # ManualInterventionRequired
+      - *startTransaction
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { x: 1 }
+          session: *session0
+        expectError: &nonTransientExpectedError
+          errorCode: *nonTransientErrorCode
+          errorLabelsOmit: [ TransientTransactionError ]
+      - *assertConnectionPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for setting the fail point.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the transactional insert.
+          - connectionCheckedOutEvent: {}
+
+  - description: pinned connection is not released after a non-transient commit error
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ commitTransaction ]
+              errorCode: *nonTransientErrorCode
+      - *startTransaction
+      - *transactionalInsert
+      - name: commitTransaction
+        object: *session0
+        expectError: *nonTransientExpectedError
+      - *assertConnectionPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *commitStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for setting the fail point.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the transactional insert and commit.
+          - connectionCheckedOutEvent: {}
+
+  # Errors during abort are different than errors during commit and CRUD operations because the pinned connection is
+  # always released after abort.
+  - description: pinned connection is released after a non-transient abort error
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ abortTransaction ]
+              errorCode: &nonTransientErrorCode 51 # ManualInterventionRequired
+      - *startTransaction
+      - *transactionalInsert
+      - name: abortTransaction
+        object: *session0
+      - &assertConnectionNotPinned
+        name: assertNumberConnectionsCheckedOut
+        object: testRunner
+        arguments:
+          client: *client0
+          connections: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - &abortStarted
+            commandStartedEvent:
+              commandName: abortTransaction
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for setting the fail point.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the transactional insert and abort.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connection is released after a transient non-network CRUD error
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              errorCode: &transientErrorCode 24 # LockTimeout
+      - *startTransaction
+      - <<: *transactionalInsert
+        expectError: &transientExpectedServerError
+          errorCode: *transientErrorCode
+          errorLabelsContain: [ TransientTransactionError ]
+      - *assertConnectionNotPinned
+      - name: abortTransaction
+        object: *session0
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *abortStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for setting the failpoint.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the insert.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for abortTransction.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connection is released after a transient network CRUD error
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ insert ]
+              closeConnection: true
+      - *startTransaction
+      - <<: *transactionalInsert
+        expectError: &transientExpectedNetworkError
+          isClientError: true
+          errorLabelsContain: [ TransientTransactionError ]
+      - *assertConnectionNotPinned
+      - name: abortTransaction
+        object: *session0
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *abortStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for setting the failpoint.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the insert.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent:
+              reason: error
+          # Events for abortTransaction
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connection is released after a transient non-network commit error
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ commitTransaction ]
+              errorCode: *transientErrorCode
+      - *startTransaction
+      - *transactionalInsert
+      - <<: *commitTransaction
+        expectError: *transientExpectedServerError
+      - *assertConnectionNotPinned
+      - *commitTransaction
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *commitStarted
+          - *commitStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for setting the failpoint.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the insert.
+          - connectionCheckedOutEvent: {}
+          # Events for first commitTransaction.
+          - connectionCheckedInEvent: {}
+          # Events for second commitTransaction.
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connection is released after a transient network commit error
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ commitTransaction ]
+              closeConnection: true
+      - *startTransaction
+      - *transactionalInsert
+      - <<: *commitTransaction
+        # Ignore the result and error because the operation might fail if it targets a new mongos that isn't aware of
+        # the transaction or the server-side reaper thread closes the transaction first. We only want to assert that
+        # the operation is retried, which is done via monitoring expectations, so the exact result/error is not
+        # necessary.
+        ignoreResultAndError: true
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *commitStarted
+          # The commit will be automatically retried.
+          - *commitStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for setting the failpoint.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the insert.
+          - connectionCheckedOutEvent: {}
+          # Events for the first commitTransaction.
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent:
+              reason: error
+          # Events for the commitTransaction retry.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connection is released after a transient non-network abort error
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ abortTransaction ]
+              errorCode: *transientErrorCode
+      - *startTransaction
+      - *transactionalInsert
+      - name: abortTransaction
+        object: *session0
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *abortStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for setting the failpoint.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the insert.
+          - connectionCheckedOutEvent: {}
+          # Events for abortTransaction.
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connection is released after a transient network abort error
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [ abortTransaction ]
+              closeConnection: true
+      - *startTransaction
+      - *transactionalInsert
+      - name: abortTransaction
+        object: *session0
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *abortStarted
+          # The abort will be automatically retried.
+          - *abortStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for setting the failpoint.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+          # Events for the insert.
+          - connectionCheckedOutEvent: {}
+          # Events for the first abortTransaction.
+          - connectionCheckedInEvent: {}
+          - connectionClosedEvent:
+              reason: error
+          # Events for the abortTransaction retry.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connection is released on successful abort
+    operations:
+      - *startTransaction
+      - *transactionalInsert
+      - name: abortTransaction
+        object: *session0
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *abortStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # The insert will create and pin a connection. The abort will use it and then unpin.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: pinned connection is returned when a new transaction is started
+    operations:
+      - *startTransaction
+      - *transactionalInsert
+      - *commitTransaction
+      - *assertConnectionPinned
+      - *startTransaction
+      - *assertConnectionNotPinned # startTransaction will unpin the connection.
+      - *transactionalInsert
+      - *assertConnectionPinned # The first operation in the new transaction will pin the connection again.
+      - *commitTransaction
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *commitStarted
+          - *insertStarted
+          - *commitStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for the first insert and commit.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          # Events for startTransaction.
+          - connectionCheckedInEvent: {}
+          # Events for the second insert and commit.
+          - connectionCheckedOutEvent: {}
+
+  - description: pinned connection is returned when a non-transaction operation uses the session
+    operations:
+      - *startTransaction
+      - *transactionalInsert
+      - *commitTransaction
+      - *assertConnectionPinned
+      - *transactionalInsert
+      # The insert is a non-transactional operation that uses the session, so it unpins the connection.
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - *commitStarted
+          - *insertStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for the first insert and commit.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          # Events for the second insert.
+          - connectionCheckedInEvent: {}
+          - connectionCheckedOutEvent: {}
+          - connectionCheckedInEvent: {}
+
+  - description: a connection can be shared by a transaction and a cursor
+    operations:
+      - *startTransaction
+      - *transactionalInsert
+      - *assertConnectionPinned
+      - name: createFindCursor
+        object: *collection0
+        arguments:
+          filter: {}
+          batchSize: 2
+          session: *session0
+        saveResultAsEntity: &cursor0 cursor0
+      - *assertConnectionPinned
+      - name: close
+        object: *cursor0
+      - *assertConnectionPinned
+      # Abort the transaction to ensure that the connection is unpinned.
+      - name: abortTransaction
+        object: *session0
+      - *assertConnectionNotPinned
+    expectEvents:
+      - client: *client0
+        events:
+          - *insertStarted
+          - commandStartedEvent:
+              commandName: find
+          - commandStartedEvent:
+              commandName: killCursors
+          - *abortStarted
+      - client: *client0
+        eventType: cmap
+        events:
+          # Events for the insert, find, and killCursors.
+          - connectionReadyEvent: {}
+          - connectionCheckedOutEvent: {}
+          # Events for abortTransaction.
+          - connectionCheckedInEvent: {}

--- a/source/load-balancers/tests/transactions.yml
+++ b/source/load-balancers/tests/transactions.yml
@@ -326,13 +326,10 @@ tests:
       - <<: *commitTransaction
         expectError: *transientExpectedServerError
       - *assertConnectionNotPinned
-      - *commitTransaction
-      - *assertConnectionNotPinned
     expectEvents:
       - client: *client0
         events:
           - *insertStarted
-          - *commitStarted
           - *commitStarted
       - client: *client0
         eventType: cmap
@@ -343,10 +340,7 @@ tests:
           - connectionCheckedInEvent: {}
           # Events for the insert.
           - connectionCheckedOutEvent: {}
-          # Events for first commitTransaction.
-          - connectionCheckedInEvent: {}
-          # Events for second commitTransaction.
-          - connectionCheckedOutEvent: {}
+          # Events for commitTransaction.
           - connectionCheckedInEvent: {}
 
   - description: pinned connection is released after a transient network commit error

--- a/source/load-balancers/tests/wait-queue-timeouts.json
+++ b/source/load-balancers/tests/wait-queue-timeouts.json
@@ -1,0 +1,153 @@
+{
+  "description": "wait queue timeout errors include details about checked out connections",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": true,
+        "uriOptions": {
+          "maxPoolSize": 1,
+          "waitQueueTimeoutMS": 5
+        },
+        "observeEvents": [
+          "connectionCheckedOutEvent",
+          "connectionCheckOutFailedEvent"
+        ]
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0Name"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "database0Name",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "wait queue timeout errors include cursor statistics",
+      "operations": [
+        {
+          "name": "createFindCursor",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "batchSize": 2
+          },
+          "saveResultAsEntity": "cursor0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true,
+            "errorContains": "maxPoolSize: 1, connections in use by cursors: 1, connections in use by transactions: 0, connections in use by other operations: 0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckOutFailedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "wait queue timeout errors include transaction statistics",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            },
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          },
+          "expectError": {
+            "isClientError": true,
+            "errorContains": "maxPoolSize: 1, connections in use by cursors: 0, connections in use by transactions: 1, connections in use by other operations: 0"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCheckedOutEvent": {}
+            },
+            {
+              "connectionCheckOutFailedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/load-balancers/tests/wait-queue-timeouts.yml
+++ b/source/load-balancers/tests/wait-queue-timeouts.yml
@@ -1,0 +1,82 @@
+description: wait queue timeout errors include details about checked out connections
+
+schemaVersion: '1.3'
+
+runOnRequirements:
+  - topologies: [ load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: true
+      uriOptions:
+        maxPoolSize: 1
+        waitQueueTimeoutMS: 5
+      observeEvents:
+        - connectionCheckedOutEvent
+        - connectionCheckOutFailedEvent
+  - session:
+      id: &session0 session0
+      client: *client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0Name
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - _id: 1
+      - _id: 2
+      - _id: 3
+
+tests:
+  - description: wait queue timeout errors include cursor statistics
+    operations:
+      - name: createFindCursor
+        object: *collection0
+        arguments:
+          filter: {}
+          batchSize: 2
+        saveResultAsEntity: &cursor0 cursor0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { x: 1 }
+        expectError:
+          isClientError: true
+          errorContains: 'maxPoolSize: 1, connections in use by cursors: 1, connections in use by transactions: 0, connections in use by other operations: 0'
+    expectEvents:
+      - client: *client0
+        eventType: cmap
+        events:
+          - connectionCheckedOutEvent: {}
+          - connectionCheckOutFailedEvent: {}
+
+  - description: wait queue timeout errors include transaction statistics
+    operations:
+      - name: startTransaction
+        object: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { x: 1 }
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { x: 1 }
+        expectError:
+          isClientError: true
+          errorContains: 'maxPoolSize: 1, connections in use by cursors: 0, connections in use by transactions: 1, connections in use by other operations: 0'
+    expectEvents:
+      - client: *client0
+        eventType: cmap
+        events:
+          - connectionCheckedOutEvent: {}
+          - connectionCheckOutFailedEvent: {}


### PR DESCRIPTION
This PR contains the YAML/JSON test files that were originally added in #935. They rely on the Unified Test Format changes that were merged into the `master` branch in https://github.com/mongodb/specifications/commit/ed4e62b48939378b814cbd7d9d4939a2c1076a6b.

I also added a README file describing how the cluster should be set up and what tests to run in scope of this PR. There were some modifications required to run existing tests (e.g. retryable reads/writes) against LB clusters but I didn't want to make this PR too large, so they are in #961.