### PR TITLE
DRIVERS-1720 Require passing Versioned API options to getMore and transaction-continuing commands

### DIFF
--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -656,7 +656,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",

--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -717,14 +717,10 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
+                  "apiStrict": true,
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -244,7 +244,7 @@ tests:
                   - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
-  - description: "find command with declared API version appends to the command, but getMore does not"
+  - description: "find and getMore append API version"
     operations:
       - name: find
         object: *collection

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -268,9 +268,7 @@ tests:
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                apiVersion: { $$exists: false }
-                apiStrict: { $$exists: false }
-                apiDeprecationErrors: { $$exists: false }
+                <<: *expectedApiVersion
 
   - description: "findOneAndDelete appends declared API version"
     operations:

--- a/source/versioned-api/tests/crud-api-version-1.json
+++ b/source/versioned-api/tests/crud-api-version-1.json
@@ -648,7 +648,7 @@
       ]
     },
     {
-      "description": "find command with declared API version appends to the command, but getMore does not",
+      "description": "find and getMore append API version",
       "operations": [
         {
           "name": "find",

--- a/source/versioned-api/tests/crud-api-version-1.json
+++ b/source/versioned-api/tests/crud-api-version-1.json
@@ -709,15 +709,11 @@
                       "long"
                     ]
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
+                  "apiDeprecationErrors": true
                 }
               }
             }

--- a/source/versioned-api/tests/crud-api-version-1.yml
+++ b/source/versioned-api/tests/crud-api-version-1.yml
@@ -262,9 +262,7 @@ tests:
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
-                apiVersion: { $$exists: false }
-                apiStrict: { $$exists: false }
-                apiDeprecationErrors: { $$exists: false }
+                <<: *expectedApiVersion
 
   - description: "findOneAndDelete appends declared API version"
     operations:

--- a/source/versioned-api/tests/crud-api-version-1.yml
+++ b/source/versioned-api/tests/crud-api-version-1.yml
@@ -238,7 +238,7 @@ tests:
                   - $group: { _id: 1, n: { $sum: $count }}
                 <<: *expectedApiVersion
 
-  - description: "find command with declared API version appends to the command, but getMore does not"
+  - description: "find and getMore append API version"
     operations:
       - name: find
         object: *collection

