### PR TITLE
Set the `minServerVersion` requirement to 4.9 in isMaster-network/command-error tests

### DIFF
--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.json
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.4"
+      "minServerVersion": "4.9"
     }
   ],
   "database_name": "sdam-tests",

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-command-error.yml
@@ -1,7 +1,7 @@
 # Test SDAM error handling.
 runOn:
     # failCommand appName requirements
-    - minServerVersion: "4.4"
+    - minServerVersion: "4.9"
 
 database_name: &database_name "sdam-tests"
 collection_name: &collection_name "isMaster-command-error"

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.json
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.4"
+      "minServerVersion": "4.9"
     }
   ],
   "database_name": "sdam-tests",

--- a/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.yml
+++ b/source/server-discovery-and-monitoring/tests/integration/isMaster-network-error.yml
@@ -1,7 +1,7 @@
 # Test SDAM error handling.
 runOn:
     # failCommand appName requirements
-    - minServerVersion: "4.4"
+    - minServerVersion: "4.9"
 
 database_name: &database_name "sdam-tests"
 collection_name: &collection_name "isMaster-network-error"


### PR DESCRIPTION
The complete explanation is in DRIVERS-1722. In short, this change is related to the fact that servers <4.9 do not activate fail points configured with `appName`.

DRIVERS-1722