### PR TITLE
DRIVERS-1816 Test redaction of replies to security sensitive commands

### DIFF
--- a/source/command-monitoring/tests/unified/redacted-commands.json
+++ b/source/command-monitoring/tests/unified/redacted-commands.json
@@ -12,7 +12,8 @@
       "client": {
         "id": "client",
         "observeEvents": [
-          "commandStartedEvent"
+          "commandStartedEvent",
+          "commandSucceededEvent"
         ],
         "observeSensitiveCommands": true
       }
@@ -35,7 +36,10 @@
           "arguments": {
             "commandName": "authenticate",
             "command": {
-              "authenticate": "private"
+              "authenticate": 1,
+              "mechanism": "MONGODB-X509",
+              "user": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
+              "db": "$external"
             }
           },
           "expectError": {
@@ -52,6 +56,15 @@
                 "commandName": "authenticate",
                 "command": {
                   "authenticate": {
+                    "$$exists": false
+                  },
+                  "mechanism": {
+                    "$$exists": false
+                  },
+                  "user": {
+                    "$$exists": false
+                  },
+                  "db": {
                     "$$exists": false
                   }
                 }
@@ -70,7 +83,9 @@
           "arguments": {
             "commandName": "saslStart",
             "command": {
-              "saslStart": "private"
+              "saslStart": 1,
+              "payload": "definitely-invalid-payload",
+              "db": "admin"
             }
           },
           "expectError": {
@@ -87,6 +102,12 @@
                 "commandName": "saslStart",
                 "command": {
                   "saslStart": {
+                    "$$exists": false
+                  },
+                  "payload": {
+                    "$$exists": false
+                  },
+                  "db": {
                     "$$exists": false
                   }
                 }
@@ -105,7 +126,9 @@
           "arguments": {
             "commandName": "saslContinue",
             "command": {
-              "saslContinue": "private"
+              "saslContinue": 1,
+              "conversationId": 0,
+              "payload": "definitely-invalid-payload"
             }
           },
           "expectError": {
@@ -122,6 +145,12 @@
                 "commandName": "saslContinue",
                 "command": {
                   "saslContinue": {
+                    "$$exists": false
+                  },
+                  "conversationId": {
+                    "$$exists": false
+                  },
+                  "payload": {
                     "$$exists": false
                   }
                 }
@@ -140,7 +169,7 @@
           "arguments": {
             "commandName": "getnonce",
             "command": {
-              "getnonce": "private"
+              "getnonce": 1
             }
           }
         }
@@ -154,6 +183,19 @@
                 "commandName": "getnonce",
                 "command": {
                   "getnonce": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "getnonce",
+                "reply": {
+                  "ok": {
+                    "$$exists": false
+                  },
+                  "nonce": {
                     "$$exists": false
                   }
                 }
@@ -172,7 +214,9 @@
           "arguments": {
             "commandName": "createUser",
             "command": {
-              "createUser": "private"
+              "createUser": "private",
+              "pwd": {},
+              "roles": []
             }
           },
           "expectError": {
@@ -189,6 +233,12 @@
                 "commandName": "createUser",
                 "command": {
                   "createUser": {
+                    "$$exists": false
+                  },
+                  "pwd": {
+                    "$$exists": false
+                  },
+                  "roles": {
                     "$$exists": false
                   }
                 }
@@ -207,7 +257,9 @@
           "arguments": {
             "commandName": "updateUser",
             "command": {
-              "updateUser": "private"
+              "updateUser": "private",
+              "pwd": {},
+              "roles": []
             }
           },
           "expectError": {
@@ -224,6 +276,12 @@
                 "commandName": "updateUser",
                 "command": {
                   "updateUser": {
+                    "$$exists": false
+                  },
+                  "pwd": {
+                    "$$exists": false
+                  },
+                  "roles": {
                     "$$exists": false
                   }
                 }
@@ -340,6 +398,11 @@
     },
     {
       "description": "hello with speculative authenticate",
+      "runOnRequirements": [
+        {
+          "minServerVersion": 4.9
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -347,40 +410,11 @@
           "arguments": {
             "commandName": "hello",
             "command": {
-              "hello": "private",
-              "speculativeAuthenticate": "foo"
+              "hello": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
             }
-          },
-          "expectError": {
-            "isError": true
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "ismaster",
-            "command": {
-              "ismaster": "private",
-              "speculativeAuthenticate": "foo"
-            }
-          },
-          "expectError": {
-            "isError": true
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "isMaster",
-            "command": {
-              "isMaster": "private",
-              "speculativeAuthenticate": "foo"
-            }
-          },
-          "expectError": {
-            "isError": true
           }
         }
       ],
@@ -394,15 +428,85 @@
                 "command": {
                   "hello": {
                     "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
                   }
                 }
               }
             },
             {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": true
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello with speculative authenticate",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1,
+              "speculativeAuthenticate": {
+                "saslStart": 1
+              }
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
               "commandStartedEvent": {
                 "commandName": "ismaster",
                 "command": {
                   "ismaster": {
+                    "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  },
+                  "speculativeAuthenticate": {
                     "$$exists": false
                   }
                 }
@@ -414,6 +518,22 @@
                 "command": {
                   "isMaster": {
                     "$$exists": false
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  },
+                  "speculativeAuthenticate": {
+                    "$$exists": false
                   }
                 }
               }
@@ -424,6 +544,11 @@
     },
     {
       "description": "hello without speculative authenticate is not redacted",
+      "runOnRequirements": [
+        {
+          "minServerVersion": 4.9
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -431,27 +556,7 @@
           "arguments": {
             "commandName": "hello",
             "command": {
-              "hello": "public"
-            }
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "ismaster",
-            "command": {
-              "ismaster": "public"
-            }
-          }
-        },
-        {
-          "name": "runCommand",
-          "object": "database",
-          "arguments": {
-            "commandName": "isMaster",
-            "command": {
-              "isMaster": "public"
+              "hello": 1
             }
           }
         }
@@ -464,15 +569,67 @@
               "commandStartedEvent": {
                 "commandName": "hello",
                 "command": {
-                  "hello": "public"
+                  "hello": 1
                 }
               }
             },
             {
+              "commandSucceededEvent": {
+                "commandName": "hello",
+                "reply": {
+                  "isWritablePrimary": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "legacy hello without speculative authenticate is not redacted",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ismaster",
+            "command": {
+              "ismaster": 1
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "isMaster",
+            "command": {
+              "isMaster": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
               "commandStartedEvent": {
                 "commandName": "ismaster",
                 "command": {
-                  "ismaster": "public"
+                  "ismaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "ismaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
                 }
               }
             },
@@ -480,7 +637,17 @@
               "commandStartedEvent": {
                 "commandName": "isMaster",
                 "command": {
-                  "isMaster": "public"
+                  "isMaster": 1
+                }
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "isMaster",
+                "reply": {
+                  "ismaster": {
+                    "$$exists": true
+                  }
                 }
               }
             }

--- a/source/command-monitoring/tests/unified/redacted-commands.json
+++ b/source/command-monitoring/tests/unified/redacted-commands.json
@@ -440,7 +440,7 @@
                 "commandName": "hello",
                 "reply": {
                   "isWritablePrimary": {
-                    "$$unsetOrMatches": true
+                    "$$exists": false
                   },
                   "speculativeAuthenticate": {
                     "$$exists": false
@@ -504,7 +504,7 @@
                 "commandName": "ismaster",
                 "reply": {
                   "ismaster": {
-                    "$$unsetOrMatches": true
+                    "$$exists": false
                   },
                   "speculativeAuthenticate": {
                     "$$exists": false
@@ -530,7 +530,7 @@
                 "commandName": "isMaster",
                 "reply": {
                   "ismaster": {
-                    "$$unsetOrMatches": true
+                    "$$exists": false
                   },
                   "speculativeAuthenticate": {
                     "$$exists": false

--- a/source/command-monitoring/tests/unified/redacted-commands.json
+++ b/source/command-monitoring/tests/unified/redacted-commands.json
@@ -440,7 +440,7 @@
                 "commandName": "hello",
                 "reply": {
                   "isWritablePrimary": {
-                    "$$exists": true
+                    "$$unsetOrMatches": true
                   },
                   "speculativeAuthenticate": {
                     "$$exists": false
@@ -504,7 +504,7 @@
                 "commandName": "ismaster",
                 "reply": {
                   "ismaster": {
-                    "$$exists": true
+                    "$$unsetOrMatches": true
                   },
                   "speculativeAuthenticate": {
                     "$$exists": false
@@ -530,7 +530,7 @@
                 "commandName": "isMaster",
                 "reply": {
                   "ismaster": {
-                    "$$exists": true
+                    "$$unsetOrMatches": true
                   },
                   "speculativeAuthenticate": {
                     "$$exists": false

--- a/source/command-monitoring/tests/unified/redacted-commands.json
+++ b/source/command-monitoring/tests/unified/redacted-commands.json
@@ -400,7 +400,7 @@
       "description": "hello with speculative authenticate",
       "runOnRequirements": [
         {
-          "minServerVersion": 4.9
+          "minServerVersion": "4.9"
         }
       ],
       "operations": [
@@ -546,7 +546,7 @@
       "description": "hello without speculative authenticate is not redacted",
       "runOnRequirements": [
         {
-          "minServerVersion": 4.9
+          "minServerVersion": "4.9"
         }
       ],
       "operations": [

--- a/source/command-monitoring/tests/unified/redacted-commands.yml
+++ b/source/command-monitoring/tests/unified/redacted-commands.yml
@@ -234,8 +234,10 @@ tests:
               reply:
                 # We expect the reply not to be redacted, as the server can't
                 # successfully authenticate us, which means the reply does not
-                # need to be redacted
-                isWritablePrimary: { $$exists: true }
+                # need to be redacted. However, drivers may still choose to
+                # redact the reply based on the fact that the command contained
+                # sensitive information
+                isWritablePrimary: { $$unsetOrMatches: true }
                 # This assertion will currently always hold true since we're
                 # not expecting successful authentication, in which case this
                 # field is missing anyways.
@@ -270,7 +272,7 @@ tests:
           - commandSucceededEvent:
               commandName: ismaster
               reply:
-                ismaster: { $$exists: true }
+                ismaster: { $$unsetOrMatches: true }
                 speculativeAuthenticate: { $$exists: false }
           - commandStartedEvent:
               commandName: isMaster
@@ -280,7 +282,7 @@ tests:
           - commandSucceededEvent:
               commandName: isMaster
               reply:
-                ismaster: { $$exists: true }
+                ismaster: { $$unsetOrMatches: true }
                 speculativeAuthenticate: { $$exists: false }
 
   - description: "hello without speculative authenticate is not redacted"

--- a/source/command-monitoring/tests/unified/redacted-commands.yml
+++ b/source/command-monitoring/tests/unified/redacted-commands.yml
@@ -11,6 +11,7 @@ createEntities:
       id: &client client
       observeEvents:
         - commandStartedEvent
+        - commandSucceededEvent
       observeSensitiveCommands: true
   - database:
       id: &database database
@@ -25,10 +26,12 @@ tests:
         arguments:
           commandName: authenticate
           command:
-            authenticate: "private"
-        # Malformed authentication commands will fail against the server, but we
-        # just want to assert that security-related commands are redacted
-        # in command monitoring.
+            authenticate: 1
+            mechanism: "MONGODB-X509"
+            user: "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry"
+            db: "$external"
+        # An authentication error is expected, but we want to check that the
+        # CommandStartedEvent is redacted
         expectError:
           isError: true
     expectEvents:
@@ -36,11 +39,14 @@ tests:
         events:
           - commandStartedEvent:
               commandName: authenticate
-              # This only asserts that the command name has been redacted from the published command;
-              # however, it's unlikely that a driver would redact this but leave other, sensitive fields.
-              # We cannot simply assert that command is an empty document because it's at root-level, so
-              # additional fields in the actual document will be permitted.
-              command: { authenticate: { $$exists: false } }
+              # We cannot simply assert that command is an empty document
+              # because it's at root-level, so we make a best effort to make
+              # sure sensitive fields are redacted.
+              command:
+                authenticate: { $$exists: false }
+                mechanism: { $$exists: false }
+                user: { $$exists: false }
+                db: { $$exists: false }
 
   - description: "saslStart"
     operations:
@@ -49,7 +55,9 @@ tests:
         arguments:
           commandName: saslStart
           command:
-            saslStart: "private"
+            saslStart: 1
+            payload: "definitely-invalid-payload"
+            db: "admin"
         expectError:
           isError: true
     expectEvents:
@@ -57,7 +65,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: saslStart
-              command: { saslStart: { $$exists: false } }
+              command:
+                saslStart: { $$exists: false }
+                payload: { $$exists: false }
+                db: { $$exists: false }
 
   - description: "saslContinue"
     operations:
@@ -66,7 +77,9 @@ tests:
         arguments:
           commandName: saslContinue
           command:
-            saslContinue: "private"
+            saslContinue: 1
+            conversationId: 0
+            payload: "definitely-invalid-payload"
         expectError:
           isError: true
     expectEvents:
@@ -74,7 +87,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: saslContinue
-              command: { saslContinue: { $$exists: false } }
+              command:
+                saslContinue: { $$exists: false }
+                conversationId: { $$exists: false }
+                payload: { $$exists: false }
 
   - description: "getnonce"
     operations:
@@ -83,13 +99,18 @@ tests:
         arguments:
           commandName: getnonce
           command:
-            getnonce: "private"
+            getnonce: 1
     expectEvents:
       - client: *client
         events:
           - commandStartedEvent:
               commandName: getnonce
               command: { getnonce: { $$exists: false } }
+          - commandSucceededEvent:
+              commandName: getnonce
+              reply:
+                ok: { $$exists: false }
+                nonce: { $$exists: false }
 
   - description: "createUser"
     operations:
@@ -99,6 +120,10 @@ tests:
           commandName: createUser
           command:
             createUser: "private"
+            # Passing an object is prohibited and we want to trigger a command
+            # failure
+            pwd: {}
+            roles: []
         expectError:
           isError: true
     expectEvents:
@@ -106,7 +131,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: createUser
-              command: { createUser: { $$exists: false } }
+              command:
+                createUser: { $$exists: false }
+                pwd: { $$exists: false }
+                roles: { $$exists: false }
 
   - description: "updateUser"
     operations:
@@ -116,6 +144,8 @@ tests:
           commandName: updateUser
           command:
             updateUser: "private"
+            pwd: {}
+            roles: []
         expectError:
           isError: true
     expectEvents:
@@ -123,7 +153,10 @@ tests:
         events:
           - commandStartedEvent:
               commandName: updateUser
-              command: { updateUser: { $$exists: false } }
+              command:
+                updateUser: { $$exists: false }
+                pwd: { $$exists: false }
+                roles: { $$exists: false }
 
   - description: "copydbgetnonce"
     operations:
@@ -177,76 +210,131 @@ tests:
               command: { copydb: { $$exists: false } }
 
   - description: "hello with speculative authenticate"
+    runOnRequirements:
+      - minServerVersion: 4.9
     operations:
       - name: runCommand
         object: *database
         arguments:
           commandName: hello
           command:
-            hello: "private"
-            speculativeAuthenticate: "foo"
-        expectError:
-          isError: true
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: ismaster
-          command:
-            ismaster: "private"
-            speculativeAuthenticate: "foo"
-        expectError:
-          isError: true
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: isMaster
-          command:
-            isMaster: "private"
-            speculativeAuthenticate: "foo"
-        expectError:
-          isError: true
+            hello: 1
+            speculativeAuthenticate:
+              saslStart: 1
     expectEvents:
       - client: *client
         events:
           - commandStartedEvent:
               commandName: hello
-              command: { hello: { $$exists: false } }
+              command:
+                hello: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: hello
+              reply:
+                # We expect the reply not to be redacted, as the server can't
+                # successfully authenticate us, which means the reply does not
+                # need to be redacted
+                isWritablePrimary: { $$exists: true }
+                # This assertion will currently always hold true since we're
+                # not expecting successful authentication, in which case this
+                # field is missing anyways.
+                speculativeAuthenticate: { $$exists: false }
+
+  - description: "legacy hello with speculative authenticate"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: ismaster
+          command:
+            ismaster: 1
+            speculativeAuthenticate:
+              saslStart: 1
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: isMaster
+          command:
+            isMaster: 1
+            speculativeAuthenticate:
+              saslStart: 1
+    expectEvents:
+      - client: *client
+        events:
           - commandStartedEvent:
               commandName: ismaster
-              command: { ismaster: { $$exists: false } }
+              command:
+                ismaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: ismaster
+              reply:
+                ismaster: { $$exists: true }
+                speculativeAuthenticate: { $$exists: false }
           - commandStartedEvent:
               commandName: isMaster
-              command: { isMaster: { $$exists: false } }
+              command:
+                isMaster: { $$exists: false }
+                speculativeAuthenticate: { $$exists: false }
+          - commandSucceededEvent:
+              commandName: isMaster
+              reply:
+                ismaster: { $$exists: true }
+                speculativeAuthenticate: { $$exists: false }
 
   - description: "hello without speculative authenticate is not redacted"
+    runOnRequirements:
+      - minServerVersion: 4.9
     operations:
       - name: runCommand
         object: *database
         arguments:
           commandName: hello
           command:
-            hello: "public"
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: ismaster
-          command:
-            ismaster: "public"
-      - name: runCommand
-        object: *database
-        arguments:
-          commandName: isMaster
-          command:
-            isMaster: "public"
+            hello: 1
     expectEvents:
       - client: *client
         events:
           - commandStartedEvent:
               commandName: hello
-              command: { hello: "public" }
+              command:
+                hello: 1
+          - commandSucceededEvent:
+              commandName: hello
+              reply:
+                isWritablePrimary: { $$exists: true }
+
+  - description: "legacy hello without speculative authenticate is not redacted"
+    operations:
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: ismaster
+          command:
+            ismaster: 1
+      - name: runCommand
+        object: *database
+        arguments:
+          commandName: isMaster
+          command:
+            isMaster: 1
+    expectEvents:
+      - client: *client
+        events:
           - commandStartedEvent:
               commandName: ismaster
-              command: { ismaster: "public" }
+              command:
+                ismaster: 1
+          - commandSucceededEvent:
+              commandName: ismaster
+              reply:
+                ismaster: { $$exists: true }
           - commandStartedEvent:
               commandName: isMaster
-              command: { isMaster: "public" }
+              command:
+                isMaster: 1
+          - commandSucceededEvent:
+              commandName: isMaster
+              reply:
+                ismaster: { $$exists: true }

--- a/source/command-monitoring/tests/unified/redacted-commands.yml
+++ b/source/command-monitoring/tests/unified/redacted-commands.yml
@@ -232,12 +232,10 @@ tests:
           - commandSucceededEvent:
               commandName: hello
               reply:
-                # We expect the reply not to be redacted, as the server can't
-                # successfully authenticate us, which means the reply does not
-                # need to be redacted. However, drivers may still choose to
-                # redact the reply based on the fact that the command contained
-                # sensitive information
-                isWritablePrimary: { $$unsetOrMatches: true }
+                # Even though authentication above fails and the reply does not
+                # contain sensitive information, we're expecting the reply to be
+                # redacted as well.
+                isWritablePrimary: { $$exists: false }
                 # This assertion will currently always hold true since we're
                 # not expecting successful authentication, in which case this
                 # field is missing anyways.
@@ -272,7 +270,7 @@ tests:
           - commandSucceededEvent:
               commandName: ismaster
               reply:
-                ismaster: { $$unsetOrMatches: true }
+                ismaster: { $$exists: false }
                 speculativeAuthenticate: { $$exists: false }
           - commandStartedEvent:
               commandName: isMaster
@@ -282,7 +280,7 @@ tests:
           - commandSucceededEvent:
               commandName: isMaster
               reply:
-                ismaster: { $$unsetOrMatches: true }
+                ismaster: { $$exists: false }
                 speculativeAuthenticate: { $$exists: false }
 
   - description: "hello without speculative authenticate is not redacted"

--- a/source/command-monitoring/tests/unified/redacted-commands.yml
+++ b/source/command-monitoring/tests/unified/redacted-commands.yml
@@ -211,7 +211,7 @@ tests:
 
   - description: "hello with speculative authenticate"
     runOnRequirements:
-      - minServerVersion: 4.9
+      - minServerVersion: "4.9"
     operations:
       - name: runCommand
         object: *database
@@ -285,7 +285,7 @@ tests:
 
   - description: "hello without speculative authenticate is not redacted"
     runOnRequirements:
-      - minServerVersion: 4.9
+      - minServerVersion: "4.9"
     operations:
       - name: runCommand
         object: *database

--- a/source/unified-test-format/schema-1.5.json
+++ b/source/unified-test-format/schema-1.5.json
@@ -1,0 +1,462 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "Unified Test Format",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["description", "schemaVersion", "tests"],
+  "properties": {
+    "description": { "type": "string" },
+    "schemaVersion": { "$ref": "#/definitions/version" },
+    "runOnRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/runOnRequirement" }
+    },
+    "createEntities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/entity" }
+    },
+    "initialData": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/collectionData" }
+    },
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/test" }
+    },
+    "_yamlAnchors": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+
+  "definitions": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+    },
+
+    "runOnRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "maxServerVersion": { "$ref": "#/definitions/version" },
+        "minServerVersion": { "$ref": "#/definitions/version" },
+        "topologies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["single", "replicaset", "sharded", "sharded-replicaset", "load-balanced"]
+          }
+        },
+        "serverless": {
+          "type": "string",
+          "enum": ["require", "forbid", "allow"]
+        },
+        "serverParameters": {
+          "type": "object",
+          "minProperties": 1
+        },
+        "auth": { "type": "boolean" }
+      }
+    },
+
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "client": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id"],
+          "properties": {
+            "id": { "type": "string" },
+            "uriOptions": { "type": "object" },
+            "useMultipleMongoses": { "type": "boolean" },
+            "observeEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "commandStartedEvent",
+                  "commandSucceededEvent",
+                  "commandFailedEvent",
+                  "poolCreatedEvent",
+                  "poolReadyEvent",
+                  "poolClearedEvent",
+                  "poolClosedEvent",
+                  "connectionCreatedEvent",
+                  "connectionReadyEvent",
+                  "connectionClosedEvent",
+                  "connectionCheckOutStartedEvent",
+                  "connectionCheckOutFailedEvent",
+                  "connectionCheckedOutEvent",
+                  "connectionCheckedInEvent"
+                ]
+              }
+            },
+            "ignoreCommandMonitoringEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            },
+            "storeEventsAsEntities": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/definitions/storeEventsAsEntity" }
+            },
+            "serverApi": { "$ref":  "#/definitions/serverApi" },
+            "observeSensitiveCommands": { "type": "boolean" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client", "databaseName"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "databaseOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database", "collectionName"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "collectionName": { "type": "string" },
+            "collectionOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "sessionOptions": { "type": "object" }
+          }
+        },
+        "bucket": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "bucketOptions": { "type": "object" }
+          }
+        }
+      }
+    },
+
+    "storeEventsAsEntity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "events"],
+      "properties": {
+        "id": { "type": "string" },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "PoolCreatedEvent",
+              "PoolReadyEvent",
+              "PoolClearedEvent",
+              "PoolClosedEvent",
+              "ConnectionCreatedEvent",
+              "ConnectionReadyEvent",
+              "ConnectionClosedEvent",
+              "ConnectionCheckOutStartedEvent",
+              "ConnectionCheckOutFailedEvent",
+              "ConnectionCheckedOutEvent",
+              "ConnectionCheckedInEvent",
+              "CommandStartedEvent",
+              "CommandSucceededEvent",
+              "CommandFailedEvent"
+            ]
+          }
+        }
+      }
+    },
+
+    "collectionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collectionName", "databaseName", "documents"],
+      "properties": {
+        "collectionName": { "type": "string" },
+        "databaseName": { "type": "string" },
+        "documents": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+
+    "expectedEventsForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["client", "events"],
+      "properties": {
+        "client": { "type": "string" },
+        "eventType": {
+          "type": "string",
+          "enum": ["command", "cmap"]
+        },
+        "events": { "type": "array" }
+      },
+      "oneOf": [
+        {
+          "required": ["eventType"],
+          "properties": {
+            "eventType": { "const": "command" },
+            "events": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/expectedCommandEvent" }
+            }
+          }
+        },
+        {
+          "required": ["eventType"],
+          "properties": {
+            "eventType": { "const": "cmap" },
+            "events": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/expectedCmapEvent" }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "client": { "type": "string" },
+            "events": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/expectedCommandEvent" }
+            }
+          }
+        }
+      ]
+    },
+
+    "expectedCommandEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "commandStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": { "type": "object" },
+            "commandName": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "hasServiceId": { "type": "boolean" }
+          }
+        },
+        "commandSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reply": { "type": "object" },
+            "commandName": { "type": "string" },
+            "hasServiceId": { "type": "boolean" }
+          }
+        },
+        "commandFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "commandName": { "type": "string" },
+            "hasServiceId": { "type": "boolean" }
+          }
+        }
+      }
+    },
+
+    "expectedCmapEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "poolCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolClearedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "hasServiceId": { "type": "boolean" }
+          }
+        },
+        "poolClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": { "type": "string" }
+          }
+        },
+        "connectionCheckOutStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckOutFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": { "type": "string" }
+          }
+        },
+        "connectionCheckedOutEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckedInEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      }
+    },
+
+    "collectionOrDatabaseOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readConcern": { "type": "object" },
+        "readPreference": { "type": "object" },
+        "writeConcern": { "type": "object" }
+      }
+    },
+
+    "serverApi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version"],
+      "properties": {
+        "version": { "type": "string" },
+        "strict": { "type":  "boolean" },
+        "deprecationErrors": { "type":  "boolean" }
+      }
+    },
+
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "object"],
+      "properties": {
+        "name": { "type": "string" },
+        "object": { "type": "string" },
+        "arguments": { "type": "object" },
+        "ignoreResultAndError": { "type": "boolean" },
+        "expectError":  { "$ref": "#/definitions/expectedError" },
+        "expectResult": {},
+        "saveResultAsEntity": { "type": "string" }
+      },
+      "allOf": [
+        { "not": { "required": ["expectError", "expectResult"] } },
+        { "not": { "required": ["expectError", "saveResultAsEntity"] } },
+        { "not": { "required": ["ignoreResultAndError", "expectResult"] } },
+        { "not": { "required": ["ignoreResultAndError", "expectError"] } },
+        { "not": { "required": ["ignoreResultAndError", "saveResultAsEntity"] } }
+      ]
+    },
+
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "isError": {
+          "type": "boolean",
+          "const": true
+        },
+        "isClientError": { "type": "boolean" },
+        "errorContains": { "type": "string" },
+        "errorCode": { "type": "integer" },
+        "errorCodeName": { "type": "string" },
+        "errorLabelsContain": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "errorLabelsOmit": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "expectResult": {}
+      }
+    },
+
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "operations"],
+      "properties": {
+        "description": { "type": "string" },
+        "runOnRequirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/runOnRequirement" }
+        },
+        "skipReason": { "type": "string" },
+        "operations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/operation" }
+        },
+        "expectEvents": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/expectedEventsForClient" }
+        },
+        "outcome": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/collectionData" }
+        }
+      }
+    }
+  }
+}

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -1,8 +1,8 @@
-SCHEMA=../schema-1.4.json
+SCHEMA=../schema-1.5.json
 
