### PR TITLE
Fix typo in test name TransientTransctionError -> TransientTransactionError

### DIFF
--- a/source/transactions/tests/unified/mongos-unpin.json
+++ b/source/transactions/tests/unified/mongos-unpin.json
@@ -49,7 +49,7 @@
   },
   "tests": [
     {
-      "description": "unpin after TransientTransctionError error on commit",
+      "description": "unpin after TransientTransactionError error on commit",
       "runOnRequirements": [
         {
           "serverless": "forbid"
@@ -142,7 +142,7 @@
       ]
     },
     {
-      "description": "unpin after TransientTransctionError error on abort",
+      "description": "unpin after TransientTransactionError error on abort",
       "runOnRequirements": [
         {
           "serverless": "forbid"

--- a/source/transactions/tests/unified/mongos-unpin.yml
+++ b/source/transactions/tests/unified/mongos-unpin.yml
@@ -33,7 +33,7 @@ _yamlAnchors:
     &lockTimeoutErrorCode 24
 
 tests:
-  - description: unpin after TransientTransctionError error on commit
+  - description: unpin after TransientTransactionError error on commit
     runOnRequirements:
         # serverless proxy doesn't append error labels to errors in transactions
         # caused by failpoints (CLOUDP-88216)
@@ -80,7 +80,7 @@ tests:
         object: *session0
       - *assertNoPinnedServer
 
-  - description: unpin after TransientTransctionError error on abort
+  - description: unpin after TransientTransactionError error on abort
     runOnRequirements:
         # serverless proxy doesn't append error labels to errors in transactions
         # caused by failpoints (CLOUDP-88216)


### PR DESCRIPTION
No drivers ticket needed since this only changes a test name.