### PR TITLE
DRIVERS-1603: Exclude mapReduce from serverless testing

### DIFF
--- a/source/retryable-reads/tests/mapReduce.json
+++ b/source/retryable-reads/tests/mapReduce.json
@@ -12,7 +12,8 @@
       "topology": [
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "retryable-reads-tests",

--- a/source/retryable-reads/tests/mapReduce.yml
+++ b/source/retryable-reads/tests/mapReduce.yml
@@ -5,6 +5,8 @@ runOn:
     -
         minServerVersion: "4.1.7"
         topology: ["sharded", "load-balanced"]
+        # serverless proxy does not support mapReduce operation
+        serverless: "forbid"
 
 database_name: &database_name "retryable-reads-tests"
 collection_name: &collection_name "coll"


### PR DESCRIPTION
[DRIVERS-1603](https://jira.mongodb.org/browse/DRIVERS-1603)

`mapReduce` operation is not intended to work on serverless (see comment from [CLOUDP-93419](https://jira.mongodb.org/browse/CLOUDP-93419))