### PR TITLE
DRIVERS-1820 Snapshot reads raise client-side error on <5.0

### DIFF
--- a/source/sessions/snapshot-sessions.rst
+++ b/source/sessions/snapshot-sessions.rst
@@ -238,7 +238,7 @@ Requires MongoDB 5.0+
 
 Snapshot reads require MongoDB 5.0+. When the connected server's
 maxWireVersion is less than 13, drivers MUST throw an exception with the
-message "snapshot reads require MongoDB 5.0 or later".
+message "Snapshot reads require MongoDB 5.0 or later".
 
 Motivation
 ==========

--- a/source/sessions/snapshot-sessions.rst
+++ b/source/sessions/snapshot-sessions.rst
@@ -3,7 +3,7 @@ Snapshot Reads Specification
 ============================
 
 :Spec Title: Snapshot Reads Specification (See the registry of specs)
-:Spec Version: 1.0
+:Spec Version: 1.1
 :Author: Boris Dogadov
 :Advisors: Jeff Yemin, A. Jesse Jiryu Davis, Judah Schvimer
 :Status: Draft (Could be Draft, Accepted, Rejected, Final, or Replaced)
@@ -233,6 +233,13 @@ Lists of commands that support snapshot reads:
 2. aggregate
 3. distinct
 
+Requires MongoDB 5.0+
+=====================
+
+Snapshot reads require MongoDB 5.0+. When the connected server's
+maxWireVersion is less than 13, drivers MUST throw an exception with the
+message "snapshot reads require MongoDB 5.0 or later".
+
 Motivation
 ==========
 
@@ -269,3 +276,4 @@ Changelog
 =========
 
 :2021-06-15: Initial version.
+:2021-06-28: Raise client side error on < 5.0.

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
@@ -66,7 +66,7 @@
           },
           "expectError": {
             "isClientError": true,
-            "errorContains": "snapshot reads require MongoDB 5.0 or later"
+            "errorContains": "Snapshot reads require MongoDB 5.0 or later"
           }
         }
       ],
@@ -84,7 +84,7 @@
           },
           "expectError": {
             "isClientError": true,
-            "errorContains": "snapshot reads require MongoDB 5.0 or later"
+            "errorContains": "Snapshot reads require MongoDB 5.0 or later"
           }
         }
       ],
@@ -103,7 +103,7 @@
           },
           "expectError": {
             "isClientError": true,
-            "errorContains": "snapshot reads require MongoDB 5.0 or later"
+            "errorContains": "Snapshot reads require MongoDB 5.0 or later"
           }
         }
       ],

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
@@ -66,7 +66,7 @@
           },
           "expectError": {
             "isClientError": true,
-            "errorContains": "snapshot reads requires MongoDB 5.0 or later"
+            "errorContains": "snapshot reads require MongoDB 5.0 or later"
           }
         }
       ],
@@ -84,7 +84,7 @@
           },
           "expectError": {
             "isClientError": true,
-            "errorContains": "snapshot reads requires MongoDB 5.0 or later"
+            "errorContains": "snapshot reads require MongoDB 5.0 or later"
           }
         }
       ],
@@ -103,7 +103,7 @@
           },
           "expectError": {
             "isClientError": true,
-            "errorContains": "snapshot reads requires MongoDB 5.0 or later"
+            "errorContains": "snapshot reads require MongoDB 5.0 or later"
           }
         }
       ],

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
@@ -1,0 +1,113 @@
+{
+  "description": "snapshot-sessions-not-supported-client-error",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "3.6",
+      "maxServerVersion": "4.4.99"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0",
+        "sessionOptions": {
+          "snapshot": true
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Client error on find with snapshot",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {}
+          },
+          "expectError": {
+            "isClientError": true,
+            "errorContains": "snapshot reads requires MongoDB 5.0 or later"
+          }
+        }
+      ],
+      "expectEvents": []
+    },
+    {
+      "description": "Client error on aggregate with snapshot",
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "pipeline": []
+          },
+          "expectError": {
+            "isClientError": true,
+            "errorContains": "snapshot reads requires MongoDB 5.0 or later"
+          }
+        }
+      ],
+      "expectEvents": []
+    },
+    {
+      "description": "Client error on distinct with snapshot",
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection0",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {},
+            "session": "session0"
+          },
+          "expectError": {
+            "isClientError": true,
+            "errorContains": "snapshot reads requires MongoDB 5.0 or later"
+          }
+        }
+      ],
+      "expectEvents": []
+    }
+  ]
+}

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
@@ -40,7 +40,7 @@ tests:
       filter: {}
     expectError:
       isClientError: true
