### PR TITLE
DRIVERS-1791 Fix load balancer spec test ConnectionClosedEvent reason

### DIFF
--- a/source/load-balancers/tests/sdam-error-handling.json
+++ b/source/load-balancers/tests/sdam-error-handling.json
@@ -241,7 +241,7 @@
             },
             {
               "connectionClosedEvent": {
-                "reason": "stale"
+                "reason": "error"
               }
             },
             {

--- a/source/load-balancers/tests/sdam-error-handling.yml
+++ b/source/load-balancers/tests/sdam-error-handling.yml
@@ -128,7 +128,7 @@ tests:
           - poolClearedEvent: {}
           - connectionCheckedInEvent: {}
           - connectionClosedEvent:
-              reason: stale
+              reason: error
           # Second insertOne.
           - connectionCheckedOutEvent: {}
           - connectionCheckedInEvent: {}


### PR DESCRIPTION
In this test a connection is closed because the insert command fails with a NotPrimary error so the ConnectionClosedEvent reason field should be "error" not "stale".