### PR TITLE
DRIVERS-1790: Fixing SDAM section order for topology types

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -272,7 +272,7 @@ Enums
 TopologyType
 ~~~~~~~~~~~~
 
-Single, ReplicaSetNoPrimary, ReplicaSetWithPrimary, Sharded, or Unknown.
+Single, ReplicaSetNoPrimary, ReplicaSetWithPrimary, Sharded, LoadBalanced, or Unknown.
 
 See `updating the TopologyDescription`_.
 

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -811,12 +811,6 @@ MUST be replaced with the new ServerDescription.
 .. _is compatible:
 
 
-TopologyType LoadBalanced
-`````````````````````````
-
-See the `Load Balancer Specification <../load-balancers/load-balancers.rst#server-discovery-and-monitoring>`__ for details.
-
-
 Checking wire protocol compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -857,6 +851,12 @@ A client MAY allow the user to supply a setName with an initial TopologyType
 of Single. In this case, if the ServerDescription's setName is null or wrong,
 the ServerDescription MUST be replaced with a default ServerDescription of
 type Unknown.
+
+
+TopologyType LoadBalanced
+`````````````````````````
+
+See the `Load Balancer Specification <../load-balancers/load-balancers.rst#server-discovery-and-monitoring>`__ for details.
 
 Other TopologyTypes
 ```````````````````


### PR DESCRIPTION
The load balancer section was placed too far up the document and caused the single topology type subsections to appear under the load balancer heading.