### PR TITLE
DRIVERS-1775: Correct schemaVersion in converted CRUD unified tests

### DIFF
--- a/source/crud/tests/unified/aggregate-merge.json
+++ b/source/crud/tests/unified/aggregate-merge.json
@@ -1,6 +1,6 @@
 {
   "description": "aggregate-merge",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.1.11"

--- a/source/crud/tests/unified/aggregate-merge.yml
+++ b/source/crud/tests/unified/aggregate-merge.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: aggregate-merge
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.1.11

--- a/source/crud/tests/unified/aggregate-out-readConcern.json
+++ b/source/crud/tests/unified/aggregate-out-readConcern.json
@@ -1,6 +1,6 @@
 {
   "description": "aggregate-out-readConcern",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.1.0",

--- a/source/crud/tests/unified/aggregate-out-readConcern.yml
+++ b/source/crud/tests/unified/aggregate-out-readConcern.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: aggregate-out-readConcern
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.1.0

--- a/source/crud/tests/unified/bulkWrite-arrayFilters-clientError.json
+++ b/source/crud/tests/unified/bulkWrite-arrayFilters-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-arrayFilters-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.5.5"

--- a/source/crud/tests/unified/bulkWrite-arrayFilters-clientError.yml
+++ b/source/crud/tests/unified/bulkWrite-arrayFilters-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: bulkWrite-arrayFilters-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 3.5.5

--- a/source/crud/tests/unified/bulkWrite-arrayFilters.json
+++ b/source/crud/tests/unified/bulkWrite-arrayFilters.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-arrayFilters",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.5.6"

--- a/source/crud/tests/unified/bulkWrite-arrayFilters.yml
+++ b/source/crud/tests/unified/bulkWrite-arrayFilters.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: bulkWrite-arrayFilters
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 3.5.6

--- a/source/crud/tests/unified/bulkWrite-delete-hint-clientError.json
+++ b/source/crud/tests/unified/bulkWrite-delete-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-delete-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/source/crud/tests/unified/bulkWrite-delete-hint-clientError.yml
+++ b/source/crud/tests/unified/bulkWrite-delete-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: bulkWrite-delete-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 3.3.99

--- a/source/crud/tests/unified/bulkWrite-delete-hint-serverError.json
+++ b/source/crud/tests/unified/bulkWrite-delete-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-delete-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/source/crud/tests/unified/bulkWrite-delete-hint-serverError.yml
+++ b/source/crud/tests/unified/bulkWrite-delete-hint-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: bulkWrite-delete-hint-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 3.4.0

--- a/source/crud/tests/unified/bulkWrite-delete-hint.json
+++ b/source/crud/tests/unified/bulkWrite-delete-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-delete-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.4"

--- a/source/crud/tests/unified/bulkWrite-delete-hint.yml
+++ b/source/crud/tests/unified/bulkWrite-delete-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: bulkWrite-delete-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.3.4

--- a/source/crud/tests/unified/bulkWrite-update-hint-clientError.json
+++ b/source/crud/tests/unified/bulkWrite-update-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-update-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/source/crud/tests/unified/bulkWrite-update-hint-clientError.yml
+++ b/source/crud/tests/unified/bulkWrite-update-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: bulkWrite-update-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 3.3.99

--- a/source/crud/tests/unified/bulkWrite-update-hint-serverError.json
+++ b/source/crud/tests/unified/bulkWrite-update-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-update-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/source/crud/tests/unified/bulkWrite-update-hint-serverError.yml
+++ b/source/crud/tests/unified/bulkWrite-update-hint-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: bulkWrite-update-hint-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 3.4.0

--- a/source/crud/tests/unified/bulkWrite-update-hint.json
+++ b/source/crud/tests/unified/bulkWrite-update-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-update-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0"

--- a/source/crud/tests/unified/bulkWrite-update-hint.yml
+++ b/source/crud/tests/unified/bulkWrite-update-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: bulkWrite-update-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.2.0

--- a/source/crud/tests/unified/bulkWrite-update-validation.json
+++ b/source/crud/tests/unified/bulkWrite-update-validation.json
@@ -1,6 +1,6 @@
 {
   "description": "bulkWrite-update-validation",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/bulkWrite-update-validation.yml
+++ b/source/crud/tests/unified/bulkWrite-update-validation.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: bulkWrite-update-validation
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/deleteMany-hint-clientError.json
+++ b/source/crud/tests/unified/deleteMany-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteMany-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/source/crud/tests/unified/deleteMany-hint-clientError.yml
+++ b/source/crud/tests/unified/deleteMany-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: deleteMany-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 3.3.99

--- a/source/crud/tests/unified/deleteMany-hint-serverError.json
+++ b/source/crud/tests/unified/deleteMany-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteMany-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/source/crud/tests/unified/deleteMany-hint-serverError.yml
+++ b/source/crud/tests/unified/deleteMany-hint-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: deleteMany-hint-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 3.4.0

--- a/source/crud/tests/unified/deleteMany-hint.json
+++ b/source/crud/tests/unified/deleteMany-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteMany-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.4"

--- a/source/crud/tests/unified/deleteMany-hint.yml
+++ b/source/crud/tests/unified/deleteMany-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: deleteMany-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.3.4

--- a/source/crud/tests/unified/deleteOne-hint-clientError.json
+++ b/source/crud/tests/unified/deleteOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/source/crud/tests/unified/deleteOne-hint-clientError.yml
+++ b/source/crud/tests/unified/deleteOne-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: deleteOne-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 3.3.99

--- a/source/crud/tests/unified/deleteOne-hint-serverError.json
+++ b/source/crud/tests/unified/deleteOne-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteOne-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/source/crud/tests/unified/deleteOne-hint-serverError.yml
+++ b/source/crud/tests/unified/deleteOne-hint-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: deleteOne-hint-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 3.4.0

--- a/source/crud/tests/unified/deleteOne-hint.json
+++ b/source/crud/tests/unified/deleteOne-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "deleteOne-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.4"

--- a/source/crud/tests/unified/deleteOne-hint.yml
+++ b/source/crud/tests/unified/deleteOne-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: deleteOne-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.3.4

--- a/source/crud/tests/unified/find-allowdiskuse-clientError.json
+++ b/source/crud/tests/unified/find-allowdiskuse-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "find-allowdiskuse-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.0.99"

--- a/source/crud/tests/unified/find-allowdiskuse-clientError.yml
+++ b/source/crud/tests/unified/find-allowdiskuse-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: find-allowdiskuse-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 3.0.99

--- a/source/crud/tests/unified/find-allowdiskuse-serverError.json
+++ b/source/crud/tests/unified/find-allowdiskuse-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "find-allowdiskuse-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.2",

--- a/source/crud/tests/unified/find-allowdiskuse-serverError.yml
+++ b/source/crud/tests/unified/find-allowdiskuse-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: find-allowdiskuse-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: '3.2'

--- a/source/crud/tests/unified/find-allowdiskuse.json
+++ b/source/crud/tests/unified/find-allowdiskuse.json
@@ -1,6 +1,6 @@
 {
   "description": "find-allowdiskuse",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.1"

--- a/source/crud/tests/unified/find-allowdiskuse.yml
+++ b/source/crud/tests/unified/find-allowdiskuse.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: find-allowdiskuse
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.3.1

--- a/source/crud/tests/unified/findOneAndDelete-hint-clientError.json
+++ b/source/crud/tests/unified/findOneAndDelete-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndDelete-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "4.0.99"

--- a/source/crud/tests/unified/findOneAndDelete-hint-clientError.yml
+++ b/source/crud/tests/unified/findOneAndDelete-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: findOneAndDelete-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 4.0.99

--- a/source/crud/tests/unified/findOneAndDelete-hint-serverError.json
+++ b/source/crud/tests/unified/findOneAndDelete-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndDelete-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0",

--- a/source/crud/tests/unified/findOneAndDelete-hint-serverError.yml
+++ b/source/crud/tests/unified/findOneAndDelete-hint-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: findOneAndDelete-hint-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.2.0

--- a/source/crud/tests/unified/findOneAndDelete-hint.json
+++ b/source/crud/tests/unified/findOneAndDelete-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndDelete-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.4"

--- a/source/crud/tests/unified/findOneAndDelete-hint.yml
+++ b/source/crud/tests/unified/findOneAndDelete-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: findOneAndDelete-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.3.4

--- a/source/crud/tests/unified/findOneAndReplace-hint-clientError.json
+++ b/source/crud/tests/unified/findOneAndReplace-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndReplace-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "4.0.99"

--- a/source/crud/tests/unified/findOneAndReplace-hint-clientError.yml
+++ b/source/crud/tests/unified/findOneAndReplace-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: findOneAndReplace-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 4.0.99

--- a/source/crud/tests/unified/findOneAndReplace-hint-serverError.json
+++ b/source/crud/tests/unified/findOneAndReplace-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndReplace-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0",

--- a/source/crud/tests/unified/findOneAndReplace-hint-serverError.yml
+++ b/source/crud/tests/unified/findOneAndReplace-hint-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: findOneAndReplace-hint-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.2.0

--- a/source/crud/tests/unified/findOneAndReplace-hint.json
+++ b/source/crud/tests/unified/findOneAndReplace-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndReplace-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.1"

--- a/source/crud/tests/unified/findOneAndReplace-hint.yml
+++ b/source/crud/tests/unified/findOneAndReplace-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: findOneAndReplace-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.3.1

--- a/source/crud/tests/unified/findOneAndUpdate-hint-clientError.json
+++ b/source/crud/tests/unified/findOneAndUpdate-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndUpdate-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "4.0.99"

--- a/source/crud/tests/unified/findOneAndUpdate-hint-clientError.yml
+++ b/source/crud/tests/unified/findOneAndUpdate-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: findOneAndUpdate-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 4.0.99

--- a/source/crud/tests/unified/findOneAndUpdate-hint-serverError.json
+++ b/source/crud/tests/unified/findOneAndUpdate-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndUpdate-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0",

--- a/source/crud/tests/unified/findOneAndUpdate-hint-serverError.yml
+++ b/source/crud/tests/unified/findOneAndUpdate-hint-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: findOneAndUpdate-hint-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.2.0

--- a/source/crud/tests/unified/findOneAndUpdate-hint.json
+++ b/source/crud/tests/unified/findOneAndUpdate-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "findOneAndUpdate-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.3.1"

--- a/source/crud/tests/unified/findOneAndUpdate-hint.yml
+++ b/source/crud/tests/unified/findOneAndUpdate-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: findOneAndUpdate-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.3.1

--- a/source/crud/tests/unified/replaceOne-hint.json
+++ b/source/crud/tests/unified/replaceOne-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "replaceOne-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0"

--- a/source/crud/tests/unified/replaceOne-hint.yml
+++ b/source/crud/tests/unified/replaceOne-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: replaceOne-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.2.0

--- a/source/crud/tests/unified/replaceOne-validation.json
+++ b/source/crud/tests/unified/replaceOne-validation.json
@@ -1,6 +1,6 @@
 {
   "description": "replaceOne-validation",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/replaceOne-validation.yml
+++ b/source/crud/tests/unified/replaceOne-validation.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: replaceOne-validation
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-bulkWrite-delete-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-bulkWrite-delete-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-bulkWrite-delete-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-bulkWrite-delete-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-bulkWrite-delete-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-bulkWrite-delete-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-bulkWrite-update-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-bulkWrite-update-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-bulkWrite-update-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-bulkWrite-update-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-bulkWrite-update-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-bulkWrite-update-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-deleteMany-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-deleteMany-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-deleteMany-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-deleteMany-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-deleteMany-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-deleteMany-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-deleteOne-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-deleteOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-deleteOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-deleteOne-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-deleteOne-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-deleteOne-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-findOneAndDelete-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-findOneAndDelete-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-findOneAndDelete-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-findOneAndDelete-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-findOneAndDelete-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-findOneAndDelete-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-findOneAndReplace-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-findOneAndReplace-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-findOneAndReplace-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-findOneAndReplace-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-findOneAndReplace-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-findOneAndReplace-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-findOneAndUpdate-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-findOneAndUpdate-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-findOneAndUpdate-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-findOneAndUpdate-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-findOneAndUpdate-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-findOneAndUpdate-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-replaceOne-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-replaceOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-replaceOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-replaceOne-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-replaceOne-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-replaceOne-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-updateMany-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-updateMany-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-updateMany-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-updateMany-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-updateMany-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-updateMany-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/unacknowledged-updateOne-hint-clientError.json
+++ b/source/crud/tests/unified/unacknowledged-updateOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-updateOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/unacknowledged-updateOne-hint-clientError.yml
+++ b/source/crud/tests/unified/unacknowledged-updateOne-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: unacknowledged-updateOne-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/updateMany-hint-clientError.json
+++ b/source/crud/tests/unified/updateMany-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "updateMany-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/source/crud/tests/unified/updateMany-hint-clientError.yml
+++ b/source/crud/tests/unified/updateMany-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: updateMany-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 3.3.99

--- a/source/crud/tests/unified/updateMany-hint-serverError.json
+++ b/source/crud/tests/unified/updateMany-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "updateMany-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/source/crud/tests/unified/updateMany-hint-serverError.yml
+++ b/source/crud/tests/unified/updateMany-hint-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: updateMany-hint-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 3.4.0

--- a/source/crud/tests/unified/updateMany-hint.json
+++ b/source/crud/tests/unified/updateMany-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "updateMany-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0"

--- a/source/crud/tests/unified/updateMany-hint.yml
+++ b/source/crud/tests/unified/updateMany-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: updateMany-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.2.0

--- a/source/crud/tests/unified/updateMany-validation.json
+++ b/source/crud/tests/unified/updateMany-validation.json
@@ -1,6 +1,6 @@
 {
   "description": "updateMany-validation",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/updateMany-validation.yml
+++ b/source/crud/tests/unified/updateMany-validation.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: updateMany-validation
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/updateOne-hint-clientError.json
+++ b/source/crud/tests/unified/updateOne-hint-clientError.json
@@ -1,6 +1,6 @@
 {
   "description": "updateOne-hint-clientError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "maxServerVersion": "3.3.99"

--- a/source/crud/tests/unified/updateOne-hint-clientError.yml
+++ b/source/crud/tests/unified/updateOne-hint-clientError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: updateOne-hint-clientError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     maxServerVersion: 3.3.99

--- a/source/crud/tests/unified/updateOne-hint-serverError.json
+++ b/source/crud/tests/unified/updateOne-hint-serverError.json
@@ -1,6 +1,6 @@
 {
   "description": "updateOne-hint-serverError",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4.0",

--- a/source/crud/tests/unified/updateOne-hint-serverError.yml
+++ b/source/crud/tests/unified/updateOne-hint-serverError.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: updateOne-hint-serverError
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 3.4.0

--- a/source/crud/tests/unified/updateOne-hint.json
+++ b/source/crud/tests/unified/updateOne-hint.json
@@ -1,6 +1,6 @@
 {
   "description": "updateOne-hint",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2.0"

--- a/source/crud/tests/unified/updateOne-hint.yml
+++ b/source/crud/tests/unified/updateOne-hint.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: updateOne-hint
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.2.0

--- a/source/crud/tests/unified/updateOne-validation.json
+++ b/source/crud/tests/unified/updateOne-validation.json
@@ -1,6 +1,6 @@
 {
   "description": "updateOne-validation",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/updateOne-validation.yml
+++ b/source/crud/tests/unified/updateOne-validation.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: updateOne-validation
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 createEntities:
   -
     client:

--- a/source/crud/tests/unified/updateWithPipelines.json
+++ b/source/crud/tests/unified/updateWithPipelines.json
@@ -1,6 +1,6 @@
 {
   "description": "updateWithPipelines",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.0",
   "runOnRequirements": [
     {
       "minServerVersion": "4.1.11"

--- a/source/crud/tests/unified/updateWithPipelines.yml
+++ b/source/crud/tests/unified/updateWithPipelines.yml
@@ -2,7 +2,7 @@
 # Please review the generated file, then remove this notice.
 
 description: updateWithPipelines
-schemaVersion: '1.1'
+schemaVersion: '1.0'
 runOnRequirements:
   -
     minServerVersion: 4.1.11


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1775

Note: `db-aggregate.yml` requires schemaVersion 1.4 for `serverless: forbid` and has been excluded from this PR. Everything else is valid for 1.0.

```
$ ajv test -s unified-test-format/schema-1.0.json -d "crud/tests/unified/*.yml" --valid
crud/tests/unified/aggregate-merge.yml passed test
crud/tests/unified/aggregate-out-readConcern.yml passed test
crud/tests/unified/aggregate.yml passed test
crud/tests/unified/bulkWrite-arrayFilters-clientError.yml passed test
crud/tests/unified/bulkWrite-arrayFilters.yml passed test
crud/tests/unified/bulkWrite-delete-hint-clientError.yml passed test
crud/tests/unified/bulkWrite-delete-hint-serverError.yml passed test
crud/tests/unified/bulkWrite-delete-hint.yml passed test
crud/tests/unified/bulkWrite-update-hint-clientError.yml passed test
crud/tests/unified/bulkWrite-update-hint-serverError.yml passed test
crud/tests/unified/bulkWrite-update-hint.yml passed test
crud/tests/unified/bulkWrite-update-validation.yml passed test
crud/tests/unified/db-aggregate.yml failed test
[
  {
    keyword: 'additionalProperties',
    dataPath: '/runOnRequirements/0',
    schemaPath: '#/additionalProperties',
    params: { additionalProperty: 'serverless' },
    message: 'should NOT have additional properties'
  }
]
crud/tests/unified/deleteMany-hint-clientError.yml passed test
crud/tests/unified/deleteMany-hint-serverError.yml passed test
crud/tests/unified/deleteMany-hint.yml passed test
crud/tests/unified/deleteOne-hint-clientError.yml passed test
crud/tests/unified/deleteOne-hint-serverError.yml passed test
crud/tests/unified/deleteOne-hint.yml passed test
crud/tests/unified/estimatedDocumentCount.yml passed test
crud/tests/unified/find-allowdiskuse-clientError.yml passed test
crud/tests/unified/find-allowdiskuse-serverError.yml passed test
crud/tests/unified/find-allowdiskuse.yml passed test
crud/tests/unified/find.yml passed test
crud/tests/unified/findOneAndDelete-hint-clientError.yml passed test
crud/tests/unified/findOneAndDelete-hint-serverError.yml passed test
crud/tests/unified/findOneAndDelete-hint.yml passed test
crud/tests/unified/findOneAndReplace-hint-clientError.yml passed test
crud/tests/unified/findOneAndReplace-hint-serverError.yml passed test
crud/tests/unified/findOneAndReplace-hint.yml passed test
crud/tests/unified/findOneAndUpdate-hint-clientError.yml passed test
crud/tests/unified/findOneAndUpdate-hint-serverError.yml passed test
crud/tests/unified/findOneAndUpdate-hint.yml passed test
crud/tests/unified/replaceOne-hint.yml passed test
crud/tests/unified/replaceOne-validation.yml passed test
crud/tests/unified/unacknowledged-bulkWrite-delete-hint-clientError.yml passed test
crud/tests/unified/unacknowledged-bulkWrite-update-hint-clientError.yml passed test
crud/tests/unified/unacknowledged-deleteMany-hint-clientError.yml passed test
crud/tests/unified/unacknowledged-deleteOne-hint-clientError.yml passed test
crud/tests/unified/unacknowledged-findOneAndDelete-hint-clientError.yml passed test
crud/tests/unified/unacknowledged-findOneAndReplace-hint-clientError.yml passed test
crud/tests/unified/unacknowledged-findOneAndUpdate-hint-clientError.yml passed test
crud/tests/unified/unacknowledged-replaceOne-hint-clientError.yml passed test
crud/tests/unified/unacknowledged-updateMany-hint-clientError.yml passed test
crud/tests/unified/unacknowledged-updateOne-hint-clientError.yml passed test
crud/tests/unified/updateMany-hint-clientError.yml passed test
crud/tests/unified/updateMany-hint-serverError.yml passed test
crud/tests/unified/updateMany-hint.yml passed test
crud/tests/unified/updateMany-validation.yml passed test
crud/tests/unified/updateOne-hint-clientError.yml passed test
crud/tests/unified/updateOne-hint-serverError.yml passed test
crud/tests/unified/updateOne-hint.yml passed test
crud/tests/unified/updateOne-validation.yml passed test
crud/tests/unified/updateWithPipelines.yml passed test
```