### PR TITLE
DRIVERS-1141 Add serverConnectionId to command monitoring events

### DIFF
--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -304,7 +304,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
      * from the server on 4.2+.
      */
-    serverConnectionId: Int64;
+    serverConnectionId: Optional<Int64>;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.
@@ -357,7 +357,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
      * from the server on 4.2+.
      */
-    serverConnectionId: Int64;
+    serverConnectionId: Optional<Int64>;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -300,6 +300,13 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
     connectionId: ConnectionId;
 
     /**
+     * Returns the server connection id for the command. The server connection id is distinct from
+     * the connection id and is returned by the hello or legacy hello response as "connectionId"
+     * from the server on 4.2+.
+     */
+    serverConnectionId: Int64;
+
+    /**
      * Returns the service id for the command when the driver is in load balancer mode.
      * For drivers that wish to include this in their ConnectionId object, this field is
      * optional.
@@ -344,6 +351,13 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
      * The name of this field is flexible to match the object that is returned from the driver.
      */
     connectionId: ConnectionId;
+
+    /**
+     * Returns the server connection id for the command. The server connection id is distinct from
+     * the connection id and is returned by the hello or legacy hello response as "connectionId"
+     * from the server on 4.2+.
+     */
+    serverConnectionId: Int64;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.
@@ -391,6 +405,13 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
      * The name of this field is flexible to match the object that is returned from the driver.
      */
     connectionId: ConnectionId;
+
+    /**
+     * Returns the server connection id for the command. The server connection id is distinct from
+     * the connection id and is returned by the hello or legacy hello response as "connectionId"
+     * from the server on 4.2+.
+     */
+    serverConnectionId: Optional<Int64>;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -302,7 +302,8 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
     /**
      * Returns the server connection id for the command. The server connection id is distinct from
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
-     * from the server on 4.2+.
+     * from the server on 4.2+. Drivers MAY use a wider type to represent the server connection ID
+     * value, but the server's behavior is to return an Int32.
      */
     serverConnectionId: Optional<Int32>;
 
@@ -355,7 +356,8 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
     /**
      * Returns the server connection id for the command. The server connection id is distinct from
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
-     * from the server on 4.2+.
+     * from the server on 4.2+. Drivers MAY use a wider type to represent the server connection ID
+     * value, but the server's behavior is to return an Int32.
      */
     serverConnectionId: Optional<Int32>;
 
@@ -409,7 +411,8 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
     /**
      * Returns the server connection id for the command. The server connection id is distinct from
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
-     * from the server on 4.2+.
+     * from the server on 4.2+. Drivers MAY use a wider type to represent the server connection ID
+     * value, but the server's behavior is to return an Int32.
      */
     serverConnectionId: Optional<Int32>;
 

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -304,7 +304,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
      * from the server on 4.2+.
      */
-    serverConnectionId: Optional<Int64>;
+    serverConnectionId: Optional<Int32>;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.
@@ -357,7 +357,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
      * from the server on 4.2+.
      */
-    serverConnectionId: Optional<Int64>;
+    serverConnectionId: Optional<Int32>;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.
@@ -411,7 +411,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
      * from the server on 4.2+.
      */
-    serverConnectionId: Optional<Int64>;
+    serverConnectionId: Optional<Int32>;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.

