### PR TITLE
DRIVERS-1774 Move expireAfterSeconds in time-series tests

### DIFF
--- a/source/collection-management/tests/timeseries-collection.json
+++ b/source/collection-management/tests/timeseries-collection.json
@@ -53,10 +53,12 @@
           "object": "database0",
           "arguments": {
             "collection": "test",
+            "expireAfterSeconds": {
+              "$numberLong": "604800"
+            },
             "timeseries": {
               "timeField": "time",
-              "metaField": "meta",
-              "expireAfterSeconds": 604800
+              "metaField": "meta"
             }
           }
         },
@@ -87,8 +89,7 @@
                   "create": "test",
                   "timeseries": {
                     "timeField": "time",
-                    "metaField": "meta",
-                    "expireAfterSeconds": 604800
+                    "metaField": "meta"
                   }
                 },
                 "databaseName": "ts-tests"
@@ -113,10 +114,12 @@
           "object": "database0",
           "arguments": {
             "collection": "test",
+            "expireAfterSeconds": {
+              "$numberLong": "604800"
+            },
             "timeseries": {
               "timeField": "time",
-              "metaField": "meta",
-              "expireAfterSeconds": 604800
+              "metaField": "meta"
             }
           }
         },
@@ -171,8 +174,7 @@
                   "create": "test",
                   "timeseries": {
                     "timeField": "time",
-                    "metaField": "meta",
-                    "expireAfterSeconds": 604800
+                    "metaField": "meta"
                   }
                 },
                 "databaseName": "ts-tests"
@@ -200,30 +202,6 @@
                       }
                     }
                   ]
-                }
-              }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "test",
-          "databaseName": "ts-tests",
-          "documents": [
-            {
-              "_id": 1,
-              "time": {
-                "$date": {
-                  "$numberLong": "1552949630482"
-                }
-              }
-            },
-            {
-              "_id": 1,
-              "time": {
-                "$date": {
-                  "$numberLong": "1552949630483"
                 }
               }
             }

--- a/source/collection-management/tests/timeseries-collection.json
+++ b/source/collection-management/tests/timeseries-collection.json
@@ -240,7 +240,6 @@
                     "time": 1
                   }
                 },
-                "commandName": "find",
                 "databaseName": "ts-tests"
               }
             }

--- a/source/collection-management/tests/timeseries-collection.json
+++ b/source/collection-management/tests/timeseries-collection.json
@@ -53,9 +53,7 @@
           "object": "database0",
           "arguments": {
             "collection": "test",
-            "expireAfterSeconds": {
-              "$numberLong": "604800"
-            },
+            "expireAfterSeconds": 604800,
             "timeseries": {
               "timeField": "time",
               "metaField": "meta"
@@ -87,6 +85,9 @@
               "commandStartedEvent": {
                 "command": {
                   "create": "test",
+                  "expireAfterSeconds": {
+                    "$numberLong": "604800"
+                  },
                   "timeseries": {
                     "timeField": "time",
                     "metaField": "meta"
@@ -114,9 +115,7 @@
           "object": "database0",
           "arguments": {
             "collection": "test",
-            "expireAfterSeconds": {
-              "$numberLong": "604800"
-            },
+            "expireAfterSeconds": 604800,
             "timeseries": {
               "timeField": "time",
               "metaField": "meta"
@@ -154,6 +153,34 @@
               }
             ]
           }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "time": 1
+            }
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "time": {
+                "$date": {
+                  "$numberLong": "1552949630482"
+                }
+              }
+            },
+            {
+              "_id": 1,
+              "time": {
+                "$date": {
+                  "$numberLong": "1552949630483"
+                }
+              }
+            }
+          ]
         }
       ],
       "expectEvents": [
@@ -172,6 +199,9 @@
               "commandStartedEvent": {
                 "command": {
                   "create": "test",
+                  "expireAfterSeconds": {
+                    "$numberLong": "604800"
+                  },
                   "timeseries": {
                     "timeField": "time",
                     "metaField": "meta"
@@ -203,6 +233,19 @@
                     }
                   ]
                 }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "filter": {},
+                  "sort": {
+                    "time": 1
+                  }
+                },
+                "commandName": "find",
+                "databaseName": "ts-tests"
               }
             }
           ]

