### PR TITLE
DRIVERS-1754: Restore old unified test format schema versions

### DIFF
--- a/source/unified-test-format/schema-1.0.json
+++ b/source/unified-test-format/schema-1.0.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "Unified Test Format",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["description", "schemaVersion", "tests"],
+  "properties": {
+    "description": { "type": "string" },
+    "schemaVersion": { "$ref": "#/definitions/version" },
+    "runOnRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/runOnRequirement" }
+    },
+    "createEntities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/entity" }
+    },
+    "initialData": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/collectionData" }
+    },
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/test" }
+    }
+  },
+
+  "definitions": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+    },
+
+    "runOnRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "maxServerVersion": { "$ref": "#/definitions/version" },
+        "minServerVersion": { "$ref": "#/definitions/version" },
+        "topologies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["single", "replicaset", "sharded", "sharded-replicaset"]
+          }
+        }
+      }
+    },
+
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "client": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id"],
+          "properties": {
+            "id": { "type": "string" },
+            "uriOptions": { "type": "object" },
+            "useMultipleMongoses": { "type": "boolean" },
+            "observeEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": ["commandStartedEvent", "commandSucceededEvent", "commandFailedEvent"]
+              }
+            },
+            "ignoreCommandMonitoringEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client", "databaseName"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "databaseOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database", "collectionName"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "collectionName": { "type": "string" },
+            "collectionOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "sessionOptions": { "type": "object" }
+          }
+        },
+        "bucket": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "bucketOptions": { "type": "object" }
+          }
+        }
+      }
+    },
+
+    "collectionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collectionName", "databaseName", "documents"],
+      "properties": {
+        "collectionName": { "type": "string" },
+        "databaseName": { "type": "string" },
+        "documents": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+
+    "expectedEventsForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["client", "events"],
+      "properties": {
+        "client": { "type": "string" },
+        "events": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/expectedEvent" }
+        }
+      }
+    },
+
+    "expectedEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "commandStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": { "type": "object" },
+            "commandName": { "type": "string" },
+            "databaseName": { "type": "string" }
+          }
+        },
+        "commandSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reply": { "type": "object" },
+            "commandName": { "type": "string" }
+          }
+        },
+        "commandFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "commandName": { "type": "string" }
+          }
+        }
+      }
+    },
+
+    "collectionOrDatabaseOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readConcern": { "type": "object" },
+        "readPreference": { "type": "object" },
+        "writeConcern": { "type": "object" }
+      }
+    },
+
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "object"],
+      "properties": {
+        "name": { "type": "string" },
+        "object": { "type": "string" },
+        "arguments": { "type": "object" },
+        "expectError":  { "$ref": "#/definitions/expectedError" },
+        "expectResult": {},
+        "saveResultAsEntity": { "type": "string" }
+      },
+      "allOf": [
+        { "not": { "required": ["expectError", "expectResult"] } },
+        { "not": { "required": ["expectError", "saveResultAsEntity"] } }
+      ]
+    },
+
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "isError": {
+          "type": "boolean",
+          "const": true
+        },
+        "isClientError": { "type": "boolean" },
+        "errorContains": { "type": "string" },
+        "errorCode": { "type": "integer" },
+        "errorCodeName": { "type": "string" },
+        "errorLabelsContain": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "errorLabelsOmit": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "expectResult": {}
+      }
+    },
+
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "operations"],
+      "properties": {
+        "description": { "type": "string" },
+        "runOnRequirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/runOnRequirement" }
+        },
+        "skipReason": { "type": "string" },
+        "operations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/operation" }
+        },
+        "expectEvents": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/expectedEventsForClient" }
+        },
+        "outcome": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/collectionData" }
+        }
+      }
+    }
+  }
+}