--- a/source/command-monitoring/tests/unified/pre-42-server-connection-id.json
+++ b/source/command-monitoring/tests/unified/pre-42-server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "pre-42-server-connection-id",
+  "schemaVersion": "1.6",
+  "runOnRequirements": [
+    {
+      "maxServerVersion": "4.0.99"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events do not include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": false
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/command-monitoring/tests/unified/pre-42-server-connection-id.yml
+++ b/source/command-monitoring/tests/unified/pre-42-server-connection-id.yml
@@ -1,0 +1,56 @@
+description: "pre-42-server-connection-id"
+
+schemaVersion: "1.6"
+
+runOnRequirements:
+  - maxServerVersion: "4.0.99"
+
+createEntities:
+  - client:
+      id: &client client
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName server-connection-id-tests
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: &collectionName coll
+
+initialData:
+  - databaseName: *databaseName
+    collectionName: *collectionName
+    documents: []
+
+tests:
+  - description: "command events do not include server connection id"
+    operations:
+      - name: insertOne
+        object: *collection
+        arguments:
+            document: { x: 1 }
+      - name: find
+        object: *collection
+        arguments:
+          filter: { $or: true }
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              hasServerConnectionId: false
+          - commandSucceededEvent:
+              commandName: insert
+              hasServerConnectionId: false
+          - commandStartedEvent:
+              commandName: find
+              hasServerConnectionId: false
+          - commandFailedEvent:
+              commandName: find
+              hasServerConnectionId: false

--- a/source/command-monitoring/tests/unified/server-connection-id.json
+++ b/source/command-monitoring/tests/unified/server-connection-id.json
@@ -1,6 +1,6 @@
 {
   "description": "server-connection-id",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.6",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2"

--- a/source/command-monitoring/tests/unified/server-connection-id.json
+++ b/source/command-monitoring/tests/unified/server-connection-id.json
@@ -1,0 +1,101 @@
+{
+  "description": "server-connection-id",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent",
+          "commandSucceededEvent",
+          "commandFailedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "server-connection-id-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "server-connection-id-tests",
+      "collectionName": "coll",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "command events include server connection id",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "x": 1
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "$or": true
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "commandName": "insert",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            },
+            {
+              "commandFailedEvent": {
+                "commandName": "find",
+                "hasServerConnectionId": true
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/command-monitoring/tests/unified/server-connection-id.yml
+++ b/source/command-monitoring/tests/unified/server-connection-id.yml
@@ -1,6 +1,6 @@
 description: "server-connection-id"
 
-schemaVersion: "1.0"
+schemaVersion: "1.6"
 
 runOnRequirements:
   - minServerVersion: "4.2"

--- a/source/command-monitoring/tests/unified/server-connection-id.yml
+++ b/source/command-monitoring/tests/unified/server-connection-id.yml
@@ -1,0 +1,56 @@
+description: "server-connection-id"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "4.2"
+
+createEntities:
+  - client:
+      id: &client client
+      observeEvents:
+        - commandStartedEvent
+        - commandSucceededEvent
+        - commandFailedEvent
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName server-connection-id-tests
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: &collectionName coll
+
+initialData:
+  - databaseName: *databaseName
+    collectionName: *collectionName
+    documents: []
+
+tests:
+  - description: "command events include server connection id"
+    operations:
+      - name: insertOne
+        object: *collection
+        arguments:
+            document: { x: 1 }
+      - name: find
+        object: *collection
+        arguments:
+          filter: { $or: true }
+        expectError:
+          isError: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              hasServerConnectionId: true
+          - commandSucceededEvent:
+              commandName: insert
+              hasServerConnectionId: true
+          - commandStartedEvent:
+              commandName: find
+              hasServerConnectionId: true
+          - commandFailedEvent:
+              commandName: find
+              hasServerConnectionId: true

--- a/source/unified-test-format/schema-1.6.json
+++ b/source/unified-test-format/schema-1.6.json
@@ -1,0 +1,466 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "title": "Unified Test Format",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["description", "schemaVersion", "tests"],
+  "properties": {
+    "description": { "type": "string" },
+    "schemaVersion": { "$ref": "#/definitions/version" },
+    "runOnRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/runOnRequirement" }
+    },
+    "createEntities": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/entity" }
+    },
+    "initialData": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/collectionData" }
+    },
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/test" }
+    },
+    "_yamlAnchors": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+
+  "definitions": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+    },
+
+    "runOnRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "maxServerVersion": { "$ref": "#/definitions/version" },
+        "minServerVersion": { "$ref": "#/definitions/version" },
+        "topologies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["single", "replicaset", "sharded", "sharded-replicaset", "load-balanced"]
+          }
+        },
+        "serverless": {
+          "type": "string",
+          "enum": ["require", "forbid", "allow"]
+        },
+        "serverParameters": {
+          "type": "object",
+          "minProperties": 1
+        },
+        "auth": { "type": "boolean" }
+      }
+    },
+
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "client": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id"],
+          "properties": {
+            "id": { "type": "string" },
+            "uriOptions": { "type": "object" },
+            "useMultipleMongoses": { "type": "boolean" },
+            "observeEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "commandStartedEvent",
+                  "commandSucceededEvent",
+                  "commandFailedEvent",
+                  "poolCreatedEvent",
+                  "poolReadyEvent",
+                  "poolClearedEvent",
+                  "poolClosedEvent",
+                  "connectionCreatedEvent",
+                  "connectionReadyEvent",
+                  "connectionClosedEvent",
+                  "connectionCheckOutStartedEvent",
+                  "connectionCheckOutFailedEvent",
+                  "connectionCheckedOutEvent",
+                  "connectionCheckedInEvent"
+                ]
+              }
+            },
+            "ignoreCommandMonitoringEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            },
+            "storeEventsAsEntities": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/definitions/storeEventsAsEntity" }
+            },
+            "serverApi": { "$ref":  "#/definitions/serverApi" },
+            "observeSensitiveCommands": { "type": "boolean" }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client", "databaseName"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "databaseOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database", "collectionName"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "collectionName": { "type": "string" },
+            "collectionOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "client"],
+          "properties": {
+            "id": { "type": "string" },
+            "client": { "type": "string" },
+            "sessionOptions": { "type": "object" }
+          }
+        },
+        "bucket": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "database"],
+          "properties": {
+            "id": { "type": "string" },
+            "database": { "type": "string" },
+            "bucketOptions": { "type": "object" }
+          }
+        }
+      }
+    },
+
+    "storeEventsAsEntity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "events"],
+      "properties": {
+        "id": { "type": "string" },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "PoolCreatedEvent",
+              "PoolReadyEvent",
+              "PoolClearedEvent",
+              "PoolClosedEvent",
+              "ConnectionCreatedEvent",
+              "ConnectionReadyEvent",
+              "ConnectionClosedEvent",
+              "ConnectionCheckOutStartedEvent",
+              "ConnectionCheckOutFailedEvent",
+              "ConnectionCheckedOutEvent",
+              "ConnectionCheckedInEvent",
+              "CommandStartedEvent",
+              "CommandSucceededEvent",
+              "CommandFailedEvent"
+            ]
+          }
+        }
+      }
+    },
+
+    "collectionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["collectionName", "databaseName", "documents"],
+      "properties": {
+        "collectionName": { "type": "string" },
+        "databaseName": { "type": "string" },
+        "documents": {
+          "type": "array",
+          "items": { "type": "object" }
+        }
+      }
+    },
+
+    "expectedEventsForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["client", "events"],
+      "properties": {
+        "client": { "type": "string" },
+        "eventType": {
+          "type": "string",
+          "enum": ["command", "cmap"]
+        },
+        "events": { "type": "array" }
+      },
+      "oneOf": [
+        {
+          "required": ["eventType"],
+          "properties": {
+            "eventType": { "const": "command" },
+            "events": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/expectedCommandEvent" }
+            }
+          }
+        },
+        {
+          "required": ["eventType"],
+          "properties": {
+            "eventType": { "const": "cmap" },
+            "events": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/expectedCmapEvent" }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "client": { "type": "string" },
+            "events": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/expectedCommandEvent" }
+            }
+          }
+        }
+      ]
+    },
+
+    "expectedCommandEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "commandStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": { "type": "object" },
+            "commandName": { "type": "string" },
+            "databaseName": { "type": "string" },
+            "hasServiceId": { "type": "boolean" },
+            "hasServerConnectionId": { "type": "boolean" }
+          }
+        },
+        "commandSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reply": { "type": "object" },
+            "commandName": { "type": "string" },
+            "hasServiceId": { "type": "boolean" },
+            "hasServerConnectionId": { "type": "boolean" }
+          }
+        },
+        "commandFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "commandName": { "type": "string" },
+            "hasServiceId": { "type": "boolean" },
+            "hasServerConnectionId": { "type": "boolean" }
+          }
+        }
+      }
+    },
+
+    "expectedCmapEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "poolCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolClearedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "hasServiceId": { "type": "boolean" }
+          }
+        },
+        "poolClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": { "type": "string" }
+          }
+        },
+        "connectionCheckOutStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckOutFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": { "type": "string" }
+          }
+        },
+        "connectionCheckedOutEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckedInEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      }
+    },
+
+    "collectionOrDatabaseOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readConcern": { "type": "object" },
+        "readPreference": { "type": "object" },
+        "writeConcern": { "type": "object" }
+      }
+    },
+
+    "serverApi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version"],
+      "properties": {
+        "version": { "type": "string" },
+        "strict": { "type":  "boolean" },
+        "deprecationErrors": { "type":  "boolean" }
+      }
+    },
+
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "object"],
+      "properties": {
+        "name": { "type": "string" },
+        "object": { "type": "string" },
+        "arguments": { "type": "object" },
+        "ignoreResultAndError": { "type": "boolean" },
+        "expectError":  { "$ref": "#/definitions/expectedError" },
+        "expectResult": {},
+        "saveResultAsEntity": { "type": "string" }
+      },
+      "allOf": [
+        { "not": { "required": ["expectError", "expectResult"] } },
+        { "not": { "required": ["expectError", "saveResultAsEntity"] } },
+        { "not": { "required": ["ignoreResultAndError", "expectResult"] } },
+        { "not": { "required": ["ignoreResultAndError", "expectError"] } },
+        { "not": { "required": ["ignoreResultAndError", "saveResultAsEntity"] } }
+      ]
+    },
+
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "isError": {
+          "type": "boolean",
+          "const": true
+        },
+        "isClientError": { "type": "boolean" },
+        "errorContains": { "type": "string" },
+        "errorCode": { "type": "integer" },
+        "errorCodeName": { "type": "string" },
+        "errorLabelsContain": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "errorLabelsOmit": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "expectResult": {}
+      }
+    },
+
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "operations"],
+      "properties": {
+        "description": { "type": "string" },
+        "runOnRequirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/runOnRequirement" }
+        },
+        "skipReason": { "type": "string" },
+        "operations": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/operation" }
+        },
+        "expectEvents": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/expectedEventsForClient" }
+        },
+        "outcome": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/definitions/collectionData" }
+        }
+      }
+    }
+  }
+}

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -1,4 +1,4 @@
-SCHEMA=../schema-1.5.json
+SCHEMA=../schema-1.6.json
 
 .PHONY: all invalid valid-fail valid-pass versioned-api load-balancers gridfs transactions crud collection-management sessions command-monitoring HAS_AJV
 

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandFailedEvent-hasServerConnectionId-type.json
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandFailedEvent-hasServerConnectionId-type.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedCommandEvent-commandFailedEvent-hasServerConnectionId-type",
+  "schemaVersion": "1.6",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandFailedEvent": {
+                "hasServerConnectionId": "foo"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandFailedEvent-hasServerConnectionId-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandFailedEvent-hasServerConnectionId-type.yml
@@ -1,0 +1,16 @@
+description: expectedCommandEvent-commandFailedEvent-hasServerConnectionId-type
+
+schemaVersion: '1.6'
+
+createEntities:
+  - client:
+      id: &client0 client0
+
+tests:
+  - description: foo
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandFailedEvent:
+              hasServerConnectionId: foo

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandStartedEvent-hasServerConnectionId-type.json
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandStartedEvent-hasServerConnectionId-type.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedCommandEvent-commandStartedEvent-hasServerConnectionId-type",
+  "schemaVersion": "1.6",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "hasServerConnectionId": "foo"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandStartedEvent-hasServerConnectionId-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandStartedEvent-hasServerConnectionId-type.yml
@@ -1,0 +1,16 @@
+description: expectedCommandEvent-commandStartedEvent-hasServerConnectionId-type
+
+schemaVersion: '1.6'
+
+createEntities:
+  - client:
+      id: &client0 client0
+
+tests:
+  - description: foo
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              hasServerConnectionId: foo

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandSucceededEvent-hasServerConnectionId-type.json
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandSucceededEvent-hasServerConnectionId-type.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedCommandEvent-commandSucceededEvent-hasServerConnectionId-type",
+  "schemaVersion": "1.6",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandSucceededEvent": {
+                "hasServerConnectionId": "foo"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandSucceededEvent-hasServerConnectionId-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandSucceededEvent-hasServerConnectionId-type.yml
@@ -1,0 +1,16 @@
+description: expectedCommandEvent-commandSucceededEvent-hasServerConnectionId-type
+
+schemaVersion: '1.6'
+
+createEntities:
+  - client:
+      id: &client0 client0
+
+tests:
+  - description: foo
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandSucceededEvent:
+              hasServerConnectionId: foo

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -1182,7 +1182,9 @@ hasServerConnectionId
 This field is an optional boolean that specifies whether or not the
 ``serverConnectionId`` field of an event is set. If true, test runners MUST
 assert that the field is set and is a positive Int32. If false, test runners
