### PR TITLE
DRIVERS-1483 Add error label to retryable writes `PoolClearedError` prose test

### DIFF
--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -183,7 +183,7 @@ PoolClearedError Retryability Test
 
 This test will be used to ensure drivers properly retry after encountering PoolClearedErrors.
 It MUST be implemented by any driver that implements the CMAP specification.
-This test requires MongoDB 4.2.9+ for `blockConnection` support in the failpoint.
+This test requires MongoDB 4.2.9+ for ``blockConnection`` support in the failpoint.
 
 1. Create a client with maxPoolSize=1 and retryReads=true. If testing against a
    sharded deployment, be sure to connect to only a single mongos.

--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -182,7 +182,8 @@ PoolClearedError Retryability Test
 ==================================
 
 This test will be used to ensure drivers properly retry after encountering PoolClearedErrors.
-This test MUST be implemented by any driver that implements the CMAP specification.
+It MUST be implemented by any driver that implements the CMAP specification.
+This test requires MongoDB 4.2.9+ for `blockConnection` support in the failpoint.
 
 1. Create a client with maxPoolSize=1 and retryReads=true. If testing against a
    sharded deployment, be sure to connect to only a single mongos.

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -330,7 +330,7 @@ and sharded clusters.
 
 #. Test that drivers properly retry after encountering PoolClearedErrors. This
    test MUST be implemented by any driver that implements the CMAP
-   specification.
+   specification. This test requires MongoDB 4.2.9+ for `blockConnection` support in the failpoint.
 
    1. Create a client with maxPoolSize=1 and retryWrites=true. If testing
       against a sharded deployment, be sure to connect to only a single mongos.
@@ -344,7 +344,8 @@ and sharded clusters.
                failCommands: ["insert"],
                errorCode: 91,
                blockConnection: true,
-               blockTimeMS: 1000
+               blockTimeMS: 1000,
+               errorLabels: ["RetryableWriteError"]
            }
        }
 

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -330,7 +330,7 @@ and sharded clusters.
 
 #. Test that drivers properly retry after encountering PoolClearedErrors. This
    test MUST be implemented by any driver that implements the CMAP
-   specification. This test requires MongoDB 4.2.9+ for `blockConnection` support in the failpoint.
+   specification. This test requires MongoDB 4.2.9+ for ``blockConnection`` support in the failpoint.
 
    1. Create a client with maxPoolSize=1 and retryWrites=true. If testing
       against a sharded deployment, be sure to connect to only a single mongos.


### PR DESCRIPTION
This PR adds an error label to the failpoint used in the `PoolClearedError` retryable writes test. Without it, the test would fail on MongoDB 4.4+. This PR also adds information regarding the minimum MongoDB version required to run the retryability tests against.