--- a/source/unified-test-format/schema-1.1.json
+++ b/source/unified-test-format/schema-1.1.json
@@ -1,0 +1,294 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "Unified Test Format",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["description", "schemaVersion", "tests"],
+  "properties": {
+    "description": { "type": "string" },
+    "schemaVersion": { "$ref": "#/definitions/version" },
+    "runOnRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/runOnRequirement" }
+    },
+    "createEntities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/entity" }
+    },
+    "initialData": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/collectionData" }
+    },
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/test" }
+    },
+    "_yamlAnchors": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+
+  "definitions": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+    },
+
+    "runOnRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "maxServerVersion": { "$ref": "#/definitions/version" },
+        "minServerVersion": { "$ref": "#/definitions/version" },
+        "topologies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["single", "replicaset", "sharded", "sharded-replicaset"]
+          }
+        },
+        "serverParameters": {
+          "type": "object",
+          "minProperties": 1
+        }
+      }
+    },
+
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "client": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id"],
+          "properties": {
+            "id": { "type": "string" },
+            "uriOptions": { "type": "object" },
+            "useMultipleMongoses": { "type": "boolean" },
+            "observeEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": ["commandStartedEvent", "commandSucceededEvent", "commandFailedEvent"]
+              }
+            },
+            "ignoreCommandMonitoringEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            },
+            "serverApi": { "$ref":  "#/definitions/serverApi" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client", "databaseName"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "databaseOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database", "collectionName"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "collectionName": { "type": "string" },
+            "collectionOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "sessionOptions": { "type": "object" }
+          }
+        },
+        "bucket": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "bucketOptions": { "type": "object" }
+          }
+        }
+      }
+    },
+
+    "collectionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collectionName", "databaseName", "documents"],
+      "properties": {
+        "collectionName": { "type": "string" },
+        "databaseName": { "type": "string" },
+        "documents": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+
+    "expectedEventsForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["client", "events"],
+      "properties": {
+        "client": { "type": "string" },
+        "events": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/expectedEvent" }
+        }
+      }
+    },
+
+    "expectedEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "commandStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": { "type": "object" },
+            "commandName": { "type": "string" },
+            "databaseName": { "type": "string" }
+          }
+        },
+        "commandSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reply": { "type": "object" },
+            "commandName": { "type": "string" }
+          }
+        },
+        "commandFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "commandName": { "type": "string" }
+          }
+        }
+      }
+    },
+
+    "collectionOrDatabaseOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readConcern": { "type": "object" },
+        "readPreference": { "type": "object" },
+        "writeConcern": { "type": "object" }
+      }
+    },
+
+    "serverApi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version"],
+      "properties": {
+        "version": { "type": "string" },
+        "strict": { "type":  "boolean" },
+        "deprecationErrors": { "type":  "boolean" }
+      }
+    },
+
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "object"],
+      "properties": {
+        "name": { "type": "string" },
+        "object": { "type": "string" },
+        "arguments": { "type": "object" },
+        "expectError":  { "$ref": "#/definitions/expectedError" },
+        "expectResult": {},
+        "saveResultAsEntity": { "type": "string" }
+      },
+      "allOf": [
+        { "not": { "required": ["expectError", "expectResult"] } },
+        { "not": { "required": ["expectError", "saveResultAsEntity"] } }
+      ]
+    },
+
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "isError": {
+          "type": "boolean",
+          "const": true
+        },
+        "isClientError": { "type": "boolean" },
+        "errorContains": { "type": "string" },
+        "errorCode": { "type": "integer" },
+        "errorCodeName": { "type": "string" },
+        "errorLabelsContain": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "errorLabelsOmit": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "expectResult": {}
+      }
+    },
+
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "operations"],
+      "properties": {
+        "description": { "type": "string" },
+        "runOnRequirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/runOnRequirement" }
+        },
+        "skipReason": { "type": "string" },
+        "operations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/operation" }
+        },
+        "expectEvents": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/expectedEventsForClient" }
+        },
+        "outcome": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/collectionData" }
+        }
+      }
+    }
+  }
+}