-MUST assert that the field is not set or is a nonpositive Int32.
+MUST assert that the field is not set, or, if the driver uses a nonpositive Int32
+value to indicate the field being unset, MUST assert that ``serverConnectionId``
+is a nonpositive Int32.
 
 
 collectionOrDatabaseOptions

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -1181,8 +1181,8 @@ hasServerConnectionId
 
 This field is an optional boolean that specifies whether or not the
 ``serverConnectionId`` field of an event is set. If true, test runners MUST
-assert that the field is set and is a positive Int64. If false, test runners
-MUST assert that the field is not set or is a nonpositive Int64.
+assert that the field is set and is a positive Int32. If false, test runners
+MUST assert that the field is not set or is a nonpositive Int32.
 
 
 collectionOrDatabaseOptions

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -1052,6 +1052,8 @@ The structure of this object is as follows:
 
   - ``hasServiceId``: Defined in `hasServiceId`_.
 
+  - ``hasServerConnectionId``: Defined in `hasServerConnectionId`_.
+
 .. _expectedEvent_commandSucceededEvent:
 
 - ``commandSucceededEvent``: Optional object. Assertions for one or more
@@ -1069,6 +1071,8 @@ The structure of this object is as follows:
 
   - ``hasServiceId``: Defined in `hasServiceId`_.
 
