### PR TITLE
DRIVERS-720 Change existing tests to run in LB mode

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -10,7 +10,7 @@ Change Streams
 :Type: Standards
 :Minimum Server Version: 3.6
 :Last Modified: April 23, 2021
-:Version: 1.9.1
+:Version: 1.9.2
 
 .. contents::
 
@@ -886,4 +886,6 @@ Changelog
 | 2021-02-08 | Added the ``UpdateDescription.truncatedArrays`` field      |
 +------------+------------------------------------------------------------+
 | 2021-04-23 | Updated to use modern terminology                          |
++------------+------------------------------------------------------------+
+| 2021-04-29 | Added ``load-balanced`` to test topology requirements      |
 +------------+------------------------------------------------------------+

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -49,7 +49,7 @@ Each YAML file has the following keys:
     - ``database``: Watch changes on database ``database_name``
     - ``client``: Watch changes on entire clusters
   - ``topology``: An array of server topologies against which to run the test.
-    Valid topologies are ``single``, ``replicaset``, and ``sharded``.
+    Valid topologies are ``single``, ``replicaset``, ``sharded``, and "load-balanced".
   - ``changeStreamPipeline``: An array of additional aggregation pipeline stages to add to the change stream
   - ``changeStreamOptions``: Additional options to add to the changeStream
   - ``operations``: Array of documents, each describing an operation. Each document has the following fields:

--- a/source/change-streams/tests/legacy/change-streams-errors.json
+++ b/source/change-streams/tests/legacy/change-streams-errors.json
@@ -78,7 +78,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [
         {
@@ -125,7 +126,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},

--- a/source/change-streams/tests/legacy/change-streams-errors.yml
+++ b/source/change-streams/tests/legacy/change-streams-errors.yml
@@ -57,6 +57,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline:
       -
         $project: { _id: 0 }
@@ -86,6 +87,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:

--- a/source/change-streams/tests/legacy/change-streams-resume-allowlist.json
+++ b/source/change-streams/tests/legacy/change-streams-resume-allowlist.json
@@ -20,7 +20,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},

--- a/source/change-streams/tests/legacy/change-streams-resume-allowlist.yml
+++ b/source/change-streams/tests/legacy/change-streams-resume-allowlist.yml
@@ -15,6 +15,7 @@ tests:
     topology: 
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:

--- a/source/change-streams/tests/legacy/change-streams-resume-errorLabels.json
+++ b/source/change-streams/tests/legacy/change-streams-resume-errorLabels.json
@@ -18,7 +18,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -111,7 +112,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -204,7 +206,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -297,7 +300,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -390,7 +394,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -483,7 +488,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -576,7 +582,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -669,7 +676,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -762,7 +770,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -855,7 +864,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -948,7 +958,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1041,7 +1052,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1134,7 +1146,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1227,7 +1240,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1320,7 +1334,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1413,7 +1428,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1512,7 +1528,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},
@@ -1608,7 +1625,8 @@
       "target": "collection",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "changeStreamPipeline": [],
       "changeStreamOptions": {},

--- a/source/change-streams/tests/legacy/change-streams-resume-errorLabels.yml
+++ b/source/change-streams/tests/legacy/change-streams-resume-errorLabels.yml
@@ -15,6 +15,7 @@ tests:
     topology: 
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -78,6 +79,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -141,6 +143,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -204,6 +207,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -267,6 +271,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -330,6 +335,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -393,6 +399,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -456,6 +463,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -519,6 +527,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -582,6 +591,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -645,6 +655,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -708,6 +719,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -771,6 +783,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -834,6 +847,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -897,6 +911,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -960,6 +975,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -1026,6 +1042,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:
@@ -1090,6 +1107,7 @@ tests:
     topology:
       - replicaset
       - sharded
+      - load-balanced
     changeStreamPipeline: []
     changeStreamOptions: {}
     operations:

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -74,9 +74,10 @@ Each YAML file has the following keys:
     version.
 
   - ``topology`` (optional): An array of server topologies against which the
