### PR TITLE
DRIVERS-1819 Snapshot session sends readConcern with all commands even writes

### DIFF
--- a/source/sessions/snapshot-sessions.rst
+++ b/source/sessions/snapshot-sessions.rst
@@ -3,13 +3,13 @@ Snapshot Reads Specification
 ============================
 
 :Spec Title: Snapshot Reads Specification (See the registry of specs)
-:Spec Version: 1.1
+:Spec Version: 1.2
 :Author: Boris Dogadov
 :Advisors: Jeff Yemin, A. Jesse Jiryu Davis, Judah Schvimer
 :Status: Draft (Could be Draft, Accepted, Rejected, Final, or Replaced)
 :Type: Standards
 :Minimum Server Version: 5.0
-:Last Modified: 15-Jun-2021
+:Last Modified: 29-Jun-2021
 
 .. contents::
 
@@ -192,6 +192,7 @@ Server Errors
 =============
 1. The server may reply to read commands with a ``SnapshotTooOld`` error if the client's ``atClusterTime`` value is not available in the server's history.
 2. The server will return ``InvalidOptions`` error if both ``atClusterTime`` and ``afterClusterTime`` options are set to true.
+3. The server will return ``InvalidOptions`` error if the command does not support readConcern.level "snapshot".
 
 Snapshot read commands
 ======================
@@ -211,7 +212,7 @@ by specifying ``readConcern`` with ``snapshot`` level field, and store it as ``s
         }
     }
 
-For subsequent reads from same snapshot driver MUST send the ``snapshotTime`` saved in
+For subsequent reads in the same session, the driver MUST send the ``snapshotTime`` saved in
 the ``ClientSession`` as the value of the ``atClusterTime`` field of the
 ``readConcern`` with ``snapshot`` level field:
 
@@ -232,6 +233,12 @@ Lists of commands that support snapshot reads:
 1. find
 2. aggregate
 3. distinct
+
+Sending readConcern to the server on all commands
+=================================================
+
+Drivers MUST set the readConcern ``level`` and ``atClusterTime`` fields (as
+outlined above) on all commands in a snapshot session.
 
 Requires MongoDB 5.0+
 =====================
@@ -277,3 +284,4 @@ Changelog
 
 :2021-06-15: Initial version.
 :2021-06-28: Raise client side error on < 5.0.
+:2021-06-29: Send readConcern with all snapshot session commands.

--- a/source/sessions/snapshot-sessions.rst
+++ b/source/sessions/snapshot-sessions.rst
@@ -238,7 +238,10 @@ Sending readConcern to the server on all commands
 =================================================
 
 Drivers MUST set the readConcern ``level`` and ``atClusterTime`` fields (as
-outlined above) on all commands in a snapshot session.
+outlined above) on all commands in a snapshot session even commands like
+insert and update that do not accept a readConcern. This ensures the server
+will return an error for invalid operations, such as writes, within a session
+configured for snapshot reads.
 
 Requires MongoDB 5.0+
 =====================

--- a/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.json
+++ b/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.json
@@ -454,7 +454,7 @@
             "session": "session0",
             "commandName": "listCollections",
             "command": {
-              "listIndexes": "collection0"
+              "listCollections": 1
             }
           },
           "expectError": {
@@ -482,7 +482,7 @@
             },
             {
               "commandFailedEvent": {
-                "listCollections": "insert"
+                "commandName": "listCollections"
               }
             }
           ]

