### PR TITLE
Fix schema version in versioned API transaction handling test file

### DIFF
--- a/source/versioned-api/tests/transaction-handling.json
+++ b/source/versioned-api/tests/transaction-handling.json
@@ -1,6 +1,6 @@
 {
   "description": "Transaction handling",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.3",
   "runOnRequirements": [
     {
       "minServerVersion": "4.9",

--- a/source/versioned-api/tests/transaction-handling.yml
+++ b/source/versioned-api/tests/transaction-handling.yml
@@ -1,6 +1,6 @@
 description: "Transaction handling"
 
-schemaVersion: "1.1"
+schemaVersion: "1.3"
 
 runOnRequirements:
   - minServerVersion: "4.9"


### PR DESCRIPTION
It seems in #961 where load balancer testing support was added the schema version should have been bumped in these files as they run against the load-balanced topology.