### PR TITLE
DRIVERS-1724 Add `backgroundThreadIntervalMS` pool option to CMAP test specification

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -736,24 +736,15 @@ A Pool SHOULD have a background Thread that is responsible for
 monitoring the state of all available `Connections <#connection>`_. This background
 thread SHOULD
 
--  Populate `Connections <#connection>`_ to ensure that the pool always satisfies **minPoolSize**
-    - The background thread SHOULD just go back to sleep instead of waiting for
-      pendingConnectionCount to become less than maxConnecting when satisfying
-      minPoolSize.
+-  Populate `Connections <#connection>`_ to ensure that the pool always satisfies minPoolSize
 -  Remove and close perished available `Connections <#connection>`_.
 
-Conceptually, the aforementioned activities are organized into sequential Background Thread Runs of unspecified finite duration.
-Each Run MUST do as much work as possible, for example
+Conceptually, the aforementioned activities are organized into sequential Background Thread Runs of unspecified duration.
+A Run MUST do as much work as readily available and then end instead of waiting for more work.
+For example, instead of waiting for pendingConnectionCount to become less than maxConnecting when satisfying minPoolSize,
+a Run MUST either proceed with the rest of its duties, e.g., closing available perished connections, or end.
 
--  if at the beginning of a Run a Connection Pool needed three more Connections to satisfy minPoolSize, then the Run MUST try to populate
-   the Connection Pool with three more connections instead of populating it with only one and ending,
-   unless it encounters a situation preventing it from continuing;
--  if at the beginning of a Run a Connection Pool had three perished available connections, the Run MUST try to close all of them
-   instead of closing only one and ending.
-
-The first Run MUST start as soon after a Connection Pool becomes `ready <#marking-a-connection-pool-as-ready>`__ as practically possible.
-Neither the minimum delay between Runs (the minimum interval between the end of a Run and the beginning of the next Run)
-nor the desired period of Runs (the desired interval between the beginning of a Run and the beginning of the next Run) is specified.
+Marking a pool as `ready <#marking-a-connection-pool-as-ready>`__ MUST start a new Run as soon as possible.
 The
 `Test Format and Runner Specification <https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests>`__
 may change the specified restrictions or introduce new ones to facilitate testing.

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -417,7 +417,7 @@ method MUST immediately return and MUST NOT emit a PoolReadyEvent.
 
    mark pool as "ready"
    emit PoolReadyEvent
-   resume background thread
+   allow background thread to create connections
 
 Note that resuming the background thread after emitting PoolReadyEvent is of the essence,
 and it must be the case that no observer is able to observe actions of the background thread
@@ -743,8 +743,6 @@ Conceptually, the aforementioned activities are organized into sequential Backgr
 A Run MUST do as much work as readily available and then end instead of waiting for more work.
 For example, instead of waiting for pendingConnectionCount to become less than maxConnecting when satisfying minPoolSize,
 a Run MUST either proceed with the rest of its duties, e.g., closing available perished connections, or end.
-
-Marking a pool as `ready <#marking-a-connection-pool-as-ready>`__ MUST start a new Run as soon as possible.
 
 The duration of intervals between the end of one Run and the beginning of the next Run is not specified,
 but the

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -9,8 +9,8 @@ Connection Monitoring and Pooling
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-04-12
-:Version: 1.5.0
+:Last Modified: 2021-05-26
+:Version: 1.5.1
 
 .. contents::
 
@@ -745,17 +745,17 @@ thread SHOULD
 Conceptually, the aforementioned activities are organized into sequential Background Thread Runs of unspecified finite duration.
 Each Run MUST do as much work as possible, for example
 
--  if at the beginning of the Run the Connection Pool needed three more Connections to satisfy minPoolSize, then the Run MUST try to populate
-   the Connection Pool with three more connections instead of populating it with only one,
+-  if at the beginning of a Run a Connection Pool needed three more Connections to satisfy minPoolSize, then the Run MUST try to populate
+   the Connection Pool with three more connections instead of populating it with only one and ending,
    unless it encounters a situation preventing it from continuing;
