### PR TITLE
DRIVERS-1779 Add granularity option to time-series tests

### DIFF
--- a/source/collection-management/tests/timeseries-collection.json
+++ b/source/collection-management/tests/timeseries-collection.json
@@ -56,7 +56,8 @@
             "expireAfterSeconds": 604800,
             "timeseries": {
               "timeField": "time",
-              "metaField": "meta"
+              "metaField": "meta",
+              "granularity": "minutes"
             }
           }
         },
@@ -88,7 +89,8 @@
                   "expireAfterSeconds": 604800,
                   "timeseries": {
                     "timeField": "time",
-                    "metaField": "meta"
+                    "metaField": "meta",
+                    "granularity": "minutes"
                   }
                 },
                 "databaseName": "ts-tests"
@@ -116,7 +118,8 @@
             "expireAfterSeconds": 604800,
             "timeseries": {
               "timeField": "time",
-              "metaField": "meta"
+              "metaField": "meta",
+              "granularity": "minutes"
             }
           }
         },
@@ -200,7 +203,8 @@
                   "expireAfterSeconds": 604800,
                   "timeseries": {
                     "timeField": "time",
-                    "metaField": "meta"
+                    "metaField": "meta",
+                    "granularity": "minutes"
                   }
                 },
                 "databaseName": "ts-tests"

--- a/source/collection-management/tests/timeseries-collection.yml
+++ b/source/collection-management/tests/timeseries-collection.yml
@@ -39,6 +39,7 @@ tests:
           timeseries: &timeseries0
             timeField: "time"
             metaField: "meta"
+            granularity: "minutes"
       - name: assertCollectionExists
         object: testRunner
         arguments:


### PR DESCRIPTION
DRIVERS-1779

Adds the `granularity` option to the `createCollection` operations for time-series tests to ensure that drivers can support non-default granularities (like "minutes").