### PR TITLE
DRIVERS-1237: Do not rely on dotted field for client-side error

### DIFF
--- a/source/transactions/tests/legacy/errors-client.json
+++ b/source/transactions/tests/legacy/errors-client.json
@@ -25,14 +25,15 @@
           "object": "session0"
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "error": true
@@ -60,22 +61,23 @@
           "arguments": {
             "session": "session0",
             "document": {
-              "_id": 4
+              "_id": 1
             }
           },
           "result": {
-            "insertedId": 4
+            "insertedId": 1
           }
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "error": true

--- a/source/transactions/tests/legacy/errors-client.yml
+++ b/source/transactions/tests/legacy/errors-client.yml
@@ -16,12 +16,12 @@ tests:
     operations:
       - name: startTransaction
         object: session0
-      - name: insertOne
+      - name: updateOne
         object: collection
         arguments:
           session: session0
-          document:
-            _id: {.: .}
+          filter: { _id: 1 }
+          update: { x: 1 }
         error: true
       - name: assertSessionTransactionState
         object: testRunner
@@ -38,16 +38,15 @@ tests:
         object: collection
         arguments:
           session: session0
-          document:
-            _id: 4
+          document: { _id: 1 }
         result:
-          insertedId: 4
-      - name: insertOne
+          insertedId: 1
+      - name: updateOne
         object: collection
         arguments:
           session: session0
-          document:
-            _id: {.: .}
+          filter: { _id: 1 }
+          update: { x: 1 }
         error: true
       - name: assertSessionTransactionState
         object: testRunner

--- a/source/unified-test-format/tests/valid-pass/poc-transactions.json
+++ b/source/unified-test-format/tests/valid-pass/poc-transactions.json
@@ -61,14 +61,15 @@
           "object": "session0"
         },
         {
-          "name": "insertOne",
+          "name": "updateOne",
           "object": "collection0",
           "arguments": {
             "session": "session0",
-            "document": {
-              "_id": {
-                ".": "."
-              }
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "x": 1
             }
           },
           "expectError": {

--- a/source/unified-test-format/tests/valid-pass/poc-transactions.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-transactions.yml
@@ -34,11 +34,12 @@ tests:
     operations:
       - name: startTransaction
         object: *session0
-      - name: insertOne
+      - name: updateOne
         object: *collection0
         arguments:
           session: *session0
-          document: { _id: { .: . } }
+          filter: { _id: 1 }
+          update: { x: 1 }
         # Original test only asserted a generic error
         expectError: { isClientError: true }
       - name: assertSessionTransactionState


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1237

Since dots/dollars are no longer prohibited, these tests can use update/replace validation to yield a client-side error.