### PR TITLE
DRIVERS-1828: Remove insertedCount and improve use of $$unsetOrMatches

### DIFF
--- a/source/crud/tests/unified/insertMany-dots_and_dollars.json
+++ b/source/crud/tests/unified/insertMany-dots_and_dollars.json
@@ -53,10 +53,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }
@@ -162,10 +163,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }
@@ -221,10 +223,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }
@@ -284,10 +287,11 @@
             ]
           },
           "expectResult": {
-            "insertedCount": 1,
-            "insertedIds": {
-              "$$unsetOrMatches": {
-                "0": 1
+            "$$unsetOrMatches": {
+              "insertedIds": {
+                "$$unsetOrMatches": {
+                  "0": 1
+                }
               }
             }
           }

--- a/source/crud/tests/unified/insertMany-dots_and_dollars.yml
+++ b/source/crud/tests/unified/insertMany-dots_and_dollars.yml
@@ -31,8 +31,8 @@ tests:
           documents:
             - &dollarPrefixedKey { _id: 1, $a: 1 }
         expectResult: &insertResult
-          insertedCount: 1
-          insertedIds: { $$unsetOrMatches: { 0: 1 } }
+          # InsertManyResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedIds: { $$unsetOrMatches: { 0: 1 } } }
     expectEvents: &expectEventsDollarPrefixedKey
       - client: *client0
         events:

--- a/source/crud/tests/unified/insertOne-dots_and_dollars.json
+++ b/source/crud/tests/unified/insertOne-dots_and_dollars.json
@@ -63,8 +63,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -165,8 +167,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -219,8 +223,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -277,8 +283,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -386,9 +394,11 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": {
-                "a.b": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": {
+                  "a.b": 1
+                }
               }
             }
           }
@@ -496,8 +506,10 @@
             }
           },
           "expectResult": {
-            "insertedId": {
-              "$$unsetOrMatches": 1
+            "$$unsetOrMatches": {
+              "insertedId": {
+                "$$unsetOrMatches": 1
+              }
             }
           }
         }
@@ -558,8 +570,10 @@
             }
           },
           "expectResult": {
-            "acknowledged": {
-              "$$unsetOrMatches": false
+            "$$unsetOrMatches": {
+              "acknowledged": {
+                "$$unsetOrMatches": false
+              }
             }
           }
         }

--- a/source/crud/tests/unified/insertOne-dots_and_dollars.yml
+++ b/source/crud/tests/unified/insertOne-dots_and_dollars.yml
@@ -36,7 +36,8 @@ tests:
         arguments:
           document: &dollarPrefixedKey { _id: 1, $a: 1 }
         expectResult: &insertResult
-          insertedId: { $$unsetOrMatches: 1 }
+          # InsertOneResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 1 } }
     expectEvents: &expectEventsDollarPrefixedKey
       - client: *client0
         events:
@@ -155,7 +156,8 @@ tests:
         arguments:
           document: &dottedKeyInId { _id: { a.b: 1 } }
         expectResult:
-          insertedId: { $$unsetOrMatches: { a.b: 1 } }
+          # InsertOneResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: { a.b: 1 } } }
     expectEvents: &expectEventsDottedKeyInId
       - client: *client0
         events:
@@ -222,7 +224,8 @@ tests:
         arguments:
           document: *dollarPrefixedKeyInId
         expectResult:
-          acknowledged: { $$unsetOrMatches: false }
+          # InsertOneResult is optional because all of its fields are optional
+          $$unsetOrMatches: { acknowledged: { $$unsetOrMatches: false } }
     expectEvents:
       - client: *client0
         events:

--- a/source/unified-test-format/tests/valid-pass/poc-crud.json
+++ b/source/unified-test-format/tests/valid-pass/poc-crud.json
@@ -242,12 +242,14 @@
           },
           "expectError": {
             "expectResult": {
-              "deletedCount": 0,
-              "insertedCount": 2,
-              "matchedCount": 0,
-              "modifiedCount": 0,
-              "upsertedCount": 0,
-              "upsertedIds": {}
+              "$$unsetOrMatches": {
+                "deletedCount": 0,
+                "insertedCount": 2,
+                "matchedCount": 0,
+                "modifiedCount": 0,
+                "upsertedCount": 0,
+                "upsertedIds": {}
+              }
             }
           }
         }