--- a/source/versioned-api/tests/transaction-handling.json
+++ b/source/versioned-api/tests/transaction-handling.json
@@ -87,7 +87,7 @@
   ],
   "tests": [
     {
-      "description": "All commands in a transaction declares an API version",
+      "description": "All commands in a transaction declare an API version",
       "runOnRequirements": [
         {
           "topologies": [

--- a/source/versioned-api/tests/transaction-handling.json
+++ b/source/versioned-api/tests/transaction-handling.json
@@ -54,17 +54,6 @@
         "apiDeprecationErrors": {
           "$$unsetOrMatches": false
         }
-      },
-      {
-        "apiVersion": {
-          "$$exists": false
-        },
-        "apiStrict": {
-          "$$exists": false
-        },
-        "apiDeprecationErrors": {
-          "$$exists": false
-        }
       }
     ]
   },
@@ -98,7 +87,7 @@
   ],
   "tests": [
     {
-      "description": "Only the first command in a transaction declares an API version",
+      "description": "All commands in a transaction declares an API version",
       "runOnRequirements": [
         {
           "topologies": [
@@ -195,120 +184,6 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "Committing a transaction twice does not append server API options",
-      "runOnRequirements": [
-        {
-          "topologies": [
-            "replicaset",
-            "sharded-replicaset",
-            "load-balanced"
-          ]
-        }
-      ],
-      "operations": [
-        {
-          "name": "startTransaction",
-          "object": "session"
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 6,
-              "x": 66
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 6
-              }
-            }
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "session": "session",
-            "document": {
-              "_id": 7,
-              "x": 77
-            }
-          },
-          "expectResult": {
-            "$$unsetOrMatches": {
-              "insertedId": {
-                "$$unsetOrMatches": 7
-              }
-            }
-          }
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        },
-        {
-          "name": "commitTransaction",
-          "object": "session"
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 6,
-                      "x": 66
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "startTransaction": true,
                   "apiVersion": "1",
                   "apiStrict": {
                     "$$unsetOrMatches": false
@@ -322,62 +197,16 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "insert": "test",
-                  "documents": [
-                    {
-                      "_id": 7,
-                      "x": 77
-                    }
-                  ],
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
                   "commitTransaction": 1,
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "commitTransaction": 1,
-                  "lsid": {
-                    "$$sessionLsid": "session"
-                  },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
-                  "apiStrict": {
-                    "$$exists": false
-                  },
-                  "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -387,7 +216,7 @@
       ]
     },
     {
-      "description": "abortTransaction does not include an API version",
+      "description": "abortTransaction includes an API version",
       "runOnRequirements": [
         {
           "topologies": [
@@ -484,14 +313,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }
@@ -503,14 +330,12 @@
                   "lsid": {
                     "$$sessionLsid": "session"
                   },
-                  "apiVersion": {
-                    "$$exists": false
-                  },
+                  "apiVersion": "1",
                   "apiStrict": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   },
                   "apiDeprecationErrors": {
-                    "$$exists": false
+                    "$$unsetOrMatches": false
                   }
                 }
               }

--- a/source/versioned-api/tests/transaction-handling.yml
+++ b/source/versioned-api/tests/transaction-handling.yml
@@ -44,7 +44,7 @@ initialData:
       - { _id: 5, x: 55 }
 
 tests:
-  - description: "All commands in a transaction declares an API version"
+  - description: "All commands in a transaction declare an API version"
     runOnRequirements:
       - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:

--- a/source/versioned-api/tests/transaction-handling.yml
+++ b/source/versioned-api/tests/transaction-handling.yml
@@ -31,10 +31,6 @@ _yamlAnchors:
       apiVersion: "1"
       apiStrict: { $$unsetOrMatches: false }
       apiDeprecationErrors: { $$unsetOrMatches: false }
-    - &noApiVersion
-      apiVersion: { $$exists: false }
-      apiStrict: { $$exists: false }
-      apiDeprecationErrors: { $$exists: false }
 
 
 initialData:
@@ -48,7 +44,7 @@ initialData:
       - { _id: 5, x: 55 }
 
 tests:
-  - description: "Only the first command in a transaction declares an API version"
+  - description: "All commands in a transaction declares an API version"
     runOnRequirements:
       - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:
@@ -83,61 +79,13 @@ tests:
                 insert: *collectionName
                 documents: [ { _id: 7, x: 77 } ]
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
-                commitTransaction: 1
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-  - description: "Committing a transaction twice does not append server API options"
-    runOnRequirements:
-      - topologies: [ replicaset, sharded-replicaset, load-balanced ]
-    operations:
-      - name: startTransaction
-        object: *session
-      - name: insertOne
-        object: *collection
-        arguments:
-          session: *session
-          document: { _id: 6, x: 66 }
-        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 6 } } }
-      - name: insertOne
-        object: *collection
-        arguments:
-          session: *session
-          document: { _id: 7, x: 77 }
-        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 7 } } }
-      - name: commitTransaction
-        object: *session
-      - name: commitTransaction
-        object: *session
-    expectEvents:
-      - client: *client
-        events:
-          - commandStartedEvent:
-              command:
-                insert: *collectionName
-                documents: [ { _id: 6, x: 66 } ]
-                lsid: { $$sessionLsid: *session }
-                startTransaction: true
                 <<: *expectedApiVersion
           - commandStartedEvent:
               command:
-                insert: *collectionName
-                documents: [ { _id: 7, x: 77 } ]
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
                 commitTransaction: 1
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-          - commandStartedEvent:
-              command:
-                commitTransaction: 1
-                lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
-  - description: "abortTransaction does not include an API version"
+                <<: *expectedApiVersion
+  - description: "abortTransaction includes an API version"
     runOnRequirements:
       - topologies: [ replicaset, sharded-replicaset, load-balanced ]
     operations:
