### PR TITLE
DRIVERS-1293: Added hello to the list of fail points where needed in …

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.json
@@ -14,7 +14,8 @@
     },
     "data": {
       "failCommands": [
-        "isMaster"
+        "isMaster",
+        "hello"
       ],
       "closeConnection": false,
       "blockConnection": true,

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-is-enforced.yml
@@ -10,7 +10,7 @@ failPoint:
   # high amount to ensure not interfered with by monitor checks.
   mode: { times: 50 }
   data:
-    failCommands: ["isMaster"]
+    failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.json
@@ -14,7 +14,8 @@
     },
     "data": {
       "failCommands": [
-        "isMaster"
+        "isMaster",
+        "hello"
       ],
       "closeConnection": false,
       "blockConnection": true,

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-maxConnecting-timeout.yml
@@ -10,7 +10,7 @@ failPoint:
   # high amount to ensure not interfered with by monitor checks.
   mode: { times: 50 }
   data:
-    failCommands: ["isMaster"]
+    failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.json
@@ -14,7 +14,8 @@
     },
     "data": {
       "failCommands": [
-        "isMaster"
+        "isMaster",
+        "hello"
       ],
       "closeConnection": false,
       "blockConnection": true,

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-returned-connection-maxConnecting.yml
@@ -10,7 +10,7 @@ failPoint:
   # high amount to ensure not interfered with by monitor checks.
   mode: { times: 50 }
   data:
-    failCommands: ["isMaster"]
+    failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.json
@@ -14,7 +14,8 @@
     },
     "data": {
       "failCommands": [
-        "isMaster"
+        "isMaster",
+        "hello"
       ],
       "appName": "poolCreateMinSizeErrorTest",
       "closeConnection": true

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.yml
@@ -10,7 +10,7 @@ failPoint:
   # high amount to ensure not interfered with by monitor checks.
   mode: { times: 50 }
   data:
-    failCommands: ["isMaster"]
+    failCommands: ["isMaster","hello"]
     closeConnection: true
     appName: "poolCreateMinSizeErrorTest"
 poolOptions:


### PR DESCRIPTION
There were no changes required to the CMAP spec for deprecated language, but the failpoints in certain tests needed `hello` added to them. Without these additional failpoints, these tests will fail when drivers start using `hello` for heartbeats to supporting servers.