--- a/source/unified-test-format/schema-1.2.json
+++ b/source/unified-test-format/schema-1.2.json
@@ -1,0 +1,331 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "Unified Test Format",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["description", "schemaVersion", "tests"],
+  "properties": {
+    "description": { "type": "string" },
+    "schemaVersion": { "$ref": "#/definitions/version" },
+    "runOnRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/runOnRequirement" }
+    },
+    "createEntities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/entity" }
+    },
+    "initialData": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/collectionData" }
+    },
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/test" }
+    },
+    "_yamlAnchors": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+
+  "definitions": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+    },
+
+    "runOnRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "maxServerVersion": { "$ref": "#/definitions/version" },
+        "minServerVersion": { "$ref": "#/definitions/version" },
+        "topologies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["single", "replicaset", "sharded", "sharded-replicaset"]
+          }
+        },
+        "serverParameters": {
+          "type": "object",
+          "minProperties": 1
+        }
+      }
+    },
+
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "client": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id"],
+          "properties": {
+            "id": { "type": "string" },
+            "uriOptions": { "type": "object" },
+            "useMultipleMongoses": { "type": "boolean" },
+            "observeEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": ["commandStartedEvent", "commandSucceededEvent", "commandFailedEvent"]
+              }
+            },
+            "ignoreCommandMonitoringEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            },
+            "storeEventsAsEntities": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/definitions/storeEventsAsEntity" }
+            },
+            "serverApi": { "$ref":  "#/definitions/serverApi" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client", "databaseName"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "databaseOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database", "collectionName"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "collectionName": { "type": "string" },
+            "collectionOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "sessionOptions": { "type": "object" }
+          }
+        },
+        "bucket": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "bucketOptions": { "type": "object" }
+          }
+        }
+      }
+    },
+
+    "storeEventsAsEntity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "events"],
+      "properties": {
+        "id": { "type": "string" },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "PoolCreatedEvent",
+              "PoolReadyEvent",
+              "PoolClearedEvent",
+              "PoolClosedEvent",
+              "ConnectionCreatedEvent",
+              "ConnectionReadyEvent",
+              "ConnectionClosedEvent",
+              "ConnectionCheckOutStartedEvent",
+              "ConnectionCheckOutFailedEvent",
+              "ConnectionCheckedOutEvent",
+              "ConnectionCheckedInEvent",
+              "CommandStartedEvent",
+              "CommandSucceededEvent",
+              "CommandFailedEvent"
+            ]
+          }
+        }
+      }
+    },
+
+    "collectionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collectionName", "databaseName", "documents"],
+      "properties": {
+        "collectionName": { "type": "string" },
+        "databaseName": { "type": "string" },
+        "documents": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+
+    "expectedEventsForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["client", "events"],
+      "properties": {
+        "client": { "type": "string" },
+        "events": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/expectedEvent" }
+        }
+      }
+    },
+
+    "expectedEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "commandStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": { "type": "object" },
+            "commandName": { "type": "string" },
+            "databaseName": { "type": "string" }
+          }
+        },
+        "commandSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reply": { "type": "object" },
+            "commandName": { "type": "string" }
+          }
+        },
+        "commandFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "commandName": { "type": "string" }
+          }
+        }
+      }
+    },
+
+    "collectionOrDatabaseOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readConcern": { "type": "object" },
+        "readPreference": { "type": "object" },
+        "writeConcern": { "type": "object" }
+      }
+    },
+
+    "serverApi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version"],
+      "properties": {
+        "version": { "type": "string" },
+        "strict": { "type":  "boolean" },
+        "deprecationErrors": { "type":  "boolean" }
+      }
+    },
+
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "object"],
+      "properties": {
+        "name": { "type": "string" },
+        "object": { "type": "string" },
+        "arguments": { "type": "object" },
+        "expectError":  { "$ref": "#/definitions/expectedError" },
+        "expectResult": {},
+        "saveResultAsEntity": { "type": "string" }
+      },
+      "allOf": [
+        { "not": { "required": ["expectError", "expectResult"] } },
+        { "not": { "required": ["expectError", "saveResultAsEntity"] } }
+      ]
+    },
+
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "isError": {
+          "type": "boolean",
+          "const": true
+        },
+        "isClientError": { "type": "boolean" },
+        "errorContains": { "type": "string" },
+        "errorCode": { "type": "integer" },
+        "errorCodeName": { "type": "string" },
+        "errorLabelsContain": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "errorLabelsOmit": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "expectResult": {}
+      }
+    },
+
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "operations"],
+      "properties": {
+        "description": { "type": "string" },
+        "runOnRequirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/runOnRequirement" }
+        },
+        "skipReason": { "type": "string" },
+        "operations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/operation" }
+        },
+        "expectEvents": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/expectedEventsForClient" }
+        },
+        "outcome": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/collectionData" }
+        }
+      }
+    }
+  }
+}

