### PR TITLE
DRIVERS-1554 Clarify internal per-mongos clients may be used for targetedFailPoint

### DIFF
--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3286,7 +3286,8 @@ Change Log
 :2021-08-30: Test runners may create an internal MongoClient for each mongos.
              Better clarify how internal MongoClients may be used.
              Clarify that drivers creating an internal MongoClient for each
-             mongos should use clients for ``targetedFailPoint`` operations.
+             mongos should use those clients for ``targetedFailPoint``
+             operations.
 
 :2021-08-23: Allow ``runOnRequirement`` conditions to be evaluated in any order.
 

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -1893,7 +1893,10 @@ test runner SHOULD use the client entity associated with the session
 to execute the ``configureFailPoint`` command. In this case, the test runner
 MUST also ensure that this command is excluded from the list of observed
 command monitoring events for this client (if applicable). If such an API is
-not available, test runners MUST create a new MongoClient that is directly
+not available, but the test runner creates an internal MongoClient for each
+mongos, the test runner MAY use the internal MongoClient corresponding to
+the session's pinned server for this operation.
+Otherwise, test runners MUST create a new MongoClient that is directly
 connected to the session's pinned server for this operation. The new
 MongoClient instance MUST be closed once the command has finished executing.
 

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -1894,7 +1894,7 @@ to execute the ``configureFailPoint`` command. In this case, the test runner
 MUST also ensure that this command is excluded from the list of observed
 command monitoring events for this client (if applicable). If such an API is
 not available, but the test runner creates an internal MongoClient for each
-mongos, the test runner MAY use the internal MongoClient corresponding to
+mongos, the test runner SHOULD use the internal MongoClient corresponding to
 the session's pinned server for this operation.
 Otherwise, test runners MUST create a new MongoClient that is directly
 connected to the session's pinned server for this operation. The new
@@ -3283,8 +3283,10 @@ Change Log
 :2021-08-30: Add ``hasServerConnectionId`` field to ``commandStartedEvent``,
              ``commandSuccededEvent`` and ``commandFailedEvent``.
 
-:2021-08-24: Test runners may create an internal MongoClient for each mongos.
+:2021-08-30: Test runners may create an internal MongoClient for each mongos.
              Better clarify how internal MongoClients may be used.
+             Clarify that drivers creating an internal MongoClient for each
+             mongos should use clients for ``targetedFailPoint`` operations.
 
 :2021-08-23: Allow ``runOnRequirement`` conditions to be evaluated in any order.
 


### PR DESCRIPTION
I left spec version as-is and didn't bother changing the last updated date or change log since this is part of the same drivers ticket/clarification work you just did, but let me know if you think I should do so.