### PR TITLE
DRIVERS-1633 Require using "hello" command with versioned API

### DIFF
--- a/source/message/OP_MSG.rst
+++ b/source/message/OP_MSG.rst
@@ -10,9 +10,9 @@ OP_MSG
 :Informed: Bryan Reinero, Chris Hendel, drivers@
 :Status: Approved
 :Type: Standards
-:Last Modified: 2021-04-06
+:Last Modified: 2021-04-20
 :Minimum Server Version: 3.6
-:Version: 1.2
+:Version: 1.3
 
 
 
@@ -51,7 +51,9 @@ Usage
 -----
 
 ``OP_MSG`` is only available in MongoDB 3.6 (``maxWireVersion >= 6``) and later.
-MongoDB drivers MUST continue to perform the MongoDB Handshake using ``OP_QUERY``
+MongoDB drivers SHOULD perform the MongoDB handshake using ``OP_MSG`` if an API
+version was declared on the client, but MAY decide to use ``OP_QUERY``. If no
+API version was declared, drivers MUST perform the handshake using ``OP_QUERY``
 to determine if the node supports ``OP_MSG``.
 
 If the node supports ``OP_MSG``, any and all messages MUST use ``OP_MSG``,
@@ -616,6 +618,7 @@ Q & A
 Changelog
 =========
 
+- 2021-04-20 Suggest using OP_MSG for initial handshake when using versioned API
 - 2021-04-06 Updated to use hello and not writable primary
 - 2017-11-12 Specify read preferences for OP_MSG with direct connection
 - 2017-08-17 Added the ``User originating command`` section

--- a/source/message/OP_MSG.rst
+++ b/source/message/OP_MSG.rst
@@ -52,9 +52,12 @@ Usage
 
 ``OP_MSG`` is only available in MongoDB 3.6 (``maxWireVersion >= 6``) and later.
 MongoDB drivers SHOULD perform the MongoDB handshake using ``OP_MSG`` if an API
-version was declared on the client, but MAY decide to use ``OP_QUERY``. If no
-API version was declared, drivers MUST perform the handshake using ``OP_QUERY``
-to determine if the node supports ``OP_MSG``.
+version was declared on the client, but MAY decide to use ``OP_QUERY``.
+
+If no API version was declared, drivers that support MognoDB 3.4 and earlier
+MUST perform the handshake using ``OP_QUERY`` to determine if the node supports
+``OP_MSG``. Drivers that only support MongoDB 3.6 and newer MAY default to using
+``OP_MSG``.
 
 If the node supports ``OP_MSG``, any and all messages MUST use ``OP_MSG``,
 optionally compressed with ``OP_COMPRESSED``.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -194,7 +194,7 @@ This test requires MongoDB 4.9.0+.
          configureFailPoint: "failCommand",
          mode: { times: 5 },
          data: {
-             failCommands: ["isMaster"],
+             failCommands: ["isMaster", "hello"],
              errorCode: 1234,
              appName: "SDAMMinHeartbeatFrequencyTest"
          }
@@ -231,7 +231,7 @@ MongoDB 4.2.9+.
          configureFailPoint: "failCommand",
          mode: { times: 2 },
          data: {
-             failCommands: ["isMaster"],
+             failCommands: ["isMaster", "hello"],
              errorCode: 1234,
              appName: "SDAMPoolManagementTest"
          }

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -8,8 +8,8 @@ Server Discovery And Monitoring
 :Advisors: David Golden, Craig Wilson
 :Status: Accepted
 :Type: Standards
-:Version: 2.30
-:Last Modified: 2021-04-12
+:Version: 2.31
+:Last Modified: 2021-05-03
 
 .. contents::
 
@@ -562,6 +562,11 @@ This replacement MUST happen even if the new server description compares equal
 to the previous one, in order to keep client-tracked attributes like last
 update time and round trip time up to date.
 
+Drivers MUST be able to handle responses to both ``hello`` and legacy hello
+commands. When checking results, drivers MUST first check for the
+``isWritablePrimary`` field and fall back to checking for an ``ismaster`` field
+if ``isWritablePrimary`` was not found.
+
 ServerDescriptions are created from ismaster outcomes as follows:
 
 type
