### PR TITLE
DRIVERS-720 small fix to unified test format changes for LB support

### DIFF
--- a/source/unified-test-format/tests/valid-pass/entity-find-cursor.json
+++ b/source/unified-test-format/tests/valid-pass/entity-find-cursor.json
@@ -166,7 +166,9 @@
               "commandSucceededEvent": {
                 "reply": {
                   "cursorsKilled": {
-                    "$$type": "array"
+                    "$$unsetorMatches": {
+                      "$$type": "array"
+                    }
                   }
                 },
                 "commandName": "killCursors"

--- a/source/unified-test-format/tests/valid-pass/entity-find-cursor.json
+++ b/source/unified-test-format/tests/valid-pass/entity-find-cursor.json
@@ -166,7 +166,7 @@
               "commandSucceededEvent": {
                 "reply": {
                   "cursorsKilled": {
-                    "$$unsetorMatches": {
+                    "$$unsetOrMatches": {
                       "$$type": "array"
                     }
                   }

--- a/source/unified-test-format/tests/valid-pass/entity-find-cursor.yml
+++ b/source/unified-test-format/tests/valid-pass/entity-find-cursor.yml
@@ -84,5 +84,6 @@ tests:
               commandName: killCursors
           - commandSucceededEvent:
               reply:
-                cursorsKilled: { $$unsetorMatches: { $$type: array } }
+                # No cursorsKilled field expected on pre-3.2 servers
+                cursorsKilled: { $$unsetOrMatches: { $$type: array } }
               commandName: killCursors

--- a/source/unified-test-format/tests/valid-pass/entity-find-cursor.yml
+++ b/source/unified-test-format/tests/valid-pass/entity-find-cursor.yml
@@ -84,5 +84,5 @@ tests:
               commandName: killCursors
           - commandSucceededEvent:
               reply:
-                cursorsKilled: { $$type: array }
+                cursorsKilled: { $$unsetorMatches: { $$type: array } }
               commandName: killCursors


### PR DESCRIPTION
Divjot, 

Java driver fails this type assertion on 2.6 and 3.0, since the cursorsKilled field isn't manufactured when translating from OP_KILL_CURSORS.  This changes works around that.  

How is Go driver dealing with this this?