--- a/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.json
+++ b/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.json
@@ -1,0 +1,468 @@
+{
+  "description": "snapshot-sessions-unsupported-ops",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "5.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0",
+        "sessionOptions": {
+          "snapshot": true
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Server returns an error on insertOne with snapshot",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 22,
+              "x": 22
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on insertMany with snapshot",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "documents": [
+              {
+                "_id": 22,
+                "x": 22
+              },
+              {
+                "_id": 33,
+                "x": 33
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on deleteOne with snapshot",
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {}
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "delete"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on updateOne with snapshot",
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "update"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on findOneAndUpdate with snapshot",
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0",
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$inc": {
+                "x": 1
+              }
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "findAndModify"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on listDatabases with snapshot",
+      "operations": [
+        {
+          "name": "listDatabases",
+          "object": "client0",
+          "arguments": {
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listDatabases": 1,
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "listDatabases"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on listCollections with snapshot",
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database0",
+          "arguments": {
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "listCollections"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on listIndexes with snapshot",
+      "operations": [
+        {
+          "name": "listIndexes",
+          "object": "collection0",
+          "arguments": {
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listIndexes": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "listIndexes"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Server returns an error on runComand with snapshot",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "session": "session0",
+            "commandName": "insert",
+            "command": {
+              "insert": "collection0",
+              "documents": [
+                {}
+              ]
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.json
+++ b/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.json
@@ -59,6 +59,13 @@
   "tests": [
     {
       "description": "Server returns an error on insertOne with snapshot",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "insertOne",
@@ -104,6 +111,13 @@
     },
     {
       "description": "Server returns an error on insertMany with snapshot",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "insertMany",
@@ -155,6 +169,13 @@
     },
     {
       "description": "Server returns an error on deleteOne with snapshot",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "deleteOne",
@@ -197,6 +218,13 @@
     },
     {
       "description": "Server returns an error on updateOne with snapshot",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "updateOne",
@@ -424,12 +452,9 @@
           "object": "database0",
           "arguments": {
             "session": "session0",
-            "commandName": "insert",
+            "commandName": "listCollections",
             "command": {
-              "insert": "collection0",
-              "documents": [
-                {}
-              ]
+              "listIndexes": "collection0"
             }
           },
           "expectError": {
@@ -445,7 +470,7 @@
             {
               "commandStartedEvent": {
                 "command": {
-                  "insert": "collection0",
+                  "listCollections": 1,
                   "readConcern": {
                     "level": "snapshot",
                     "atClusterTime": {
@@ -457,7 +482,7 @@
             },
             {
               "commandFailedEvent": {
-                "commandName": "insert"
+                "listCollections": "insert"
               }
             }
           ]

--- a/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.json
+++ b/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.json
@@ -417,7 +417,7 @@
       ]
     },
     {
-      "description": "Server returns an error on runComand with snapshot",
+      "description": "Server returns an error on runCommand with snapshot",
       "operations": [
         {
           "name": "runCommand",

--- a/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.yml
@@ -220,7 +220,7 @@ tests:
     - commandFailedEvent:
         commandName: listIndexes
 
-- description: Server returns an error on runComand with snapshot
+- description: Server returns an error on runCommand with snapshot
   operations:
   - name: runCommand
     object: database0

--- a/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.yml
@@ -1,0 +1,247 @@
+description: snapshot-sessions-unsupported-ops
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "5.0"
+    topologies: [replicaset, sharded-replicaset]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent, commandFailedEvent ]
+  - database:
+      id: &database0Name database0
+      client: *client0
+      databaseName: *database0Name
+  - collection:
+      id: &collection0Name collection0
+      database: *database0Name
+      collectionName: *collection0Name
+  - session:
+      id: session0
+      client: client0
+      sessionOptions:
+        snapshot: true
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: 11 }
+
+tests:
+- description: Server returns an error on insertOne with snapshot
+  operations:
+  - name: insertOne
+    object: collection0
+    arguments:
+      session: session0
+      document:
+        _id: 22
+        x: 22
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          insert: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: insert
+
+- description: Server returns an error on insertMany with snapshot
+  operations:
+  - name: insertMany
+    object: collection0
+    arguments:
+      session: session0
+      documents:
+        - _id: 22
+          x: 22
+        - _id: 33
+          x: 33
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          insert: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: insert
+
+- description: Server returns an error on deleteOne with snapshot
+  operations:
+  - name: deleteOne
+    object: collection0
+    arguments:
+      session: session0
+      filter: {}
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          delete: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: delete
+
+- description: Server returns an error on updateOne with snapshot
+  operations:
+  - name: updateOne
+    object: collection0
+    arguments:
+      session: session0
+      filter: { _id: 1 }
+      update: { $inc: { x: 1 } }
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          update: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: update
+
+- description: Server returns an error on findOneAndUpdate with snapshot
+  operations:
+  - name: findOneAndUpdate
+    object: collection0
+    arguments:
+      session: session0
+      filter: { _id: 1 }
+      update: { $inc: { x: 1 } }
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          findAndModify: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: findAndModify
+
+- description: Server returns an error on listDatabases with snapshot
+  operations:
+  - name: listDatabases
+    object: client0
+    arguments:
+      session: session0
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          listDatabases: 1
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: listDatabases
+
+- description: Server returns an error on listCollections with snapshot
+  operations:
+  - name: listCollections
+    object: database0
+    arguments:
+      session: session0
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          listCollections: 1
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: listCollections
+
+- description: Server returns an error on listIndexes with snapshot
+  operations:
+  - name: listIndexes
+    object: collection0
+    arguments:
+      session: session0
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          listIndexes: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: listIndexes
+
+- description: Server returns an error on runComand with snapshot
+  operations:
+  - name: runCommand
+    object: database0
+    arguments:
+      session: session0
+      commandName: insert
+      command:
+        insert: collection0
+        documents: [{}]
+    expectError:
+      isError: true
+      isClientError: false
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          insert: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandFailedEvent:
+        commandName: insert

--- a/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.yml
@@ -32,6 +32,9 @@ initialData:
 
 tests:
 - description: Server returns an error on insertOne with snapshot
+  # Skip on sharded clusters due to SERVER-58176.
+  runOnRequirements:
+    - topologies: [replicaset]
   operations:
   - name: insertOne
     object: collection0
@@ -57,6 +60,9 @@ tests:
         commandName: insert
 
 - description: Server returns an error on insertMany with snapshot
+  # Skip on sharded clusters due to SERVER-58176.
+  runOnRequirements:
+    - topologies: [replicaset]
   operations:
   - name: insertMany
     object: collection0
@@ -84,6 +90,9 @@ tests:
         commandName: insert
 
 - description: Server returns an error on deleteOne with snapshot
+  # Skip on sharded clusters due to SERVER-58176.
+  runOnRequirements:
+    - topologies: [replicaset]
   operations:
   - name: deleteOne
     object: collection0
@@ -107,6 +116,9 @@ tests:
         commandName: delete
 
 - description: Server returns an error on updateOne with snapshot
+  # Skip on sharded clusters due to SERVER-58176.
+  runOnRequirements:
+    - topologies: [replicaset]
   operations:
   - name: updateOne
     object: collection0
@@ -226,10 +238,9 @@ tests:
     object: database0
     arguments:
       session: session0
-      commandName: insert
+      commandName: listCollections
       command:
-        insert: collection0
-        documents: [{}]
+        listIndexes: collection0
     expectError:
       isError: true
       isClientError: false
@@ -238,10 +249,10 @@ tests:
     events:
     - commandStartedEvent:
         command:
-          insert: collection0
+          listCollections: 1
           readConcern:
             level: snapshot
             atClusterTime:
               "$$exists": false
     - commandFailedEvent:
-        commandName: insert
+        listCollections: insert

--- a/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-unsupported-ops.yml
@@ -240,7 +240,7 @@ tests:
       session: session0
       commandName: listCollections
       command:
-        listIndexes: collection0
+        listCollections: 1
     expectError:
       isError: true
       isClientError: false
@@ -255,4 +255,4 @@ tests:
             atClusterTime:
               "$$exists": false
     - commandFailedEvent:
-        listCollections: insert
+        commandName: listCollections

--- a/source/sessions/tests/unified/snapshot-sessions.json
+++ b/source/sessions/tests/unified/snapshot-sessions.json
@@ -656,6 +656,62 @@
       ]
     },
     {
+      "description": "countDocuments operation with snapshot",
+      "operations": [
+        {
+          "name": "countDocuments",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "session": "session0"
+          },
+          "expectResult": 2
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "session": "session0"
+          },
+          "expectResult": 2
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "collection0",
+                  "readConcern": {
+                    "level": "snapshot",
+                    "atClusterTime": {
+                      "$$exists": true
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "description": "Mixed operation with snapshot",
       "operations": [
         {

--- a/source/sessions/tests/unified/snapshot-sessions.json
+++ b/source/sessions/tests/unified/snapshot-sessions.json
@@ -813,7 +813,6 @@
           "name": "insertOne",
           "object": "collection0",
           "arguments": {
-            "session": "session0",
             "document": {
               "_id": 22,
               "x": 33
@@ -827,7 +826,6 @@
             "filter": {
               "_id": 1
             },
-            "session": "session0",
             "update": {
               "$inc": {
                 "x": 1

--- a/source/sessions/tests/unified/snapshot-sessions.yml
+++ b/source/sessions/tests/unified/snapshot-sessions.yml
@@ -387,7 +387,6 @@ tests:
   - name: insertOne
     object: collection0
     arguments:
-      session: session0
       document:
         _id: 22
         x: 33
@@ -395,7 +394,6 @@ tests:
     object: collection0
     arguments:
       filter: { _id: 1 }
-      session: session0
       update: { $inc: { x: 1 } }
   - name: find
     object: collection0

--- a/source/sessions/tests/unified/snapshot-sessions.yml
+++ b/source/sessions/tests/unified/snapshot-sessions.yml
@@ -309,6 +309,38 @@ tests:
             atClusterTime:
               "$$exists": true
 
+- description: countDocuments operation with snapshot
+  operations:
+  - name: countDocuments
+    object: collection0
+    arguments:
+      filter: {}
+      session: session0
+    expectResult: 2
+  - name: countDocuments
+    object: collection0
+    arguments:
+      filter: {}
+      session: session0
+    expectResult: 2
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          aggregate: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandStartedEvent:
+        command:
+          aggregate: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": true
+
 - description: Mixed operation with snapshot
   operations:
   - name: find


### PR DESCRIPTION
This PR requires drivers to send readConcern with all commands in a snapshot session (even writes). This effectively bans all unsupported operations in a snapshot session because the server will reject commands that do not support readConcern.level "snapshot". For example:
```
MongoDB Enterprise repl0:PRIMARY> db.runCommand({'listCollections': 'test', readConcern: {level: 'snapshot'}})
{
"ok" : 0,
"errmsg" : "Command listCollections does not support { readConcern: { level: \"snapshot\", provenance: \"clientSupplied\" } } :: caused by :: read concern not supported",
"code" : 72,
"codeName" : "InvalidOptions"
}
MongoDB Enterprise repl0:PRIMARY> db.runCommand({'insert': 'test', documents: [{}], readConcern: {level: 'snapshot'}})
{
"ok" : 0,
"errmsg" : "Command insert does not support { readConcern: { level: \"snapshot\", provenance: \"clientSupplied\" } } :: caused by :: read concern not supported",
"code" : 72,
"codeName" : "InvalidOptions"
}
```

I've added tests for a variety of methods to ensure we send readConcern.level correctly and that the server rejects the field. I can add tests for more operations once we decide this approach is reasonable.