--- a/source/unified-test-format/schema-1.3.json
+++ b/source/unified-test-format/schema-1.3.json
@@ -1,0 +1,457 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "Unified Test Format",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["description", "schemaVersion", "tests"],
+  "properties": {
+    "description": { "type": "string" },
+    "schemaVersion": { "$ref": "#/definitions/version" },
+    "runOnRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/runOnRequirement" }
+    },
+    "createEntities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/entity" }
+    },
+    "initialData": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/collectionData" }
+    },
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/test" }
+    },
+    "_yamlAnchors": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+
+  "definitions": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+    },
+
+    "runOnRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "maxServerVersion": { "$ref": "#/definitions/version" },
+        "minServerVersion": { "$ref": "#/definitions/version" },
+        "topologies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["single", "replicaset", "sharded", "sharded-replicaset", "load-balanced"]
+          }
+        },
+        "serverParameters": {
+          "type": "object",
+          "minProperties": 1
+        },
+        "auth": { "type": "boolean" }
+      }
+    },
+
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "client": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id"],
+          "properties": {
+            "id": { "type": "string" },
+            "uriOptions": { "type": "object" },
+            "useMultipleMongoses": { "type": "boolean" },
+            "observeEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "commandStartedEvent",
+                  "commandSucceededEvent",
+                  "commandFailedEvent",
+                  "poolCreatedEvent",
+                  "poolReadyEvent",
+                  "poolClearedEvent",
+                  "poolClosedEvent",
+                  "connectionCreatedEvent",
+                  "connectionReadyEvent",
+                  "connectionClosedEvent",
+                  "connectionCheckOutStartedEvent",
+                  "connectionCheckOutFailedEvent",
+                  "connectionCheckedOutEvent",
+                  "connectionCheckedInEvent"
+                ]
+              }
+            },
+            "ignoreCommandMonitoringEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            },
+            "storeEventsAsEntities": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/definitions/storeEventsAsEntity" }
+            },
+            "serverApi": { "$ref":  "#/definitions/serverApi" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client", "databaseName"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "databaseOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database", "collectionName"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "collectionName": { "type": "string" },
+            "collectionOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "sessionOptions": { "type": "object" }
+          }
+        },
+        "bucket": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "bucketOptions": { "type": "object" }
+          }
+        }
+      }
+    },
+
+    "storeEventsAsEntity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "events"],
+      "properties": {
+        "id": { "type": "string" },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "PoolCreatedEvent",
+              "PoolReadyEvent",
+              "PoolClearedEvent",
+              "PoolClosedEvent",
+              "ConnectionCreatedEvent",
+              "ConnectionReadyEvent",
+              "ConnectionClosedEvent",
+              "ConnectionCheckOutStartedEvent",
+              "ConnectionCheckOutFailedEvent",
+              "ConnectionCheckedOutEvent",
+              "ConnectionCheckedInEvent",
+              "CommandStartedEvent",
+              "CommandSucceededEvent",
+              "CommandFailedEvent"
+            ]
+          }
+        }
+      }
+    },
+
+    "collectionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collectionName", "databaseName", "documents"],
+      "properties": {
+        "collectionName": { "type": "string" },
+        "databaseName": { "type": "string" },
+        "documents": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+
+    "expectedEventsForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["client", "events"],
+      "properties": {
+        "client": { "type": "string" },
+        "eventType": {
+          "type": "string",
+          "enum": ["command", "cmap"]
+        },
+        "events": { "type": "array" }
+      },
+      "oneOf": [
+        {
+          "required": ["eventType"],
+          "properties": {
+            "eventType": { "const": "command" },
+            "events": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/expectedCommandEvent" }
+            }
+          }
+        },
+        {
+          "required": ["eventType"],
+          "properties": {
+            "eventType": { "const": "cmap" },
+            "events": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/expectedCmapEvent" }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "client": { "type": "string" },
+            "events": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/expectedCommandEvent" }
+            }
+          }
+        }
+      ]
+    },
+
+    "expectedCommandEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "commandStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": { "type": "object" },
+            "commandName": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "hasServiceId": { "type": "boolean" }
+          }
+        },
+        "commandSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reply": { "type": "object" },
+            "commandName": { "type": "string" },
+            "hasServiceId": { "type": "boolean" }
+          }
+        },
+        "commandFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "commandName": { "type": "string" },
+            "hasServiceId": { "type": "boolean" }
+          }
+        }
+      }
+    },
+
+    "expectedCmapEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "poolCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolClearedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "hasServiceId": { "type": "boolean" }
+          }
+        },
+        "poolClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": { "type": "string" }
+          }
+        },
+        "connectionCheckOutStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckOutFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": { "type": "string" }
+          }
+        },
+        "connectionCheckedOutEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckedInEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      }
+    },
+
+    "collectionOrDatabaseOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readConcern": { "type": "object" },
+        "readPreference": { "type": "object" },
+        "writeConcern": { "type": "object" }
+      }
+    },
+
+    "serverApi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version"],
+      "properties": {
+        "version": { "type": "string" },
+        "strict": { "type":  "boolean" },
+        "deprecationErrors": { "type":  "boolean" }
+      }
+    },
+
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "object"],
+      "properties": {
+        "name": { "type": "string" },
+        "object": { "type": "string" },
+        "arguments": { "type": "object" },
+        "ignoreResultAndError": { "type": "boolean" },
+        "expectError":  { "$ref": "#/definitions/expectedError" },
+        "expectResult": {},
+        "saveResultAsEntity": { "type": "string" }
+      },
+      "allOf": [
+        { "not": { "required": ["expectError", "expectResult"] } },
+        { "not": { "required": ["expectError", "saveResultAsEntity"] } },
+        { "not": { "required": ["ignoreResultAndError", "expectResult"] } },
+        { "not": { "required": ["ignoreResultAndError", "expectError"] } },
+        { "not": { "required": ["ignoreResultAndError", "saveResultAsEntity"] } }
+      ]
+    },
+
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "isError": {
+          "type": "boolean",
+          "const": true
+        },
+        "isClientError": { "type": "boolean" },
+        "errorContains": { "type": "string" },
+        "errorCode": { "type": "integer" },
+        "errorCodeName": { "type": "string" },
+        "errorLabelsContain": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "errorLabelsOmit": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "expectResult": {}
+      }
+    },
+
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "operations"],
+      "properties": {
+        "description": { "type": "string" },
+        "runOnRequirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/runOnRequirement" }
+        },
+        "skipReason": { "type": "string" },
+        "operations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/operation" }
+        },
+        "expectEvents": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/expectedEventsForClient" }
+        },
+        "outcome": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/collectionData" }
+        }
+      }
+    }
+  }
+}

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3,13 +3,13 @@ Unified Test Format
 ===================
 
 :Spec Title: Unified Test Format