-.PHONY: all invalid valid-fail valid-pass versioned-api load-balancers gridfs transactions crud collection-management HAS_AJV
+.PHONY: all invalid valid-fail valid-pass versioned-api load-balancers gridfs transactions crud collection-management sessions command-monitoring HAS_AJV
 
-all: invalid valid-fail valid-pass versioned-api load-balancers gridfs transactions crud collection-management
+all: invalid valid-fail valid-pass versioned-api load-balancers gridfs transactions crud collection-management sessions command-monitoring
 
 invalid: HAS_AJV
 	@# Redirect stdout to hide expected validation errors
@@ -34,6 +34,9 @@ collection-management: HAS_AJV
 
 sessions: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../sessions/tests/unified/*.yml" --valid
+
+command-monitoring: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../command-monitoring/tests/unified/*.yml" --valid
 
 HAS_AJV:
 	@if ! command -v ajv > /dev/null; then                \

--- a/source/unified-test-format/tests/invalid/entity-client-observeSensitiveCommands-type.json
+++ b/source/unified-test-format/tests/invalid/entity-client-observeSensitiveCommands-type.json
@@ -1,6 +1,6 @@
 {
   "description": "entity-client-observeSensitiveCommands-type",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.5",
   "createEntities": [
     {
       "client": {

--- a/source/unified-test-format/tests/invalid/entity-client-observeSensitiveCommands-type.json
+++ b/source/unified-test-format/tests/invalid/entity-client-observeSensitiveCommands-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-observeSensitiveCommands-type",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeSensitiveCommands": 0
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/entity-client-observeSensitiveCommands-type.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-observeSensitiveCommands-type.yml
@@ -1,6 +1,6 @@
 description: "entity-client-observeSensitiveCommands-type"
 
-schemaVersion: "1.0"
+schemaVersion: "1.5"
 
 createEntities:
   - client:

--- a/source/unified-test-format/tests/invalid/entity-client-observeSensitiveCommands-type.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-observeSensitiveCommands-type.yml
@@ -1,0 +1,12 @@
+description: "entity-client-observeSensitiveCommands-type"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      observeSensitiveCommands: 0
+
+tests:
+  - description: "foo"
+    operations: []


### PR DESCRIPTION
DRIVERS-1816

This does not cover replies to all commands, since we're only able to make assertions against successful commands. With some authentication commands, getting them to work is a sizeable effort. For that reason, it's up to engineers to ensure they're not just redacting replies to the commands where we test this, but rather all commands. This includes replies that are potentially sensitive, e.g. replies for `saslStart` and `saslContinue`.

Note that due to a limitation of the unified test format, we can't make assertions against the contents of CommandFailedEvents. While the spec doesn't explicitly mention this event, it is assumed that drivers redact replies when they are exposed in CommandFailedEvents. That said, most if not all replies will not contain sensitive information, so I believe it's ok to leave this untested for the time being.