### PR TITLE
DRIVERS-1851 Skip crud-v1 tests for $out and collation on Serverless

### DIFF
--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -21,12 +21,12 @@ Subdirectories for Test Formats
 
 This document describes a legacy format for CRUD tests: legacy-v1, which dates back
 to the first version of the CRUD specification. New CRUD tests should be written
-in the `unified test format <../../../../unified-test-format/unified-test-format.rst>`_
+in the `unified test format <../../../unified-test-format/unified-test-format.rst>`_
 and placed under ``unified/``. Until such time that all original tests have been ported
 to the unified test format, tests in each format will be grouped in their own subdirectory:
 
 - ``v1/``: Legacy-v1 format tests
-- ``unified/``: Tests using the `unified test format <../../../../unified-test-format/unified-test-format.rst>`_
+- ``unified/``: Tests using the `unified test format <../../../unified-test-format/unified-test-format.rst>`_
 
 Since some drivers may not have a unified test runner capable of executing tests
 in all two formats, segregating tests in this manner will make it easier for
@@ -59,7 +59,7 @@ single operation. Notable differences from the legacy-v2 format are as follows:
   there is no corresponding bound on the required server version. The
   ``serverless`` requirement behaves the same as the ``serverless`` field of the
   `unified test format's runOnRequirement
-  <../../../../unified-test-format/unified-test-format.rst#runonrequirement>`_.
+  <../../../unified-test-format/unified-test-format.rst#runonrequirement>`_.
 
 The legacy-v1 format should not conflict with the newer, multi-operation format
 used by other specs (e.g. Transactions). It is possible to create a unified test

--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -21,12 +21,12 @@ Subdirectories for Test Formats
 
 This document describes a legacy format for CRUD tests: legacy-v1, which dates back
 to the first version of the CRUD specification. New CRUD tests should be written
-in the `unified test format <../../../unified-test-format/unified-test-format.rst>`_
+in the `unified test format <../../unified-test-format/unified-test-format.rst>`_
 and placed under ``unified/``. Until such time that all original tests have been ported
 to the unified test format, tests in each format will be grouped in their own subdirectory:
 
 - ``v1/``: Legacy-v1 format tests
-- ``unified/``: Tests using the `unified test format <../../../unified-test-format/unified-test-format.rst>`_
+- ``unified/``: Tests using the `unified test format <../../unified-test-format/unified-test-format.rst>`_
 
 Since some drivers may not have a unified test runner capable of executing tests
 in all two formats, segregating tests in this manner will make it easier for
@@ -58,8 +58,7 @@ single operation. Notable differences from the legacy-v2 format are as follows:
   for running the test. If a field is not present, it should be assumed that
   there is no corresponding bound on the required server version. The
   ``serverless`` requirement behaves the same as the ``serverless`` field of the
-  `unified test format's runOnRequirement
-  <../../../unified-test-format/unified-test-format.rst#runonrequirement>`_.
+  `unified test format's runOnRequirement <../../unified-test-format/unified-test-format.rst#runonrequirement>`_.
 
 The legacy-v1 format should not conflict with the newer, multi-operation format
 used by other specs (e.g. Transactions). It is possible to create a unified test

--- a/source/crud/tests/README.rst
+++ b/source/crud/tests/README.rst
@@ -52,11 +52,14 @@ single operation. Notable differences from the legacy-v2 format are as follows:
   fields.
 
 - Instead of a top-level ``runOn`` field, server requirements are denoted by
-  separate top-level ``minServerVersion`` and ``maxServerVersion`` fields. The
-  minimum server version is an inclusive lower bound for running the test. The
-  maximum server version is an exclusive upper bound for running the test. If a
-  field is not present, it should be assumed that there is no corresponding bound
-  on the required server version.
+  separate top-level ``minServerVersion``, ``maxServerVersion``, and
+  ``serverless`` fields. The minimum server version is an inclusive lower bound
+  for running the test. The maximum server version is an exclusive upper bound
+  for running the test. If a field is not present, it should be assumed that
+  there is no corresponding bound on the required server version. The
+  ``serverless`` requirement behaves the same as the ``serverless`` field of the
+  `unified test format's runOnRequirement
+  <../../../../unified-test-format/unified-test-format.rst#runonrequirement>`_.
 
 The legacy-v1 format should not conflict with the newer, multi-operation format
 used by other specs (e.g. Transactions). It is possible to create a unified test

--- a/source/crud/tests/v1/read/aggregate-collation.json
+++ b/source/crud/tests/v1/read/aggregate-collation.json
@@ -6,6 +6,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Aggregate with collation",