-:Spec Version: 1.4.0
+:Spec Version: 1.4.1
 :Author: Jeremy Mikola
 :Advisors: Prashant Mital, Isabel Atkinson, Thomas Reggi
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-04-19
+:Last Modified: 2021-05-17
 
 .. contents::
 
@@ -99,12 +99,13 @@ they specify (as noted in `schemaVersion`_).
 JSON Schema Validation
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Each major version of this specification SHALL have one JSON schema, which will
-correspond to its most recent minor version. When a new minor version is
-introduced, the previous schema file for that major version SHALL be renamed.
-For example: if an additive change is made to version 1.0 of the spec, the
-``schema-1.0.json`` file will be renamed to ``schema-1.1.json`` and modified
-accordingly.
+Each major or minor version that changes the `Test Format`_ SHALL have a
+corresponding JSON schema. When a new schema file is introduced, any existing
+schema files MUST remain in place since they may be needed for validation. For
+example: if an additive change is made to version 1.0 of the spec, the
+``schema-1.0.json`` file will be copied to ``schema-1.1.json`` and modified
+accordingly. A new or existing test file using `schemaVersion`_ "1.0" would then
+be expected to validate against both schema files.
 
 A particular minor version MUST be capable of validating any and all test files
 in that major version series up to and including the minor version. For example,
@@ -114,8 +115,7 @@ in that major version series up to and including the minor version. For example,
 
 The JSON schema MUST remain consistent with the `Test Format`_ section. If and
 when a new major version is introduced, the `Breaking Changes`_ section MUST be
-updated and any JSON schema(s) for a previous major version(s) MUST remain
-available so that older test files can still be validated.
+updated.
 
 `Ajv <https://ajv.js.org/>`__ MAY be used to programmatically validate both YAML
 and JSON files using the JSON schema. The JSON schema MUST NOT use syntax that
@@ -3211,6 +3211,8 @@ spec changes developed in parallel or during the same release cycle.
 
 Change Log
 ==========
+
+:2021-05-17: Ensure old JSON schema files remain in place
 
 :2021-04-19: Introduce ``serverless`` `runOnRequirement`_.
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1754

Older schemas were taken from the last revision before being deleted:

 * https://github.com/mongodb/specifications/commits/master/source/unified-test-format/schema-1.3.json
 * https://github.com/mongodb/specifications/commits/master/source/unified-test-format/schema-1.2.json
 * https://github.com/mongodb/specifications/commits/master/source/unified-test-format/schema-1.1.json
 * https://github.com/mongodb/specifications/commits/master/source/unified-test-format/schema-1.0.json

The only exception is that I manually removed the stream entity from _all_ older files (per https://github.com/mongodb/specifications/commit/59d8f93199bad36a6e32c30f434aa33259788f88).

The Makefile can continue to validate files against the most recent minor version; however, having access to the older schemas will help when writing a test file that is "conservative in the minor version they specify" (per the spec's own guidance). For instance, the recently converted CRUD v2 tests currently specify 1.1, but could have used 1.0.