### PR TITLE
Clarify KMS TLS prose tests

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1051,6 +1051,8 @@ Invalid KMS Certificate
       }
 
    Expect this to fail with an exception with a message referencing an expired certificate. This message will be language dependent.
+   In Python, this message is "certificate verify failed: certificate has expired". In Go, this message is
+   "certificate has expired or is not yet valid".
 
 Invalid Hostname in KMS Certificate
 ```````````````````````````````````
@@ -1068,3 +1070,5 @@ Invalid Hostname in KMS Certificate
       }
 
    Expect this to fail with an exception with a message referencing an incorrect or unexpected host. This message will be language dependent.
+   In Python, this message is "certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'". In Go, this message
+   is "cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs".

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1019,6 +1019,7 @@ KMS TLS Tests
 The following tests that connections to KMS servers with TLS verify peer certificates.
 
 The two tests below make use of mock KMS servers which can be run on Evergreen using `the mock KMS server script <https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/kms_http_server.py>`_.
+Drivers can set up their local Python enviroment for the mock KMS server by running `the virtualenv activation script <https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/activate_venv.sh>`_.
 
 To start a mock KMS server on port 8000 with `ca.pem`_ as a CA file and `expired.pem`_ as a cert file, run the following Python command from the ``.evergreen/csfle`` directory.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1018,20 +1018,13 @@ KMS TLS Tests
 
 The following tests that connections to KMS servers with TLS verify peer certificates.
 
-The two tests below make use of mock KMS servers which can be run on Evergreen using `the mock KMS server script <https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/mock_kms.js>`_.
+The two tests below make use of mock KMS servers which can be run on Evergreen using `the mock KMS server script <https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/kms_http_server.py>`_.
 
-To start a mock KMS server on port 8000 with `ca.pem`_ as a CA file and `expired.pem`_ as a cert file, run the following bash snippet from the ``.evergreen/csfle`` directory.
+To start a mock KMS server on port 8000 with `ca.pem`_ as a CA file and `expired.pem`_ as a cert file, run the following Python command from the ``.evergreen/csfle`` directory.
 
-.. code:: bash
+.. code:: python
 
-   cat <<EOF > kms_setup.json
-   {
-      "kms_ca_file": "ca.pem",
-      "kms_cert_file": "expired.pem",
-      "port": "8000"
-   }
-   EOF
-   mongo --nodb mock_kms.js
+   python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000
 
 Setup
 `````

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1021,10 +1021,11 @@ The following tests that connections to KMS servers with TLS verify peer certifi
 The two tests below make use of mock KMS servers which can be run on Evergreen using `the mock KMS server script <https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/kms_http_server.py>`_.
 Drivers can set up their local Python enviroment for the mock KMS server by running `the virtualenv activation script <https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/activate_venv.sh>`_.
 
-To start a mock KMS server on port 8000 with `ca.pem`_ as a CA file and `expired.pem`_ as a cert file, run the following Python command from the ``.evergreen/csfle`` directory.
+To start a mock KMS server on port 8000 with `ca.pem`_ as a CA file and `expired.pem`_ as a cert file, run the following commands from the ``.evergreen/csfle`` directory.
 
-.. code:: python
+.. code::
 
+   . ./activate_venv.sh
    python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000
 
 Setup


### PR DESCRIPTION
The KMS TLS prose tests were not clear on how to start a KMS mock server with the [mock_kms script](https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/mock_kms.js). Gives an example of starting a KMS mock server, acknowledges that TLS cert verification errors will have language-dependent messages, and removes misleading `mongodb://` protocol name on the KMS masterKeys.