--  if at the beginning of the Run the Connection Pool had three perished available connections, the Run MUST try to close all of them
-   instead of closing only one.
+-  if at the beginning of a Run a Connection Pool had three perished available connections, the Run MUST try to close all of them
+   instead of closing only one and ending.
 
 The first Run MUST start as soon after a Connection Pool becomes `ready <#marking-a-connection-pool-as-ready>`__ as practically possible.
 Neither the minimum delay between Runs (the minimum interval between the end of a Run and the beginning of the next Run)
 nor the desired period of Runs (the desired interval between the beginning of a Run and the beginning of the next Run) is specified.
 The
-`Test Format and Runner specification <https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests>`__
+`Test Format and Runner Specification <https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests>`__
 may change the specified restrictions or introduce new ones to facilitate testing.
 
 withConnection
@@ -1130,6 +1130,8 @@ Change log
              ConnectionCheckOutFailedEvent
 
 :2021-4-12: Adding in behaviour for load balancer mode.
+
+:2021-05-26: Formalize the behavior of a `Background Thread <#background-thread>`__.
 
 .. Section for links.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -742,6 +742,22 @@ thread SHOULD
       minPoolSize.
 -  Remove and close perished available `Connections <#connection>`_.
 
+Conceptually, the aforementioned activities are organized into sequential Background Thread Runs of unspecified finite duration.
+Each Run MUST do as much work as possible, for example
+
+-  if at the beginning of the Run the Connection Pool needed three more Connections to satisfy minPoolSize, then the Run MUST try to populate
+   the Connection Pool with three more connections instead of populating it with only one,
+   unless it encounters a situation preventing it from continuing;
+-  if at the beginning of the Run the Connection Pool had three perished available connections, the Run MUST try to close all of them
+   instead of closing only one.
+
+The first Run MUST start as soon after a Connection Pool becomes `ready <#marking-a-connection-pool-as-ready>`__ as practically possible.
+Neither the minimum delay between Runs (the minimum interval between the end of a Run and the beginning of the next Run)
+nor the desired period of Runs (the desired interval between the beginning of a Run and the beginning of the next Run) is specified.
+The
+`Test Format and Runner specification <https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests>`__
+may change the specified restrictions or introduce new ones to facilitate testing.
+
 withConnection
 ^^^^^^^^^^^^^^
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -736,7 +736,7 @@ A Pool SHOULD have a background Thread that is responsible for
 monitoring the state of all available `Connections <#connection>`_. This background
 thread SHOULD
 
--  Populate `Connections <#connection>`_ to ensure that the pool always satisfies minPoolSize
+-  Populate `Connections <#connection>`_ to ensure that the pool always satisfies minPoolSize.
 -  Remove and close perished available `Connections <#connection>`_.
 
 Conceptually, the aforementioned activities are organized into sequential Background Thread Runs.

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -9,7 +9,7 @@ Connection Monitoring and Pooling
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-05-26
+:Last Modified: 2021-06-02
 :Version: 1.5.1
 
 .. contents::
@@ -739,7 +739,7 @@ thread SHOULD
 -  Populate `Connections <#connection>`_ to ensure that the pool always satisfies minPoolSize
 -  Remove and close perished available `Connections <#connection>`_.
 
-Conceptually, the aforementioned activities are organized into sequential Background Thread Runs of unspecified duration.
+Conceptually, the aforementioned activities are organized into sequential Background Thread Runs.
 A Run MUST do as much work as readily available and then end instead of waiting for more work.
 For example, instead of waiting for pendingConnectionCount to become less than maxConnecting when satisfying minPoolSize,
 a Run MUST either proceed with the rest of its duties, e.g., closing available perished connections, or end.
@@ -1122,7 +1122,7 @@ Change log
 
 :2021-4-12: Adding in behaviour for load balancer mode.
 
-:2021-05-26: Formalize the behavior of a `Background Thread <#background-thread>`__.
+:2021-06-02: Formalize the behavior of a `Background Thread <#background-thread>`__.
 
 .. Section for links.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -745,9 +745,11 @@ For example, instead of waiting for pendingConnectionCount to become less than m
 a Run MUST either proceed with the rest of its duties, e.g., closing available perished connections, or end.
 
 Marking a pool as `ready <#marking-a-connection-pool-as-ready>`__ MUST start a new Run as soon as possible.
-The
+
+The duration of intervals between the end of one Run and the beginning of the next Run is not specified,
+but the
 `Test Format and Runner Specification <https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling/tests>`__