+  - ``hasServerConnectionId``: Defined in `hasServerConnectionId`_.
+
 .. _expectedEvent_commandFailedEvent:
 
 - ``commandFailedEvent``: Optional object. Assertions for one or more
@@ -1081,6 +1085,8 @@ The structure of this object is as follows:
     name matches this value.
 
   - ``hasServiceId``: Defined in `hasServiceId`_.
+
+  - ``hasServerConnectionId``: Defined in `hasServerConnectionId`_.
 
 expectedCmapEvent
 `````````````````
@@ -1169,6 +1175,14 @@ This field is an optional boolean that specifies whether or not the
 that the field is set and is a non-empty BSON ObjectId (i.e. all bytes of the
 ObjectId are not 0). If false, test runners MUST assert that the field is not
 set or is an empty BSON ObjectId.
+
+hasServerConnectionId
+`````````````````````
+
+This field is an optional boolean that specifies whether or not the
+``serverConnectionId`` field of an event is set. If true, test runners MUST
+assert that the field is set and is an Int64. If false, test runners MUST assert
+that the field is not set.
 
 
 collectionOrDatabaseOptions

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -1181,8 +1181,8 @@ hasServerConnectionId
 
 This field is an optional boolean that specifies whether or not the
 ``serverConnectionId`` field of an event is set. If true, test runners MUST