-      errorContains: snapshot reads require MongoDB 5.0 or later
+      errorContains: Snapshot reads require MongoDB 5.0 or later
   expectEvents: []
 
 - description: Client error on aggregate with snapshot
@@ -52,7 +52,7 @@ tests:
       pipeline: []
     expectError:
       isClientError: true
-      errorContains: snapshot reads require MongoDB 5.0 or later
+      errorContains: Snapshot reads require MongoDB 5.0 or later
   expectEvents: []
 
 - description: Client error on distinct with snapshot
@@ -65,5 +65,5 @@ tests:
       session: session0
     expectError:
       isClientError: true
-      errorContains: snapshot reads require MongoDB 5.0 or later
+      errorContains: Snapshot reads require MongoDB 5.0 or later
   expectEvents: []

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
@@ -1,0 +1,69 @@
+description: snapshot-sessions-not-supported-client-error
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "3.6"
+    maxServerVersion: "4.4.99"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent, commandFailedEvent ]
+  - database:
+      id: &database0Name database0
+      client: *client0
+      databaseName: *database0Name
+  - collection:
+      id: &collection0Name collection0
+      database: *database0Name
+      collectionName: *collection0Name
+  - session:
+      id: session0
+      client: client0
+      sessionOptions:
+        snapshot: true
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+- description: Client error on find with snapshot
+  operations:
+  - name: find
+    object: collection0
+    arguments:
+      session: session0
+      filter: {}
+    expectError:
+      isClientError: true
+      errorContains: snapshot reads requires MongoDB 5.0 or later
+  expectEvents: []
+
+- description: Client error on aggregate with snapshot
+  operations:
+  - name: aggregate
+    object: collection0
+    arguments:
+      session: session0
+      pipeline: []
+    expectError:
+      isClientError: true
+      errorContains: snapshot reads requires MongoDB 5.0 or later
+  expectEvents: []
+
+- description: Client error on distinct with snapshot
+  operations:
+  - name: distinct
+    object: collection0
+    arguments:
+      fieldName: x
+      filter: {}
+      session: session0
+    expectError:
+      isClientError: true
+      errorContains: snapshot reads requires MongoDB 5.0 or later
+  expectEvents: []

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
@@ -40,7 +40,7 @@ tests:
       filter: {}
     expectError:
       isClientError: true
-      errorContains: snapshot reads requires MongoDB 5.0 or later
+      errorContains: snapshot reads require MongoDB 5.0 or later
   expectEvents: []
 
 - description: Client error on aggregate with snapshot
@@ -52,7 +52,7 @@ tests:
       pipeline: []
     expectError:
       isClientError: true
-      errorContains: snapshot reads requires MongoDB 5.0 or later
+      errorContains: snapshot reads require MongoDB 5.0 or later
   expectEvents: []
 
 - description: Client error on distinct with snapshot
@@ -65,5 +65,5 @@ tests:
       session: session0
     expectError:
       isClientError: true