-may change the specified restrictions or introduce new ones to facilitate testing.
+may restrict this duration, or introduce other restrictions to facilitate testing.
 
 withConnection
 ^^^^^^^^^^^^^^

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -419,7 +419,7 @@ method MUST immediately return and MUST NOT emit a PoolReadyEvent.
    emit PoolReadyEvent
    allow background thread to create connections
 
-Note that resuming the background thread after emitting PoolReadyEvent is of the essence,
+Note that the PoolReadyEvent MUST be emitted before the background thread is allowed to resume creating new connections,
 and it must be the case that no observer is able to observe actions of the background thread
 related to creating new connections before observing the PoolReadyEvent event.
 

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -36,7 +36,21 @@ Unit Test Format:
 
 All Unit Tests have some of the following fields:
 
-- ``poolOptions``: if present, connection pool options to use when creating a pool
+- ``poolOptions``: If present, connection pool options to use when creating a pool;
+  both `standard ConnectionPoolOptions <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1>`__
+  and the following test-specific options are allowed:
+
+  - ``backgroundThreadDelayMS``: An artificial delay before starting observable activities in a
+    `Background Thread <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`__.
+    The Test Runner / Connection Pool MUST try to start counting time towards this delay
+    at an instant as close to starting executing ``operations`` as reasonably possible.
+    If a Connection Pool does not implement a Background Thread, the Test Runner MUST ignore the option.
+    Possible values:
+
+    - 0 (default)—no delay;
+    - a negative value—an infinite delay;
+    - a positive value—a finite delay in milliseconds.
+
 - ``operations``: A list of operations to perform. All operations support the following fields:
 
   - ``name``: A string describing which operation to issue.

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -40,15 +40,20 @@ All Unit Tests have some of the following fields:
   both `standard ConnectionPoolOptions <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1>`__
   and the following test-specific options are allowed:
 
-  - ``backgroundThread``: Whether or not to start activities of a
-    `Background Thread <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`__.
+  - ``backgroundThreadPeriodMS`` (50 by default): The desired period of
+    `Background Thread Runs <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`__.
     If a Connection Pool does not implement a Background Thread, the Test Runner MUST ignore the option.
-    This option affects only preemptive population of a Connection Pool and preemptive removal of perished available connections,
-    as specified `here <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`.
+
+    Note that this period may be overestimated by an implementation because it is impossible to guarantee otherwise.
+    This period is also allowed to be underestimated by an implementation: if the beginning of a Run is delayed as a result of previous Runs
+    taking too much time to complete, then the duration between the beginning of the previous Run and the beginning of the delayed Run
+    may be made smaller than the desired period to achieve the number of Runs beginning within a time interval ``t``
+    (``t ≫ backgroundThreadPeriodMS``) being as close to ``t / backgroundThreadPeriodMS`` as possible.
+
     Possible values:
 
-    - true (default)—start;
-    - false—do not start.
+    - a negative value—never begin a Run;
+    - a positive value—the desired period of Runs in milliseconds.
 
 - ``operations``: A list of operations to perform. All operations support the following fields:
 
@@ -168,8 +173,6 @@ For each YAML file with ``style: unit``:
 
   - If ``poolOptions`` is specified, use those options to initialize both pools
   - The returned pool must have an ``address`` set as a string value.
-  - If the pool uses a background thread to satisfy ``minPoolSize``, ensure it
-    attempts to create a new connection every 50ms.
 
 - Process each ``operation`` in ``operations`` (on the main thread)
 

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -40,16 +40,15 @@ All Unit Tests have some of the following fields:
   both `standard ConnectionPoolOptions <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1>`__
   and the following test-specific options are allowed:
 
-  - ``backgroundThreadDelayMS``: An artificial delay before starting observable activities in a
+  - ``backgroundThread``: Whether or not to start activities of a
     `Background Thread <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`__.
-    The Test Runner / Connection Pool MUST try to start counting time towards this delay
-    at an instant as close to starting executing ``operations`` as reasonably possible.
     If a Connection Pool does not implement a Background Thread, the Test Runner MUST ignore the option.
+    This option affects only preemptive population of a Connection Pool and preemptive removal of perished available connections,
+    as specified `here <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`.
     Possible values:
 