-assert that the field is set and is an Int64. If false, test runners MUST assert
-that the field is not set.
+assert that the field is set and is a positive Int64. If false, test runners
+MUST assert that the field is not set or is a nonpositive Int64.
 
 
 collectionOrDatabaseOptions


### PR DESCRIPTION
DRIVERS-1141

Adds a new `serverConnectionId` field to `CommandStartedEvent`, `CommandSucceededEvent` and `CommandFailedEvent` so users of APM can correlate client-side `connectionId`s with server-side `serverConnectionId`s (see ticket for more details). Adds a new unified command monitoring test to verify that `serverConnectionId` is present in command monitoring events. 

Adds a new `hasServerConnectionId` field to `commandStartedEvent`, `commandSucceededEvent` and `commandFailedEvent` in the unified test format. This field is similar to the existing [`hasServiceId`](https://github.com/mongodb/specifications/blob/master/source/unified-test-format/unified-test-format.rst#hasserviceid) field and lets us assert the existence of `serverConnectionId` without explicitly checking its value (which will always be dependent on the connected server).

My implementation in the Go driver is available [here](https://github.com/benjirewis/mongo-go-driver/tree/serverConnectionID.2085). And here is a [patch](https://spruce.mongodb.com/version/611ec60e30661523556162d2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) of that implementation passing our latest tests.