### PR TITLE
DRIVERS-1879 Remove modifiers option from command monitoring spec test

### DIFF
--- a/source/command-monitoring/tests/legacy/find.json
+++ b/source/command-monitoring/tests/legacy/find.json
@@ -89,21 +89,19 @@
           "skip": {
             "$numberLong": "2"
           },
-          "modifiers": {
-            "$comment": "test",
-            "$hint": {
-              "_id": 1
-            },
-            "$max": {
-              "_id": 6
-            },
-            "$maxTimeMS": 6000,
-            "$min": {
-              "_id": 0
-            },
-            "$returnKey": false,
-            "$showDiskLoc": false
-          }
+          "comment": "test",
+          "hint": {
+            "_id": 1
+          },
+          "max": {
+            "_id": 6
+          },
+          "maxTimeMS": 6000,
+          "min": {
+            "_id": 0
+          },
+          "returnKey": false,
+          "showRecordId": false
         }
       },
       "expectations": [

--- a/source/command-monitoring/tests/legacy/find.yml
+++ b/source/command-monitoring/tests/legacy/find.yml
@@ -43,14 +43,13 @@ tests:
         filter: { _id: { $gt: 1 } }
         sort: { _id: 1 }
         skip: {"$numberLong": "2"}
-        modifiers:
-          $comment: "test"
-          $hint: { _id: 1 }
-          $max: { _id: 6 }
-          $maxTimeMS: 6000
-          $min: { _id: 0 }
-          $returnKey: false
-          $showDiskLoc: false
+        comment: "test"
+        hint: { _id: 1 }
+        max: { _id: 6 }
+        maxTimeMS: 6000
+        min: { _id: 0 }
+        returnKey: false
+        showRecordId: false
     expectations:
       -
         command_started_event:


### PR DESCRIPTION
The modifiers option was removed from the crud spec long ago. See https://jira.mongodb.org/browse/DRIVERS-1879.

I'm testing this change in https://github.com/mongodb/mongo-python-driver/pull/696