--- a/source/unified-test-format/tests/valid-pass/poc-crud.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-crud.yml
@@ -101,16 +101,19 @@ tests:
           ordered: false
         expectError:
           expectResult:
-            deletedCount: 0
-            insertedCount: 2
-            # Since the map of insertedIds is generated before execution it
-            # could indicate inserts that did not actually succeed. We omit
-            # this field rather than expect drivers to provide an accurate
-            # map filtered by write errors.
-            matchedCount: 0
-            modifiedCount: 0
-            upsertedCount: 0
-            upsertedIds: { }
+            # insertMany throws BulkWriteException, which may optionally include
+            # an intermediary BulkWriteResult
+            $$unsetOrMatches:
+              deletedCount: 0
+              insertedCount: 2
+              # Since the map of insertedIds is generated before execution it
+              # could indicate inserts that did not actually succeed. We omit
+              # this field rather than expect drivers to provide an accurate
+              # map filtered by write errors.
+              matchedCount: 0
+              modifiedCount: 0
+              upsertedCount: 0
+              upsertedIds: { }
     outcome:
       - collectionName: *collection1Name
         databaseName: *database0Name

--- a/source/unified-test-format/tests/valid-pass/poc-retryable-writes.json
+++ b/source/unified-test-format/tests/valid-pass/poc-retryable-writes.json
@@ -298,9 +298,6 @@
           },
           "expectResult": {
             "$$unsetOrMatches": {
-              "insertedCount": {
-                "$$unsetOrMatches": 2
-              },
               "insertedIds": {
                 "$$unsetOrMatches": {
                   "0": 3,

--- a/source/unified-test-format/tests/valid-pass/poc-retryable-writes.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-retryable-writes.yml
@@ -141,9 +141,8 @@ tests:
             - { _id: 4, x: 44 }
           ordered: true
         expectResult:
-          $$unsetOrMatches:
-            insertedCount: { $$unsetOrMatches: 2 }
-            insertedIds: { $$unsetOrMatches: { 0: 3, 1: 4 } }
+          # InsertManyResult is optional because all of its fields are optional
+          $$unsetOrMatches: { insertedIds: { $$unsetOrMatches: { 0: 3, 1: 4 } } }
     outcome:
       - collectionName: *collectionName
         databaseName: *databaseName

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3,13 +3,13 @@ Unified Test Format
 ===================
 
 :Spec Title: Unified Test Format
-:Spec Version: 1.5.1
+:Spec Version: 1.5.2
 :Author: Jeremy Mikola
 :Advisors: Prashant Mital, Isabel Atkinson, Thomas Reggi
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-06-28
+:Last Modified: 2021-07-01
 
 .. contents::
 
@@ -972,7 +972,9 @@ The structure of this object is as follows:
   `operation.expectResult <operation_expectResult_>`_ and is only used in cases
   where the error includes a result (e.g. `bulkWrite`_). If specified, the test
   runner MUST assert that the error includes a result and that it matches this
-  value.
+  value. If the result is optional (e.g. BulkWriteResult reported through the
+  ``writeResult`` property of a BulkWriteException), this assertion SHOULD
+  utilize the `$$unsetOrMatches`_ operator.
 
 
 expectedEventsForClient
@@ -3239,6 +3241,9 @@ spec changes developed in parallel or during the same release cycle.
 
 Change Log
 ==========
+
+:2021-07-01: Note that ``expectError.expectResult`` should use
+             ``$$unsetOrMatches`` when the result is optional.
 
 :2021-06-09: Added an ``observeSensitiveCommands`` property to the ``client``
              entity type.


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1828

I ran the modified tests through PHPLIB, but would appreciate it if someone else tests in their driver as well.