### PR TITLE
DRIVERS-1739 Fix broken aggregation test

### DIFF
--- a/source/crud/tests/unified/aggregate.json
+++ b/source/crud/tests/unified/aggregate.json
@@ -42,6 +42,18 @@
         {
           "_id": 3,
           "x": 33
+        },
+        {
+          "_id": 4,
+          "x": 44
+        },
+        {
+          "_id": 5,
+          "x": 55
+        },
+        {
+          "_id": 6,
+          "x": 66
         }
       ]
     }
@@ -62,7 +74,7 @@
                 }
               }
             ],
-            "batchSize": 1
+            "batchSize": 2
           },
           "object": "collection0",
           "expectResult": [
@@ -73,6 +85,18 @@
             {
               "_id": 3,
               "x": 33
+            },
+            {
+              "_id": 4,
+              "x": 44
+            },
+            {
+              "_id": 5,
+              "x": 55
+            },
+            {
+              "_id": 6,
+              "x": 66
             }
           ]
         }
@@ -95,7 +119,7 @@
                     }
                   ],
                   "cursor": {
-                    "batchSize": 1
+                    "batchSize": 2
                   }
                 },
                 "commandName": "aggregate",
@@ -112,7 +136,7 @@
                     ]
                   },
                   "collection": "coll0",
-                  "batchSize": 1
+                  "batchSize": 2
                 },
                 "commandName": "getMore",
                 "databaseName": "aggregate-tests"
@@ -128,7 +152,7 @@
                     ]
                   },
                   "collection": "coll0",
-                  "batchSize": 1
+                  "batchSize": 2
                 },
                 "commandName": "getMore",
                 "databaseName": "aggregate-tests"

--- a/source/crud/tests/unified/aggregate.yml
+++ b/source/crud/tests/unified/aggregate.yml
@@ -23,6 +23,9 @@ initialData:
       - { _id: 1, x: 11 }
       - { _id: 2, x: 22 }
       - { _id: 3, x: 33 }
+      - { _id: 4, x: 44 }
+      - { _id: 5, x: 55 }
+      - { _id: 6, x: 66 }
 
 tests:
   - description: "aggregate with multiple batches works"
@@ -30,11 +33,14 @@ tests:
       - name: aggregate
         arguments:
           pipeline: [ { $match: { _id: { $gt: 1 } }} ]
-          batchSize: 1
+          batchSize: 2
         object: *collection0
         expectResult:
           - { _id: 2, x: 22 }
           - { _id: 3, x: 33 }
+          - { _id: 4, x: 44 }
+          - { _id: 5, x: 55 }
+          - { _id: 6, x: 66 }
     expectEvents:
       - client: *client0
         events:
@@ -42,21 +48,21 @@ tests:
               command:
                 aggregate: *collection0Name
                 pipeline: [ { $match: { _id: { $gt: 1 } }} ]
-                cursor: { batchSize: 1 }
+                cursor: { batchSize: 2 }
               commandName: aggregate
               databaseName: *database0Name
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
-                batchSize: 1
+                batchSize: 2
               commandName: getMore
               databaseName: *database0Name
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
-                batchSize: 1
+                batchSize: 2
               commandName: getMore
               databaseName: *database0Name
 


### PR DESCRIPTION
DRIVERS-1739

This PR fixes the "aggregate with multiple batches works" test in `unified/aggregate.yml` test by updating it to match the "find with multiple batches works" test in `unified/find.yml`, hopefully fixing this for good. The latter uses an odd number of result documents with a batch size of 2, which should make it so that regardless of whether the server requires an extra round trip at the end of the results, the test should still work. I've tested in on 3.6+ standalones and it seems to work on all those versions.