-    tests can be run successfully. Valid topologies are "single", "replicaset",
-    and "sharded". If this field is omitted, the default is all topologies (i.e.
-    ``["single", "replicaset", "sharded"]``).
+    tests can be run successfully. Valid topologies are "single",
+    "replicaset", "sharded", and "load-balanced". If this field is omitted,
+    the default is all topologies (i.e. ``["single", "replicaset", "sharded",
+    "load-balanced"]``).
 
   - ``serverless``: Optional string. Whether or not the test should be run on
     serverless instances imitating sharded clusters. Valid values are "require",
@@ -229,3 +230,5 @@ Changelog
 :2020-09-16: Suggest lowering heartbeatFrequencyMS in addition to minHeartbeatFrequencyMS.
 
 :2021-03-23: Add prose test for retrying PoolClearedErrors
+
+:2021-04-29: Add ``load-balanced`` to test topology requirements.

--- a/source/retryable-reads/tests/aggregate-serverErrors.json
+++ b/source/retryable-reads/tests/aggregate-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/aggregate-serverErrors.yml
+++ b/source/retryable-reads/tests/aggregate-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/aggregate.json
+++ b/source/retryable-reads/tests/aggregate.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/aggregate.yml
+++ b/source/retryable-reads/tests/aggregate.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.json
+++ b/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "serverless": "forbid"
     }

--- a/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.yml
+++ b/source/retryable-reads/tests/changeStreams-client.watch-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
         serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"

--- a/source/retryable-reads/tests/changeStreams-client.watch.json
+++ b/source/retryable-reads/tests/changeStreams-client.watch.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "serverless": "forbid"
     }

--- a/source/retryable-reads/tests/changeStreams-client.watch.yml
+++ b/source/retryable-reads/tests/changeStreams-client.watch.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
         serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.json
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "serverless": "forbid"
     }

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.yml
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
         serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch.json
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "serverless": "forbid"
     }

--- a/source/retryable-reads/tests/changeStreams-db.coll.watch.yml
+++ b/source/retryable-reads/tests/changeStreams-db.coll.watch.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
         serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"

--- a/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.json
+++ b/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "serverless": "forbid"
     }

--- a/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.yml
+++ b/source/retryable-reads/tests/changeStreams-db.watch-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
         serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"

--- a/source/retryable-reads/tests/changeStreams-db.watch.json
+++ b/source/retryable-reads/tests/changeStreams-db.watch.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ],
       "serverless": "forbid"
     }

--- a/source/retryable-reads/tests/changeStreams-db.watch.yml
+++ b/source/retryable-reads/tests/changeStreams-db.watch.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
         serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"

--- a/source/retryable-reads/tests/count-serverErrors.json
+++ b/source/retryable-reads/tests/count-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/count-serverErrors.yml
+++ b/source/retryable-reads/tests/count-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/count.json
+++ b/source/retryable-reads/tests/count.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/count.yml
+++ b/source/retryable-reads/tests/count.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/countDocuments-serverErrors.json
+++ b/source/retryable-reads/tests/countDocuments-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/countDocuments-serverErrors.yml
+++ b/source/retryable-reads/tests/countDocuments-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/countDocuments.json
+++ b/source/retryable-reads/tests/countDocuments.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/countDocuments.yml
+++ b/source/retryable-reads/tests/countDocuments.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/distinct-serverErrors.json
+++ b/source/retryable-reads/tests/distinct-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/distinct-serverErrors.yml
+++ b/source/retryable-reads/tests/distinct-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/distinct.json
+++ b/source/retryable-reads/tests/distinct.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/distinct.yml
+++ b/source/retryable-reads/tests/distinct.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/find-serverErrors.json
+++ b/source/retryable-reads/tests/find-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/find-serverErrors.yml
+++ b/source/retryable-reads/tests/find-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/find.json
+++ b/source/retryable-reads/tests/find.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/find.yml
+++ b/source/retryable-reads/tests/find.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/findOne-serverErrors.json
+++ b/source/retryable-reads/tests/findOne-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/findOne-serverErrors.yml
+++ b/source/retryable-reads/tests/findOne-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/findOne.json
+++ b/source/retryable-reads/tests/findOne.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/findOne.yml
+++ b/source/retryable-reads/tests/findOne.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/gridfs-download-serverErrors.json
+++ b/source/retryable-reads/tests/gridfs-download-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/gridfs-download-serverErrors.yml
+++ b/source/retryable-reads/tests/gridfs-download-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/source/retryable-reads/tests/gridfs-download.json
+++ b/source/retryable-reads/tests/gridfs-download.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/gridfs-download.yml
+++ b/source/retryable-reads/tests/gridfs-download.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.json
+++ b/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.yml
+++ b/source/retryable-reads/tests/gridfs-downloadByName-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/source/retryable-reads/tests/gridfs-downloadByName.json
+++ b/source/retryable-reads/tests/gridfs-downloadByName.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/gridfs-downloadByName.yml
+++ b/source/retryable-reads/tests/gridfs-downloadByName.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 bucket_name: "fs"

