### PR TITLE
Clarified listDatabaseObjects and listCollectionObjects spec tests

### DIFF
--- a/source/retryable-reads/tests/listCollectionObjects-serverErrors.yml
+++ b/source/retryable-reads/tests/listCollectionObjects-serverErrors.yml
@@ -1,3 +1,7 @@
+# listCollectionObjects returns an array of MongoCollection objects.
+# Not all drivers support this functionality. For more details, see:
+# https://github.com/mongodb/specifications/blob/master/source/enumerate-collections.rst#returning-a-list-of-collection-objects
+
 runOn:
     -
         minServerVersion: "4.0"

--- a/source/retryable-reads/tests/listCollectionObjects.yml
+++ b/source/retryable-reads/tests/listCollectionObjects.yml
@@ -1,3 +1,7 @@
+# listCollectionObjects returns an array of MongoCollection objects.
+# Not all drivers support this functionality. For more details, see:
+# https://github.com/mongodb/specifications/blob/master/source/enumerate-collections.rst#returning-a-list-of-collection-objects
+
 runOn:
     -
         minServerVersion: "4.0"

--- a/source/retryable-reads/tests/listDatabaseObjects-serverErrors.yml
+++ b/source/retryable-reads/tests/listDatabaseObjects-serverErrors.yml
@@ -1,3 +1,7 @@
+# listDatabaseObjects returns an array of MongoDatabase objects.
+# Not all drivers support this functionality. For more details, see:
+# https://github.com/mongodb/specifications/blob/master/source/enumerate-databases.rst#enumerating-mongodatabase-objects
+
 runOn:
     -
         minServerVersion: "4.0"

--- a/source/retryable-reads/tests/listDatabaseObjects.yml
+++ b/source/retryable-reads/tests/listDatabaseObjects.yml
@@ -1,3 +1,7 @@
+# listDatabaseObjects returns an array of MongoDatabase objects.
+# Not all drivers support this functionality. For more details, see:
+# https://github.com/mongodb/specifications/blob/master/source/enumerate-databases.rst#enumerating-mongodatabase-objects
+
 runOn:
     -
         minServerVersion: "4.0"


### PR DESCRIPTION
Added links to the Enumerating Databases and Enumerating Collections specs in the Retryable Reads spec tests for listDatabaseObjects and listCollectionObjects.