@@ -588,7 +593,7 @@ are not replica set member states at all.
 +-------------------+---------------------------------------------------------------+
 | PossiblePrimary   | Not yet checked, but another member thinks it is the primary. |
 +-------------------+---------------------------------------------------------------+
-| RSPrimary         | "ismaster: true", "setName" in response.                      |
+| RSPrimary         | "isWritablePrimary: true", "setName" in response.             |
 +-------------------+---------------------------------------------------------------+
 | RSSecondary       | "secondary: true", "setName" in response.                     |
 +-------------------+---------------------------------------------------------------+
@@ -2501,6 +2506,10 @@ check. Synchronize pool clearing with SDAM updates.
 2021-2-11: Errors encountered during auth are handled by SDAM. Auth errors
 mark the server Unknown and clear the pool.
 
+2021-4-12: Adding in behaviour for load balancer mode.
+
+2021-05-03: Require parsing "isWritablePrimary" field in responses.
+
 .. Section for links.
 
 .. _connection string: http://docs.mongodb.org/manual/reference/connection-string/
@@ -2514,5 +2523,3 @@ mark the server Unknown and clear the pool.
 .. _Connection Monitoring and Pooling spec: /source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
 .. _CMAP spec: /source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
 .. _Authentication spec: /source/auth/auth.rst
-
-2021-4-12: Adding in behaviour for load balancer mode.

