### PR TITLE
DRIVERS-1141 Update command monitoring and UTF spec versions

### DIFF
--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -12,7 +12,7 @@ Command Monitoring
 :Type: Standards
 :Minimum Server Version: 2.4
 :Last Modified: 2021-08-30
-:Version: 1.2.0
+:Version: 1.10.0
 
 .. contents::
 

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -11,8 +11,8 @@ Command Monitoring
 :Status: Approved
 :Type: Standards
 :Minimum Server Version: 2.4
-:Last Modified: 2021-05-05
-:Version: 1.9.1
+:Last Modified: 2021-08-30
+:Version: 1.9.2
 
 .. contents::
 
@@ -508,3 +508,6 @@ Changelog
 5 MAY 2021
   - Updated to use hello and legacy hello.
 
+30 AUG 2021:
+  - Added ``serverConnectionId`` field to ``CommandStartedEvent``, ``CommandSucceededEvent`` and
+    ``CommandFailedEvent``.

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -12,7 +12,7 @@ Command Monitoring
 :Type: Standards
 :Minimum Server Version: 2.4
 :Last Modified: 2021-08-30
-:Version: 1.9.2
+:Version: 1.2.0
 
 .. contents::
 

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3,7 +3,7 @@ Unified Test Format
 ===================
 
 :Spec Title: Unified Test Format
-:Spec Version: 1.5.7
+:Spec Version: 1.6.0
 :Author: Jeremy Mikola
 :Advisors: Prashant Mital, Isabel Atkinson, Thomas Reggi
 :Status: Accepted

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3,13 +3,13 @@ Unified Test Format
 ===================
 
 :Spec Title: Unified Test Format
-:Spec Version: 1.5.6
+:Spec Version: 1.5.7
 :Author: Jeremy Mikola
 :Advisors: Prashant Mital, Isabel Atkinson, Thomas Reggi
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-08-24
+:Last Modified: 2021-08-30
 
 .. contents::
 
@@ -3276,6 +3276,9 @@ spec changes developed in parallel or during the same release cycle.
 
 Change Log
 ==========
+
+:2021-08-30: Add ``hasServerConnectionId`` field to ``commandStartedEvent``,
+             ``commandSuccededEvent`` and ``commandFailedEvent``.
 
 :2021-08-24: Test runners may create an internal MongoClient for each mongos.
              Better clarify how internal MongoClients may be used.


### PR DESCRIPTION
DRIVERS-1141

Updates spec versions, last modified dates and change logs for the command monitoring and unified test format specs. Forgot to do this as part of #1050.