### PR TITLE
DRIVERS-1902: Fix invalid field name in regex parse error test

### DIFF
--- a/source/bson-corpus/tests/top.json
+++ b/source/bson-corpus/tests/top.json
@@ -92,11 +92,11 @@
         },
         {
             "description": "Bad $regularExpression (pattern is number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"$options\" : \"\"}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"options\" : \"\"}}}"
         },
         {
             "description": "Bad $regularExpression (options are number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"$options\" : 0}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"options\" : 0}}}"
         },
         {
             "description" : "Bad $regularExpression (missing pattern field)",


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1902

These tests are meant to test a type error for the pattern or options component. The use of $options here was a typo going back to c6d7ac82cc48800171678b9515c92d69d5bebbcd.