### PR TITLE
DRIVERS-1237: Do not assert insertedCount field for insertOne results

### DIFF
--- a/source/crud/tests/unified/insertOne-dots_and_dollars.json
+++ b/source/crud/tests/unified/insertOne-dots_and_dollars.json
@@ -63,7 +63,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -166,7 +165,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -221,7 +219,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -280,7 +277,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }
@@ -390,7 +386,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": {
                 "a.b": 1
@@ -501,7 +496,6 @@
             }
           },
           "expectResult": {
-            "insertedCount": 1,
             "insertedId": {
               "$$unsetOrMatches": 1
             }

--- a/source/crud/tests/unified/insertOne-dots_and_dollars.yml
+++ b/source/crud/tests/unified/insertOne-dots_and_dollars.yml
@@ -36,7 +36,6 @@ tests:
         arguments:
           document: &dollarPrefixedKey { _id: 1, $a: 1 }
         expectResult: &insertResult
-          insertedCount: 1
           insertedId: { $$unsetOrMatches: 1 }
     expectEvents: &expectEventsDollarPrefixedKey
       - client: *client0
@@ -156,7 +155,6 @@ tests:
         arguments:
           document: &dottedKeyInId { _id: { a.b: 1 } }
         expectResult:
-          insertedCount: 1
           insertedId: { $$unsetOrMatches: { a.b: 1 } }
     expectEvents: &expectEventsDottedKeyInId
       - client: *client0


### PR DESCRIPTION
This was inadvertently added in 851ca10388cced05117ceace0ced4b7e1aac02c4

Addresses an issue reported by @nbbeeken in [DRIVERS-1237](https://jira.mongodb.org/browse/DRIVERS-1237?focusedCommentId=3901764&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-3901764).