--- a/source/crud/tests/v1/read/aggregate-collation.yml
+++ b/source/crud/tests/v1/read/aggregate-collation.yml
@@ -1,6 +1,7 @@
 data:
     - {_id: 1, x: 'ping'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/read/aggregate-out.json
+++ b/source/crud/tests/v1/read/aggregate-out.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "2.6",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Aggregate with $out",

--- a/source/crud/tests/v1/read/aggregate-out.yml
+++ b/source/crud/tests/v1/read/aggregate-out.yml
@@ -3,6 +3,7 @@ data:
     - {_id: 2, x: 22}
     - {_id: 3, x: 33}
 minServerVersion: '2.6'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/read/count-collation.json
+++ b/source/crud/tests/v1/read/count-collation.json
@@ -6,6 +6,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Count documents with collation",

--- a/source/crud/tests/v1/read/count-collation.yml
+++ b/source/crud/tests/v1/read/count-collation.yml
@@ -1,6 +1,7 @@
 data:
     - {_id: 1, x: 'PING'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/read/distinct-collation.json
+++ b/source/crud/tests/v1/read/distinct-collation.json
@@ -10,6 +10,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Distinct with a collation",

--- a/source/crud/tests/v1/read/distinct-collation.yml
+++ b/source/crud/tests/v1/read/distinct-collation.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, string: 'PING'}
     - {_id: 2, string: 'ping'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/read/find-collation.json
+++ b/source/crud/tests/v1/read/find-collation.json
@@ -6,6 +6,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "Find with a collation",

--- a/source/crud/tests/v1/read/find-collation.yml
+++ b/source/crud/tests/v1/read/find-collation.yml
@@ -1,6 +1,7 @@
 data:
     - {_id: 1, x: 'ping'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/write/bulkWrite-collation.json
+++ b/source/crud/tests/v1/write/bulkWrite-collation.json
@@ -22,6 +22,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "BulkWrite with delete operations and collation",

--- a/source/crud/tests/v1/write/bulkWrite-collation.yml
+++ b/source/crud/tests/v1/write/bulkWrite-collation.yml
@@ -6,6 +6,7 @@ data:
     - {_id: 5, x: 'pONg'}
 
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 # See: https://docs.mongodb.com/manual/reference/collation/#collation-document
 tests:

--- a/source/crud/tests/v1/write/deleteMany-collation.json
+++ b/source/crud/tests/v1/write/deleteMany-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "DeleteMany when many documents match with collation",

--- a/source/crud/tests/v1/write/deleteMany-collation.yml
+++ b/source/crud/tests/v1/write/deleteMany-collation.yml
@@ -3,6 +3,7 @@ data:
     - {_id: 2, x: 'ping'}
     - {_id: 3, x: 'pINg'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/write/deleteOne-collation.json
+++ b/source/crud/tests/v1/write/deleteOne-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "DeleteOne when many documents matches with collation",

--- a/source/crud/tests/v1/write/deleteOne-collation.yml
+++ b/source/crud/tests/v1/write/deleteOne-collation.yml
@@ -3,6 +3,7 @@ data:
     - {_id: 2, x: 'ping'}
     - {_id: 3, x: 'pINg'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/write/findOneAndDelete-collation.json
+++ b/source/crud/tests/v1/write/findOneAndDelete-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "FindOneAndDelete when one document matches with collation",

--- a/source/crud/tests/v1/write/findOneAndDelete-collation.yml
+++ b/source/crud/tests/v1/write/findOneAndDelete-collation.yml
@@ -3,6 +3,7 @@ data:
     - {_id: 2, x: 'ping'}
     - {_id: 3, x: 'pINg'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/write/findOneAndReplace-collation.json
+++ b/source/crud/tests/v1/write/findOneAndReplace-collation.json
@@ -10,6 +10,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "FindOneAndReplace when one document matches with collation returning the document after modification",

--- a/source/crud/tests/v1/write/findOneAndReplace-collation.yml
+++ b/source/crud/tests/v1/write/findOneAndReplace-collation.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 'ping'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/write/findOneAndUpdate-collation.json
+++ b/source/crud/tests/v1/write/findOneAndUpdate-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "FindOneAndUpdate when many documents match with collation returning the document before modification",

--- a/source/crud/tests/v1/write/findOneAndUpdate-collation.yml
+++ b/source/crud/tests/v1/write/findOneAndUpdate-collation.yml
@@ -3,6 +3,7 @@ data:
     - {_id: 2, x: 'ping'}
     - {_id: 3, x: 'pINg'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/write/replaceOne-collation.json
+++ b/source/crud/tests/v1/write/replaceOne-collation.json
@@ -10,6 +10,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "ReplaceOne when one document matches with collation",

--- a/source/crud/tests/v1/write/replaceOne-collation.yml
+++ b/source/crud/tests/v1/write/replaceOne-collation.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 'ping'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/write/updateMany-collation.json
+++ b/source/crud/tests/v1/write/updateMany-collation.json
@@ -14,6 +14,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "UpdateMany when many documents match with collation",

--- a/source/crud/tests/v1/write/updateMany-collation.yml
+++ b/source/crud/tests/v1/write/updateMany-collation.yml
@@ -3,6 +3,7 @@ data:
     - {_id: 2, x: 'ping'}
     - {_id: 3, x: 'pINg'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -

--- a/source/crud/tests/v1/write/updateOne-collation.json
+++ b/source/crud/tests/v1/write/updateOne-collation.json
@@ -10,6 +10,7 @@
     }
   ],
   "minServerVersion": "3.4",
+  "serverless": "forbid",
   "tests": [
     {
       "description": "UpdateOne when one document matches with collation",

--- a/source/crud/tests/v1/write/updateOne-collation.yml
+++ b/source/crud/tests/v1/write/updateOne-collation.yml
@@ -2,6 +2,7 @@ data:
     - {_id: 1, x: 11}
     - {_id: 2, x: 'ping'}
 minServerVersion: '3.4'
+serverless: 'forbid'
 
 tests:
     -


### PR DESCRIPTION
DRIVERS-1851

Atlas Serverless doesn't currently support `$out` aggregations or collation, so the associated crud-v1 tests need to be skipped. This involved slightly amending the crud-v1 format.