-    - 0 (default)—no delay;
-    - a negative value—an infinite delay;
-    - a positive value—a finite delay in milliseconds.
+    - true (default)—start;
+    - false—do not start.
 
 - ``operations``: A list of operations to perform. All operations support the following fields:
 

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -40,17 +40,18 @@ All Unit Tests have some of the following fields:
   both `standard ConnectionPoolOptions <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1>`__
   and the following test-specific options are allowed:
 
-  - ``backgroundThreadIntervalMS``: A desired time interval between the end of a
+  - ``backgroundThreadIntervalMS``: A desired minimal time interval between the end of a
     `Background Thread Run <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`__
     and the beginning of the next Run. If a Connection Pool does not implement a Background Thread, the Test Runner MUST ignore the option.
     If the option is not specified, an implementation is free to use any value it finds reasonable.
-    An implementation is also free to use an interval smaller than the desired one. Once the specified time interval since the end of a Run passes,
-    an implementation MUST begin the next Run as soon as possible.
+    An implementation SHOULD respect the lower bound restriction,
+    but MAY violate it for example as a result of the Connection Pool paused/ready state changes.
+    Once the specified time interval since the end of a Run passes, an implementation MUST begin the next Run as soon as possible.
 
     Possible values (0 is not allowed):
 
-    - a negative value—never begin a Run;
-    - a positive value—the desired interval between Runs in milliseconds.
+    - A negative value: never begin a Run.
+    - A positive value: the desired interval between Runs in milliseconds.
 
 - ``operations``: A list of operations to perform. All operations support the following fields:
 

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -50,7 +50,7 @@ All Unit Tests have some of the following fields:
     Possible values (0 is not allowed):
 
     - a negative value—never begin a Run;
-    - a positive value—the minimal interval between Runs in milliseconds.
+    - a positive value—the desired interval between Runs in milliseconds.
 
 - ``operations``: A list of operations to perform. All operations support the following fields:
 

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -40,18 +40,15 @@ All Unit Tests have some of the following fields:
   both `standard ConnectionPoolOptions <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1>`__
   and the following test-specific options are allowed:
 
-  - ``backgroundThreadIntervalMS``: A desired minimal time interval between the end of a
+  - ``backgroundThreadIntervalMS``: A time interval between the end of a
     `Background Thread Run <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`__
     and the beginning of the next Run. If a Connection Pool does not implement a Background Thread, the Test Runner MUST ignore the option.
     If the option is not specified, an implementation is free to use any value it finds reasonable.
-    An implementation SHOULD respect the lower bound restriction,
-    but MAY violate it for example as a result of the Connection Pool paused/ready state changes.
-    Once the specified time interval since the end of a Run passes, an implementation MUST begin the next Run as soon as possible.
 
     Possible values (0 is not allowed):
 
     - A negative value: never begin a Run.
-    - A positive value: the desired interval between Runs in milliseconds.
+    - A positive value: the interval between Runs in milliseconds.
 
 - ``operations``: A list of operations to perform. All operations support the following fields:
 

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -40,20 +40,17 @@ All Unit Tests have some of the following fields:
   both `standard ConnectionPoolOptions <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1>`__
   and the following test-specific options are allowed:
 
-  - ``backgroundThreadPeriodMS`` (50 by default): The desired period of
-    `Background Thread Runs <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`__.
-    If a Connection Pool does not implement a Background Thread, the Test Runner MUST ignore the option.
+  - ``backgroundThreadIntervalMS``: A desired time interval between the end of a
+    `Background Thread Run <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#background-thread>`__
+    and the beginning of the next Run. If a Connection Pool does not implement a Background Thread, the Test Runner MUST ignore the option.
+    If the option is not specified, an implementation is free to use any value it finds reasonable.
+    An implementation is also free to use an interval smaller than the desired one. Once the specified time interval since the end of a Run passes,
+    an implementation MUST begin the next Run as soon as possible.
 
-    Note that this period may be overestimated by an implementation because it is impossible to guarantee otherwise.
-    This period is also allowed to be underestimated by an implementation: if the beginning of a Run is delayed as a result of previous Runs
-    taking too much time to complete, then the duration between the beginning of the previous Run and the beginning of the delayed Run
-    may be made smaller than the desired period to achieve the number of Runs beginning within a time interval ``t``
-    (``t ≫ backgroundThreadPeriodMS``) being as close to ``t / backgroundThreadPeriodMS`` as possible.
-
-    Possible values:
+    Possible values (0 is not allowed):
 
     - a negative value—never begin a Run;
