### PR TITLE
Use wire version 13 for 5.0 servers

### DIFF
--- a/source/wireversion-featurelist.rst
+++ b/source/wireversion-featurelist.rst
@@ -68,7 +68,7 @@ Server Wire version and Feature List
        | createIndexes "commitQuorum" option
 
    * - 5.0
-     - 12
+     - 13
      - | Consistent $collStats count behavior on sharded and non-sharded topologies
 
 For more information see MongoDB Server repo: https://github.com/mongodb/mongo/blob/master/src/mongo/db/wire_version.h


### PR DESCRIPTION
@kevinAlbs mentioned in https://github.com/mongodb/mongo-c-driver/pull/802#pullrequestreview-688918765 that wire version 12 was for 4.9. Now that 5.0 RCs are available for any pre-release testing, we can just use 13.

I'm not sure what additional features are present in wire version 13 that can be added to the feature list in the second column. If anyone has specific suggestions feel free to make a suggestion on the PR.