### PR TITLE
DRIVERS-1173: Remove DBRef parse error tests

### DIFF
--- a/source/bson-corpus/tests/top.json
+++ b/source/bson-corpus/tests/top.json
@@ -215,14 +215,6 @@
             "string": "{\"a\" : {\"$date\" : {\"$numberLong\" : \"1356351330501\"}, \"unrelated\": true}}"
         },
         {
-            "description": "Bad DBRef (ref is number, not string)",
-            "string": "{\"x\" : {\"$ref\" : 42, \"$id\" : \"abc\"}}"
-        },
-        {
-            "description": "Bad DBRef (db is number, not string)",
-            "string": "{\"x\" : {\"$ref\" : \"a\", \"$id\" : \"abc\", \"$db\" : 42}}"
-        },
-        {
             "description": "Bad $minKey (boolean, not integer)",
             "string": "{\"a\" : {\"$minKey\" : true}}"
         },


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1173

These were missed in the original PR (#996). Invalid DBRef documents are no longer parse errors but should be left as-is.