-    - a positive value—the desired period of Runs in milliseconds.
+    - a positive value—the minimal interval between Runs in milliseconds.
 
 - ``operations``: A list of operations to perform. All operations support the following fields:
 

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
@@ -4,7 +4,7 @@
   "description": "must destroy and must not check out an idle connection if found while iterating available connections",
   "poolOptions": {
     "maxIdleTimeMS": 10,
-    "backgroundThreadDelayMS": -1
+    "backgroundThread": false
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
@@ -4,7 +4,7 @@
   "description": "must destroy and must not check out an idle connection if found while iterating available connections",
   "poolOptions": {
     "maxIdleTimeMS": 10,
-    "backgroundThreadPeriodMS": -1
+    "backgroundThreadIntervalMS": -1
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
@@ -3,7 +3,8 @@
   "style": "unit",
   "description": "must destroy and must not check out an idle connection if found while iterating available connections",
   "poolOptions": {
-    "maxIdleTimeMS": 10
+    "maxIdleTimeMS": 10,
+    "backgroundThreadDelayMS": -1
   },
   "operations": [
     {
@@ -23,11 +24,6 @@
     },
     {
       "name": "checkOut"
-    },
-    {
-      "name": "waitForEvent",
-      "event": "ConnectionClosed",
-      "count": 1
     },
     {
       "name": "waitForEvent",
@@ -55,6 +51,11 @@
       "type": "ConnectionClosed",
       "connectionId": 1,
       "reason": "idle",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 2,
       "address": 42
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.json
@@ -4,7 +4,7 @@
   "description": "must destroy and must not check out an idle connection if found while iterating available connections",
   "poolOptions": {
     "maxIdleTimeMS": 10,
-    "backgroundThread": false
+    "backgroundThreadPeriodMS": -1
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
@@ -3,7 +3,7 @@ style: unit
 description: must destroy and must not check out an idle connection if found while iterating available connections
 poolOptions:
   maxIdleTimeMS: 10
-  backgroundThreadPeriodMS: -1
+  backgroundThreadIntervalMS: -1
 operations:
   - name: ready
   - name: checkOut

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
@@ -3,6 +3,7 @@ style: unit
 description: must destroy and must not check out an idle connection if found while iterating available connections
 poolOptions:
   maxIdleTimeMS: 10
+  backgroundThreadDelayMS: -1
 operations:
   - name: ready
   - name: checkOut
@@ -12,9 +13,6 @@ operations:
   - name: wait
     ms: 50
   - name: checkOut
-  - name: waitForEvent
-    event: ConnectionClosed
-    count: 1
   - name: waitForEvent
     event: ConnectionCheckedOut
     count: 2
@@ -32,6 +30,9 @@ events:
   - type: ConnectionClosed
     connectionId: 1
     reason: idle
+    address: 42
+  - type: ConnectionCheckedOut
+    connectionId: 2
     address: 42
 ignore:
   - ConnectionReady

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
@@ -3,7 +3,7 @@ style: unit
 description: must destroy and must not check out an idle connection if found while iterating available connections
 poolOptions:
   maxIdleTimeMS: 10
-  backgroundThreadDelayMS: -1
+  backgroundThread: false
 operations:
   - name: ready
   - name: checkOut

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-idle.yml
@@ -3,7 +3,7 @@ style: unit
 description: must destroy and must not check out an idle connection if found while iterating available connections
 poolOptions:
   maxIdleTimeMS: 10
-  backgroundThread: false
+  backgroundThreadPeriodMS: -1
 operations:
   - name: ready
   - name: checkOut

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
@@ -3,7 +3,7 @@
   "style": "unit",
   "description": "must destroy and must not check out a stale connection if found while iterating available connections",
   "poolOptions": {
-    "backgroundThreadPeriodMS": -1
+    "backgroundThreadIntervalMS": -1
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
@@ -3,7 +3,7 @@
   "style": "unit",
   "description": "must destroy and must not check out a stale connection if found while iterating available connections",
   "poolOptions": {
-    "backgroundThreadDelayMS": -1
+    "backgroundThread": false
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
@@ -2,6 +2,9 @@
   "version": 1,
   "style": "unit",
   "description": "must destroy and must not check out a stale connection if found while iterating available connections",
+  "poolOptions": {
+    "backgroundThreadDelayMS": -1
+  },
   "operations": [
     {
       "name": "ready"
@@ -22,11 +25,6 @@
     },
     {
       "name": "checkOut"
-    },
-    {
-      "name": "waitForEvent",
-      "event": "ConnectionClosed",
-      "count": 1
     },
     {
       "name": "waitForEvent",
@@ -58,6 +56,11 @@
       "type": "ConnectionClosed",
       "connectionId": 1,
       "reason": "stale",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 2,
       "address": 42
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.json
@@ -3,7 +3,7 @@
   "style": "unit",
   "description": "must destroy and must not check out a stale connection if found while iterating available connections",
   "poolOptions": {
-    "backgroundThread": false
+    "backgroundThreadPeriodMS": -1
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
@@ -2,7 +2,7 @@ version: 1
 style: unit
 description: must destroy and must not check out a stale connection if found while iterating available connections
 poolOptions:
-  backgroundThread: false
+  backgroundThreadPeriodMS: -1
 operations:
   - name: ready
   - name: checkOut

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
@@ -2,7 +2,7 @@ version: 1
 style: unit
 description: must destroy and must not check out a stale connection if found while iterating available connections
 poolOptions:
-  backgroundThreadPeriodMS: -1
+  backgroundThreadIntervalMS: -1
 operations:
   - name: ready
   - name: checkOut

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
@@ -2,7 +2,7 @@ version: 1
 style: unit
 description: must destroy and must not check out a stale connection if found while iterating available connections
 poolOptions:
-  backgroundThreadDelayMS: -1
+  backgroundThread: false
 operations:
   - name: ready
   - name: checkOut

--- a/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-checkout-no-stale.yml
@@ -1,6 +1,8 @@
 version: 1
 style: unit
 description: must destroy and must not check out a stale connection if found while iterating available connections
+poolOptions:
+  backgroundThreadDelayMS: -1
 operations:
   - name: ready
   - name: checkOut
@@ -10,9 +12,6 @@ operations:
   - name: clear
   - name: ready
   - name: checkOut
-  - name: waitForEvent
-    event: ConnectionClosed
-    count: 1
   - name: waitForEvent
     event: ConnectionCheckedOut
     count: 2
@@ -31,6 +30,9 @@ events:
   - type: ConnectionClosed
     connectionId: 1
     reason: stale
+    address: 42
+  - type: ConnectionCheckedOut
+    connectionId: 2
     address: 42
 ignore:
   - ConnectionReady

--- a/source/connection-monitoring-and-pooling/tests/pool-clear-min-size.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-clear-min-size.json
@@ -3,7 +3,8 @@
   "style": "unit",
   "description": "pool clear halts background minPoolSize establishments",
   "poolOptions": {
-    "minPoolSize": 1
+    "minPoolSize": 1,
+    "backgroundThreadIntervalMS": 50
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/pool-clear-min-size.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-clear-min-size.yml
@@ -3,6 +3,7 @@ style: unit
 description: pool clear halts background minPoolSize establishments
 poolOptions:
   minPoolSize: 1
+  backgroundThreadIntervalMS: 50
 operations:
   - name: ready
   - name: waitForEvent

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.json
@@ -23,6 +23,7 @@
   },
   "poolOptions": {
     "minPoolSize": 1,
+    "backgroundThreadIntervalMS": 50,
     "appName": "poolCreateMinSizeErrorTest"
   },
   "operations": [

--- a/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.yml
+++ b/source/connection-monitoring-and-pooling/tests/pool-create-min-size-error.yml
@@ -15,6 +15,7 @@ failPoint:
     appName: "poolCreateMinSizeErrorTest"
 poolOptions:
   minPoolSize: 1
+  backgroundThreadIntervalMS: 50
   appName: "poolCreateMinSizeErrorTest"
 operations:
   - name: ready


### PR DESCRIPTION
Use the new option in `pool-checkout-no-idle.yml`, `pool-checkout-no-stale.yml` to disable background thread runs.
Use the new option in `pool-clear-min-size.yml` and `pool-create-min-size-error.yml` to specify 50 ms delay between runs.

DRIVERS-1724