--- a/source/retryable-reads/tests/listCollectionNames-serverErrors.json
+++ b/source/retryable-reads/tests/listCollectionNames-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listCollectionNames-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollectionNames-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollectionNames.json
+++ b/source/retryable-reads/tests/listCollectionNames.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listCollectionNames.yml
+++ b/source/retryable-reads/tests/listCollectionNames.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollectionObjects-serverErrors.json
+++ b/source/retryable-reads/tests/listCollectionObjects-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listCollectionObjects-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollectionObjects-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollectionObjects.json
+++ b/source/retryable-reads/tests/listCollectionObjects.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listCollectionObjects.yml
+++ b/source/retryable-reads/tests/listCollectionObjects.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollections-serverErrors.json
+++ b/source/retryable-reads/tests/listCollections-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listCollections-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollections-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listCollections.json
+++ b/source/retryable-reads/tests/listCollections.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listCollections.yml
+++ b/source/retryable-reads/tests/listCollections.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabaseNames-serverErrors.json
+++ b/source/retryable-reads/tests/listDatabaseNames-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listDatabaseNames-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabaseNames-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabaseNames.json
+++ b/source/retryable-reads/tests/listDatabaseNames.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listDatabaseNames.yml
+++ b/source/retryable-reads/tests/listDatabaseNames.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabaseObjects-serverErrors.json
+++ b/source/retryable-reads/tests/listDatabaseObjects-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listDatabaseObjects-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabaseObjects-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabaseObjects.json
+++ b/source/retryable-reads/tests/listDatabaseObjects.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listDatabaseObjects.yml
+++ b/source/retryable-reads/tests/listDatabaseObjects.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabases-serverErrors.json
+++ b/source/retryable-reads/tests/listDatabases-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listDatabases-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabases-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listDatabases.json
+++ b/source/retryable-reads/tests/listDatabases.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listDatabases.yml
+++ b/source/retryable-reads/tests/listDatabases.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listIndexNames-serverErrors.json
+++ b/source/retryable-reads/tests/listIndexNames-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listIndexNames-serverErrors.yml
+++ b/source/retryable-reads/tests/listIndexNames-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listIndexNames.json
+++ b/source/retryable-reads/tests/listIndexNames.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listIndexNames.yml
+++ b/source/retryable-reads/tests/listIndexNames.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listIndexes-serverErrors.json
+++ b/source/retryable-reads/tests/listIndexes-serverErrors.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listIndexes-serverErrors.yml
+++ b/source/retryable-reads/tests/listIndexes-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/listIndexes.json
+++ b/source/retryable-reads/tests/listIndexes.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/listIndexes.yml
+++ b/source/retryable-reads/tests/listIndexes.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-reads/tests/mapReduce.json
+++ b/source/retryable-reads/tests/mapReduce.json
@@ -10,7 +10,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-reads/tests/mapReduce.yml
+++ b/source/retryable-reads/tests/mapReduce.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["single", "replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -159,9 +159,10 @@ Each YAML file has the following keys:
     version.
 
   - ``topology`` (optional): An array of server topologies against which the
-    tests can be run successfully. Valid topologies are "single", "replicaset",
-    and "sharded". If this field is omitted, the default is all topologies (i.e.
-    ``["single", "replicaset", "sharded"]``).
+    tests can be run successfully. Valid topologies are "single",
+    "replicaset", "sharded", and "load-balanced". If this field is omitted,
+    the default is all topologies (i.e. ``["single", "replicaset", "sharded",
+    "load-balanced"]``).
 
 - ``data``: The data that should exist in the collection under test before each
   test run.
@@ -366,6 +367,8 @@ and sharded clusters.
 
 Changelog
 =========
+
+:2021-04-23: Add ``load-balanced`` to test topology requirements.
 
 :2021-03-24: Add prose test verifying ``PoolClearedErrors`` are retried.
 

--- a/source/retryable-writes/tests/bulkWrite-errorLabels.json
+++ b/source/retryable-writes/tests/bulkWrite-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/bulkWrite-errorLabels.yml
+++ b/source/retryable-writes/tests/bulkWrite-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/bulkWrite-serverErrors.json
+++ b/source/retryable-writes/tests/bulkWrite-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/bulkWrite-serverErrors.yml
+++ b/source/retryable-writes/tests/bulkWrite-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/deleteMany.json
+++ b/source/retryable-writes/tests/deleteMany.json
@@ -4,7 +4,8 @@
       "minServerVersion": "3.6",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/deleteMany.yml
+++ b/source/retryable-writes/tests/deleteMany.yml
@@ -1,7 +1,7 @@
 runOn:
     -
         minServerVersion: "3.6"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/deleteOne-errorLabels.json
+++ b/source/retryable-writes/tests/deleteOne-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/deleteOne-errorLabels.yml
+++ b/source/retryable-writes/tests/deleteOne-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/deleteOne-serverErrors.json
+++ b/source/retryable-writes/tests/deleteOne-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/deleteOne-serverErrors.yml
+++ b/source/retryable-writes/tests/deleteOne-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/findOneAndDelete-errorLabels.json
+++ b/source/retryable-writes/tests/findOneAndDelete-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/findOneAndDelete-errorLabels.yml
+++ b/source/retryable-writes/tests/findOneAndDelete-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/findOneAndDelete-serverErrors.json
+++ b/source/retryable-writes/tests/findOneAndDelete-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/findOneAndDelete-serverErrors.yml
+++ b/source/retryable-writes/tests/findOneAndDelete-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/findOneAndReplace-errorLabels.json
+++ b/source/retryable-writes/tests/findOneAndReplace-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/findOneAndReplace-errorLabels.yml
+++ b/source/retryable-writes/tests/findOneAndReplace-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/findOneAndReplace-serverErrors.json
+++ b/source/retryable-writes/tests/findOneAndReplace-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/findOneAndReplace-serverErrors.yml
+++ b/source/retryable-writes/tests/findOneAndReplace-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/findOneAndUpdate-errorLabels.json
+++ b/source/retryable-writes/tests/findOneAndUpdate-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/findOneAndUpdate-errorLabels.yml
+++ b/source/retryable-writes/tests/findOneAndUpdate-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/findOneAndUpdate-serverErrors.json
+++ b/source/retryable-writes/tests/findOneAndUpdate-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
+++ b/source/retryable-writes/tests/findOneAndUpdate-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/insertMany-errorLabels.json
+++ b/source/retryable-writes/tests/insertMany-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/insertMany-errorLabels.yml
+++ b/source/retryable-writes/tests/insertMany-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/insertMany-serverErrors.json
+++ b/source/retryable-writes/tests/insertMany-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/insertMany-serverErrors.yml
+++ b/source/retryable-writes/tests/insertMany-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/insertOne-errorLabels.json
+++ b/source/retryable-writes/tests/insertOne-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/insertOne-errorLabels.yml
+++ b/source/retryable-writes/tests/insertOne-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data: []
 

--- a/source/retryable-writes/tests/insertOne-serverErrors.json
+++ b/source/retryable-writes/tests/insertOne-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/insertOne-serverErrors.yml
+++ b/source/retryable-writes/tests/insertOne-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/replaceOne-errorLabels.json
+++ b/source/retryable-writes/tests/replaceOne-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/replaceOne-errorLabels.yml
+++ b/source/retryable-writes/tests/replaceOne-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/replaceOne-serverErrors.json
+++ b/source/retryable-writes/tests/replaceOne-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/replaceOne-serverErrors.yml
+++ b/source/retryable-writes/tests/replaceOne-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/updateMany.json
+++ b/source/retryable-writes/tests/updateMany.json
@@ -4,7 +4,8 @@
       "minServerVersion": "3.6",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/updateMany.yml
+++ b/source/retryable-writes/tests/updateMany.yml
@@ -1,7 +1,7 @@
 runOn:
     -
         minServerVersion: "3.6"
-        topology: ["replicaset", "sharded"]
+        topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/updateOne-errorLabels.json
+++ b/source/retryable-writes/tests/updateOne-errorLabels.json
@@ -4,7 +4,8 @@
       "minServerVersion": "4.3.1",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/updateOne-errorLabels.yml
+++ b/source/retryable-writes/tests/updateOne-errorLabels.yml
@@ -1,6 +1,6 @@
 runOn:
     - minServerVersion: "4.3.1"
-      topology: ["replicaset", "sharded"]
+      topology: ["replicaset", "sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/retryable-writes/tests/updateOne-serverErrors.json
+++ b/source/retryable-writes/tests/updateOne-serverErrors.json
@@ -9,7 +9,8 @@
     {
       "minServerVersion": "4.1.7",
       "topology": [
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/retryable-writes/tests/updateOne-serverErrors.yml
+++ b/source/retryable-writes/tests/updateOne-serverErrors.yml
@@ -4,7 +4,7 @@ runOn:
         topology: ["replicaset"]
     -
         minServerVersion: "4.1.7"
-        topology: ["sharded"]
+        topology: ["sharded", "load-balanced"]
 
 data:
     - { _id: 1, x: 11 }

--- a/source/versioned-api/tests/transaction-handling.json
+++ b/source/versioned-api/tests/transaction-handling.json
@@ -6,7 +6,8 @@
       "minServerVersion": "4.9",
       "topologies": [
         "replicaset",
-        "sharded-replicaset"
+        "sharded-replicaset",
+        "load-balanced"
       ]
     }
   ],
@@ -102,7 +103,8 @@
         {
           "topologies": [
             "replicaset",
-            "sharded-replicaset"
+            "sharded-replicaset",
+            "load-balanced"
           ]
         }
       ],
@@ -234,7 +236,8 @@
         {
           "topologies": [
             "replicaset",
-            "sharded-replicaset"
+            "sharded-replicaset",
+            "load-balanced"
           ]
         }
       ],
