### PR TITLE
DRIVERS-1607 Fix topologies field in snapshot reads test

### DIFF
--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
@@ -4,11 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "3.6",
-      "maxServerVersion": "4.4.99",
-      "topologies": [
-        "replicaset",
-        "sharded-replicaset"
-      ]
+      "maxServerVersion": "4.4.99"
     }
   ],
   "createEntities": [

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
@@ -5,6 +5,11 @@
     {
       "minServerVersion": "3.6",
       "maxServerVersion": "4.4.99"
+    },
+    {
+      "topologies": [
+        "single"
+      ]
     }
   ],
   "createEntities": [

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
@@ -7,6 +7,7 @@
       "maxServerVersion": "4.4.99"
     },
     {
+      "minServerVersion": "3.6",
       "topologies": [
         "single"
       ]

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
@@ -6,7 +6,8 @@
       "minServerVersion": "3.6",
       "maxServerVersion": "4.4.99",
       "topologies": [
-        "replicaset, sharded-replicaset"
+        "replicaset",
+        "sharded-replicaset"
       ]
     }
   ],
@@ -17,6 +18,11 @@
         "observeEvents": [
           "commandStartedEvent",
           "commandFailedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "findAndModify",
+          "insert",
+          "update"
         ]
       }
     },
@@ -87,9 +93,7 @@
                       "$$exists": false
                     }
                   }
-                },
-                "commandName": "find",
-                "databaseName": "database0"
+                }
               }
             },
             {

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.0"
 runOnRequirements:
   - minServerVersion: "3.6"
     maxServerVersion: "4.4.99"
+  - topologies: [ single ]
 
 createEntities:
   - client:

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
@@ -5,7 +5,6 @@ schemaVersion: "1.0"
 runOnRequirements:
   - minServerVersion: "3.6"
     maxServerVersion: "4.4.99"
-    topologies: [replicaset, sharded-replicaset]
 
 createEntities:
   - client:

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
@@ -5,7 +5,8 @@ schemaVersion: "1.0"
 runOnRequirements:
   - minServerVersion: "3.6"
     maxServerVersion: "4.4.99"
-  - topologies: [ single ]
+  - minServerVersion: "3.6"
+    topologies: [ single ]
 
 createEntities:
   - client:


### PR DESCRIPTION
To fix this I deleted the json file and ran make to auto-generate the json from yaml. That's why the other changes show up here. 

Edit: I updated the test to run on all topologies <5.0 and all standalone servers (including 5.0+). 3.6 standalones report this expected error:
```
{'ok': 0.0, 'errmsg': "readConcern.level must be either 'local', 'majority', 'linearizable', or 'available'", 'code': 9, 'codeName': 'FailedToParse'}
```
4.0+ standalones report:
```
 {'ok': 0.0, 'errmsg': 'read concern level snapshot is only valid in a transaction', 'code': 72, 'codeName': 'InvalidOptions'}
```
5.0+ standalones report:
```
{'ok': 0.0, 'errmsg': 'node needs to be a replica set member to use readConcern: snapshot', 'code': 123, 'codeName': 'NotAReplicaSet'}
```