--- a/source/collection-management/tests/timeseries-collection.json
+++ b/source/collection-management/tests/timeseries-collection.json
@@ -85,9 +85,7 @@
               "commandStartedEvent": {
                 "command": {
                   "create": "test",
-                  "expireAfterSeconds": {
-                    "$numberLong": "604800"
-                  },
+                  "expireAfterSeconds": 604800,
                   "timeseries": {
                     "timeField": "time",
                     "metaField": "meta"
@@ -199,9 +197,7 @@
               "commandStartedEvent": {
                 "command": {
                   "create": "test",
-                  "expireAfterSeconds": {
-                    "$numberLong": "604800"
-                  },
+                  "expireAfterSeconds": 604800,
                   "timeseries": {
                     "timeField": "time",
                     "metaField": "meta"

--- a/source/collection-management/tests/timeseries-collection.yml
+++ b/source/collection-management/tests/timeseries-collection.yml
@@ -34,10 +34,11 @@ tests:
         object: *database0
         arguments:
           collection: *collection0Name
+          expireAfterSeconds:
+            $numberLong: "604800"
           timeseries: &timeseries0
             timeField: "time"
             metaField: "meta"
-            expireAfterSeconds: 604800
       - name: assertCollectionExists
         object: testRunner
         arguments:
@@ -67,7 +68,11 @@ tests:
         object: *database0
         arguments:
           collection: *collection0Name
-          timeseries: *timeseries0
+          expireAfterSeconds:
+            $numberLong: "604800"
+          timeseries: &timeseries0
+            timeField: "time"
+            metaField: "meta"
       - name: assertCollectionExists
         object: testRunner
         arguments:
@@ -109,7 +114,6 @@ tests:
               command:
                 insert: *collection0Name
                 documents: *docs
-    outcome:
-    - collectionName: *collection0Name
-      databaseName: *database0Name
-      documents: *docs
+
+   # Expect no particular outcome from the collection since ordering of
+   # documents may vary given duplicate _ids.

--- a/source/collection-management/tests/timeseries-collection.yml
+++ b/source/collection-management/tests/timeseries-collection.yml
@@ -34,8 +34,8 @@ tests:
         object: *database0
         arguments:
           collection: *collection0Name
-          expireAfterSeconds:
-            $numberLong: "604800"
+          # expireAfterSeconds should be an int64 (as it is stored on the server).
+          expireAfterSeconds: 604800
           timeseries: &timeseries0
             timeField: "time"
             metaField: "meta"
@@ -54,6 +54,8 @@ tests:
           - commandStartedEvent:
               command:
                 create: *collection0Name
+                expireAfterSeconds:
+                  $numberLong: "604800"
                 timeseries: *timeseries0
               databaseName: *database0Name
 
@@ -68,11 +70,9 @@ tests:
         object: *database0
         arguments:
           collection: *collection0Name
-          expireAfterSeconds:
-            $numberLong: "604800"
-          timeseries: &timeseries0
-            timeField: "time"
-            metaField: "meta"
+          # expireAfterSeconds should be an int64 (as it is stored on the server).
+          expireAfterSeconds: 604800
+          timeseries: *timeseries0
       - name: assertCollectionExists
         object: testRunner
         arguments:
@@ -98,6 +98,12 @@ tests:
                   }
                 }
               }
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+          sort: { time: 1 }
+        expectResult: *docs
     expectEvents:
       - client: *client0
         events:
@@ -108,12 +114,18 @@ tests:
           - commandStartedEvent:
               command:
                 create: *collection0Name
+                expireAfterSeconds:
+                  $numberLong: "604800"
                 timeseries: *timeseries0
               databaseName: *database0Name
           - commandStartedEvent:
               command:
                 insert: *collection0Name
                 documents: *docs
-
-   # Expect no particular outcome from the collection since ordering of
-   # documents may vary given duplicate _ids.
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: {}
+                sort: { time: 1 }
+              commandName: find
+              databaseName: *database0Name

--- a/source/collection-management/tests/timeseries-collection.yml
+++ b/source/collection-management/tests/timeseries-collection.yml
@@ -54,8 +54,7 @@ tests:
           - commandStartedEvent:
               command:
                 create: *collection0Name
-                expireAfterSeconds:
-                  $numberLong: "604800"
+                expireAfterSeconds: 604800
                 timeseries: *timeseries0
               databaseName: *database0Name
 
@@ -114,8 +113,7 @@ tests:
           - commandStartedEvent:
               command:
                 create: *collection0Name
-                expireAfterSeconds:
-                  $numberLong: "604800"
+                expireAfterSeconds: 604800
                 timeseries: *timeseries0
               databaseName: *database0Name
           - commandStartedEvent:

--- a/source/collection-management/tests/timeseries-collection.yml
+++ b/source/collection-management/tests/timeseries-collection.yml
@@ -125,5 +125,4 @@ tests:
                 find: *collection0Name
                 filter: {}
                 sort: { time: 1 }
-              commandName: find
               databaseName: *database0Name


### PR DESCRIPTION
DRIVERS-1774

Moves the `expireAfterSeconds` time-series option to be a top-level `createCollection` option instead of one under `timeseries`. Changes its value to a `$numberLong` to specify that it should be stored as an `int64` or equivalent. Removes `outcome` expectation from the duplicate `_id` test because of potential variations in ordering of documents with duplicate `_id` fields in test runners.