-      errorContains: snapshot reads requires MongoDB 5.0 or later
+      errorContains: snapshot reads require MongoDB 5.0 or later
   expectEvents: []

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
@@ -43,6 +43,20 @@
       }
     },
     {
+      "database": {
+        "id": "missingDB",
+        "client": "client0",
+        "databaseName": "missingDB"
+      }
+    },
+    {
+      "collection": {
+        "id": "missingColl",
+        "database": "missingDB",
+        "collectionName": "missingColl"
+      }
+    },
+    {
       "session": {
         "id": "session0",
         "client": "client0",
@@ -108,6 +122,48 @@
       ]
     },
     {
+      "description": "Server returns an error on find with snapshot on missing database",
+      "operations": [
+        {
+          "name": "find",
+          "object": "missingColl",
+          "arguments": {
+            "session": "session0",
+            "filter": {}
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "missingColl",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "description": "Server returns an error on aggregate with snapshot",
       "operations": [
         {
@@ -131,6 +187,48 @@
               "commandStartedEvent": {
                 "command": {
                   "aggregate": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "aggregate"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on aggregate with snapshot on missing database",
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "missingColl",
+          "arguments": {
+            "session": "session0",
+            "pipeline": []
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "missingColl",
                   "readConcern": {
                     "level": "snapshot",
                     "atClusterTime": {
@@ -174,6 +272,49 @@
               "commandStartedEvent": {
                 "command": {
                   "distinct": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "distinct"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on distinct with snapshot on missing database",
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "missingColl",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {},
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "distinct": "missingColl",
                   "readConcern": {
                     "level": "snapshot",
                     "atClusterTime": {

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
@@ -106,6 +106,91 @@
           ]
         }
       ]
+    },
+    {
+      "description": "Server returns an error on aggregate with snapshot",
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "pipeline": []
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "aggregate"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on distinct with snapshot",
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection0",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {},
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "distinct": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "distinct"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
@@ -3,11 +3,7 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
-      "minServerVersion": "3.6",
-      "maxServerVersion": "4.4.99"
-    },
-    {
-      "minServerVersion": "3.6",
+      "minServerVersion": "5.0",
       "topologies": [
         "single"
       ]
@@ -20,11 +16,6 @@
         "observeEvents": [
           "commandStartedEvent",
           "commandFailedEvent"
-        ],
-        "ignoreCommandMonitoringEvents": [
-          "findAndModify",
-          "insert",
-          "update"
         ]
       }
     },

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.json
@@ -34,20 +34,6 @@
       }
     },
     {
-      "database": {
-        "id": "missingDB",
-        "client": "client0",
-        "databaseName": "missingDB"
-      }
-    },
-    {
-      "collection": {
-        "id": "missingColl",
-        "database": "missingDB",
-        "collectionName": "missingColl"
-      }
-    },
-    {
       "session": {
         "id": "session0",
         "client": "client0",
@@ -113,48 +99,6 @@
       ]
     },
     {
-      "description": "Server returns an error on find with snapshot on missing database",
-      "operations": [
-        {
-          "name": "find",
-          "object": "missingColl",
-          "arguments": {
-            "session": "session0",
-            "filter": {}
-          },
-          "expectError": {
-            "isError": true,
-            "isClientError": false
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "find": "missingColl",
-                  "readConcern": {
-                    "level": "snapshot",
-                    "atClusterTime": {
-                      "$$exists": false
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "commandFailedEvent": {
-                "commandName": "find"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
       "description": "Server returns an error on aggregate with snapshot",
       "operations": [
         {
@@ -178,48 +122,6 @@
               "commandStartedEvent": {
                 "command": {
                   "aggregate": "collection0",
-                  "readConcern": {
-                    "level": "snapshot",
-                    "atClusterTime": {
-                      "$$exists": false
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "commandFailedEvent": {
-                "commandName": "aggregate"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "Server returns an error on aggregate with snapshot on missing database",
-      "operations": [
-        {
-          "name": "aggregate",
-          "object": "missingColl",
-          "arguments": {
-            "session": "session0",
-            "pipeline": []
-          },
-          "expectError": {
-            "isError": true,
-            "isClientError": false
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "aggregate": "missingColl",
                   "readConcern": {
                     "level": "snapshot",
                     "atClusterTime": {
@@ -263,49 +165,6 @@
               "commandStartedEvent": {
                 "command": {
                   "distinct": "collection0",
-                  "readConcern": {
-                    "level": "snapshot",
-                    "atClusterTime": {
-                      "$$exists": false
-                    }
-                  }
-                }
-              }
-            },
-            {
-              "commandFailedEvent": {
-                "commandName": "distinct"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "Server returns an error on distinct with snapshot on missing database",
-      "operations": [
-        {
-          "name": "distinct",
-          "object": "missingColl",
-          "arguments": {
-            "fieldName": "x",
-            "filter": {},
-            "session": "session0"
-          },
-          "expectError": {
-            "isError": true,
-            "isClientError": false
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "distinct": "missingColl",
                   "readConcern": {
                     "level": "snapshot",
                     "atClusterTime": {

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
@@ -18,14 +18,6 @@ createEntities:
       id: &collection0Name collection0
       database: *database0Name
       collectionName: *collection0Name
-  - database:
-      id: &missingDbName missingDB
-      client: *client0
-      databaseName: *missingDbName
-  - collection:
-      id: &missingCollName missingColl
-      database: *missingDbName
-      collectionName: *missingCollName
   - session:
       id: session0
       client: client0
@@ -62,29 +54,6 @@ tests:
     - commandFailedEvent:
         commandName: find
 
-- description: Server returns an error on find with snapshot on missing database
-  operations:
-  - name: find
-    object: *missingCollName
-    arguments:
-      session: session0
-      filter: {}
-    expectError:
-      isError: true
-      isClientError: false
-  expectEvents:
-  - client: client0
-    events:
-    - commandStartedEvent:
-        command:
-          find: *missingCollName
-          readConcern:
-            level: snapshot
-            atClusterTime:
-              "$$exists": false
-    - commandFailedEvent:
-        commandName: find
-
 - description: Server returns an error on aggregate with snapshot
   operations:
   - name: aggregate
@@ -101,29 +70,6 @@ tests:
     - commandStartedEvent:
         command:
           aggregate: collection0
-          readConcern:
-            level: snapshot
-            atClusterTime:
-              "$$exists": false
-    - commandFailedEvent:
-        commandName: aggregate
-
-- description: Server returns an error on aggregate with snapshot on missing database
-  operations:
-  - name: aggregate
-    object: *missingCollName
-    arguments:
-      session: session0
-      pipeline: []
-    expectError:
-      isError: true
-      isClientError: false
-  expectEvents:
-  - client: client0
-    events:
-    - commandStartedEvent:
-        command:
-          aggregate: *missingCollName
           readConcern:
             level: snapshot
             atClusterTime:
@@ -148,30 +94,6 @@ tests:
     - commandStartedEvent:
         command:
           distinct: collection0
-          readConcern:
-            level: snapshot
-            atClusterTime:
-              "$$exists": false
-    - commandFailedEvent:
-        commandName: distinct
-
-- description: Server returns an error on distinct with snapshot on missing database
-  operations:
-  - name: distinct
-    object: *missingCollName
-    arguments:
-      fieldName: x
-      filter: {}
-      session: session0
-    expectError:
-      isError: true
-      isClientError: false
-  expectEvents:
-  - client: client0
-    events:
-    - commandStartedEvent:
-        command:
-          distinct: *missingCollName
           readConcern:
             level: snapshot
             atClusterTime:

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
@@ -14,13 +14,21 @@ createEntities:
       observeEvents: [ commandStartedEvent, commandFailedEvent ]
       ignoreCommandMonitoringEvents: [ findAndModify, insert, update ]
   - database:
-      id: &database0 database0
+      id: &database0Name database0
       client: *client0
-      databaseName: &database0Name database0
+      databaseName: *database0Name
   - collection:
-      id: &collection0 collection0
-      database: *database0
-      collectionName: &collection0Name collection0
+      id: &collection0Name collection0
+      database: *database0Name
+      collectionName: *collection0Name
+  - database:
+      id: &missingDbName missingDB
+      client: *client0
+      databaseName: *missingDbName
+  - collection:
+      id: &missingCollName missingColl
+      database: *missingDbName
+      collectionName: *missingCollName
   - session:
       id: session0
       client: client0
@@ -57,6 +65,29 @@ tests:
     - commandFailedEvent:
         commandName: find
 
+- description: Server returns an error on find with snapshot on missing database
+  operations:
+  - name: find
+    object: *missingCollName
+    arguments:
+      session: session0
+      filter: {}
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          find: *missingCollName
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: find
+
 - description: Server returns an error on aggregate with snapshot
   operations:
   - name: aggregate
@@ -73,6 +104,29 @@ tests:
     - commandStartedEvent:
         command:
           aggregate: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: aggregate
+
+- description: Server returns an error on aggregate with snapshot on missing database
+  operations:
+  - name: aggregate
+    object: *missingCollName
+    arguments:
+      session: session0
+      pipeline: []
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          aggregate: *missingCollName
           readConcern:
             level: snapshot
             atClusterTime:
@@ -97,6 +151,30 @@ tests:
     - commandStartedEvent:
         command:
           distinct: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: distinct
+
+- description: Server returns an error on distinct with snapshot on missing database
+  operations:
+  - name: distinct
+    object: *missingCollName
+    arguments:
+      fieldName: x
+      filter: {}
+      session: session0
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          distinct: *missingCollName
           readConcern:
             level: snapshot
             atClusterTime:

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
@@ -56,3 +56,50 @@ tests:
               "$$exists": false
     - commandFailedEvent:
         commandName: find
+
+- description: Server returns an error on aggregate with snapshot
+  operations:
+  - name: aggregate
+    object: collection0
+    arguments:
+      session: session0
+      pipeline: []
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          aggregate: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: aggregate
+
+- description: Server returns an error on distinct with snapshot
+  operations:
+  - name: distinct
+    object: collection0
+    arguments:
+      fieldName: x
+      filter: {}
+      session: session0
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          distinct: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: distinct

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-server-error.yml
@@ -3,16 +3,13 @@ description: snapshot-sessions-not-supported-server-error
 schemaVersion: "1.0"
 
 runOnRequirements:
-  - minServerVersion: "3.6"
-    maxServerVersion: "4.4.99"
-  - minServerVersion: "3.6"
+  - minServerVersion: "5.0"
     topologies: [ single ]
 
 createEntities:
   - client:
       id: &client0 client0
       observeEvents: [ commandStartedEvent, commandFailedEvent ]
-      ignoreCommandMonitoringEvents: [ findAndModify, insert, update ]
   - database:
       id: &database0Name database0
       client: *client0


### PR DESCRIPTION
Updated to require drivers raise a client-side error "snapshot reads require MongoDB 5.0 or later" when a snapshot read is attempted on < 5.0.

Note: I have a POC of this change here: https://github.com/mongodb/mongo-python-driver/pull/659