### PR TITLE
DRIVERS-1878: Tests for client-side errors with snapshot reads use incorrect syntax for test.expectEvents

### DIFF
--- a/source/sessions/snapshot-sessions.rst
+++ b/source/sessions/snapshot-sessions.rst
@@ -9,7 +9,7 @@ Snapshot Reads Specification
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 5.0
-:Last Modified: 06-Aug-2021
+:Last Modified: 09-Aug-2021
 
 .. contents::
 
@@ -289,4 +289,4 @@ Changelog
 :2021-06-28: Raise client side error on < 5.0.
 :2021-06-29: Send readConcern with all snapshot session commands.
 :2021-07-16: Grammar revisions. Change SHOULD to MUST for startTransaction error to comply with existing tests.
-:2021-08-06: Updated client-side error spec tests to use correct syntax for ``test.expectEvents``
+:2021-08-09: Updated client-side error spec tests to use correct syntax for ``test.expectEvents``

--- a/source/sessions/snapshot-sessions.rst
+++ b/source/sessions/snapshot-sessions.rst
@@ -3,13 +3,13 @@ Snapshot Reads Specification
 ============================
 
 :Spec Title: Snapshot Reads Specification
-:Spec Version: 1.2.1
+:Spec Version: 1.2.2
 :Author: Boris Dogadov
 :Advisors: Jeff Yemin, A. Jesse Jiryu Davis, Judah Schvimer
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 5.0
-:Last Modified: 16-Jul-2021
+:Last Modified: 06-Aug-2021
 
 .. contents::
 
@@ -289,3 +289,4 @@ Changelog
 :2021-06-28: Raise client side error on < 5.0.
 :2021-06-29: Send readConcern with all snapshot session commands.
 :2021-07-16: Grammar revisions. Change SHOULD to MUST for startTransaction error to comply with existing tests.
+:2021-08-06: Updated client-side error spec tests to use correct syntax for ``test.expectEvents``

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.json
@@ -70,7 +70,12 @@
           }
         }
       ],
-      "expectEvents": []
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
     },
     {
       "description": "Client error on aggregate with snapshot",
@@ -88,7 +93,12 @@
           }
         }
       ],
-      "expectEvents": []
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
     },
     {
       "description": "Client error on distinct with snapshot",
@@ -107,7 +117,12 @@
           }
         }
       ],
-      "expectEvents": []
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": []
+        }
+      ]
     }
   ]
 }

--- a/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
+++ b/source/sessions/tests/unified/snapshot-sessions-not-supported-client-error.yml
@@ -41,7 +41,9 @@ tests:
     expectError:
       isClientError: true
       errorContains: Snapshot reads require MongoDB 5.0 or later
-  expectEvents: []
+  expectEvents:
+    - client: *client0
+      events: []
 
 - description: Client error on aggregate with snapshot
   operations:
@@ -53,7 +55,9 @@ tests:
     expectError:
       isClientError: true
       errorContains: Snapshot reads require MongoDB 5.0 or later
-  expectEvents: []
+  expectEvents:
+    - client: *client0
+      events: []
 
 - description: Client error on distinct with snapshot
   operations:
@@ -66,4 +70,6 @@ tests:
     expectError:
       isClientError: true
       errorContains: Snapshot reads require MongoDB 5.0 or later
-  expectEvents: []
+  expectEvents:
+    - client: *client0
+      events: []

--- a/source/unified-test-format/schema-1.0.json
+++ b/source/unified-test-format/schema-1.0.json
@@ -261,6 +261,7 @@
         },
         "expectEvents": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/definitions/expectedEventsForClient" }
         },
         "outcome": {

--- a/source/unified-test-format/schema-1.1.json
+++ b/source/unified-test-format/schema-1.1.json
@@ -281,6 +281,7 @@
         },
         "expectEvents": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/definitions/expectedEventsForClient" }
         },
         "outcome": {

--- a/source/unified-test-format/schema-1.2.json
+++ b/source/unified-test-format/schema-1.2.json
@@ -318,6 +318,7 @@
         },
         "expectEvents": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/definitions/expectedEventsForClient" }
         },
         "outcome": {

--- a/source/unified-test-format/schema-1.3.json
+++ b/source/unified-test-format/schema-1.3.json
@@ -444,6 +444,7 @@
         },
         "expectEvents": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/definitions/expectedEventsForClient" }
         },
         "outcome": {

--- a/source/unified-test-format/schema-1.4.json
+++ b/source/unified-test-format/schema-1.4.json
@@ -448,6 +448,7 @@
         },
         "expectEvents": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/definitions/expectedEventsForClient" }
         },
         "outcome": {

--- a/source/unified-test-format/schema-1.5.json
+++ b/source/unified-test-format/schema-1.5.json
@@ -449,6 +449,7 @@
         },
         "expectEvents": {
           "type": "array",
+          "minItems": 1,
           "items": { "$ref": "#/definitions/expectedEventsForClient" }
         },
         "outcome": {

--- a/source/unified-test-format/tests/invalid/test-expectEvents-minItems.json
+++ b/source/unified-test-format/tests/invalid/test-expectEvents-minItems.json
@@ -1,0 +1,11 @@
+{
+  "description": "test-expectEvents-minItems",
+  "schemaVersion": "1.0",
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/test-expectEvents-minItems.yml
+++ b/source/unified-test-format/tests/invalid/test-expectEvents-minItems.yml
@@ -1,0 +1,8 @@
+description: "test-expectEvents-minItems"
+
+schemaVersion: "1.0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectEvents: []

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3,13 +3,13 @@ Unified Test Format
 ===================
 
 :Spec Title: Unified Test Format
-:Spec Version: 1.5.3
+:Spec Version: 1.5.4
 :Author: Jeremy Mikola
 :Advisors: Prashant Mital, Isabel Atkinson, Thomas Reggi
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-07-29
+:Last Modified: 2021-08-06
 
 .. contents::
 
@@ -3250,6 +3250,9 @@ spec changes developed in parallel or during the same release cycle.
 
 Change Log
 ==========
+
+:2021-08-06: Updated all existing schema files to require at least one element
+             in ``test.expectEvents`` if specified.
 
 :2021-07-29: Note that events for sensitive commands will have redacted
              commands and replies when using ``observeSensitiveCommands``, and

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -9,7 +9,7 @@ Unified Test Format
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-08-06
+:Last Modified: 2021-08-09
 
 .. contents::
 
@@ -3251,7 +3251,7 @@ spec changes developed in parallel or during the same release cycle.
 Change Log
 ==========
 
-:2021-08-06: Updated all existing schema files to require at least one element
+:2021-08-09: Updated all existing schema files to require at least one element
              in ``test.expectEvents`` if specified.
 
 :2021-07-29: Note that events for sensitive commands will have redacted


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1878