### PR TITLE
Clarify server versions to test with Versioned API

### DIFF
--- a/source/versioned-api/tests/README.rst
+++ b/source/versioned-api/tests/README.rst
@@ -33,5 +33,5 @@ To run this test, proceed as follows:
 - If the environment variable is set, all clients created in tests MUST declare
   the ``ServerApiVersion`` specified.
 
-No other topologies must be tested until ``mongo-orchestration`` can handle
-servers with ``requireApiVersion`` enabled.
+Only standalone servers must be tested. The tests should run for each server
+version >= 5.0, including ``latest``.


### PR DESCRIPTION
With 5.0 being added to drivers-evergreen-tools, I wanted to clarify that the Versioned API tests should run on 5.0+, not only latest.