### PR TITLE
[CMAP] A pool must emit PoolReadyEvent before resuming the background thread

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -416,8 +416,12 @@ method MUST immediately return and MUST NOT emit a PoolReadyEvent.
 .. code::
 
    mark pool as "ready"
-   resume background thread
    emit PoolReadyEvent
+   resume background thread
+
+Note that resuming the background thread after emitting PoolReadyEvent is of the essence,
+and it must be the case that no observer is able to observe actions of the background thread
+related to creating new connections before observing the PoolReadyEvent event.
 
 Creating a Connection (Internal Implementation)
 -----------------------------------------------


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1726