--- a/source/server-discovery-and-monitoring/tests/README.rst
+++ b/source/server-discovery-and-monitoring/tests/README.rst
@@ -424,7 +424,7 @@ Run the following test(s) on MongoDB 4.4+.
              configureFailPoint: "failCommand",
              mode: {times: 1000},
              data: {
-               failCommands: ["isMaster"],
+               failCommands: ["isMaster", "hello"],
                blockConnection: true,
                blockTimeMS: 500,
                appName: "streamingRttTest",

--- a/source/server-discovery-and-monitoring/tests/integration/connectTimeoutMS.json
+++ b/source/server-discovery-and-monitoring/tests/integration/connectTimeoutMS.json
@@ -42,7 +42,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "connectTimeoutMS=0",
                 "blockConnection": true,

--- a/source/server-discovery-and-monitoring/tests/integration/connectTimeoutMS.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/connectTimeoutMS.yml
@@ -33,7 +33,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: connectTimeoutMS=0
                 blockConnection: true
                 blockTimeMS: 550

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.json
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "commandErrorHandshakeTest",
           "closeConnection": false,
@@ -120,7 +121,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "commandErrorCheckTest",
                 "closeConnection": false,

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-          failCommands: ["isMaster"]
+          failCommands: ["isMaster", "hello"]
           appName: commandErrorHandshakeTest
           closeConnection: false
           errorCode: 91 # ShutdownInProgress
@@ -94,7 +94,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: commandErrorCheckTest
                 closeConnection: false
                 blockConnection: true

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.json
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "networkErrorHandshakeTest",
           "closeConnection": true
@@ -119,7 +120,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "networkErrorCheckTest",
                 "closeConnection": true

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-          failCommands: ["isMaster"]
+          failCommands: ["isMaster", "hello"]
           appName: networkErrorHandshakeTest
           closeConnection: true
     clientOptions:
@@ -93,7 +93,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: networkErrorCheckTest
                 closeConnection: true
       # The network error on the next check should mark the server Unknown and

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-timeout.json
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-timeout.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "timeoutMonitorHandshakeTest",
           "blockConnection": true,
@@ -120,7 +121,8 @@
               },
               "data": {
                 "failCommands": [
-                  "isMaster"
+                  "isMaster",
+                  "hello"
                 ],
                 "appName": "timeoutMonitorCheckTest",
                 "blockConnection": true,

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-timeout.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-timeout.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { times: 2 }
       data:
-          failCommands: ["isMaster"]
+          failCommands: ["isMaster", "hello"]
           appName: timeoutMonitorHandshakeTest
           blockConnection: true
           blockTimeMS: 1000
@@ -93,7 +93,7 @@ tests:
             configureFailPoint: failCommand
             mode: { times: 2 }
             data:
-                failCommands: ["isMaster"]
+                failCommands: ["isMaster", "hello"]
                 appName: timeoutMonitorCheckTest
                 blockConnection: true
                 # blockTimeMS is evaluated after the waiting for heartbeatFrequencyMS server-side, so this value only

--- a/source/server-discovery-and-monitoring/tests/integration/minPoolSize-error.json
+++ b/source/server-discovery-and-monitoring/tests/integration/minPoolSize-error.json
@@ -17,7 +17,8 @@
         },
         "data": {
           "failCommands": [
-            "isMaster"
+            "isMaster",
+            "hello"
           ],
           "appName": "SDAMminPoolSizeError",
           "closeConnection": true

--- a/source/server-discovery-and-monitoring/tests/integration/minPoolSize-error.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/minPoolSize-error.yml
@@ -16,7 +16,7 @@ tests:
       configureFailPoint: failCommand
       mode: { skip: 3 }
       data:
-        failCommands: ["isMaster"]
+        failCommands: ["isMaster", "hello"]
         appName: SDAMminPoolSizeError
         closeConnection: true
     clientOptions:

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -172,7 +172,7 @@ API versioning options if the user did not specify them.
 Handshake behavior
 ~~~~~~~~~~~~~~~~~~
 
-if an API version was declared, drivers MUST NOT use the legacy hello command
+If an API version was declared, drivers MUST NOT use the legacy hello command
 during the initial handshake or afterwards. Instead, drivers MUST use the
 ``hello`` command exclusively. If the server does not support ``hello``, the
 server description MUST reflect this with an ``Unknown`` server type.

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -172,11 +172,10 @@ API versioning options if the user did not specify them.
 Handshake behavior
 ~~~~~~~~~~~~~~~~~~
 
-Since the legacy hello command is not part of the versioned API, drivers MUST
-NOT use this command during the initial handshake or afterwards. Instead,
-drivers MUST use the ``hello`` command exclusively. If the server does not
-support ``hello``, the server description MUST reflect this with an ``unknown``
-server type.
+if an API version was declared, drivers MUST NOT use the legacy hello command
+during the initial handshake or afterwards. Instead, drivers MUST use the
+``hello`` command exclusively. If the server does not support ``hello``, the
+server description MUST reflect this with an ``Unknown`` server type.
 
 
 Cursors

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -3,13 +3,13 @@ Versioned API For Drivers
 =========================
 
 :Spec Title: Versioned API For Drivers
-:Spec Version: 1.0.1
+:Spec Version: 1.1.0
 :Author: Andreas Braun
 :Advisors: Jeff Yemin, A. Jesse Jiryu Davis, Patrick Freed, Oleg Pudeyev
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-04-10
+:Last Modified: 2021-04-20
 
 .. contents::
 
@@ -169,6 +169,16 @@ the specified value is equal to the server default. Drivers MUST NOT add any
 API versioning options if the user did not specify them.
 
 
+Handshake behavior
+~~~~~~~~~~~~~~~~~~
+
+Since the legacy hello command is not part of the versioned API, drivers MUST
+NOT use this command during the initial handshake or afterwards. Instead,
+drivers MUST use the ``hello`` command exclusively. If the server does not
+support ``hello``, the server description MUST reflect this with an ``unknown``
+server type.
+
+
 Cursors
 ~~~~~~~
 
@@ -286,4 +296,6 @@ versioned API. This is not covered in this specification.
 
 Change Log
 ==========
+
+* 2021-04-20: Require using ``hello`` when using the versioned API
 * 2021-04-10: Replaced usages of ``acceptAPIVersion2`` with ``acceptApiVersion2``.


### PR DESCRIPTION
The legacy hello command will not be part of API Version 1. This requires drivers to exclusively use "hello" when an API Version is declared (as any server that supports the Versioned API is also expected to support "hello"). In the case that users misconfigure their clients and declare an API Version when connecting to servers that don't support "hello", the server type is expected to be "unknown", eventually triggering errors.

Note that the "Remove oppressive language" project will change the usage of hello vs. legacy hello when not using the Versioned API.

I previously considered requiring using `OP_MSG` with the Versioned API, as all servers that would support "hello" also support `OP_MSG`. However, while building the implementation in libmongoc I realised that this may cause significant workload for drivers, so I removed the requirement. Instead, the handshake spec allows for using `OP_MSG` for the initial handshake using "hello" but does not require it. This requirement will be added in a separate step after the 5.0 release.