@@ -389,7 +392,8 @@
         {
           "topologies": [
             "replicaset",
-            "sharded-replicaset"
+            "sharded-replicaset",
+            "load-balanced"
           ]
         }
       ],

--- a/source/versioned-api/tests/transaction-handling.yml
+++ b/source/versioned-api/tests/transaction-handling.yml
@@ -4,7 +4,7 @@ schemaVersion: "1.1"
 
 runOnRequirements:
   - minServerVersion: "4.9"
-    topologies: [ replicaset, sharded-replicaset ]
+    topologies: [ replicaset, sharded-replicaset, load-balanced ]
 
 createEntities:
   - client:
@@ -50,7 +50,7 @@ initialData:
 tests:
   - description: "Only the first command in a transaction declares an API version"
     runOnRequirements:
-      - topologies: [ replicaset, sharded-replicaset ]
+      - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:
       - name: startTransaction
         object: *session
@@ -91,7 +91,7 @@ tests:
                 <<: *noApiVersion
   - description: "Committing a transaction twice does not append server API options"
     runOnRequirements:
-      - topologies: [ replicaset, sharded-replicaset ]
+      - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:
       - name: startTransaction
         object: *session
@@ -139,7 +139,7 @@ tests:
                 <<: *noApiVersion
   - description: "abortTransaction does not include an API version"
     runOnRequirements:
-      - topologies: [ replicaset, sharded-replicaset ]
+      - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:
       - name: startTransaction
         object: *session


### PR DESCRIPTION
This PR is related to 958 and modifies existing spec tests for versioned API, change streams, retryable reads, and retryable writes to run against load balancers. Most of these tests files predate the unified test format and have not been ported over yet, but all of the formats contain a `runOn` directive with a `topology` option. I modified any test that was already running against `sharded` topologies to also include `load-balanced` unless the test had a `maxServerVersion` < 5.0 because LB support will only be present in 5.0+ servers.