@@ -172,9 +120,9 @@ tests:
                 insert: *collectionName
                 documents: [ { _id: 7, x: 77 } ]
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
+                <<: *expectedApiVersion
           - commandStartedEvent:
               command:
                 abortTransaction: 1
                 lsid: { $$sessionLsid: *session }
-                <<: *noApiVersion
+                <<: *expectedApiVersion

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -192,8 +192,9 @@ reply with an error.
 Transactions
 ~~~~~~~~~~~~
 
-When running commands as part of a transaction, drivers MUST send API parameters
-with all commands that are part of a transaction. If the API parameters for a
+When running commands as part of a transaction, drivers MUST send API
+parameters with all commands that are part of a transaction, including
+``commitTransaction`` and ``abortTransaction``. If the API parameters for a
 command in a transaction do not match those of the transaction-starting command,
 the server will reply with an error.
 

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -3,13 +3,13 @@ Versioned API For Drivers
 =========================
 
 :Spec Title: Versioned API For Drivers
-:Spec Version: 1.1.0
+:Spec Version: 1.2.0
 :Author: Andreas Braun
 :Advisors: Jeff Yemin, A. Jesse Jiryu Davis, Patrick Freed, Oleg Pudeyev
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-04-20
+:Last Modified: 2021-05-05
 
 .. contents::
 
@@ -167,6 +167,9 @@ every command that is sent to a server. Drivers MUST add the ``apiStrict`` and
 ``apiDeprecationErrors`` options if they were specified by the user, even when
 the specified value is equal to the server default. Drivers MUST NOT add any
 API versioning options if the user did not specify them.
+This includes the ``getMore`` command as well as all commands that are part of a
+transaction. A previous version of this specification excluded those commands,
+but that has since changed in the server.
 
 
 Handshake behavior
@@ -181,20 +184,18 @@ server description MUST reflect this with an ``Unknown`` server type.
 Cursors
 ~~~~~~~
 
-The ``getMore`` command does not accept API parameters; cursors inherit their
-API parameters from the initiating command. Drivers MUST NOT include API
-parameters when sending ``getMore`` commands to the server.
-
-In contrast, the ``killCursors`` command accepts API parameters and drivers MUST
-include them as they would with all other commands.
+For ``getMore``, drivers MUST submit API parameters. If the values given do not
+match the API parameters given in the cursor-initiating command, the server will
+reply with an error.
 
 
 Transactions
 ~~~~~~~~~~~~
 
-When running commands as part of a transaction, drivers MUST NOT send API
-parameters after the initial command that includes the ``startTransaction``
-option.
+When running commands as part of a transaction, drivers MUST send API parameters
+with all commands that are part of a transaction. If the API parameters for a
+command in a transaction do not match those of the transaction-starting command,
+the server will reply with an error.
 
 
 Generic command helper
@@ -296,5 +297,7 @@ versioned API. This is not covered in this specification.
 Change Log
 ==========
 
-* 2021-04-20: Require using ``hello`` when using the versioned API
+* 2021-05-05: Require sending versioned API parameters with ``getMore`` and
+  transaction-continuing commands.
+* 2021-04-20: Require using ``hello`` when using the versioned API.
 * 2021-04-10: Replaced usages of ``acceptAPIVersion2`` with ``acceptApiVersion2``.


### PR DESCRIPTION
DRIVERS-1720

The server already allows passing Versioned API options to transaction-continuing commands (see https://github.com/mongodb/mongo/commit/4aa27885874b90e098c1225fccb10f4daa3b3d38), and ``getMore`` will get the same treatment soon. The server will require these options no later than RC0, so we can already make the spec change.

Note that drivers implementing this will have to wait until the latest build includes the commit above as well as the commit to change ``getMore`` behaviour.