### PR TITLE
DRIVERS-521 Allow custom service names with rawsrv URI scheme

### DIFF
--- a/source/connection-string/tests/invalid-uris.json
+++ b/source/connection-string/tests/invalid-uris.json
@@ -287,6 +287,15 @@
       "hosts": null,
       "auth": null,
       "options": null
+    },
+    {
+      "description": "mongodb+rawsrv without service name",
+      "uri": "mongodb+rawsrv://tcp.test7.test.mongodb.com",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
     }
   ]
 }

--- a/source/connection-string/tests/invalid-uris.yml
+++ b/source/connection-string/tests/invalid-uris.yml
@@ -258,4 +258,13 @@ tests:
         auth: ~
         options: ~
 
-    
+    -
+        description: "mongodb+rawsrv without service name"
+        uri: "mongodb+rawsrv://tcp.test7.test.mongodb.com"
+        valid: false
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~
+
+

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -76,7 +76,7 @@ Test Format and Use
 
 These YAML and JSON files contain the following fields:
 
-- ``uri``: a mongodb+srv connection string
+- ``uri``: a mongodb+srv or mongodb+rawsrv connection string
 - ``seeds``: the expected set of initial seeds discovered from the SRV record
 - ``hosts``: the discovered topology's list of hosts once SDAM completes a scan
 - ``options``: the parsed connection string options as discovered from URI and
@@ -90,9 +90,9 @@ These YAML and JSON files contain the following fields:
 
 .. _`Connection String`: ../../connection-string/connection-string-spec.rst
 
-For each file, create MongoClient initialized with the mongodb+srv connection
-string. You SHOULD verify that the client's initial seed list matches the list of
-seeds. You MUST verify that the set of ServerDescriptions in the client's
+For each file, create MongoClient initialized with the mongodb+srv or mongodb+rawsrv
+connection string. You SHOULD verify that the client's initial seed list matches
+the list of seeds. You MUST verify that the set of ServerDescriptions in the client's
 TopologyDescription eventually matches the list of hosts. You MUST verify that
 each of the values of the Connection String Options under ``options`` match the
 Client's parsed value for that option. There may be other options parsed by

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/rawsrv-uri.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/rawsrv-uri.json
@@ -1,0 +1,14 @@
+{
+  "uri": "mongodb+rawsrv://_mongodb._tcp.test3.test.build.10gen.cc/",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true
+  }
+}

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/rawsrv-uri.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/rawsrv-uri.yml
@@ -1,0 +1,9 @@
+uri: "mongodb+rawsrv://_mongodb._tcp.test3.test.build.10gen.cc/"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    ssl: true

--- a/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
+++ b/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
@@ -9,8 +9,8 @@ Polling SRV Records for mongos Discovery
 :Author: Derick Rethans
 :Status: Accepted
 :Type: Standards
-:Last Modified: 2018-11-29
-:Version: 1.0
+:Last Modified: 2021-09-03
+:Version: 1.1
 :Spec Lead: David Golden
 
 .. contents::
@@ -61,8 +61,8 @@ for.
 Implementation
 --------------
 
-If the initial topology was created through a ``mongodb+srv://`` URI, then
-drivers MUST implement this specification by periodically rescanning the SRV
+If the initial topology was created through a ``mongodb+srv://`` or ``mongodb+rawsrv://`
+URI, then drivers MUST implement this specification by periodically rescanning the SRV
 DNS records. There MUST NOT be an option to turn this behaviour off.
 
 Drivers MUST NOT implement this specification if they do not adhere fully to
@@ -78,9 +78,14 @@ discovery section of the original specification. The behaviour of the periodic
 rescan is similar, but not identical to the behaviour of initial seedlist
 discovery.  Periodic scan MUST follow these rules:
 
-- The driver will query the DNS server for SRV records on
+- If the initial topology was created through a ``mongodb+srv://`` URI,
+  the driver will query the DNS server for SRV records on
   ``{hostname}.{domainname}``, prefixed with ``_mongodb._tcp.``:
   ``_mongodb._tcp.{hostname}.{domainname}``.
+
+- If the initial topology was created through a ``mongodb+rawsrv://`` URI,
+  the driver will query the DNS server for SRV records using the original
+  URI without the scheme: ``_{servicename}._{protocol}.{hostname}.{domainname}``.
 
 - A driver MUST verify that the host names returned through SRV records have
   the same parent ``{domainname}``. When this verification fails, a driver:
@@ -201,9 +206,9 @@ Backwards Compatibility
 
 This specification changes the behaviour of server monitoring by introducing a
 repeating DNS lookup of the SRV records. Although this is an improvement in
-the ``mongodb+srv://`` scheme it can nonetheless break expectations with users
-that were familiar with the old behaviour. We do not expect this to negatively
-impact users.
+the ``mongodb+srv://`` and ``mongodb+rawsrv://`` schemes, it can nonetheless break
+expectations with users that were familiar with the old behaviour. We do not expect
+this to negatively impact users.
 
 Reference Implementation
 ========================
@@ -227,4 +232,6 @@ No future work is expected.
 Changelog
 =========
 
-No changes yet.
+2021-09-03
+    Add guidance for new ``mongodb+rawsrv`` URI scheme: drivers should use
+    the original URI for SRV polling without prepending ``_mongodb._tcp``.

--- a/source/polling-srv-records-for-mongos-discovery/tests/README.rst
+++ b/source/polling-srv-records-for-mongos-discovery/tests/README.rst
@@ -116,8 +116,8 @@ The following tests MUST setup a MongoClient using the
 ``test3.test.build.10gen.cc`` SRV record. Each test MUST mock the described
 situation and make the specified assertions.
 
-9. Test that SRV polling is not done for load balalanced clusters
------------------------------------------------------------------
+9. Test that SRV polling is not done for load balanced clusters
+---------------------------------------------------------------
 
 Connect to ``mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true``,
 mock the addition of the following DNS record::
@@ -126,3 +126,14 @@ mock the addition of the following DNS record::
 
 Wait until ``2*rescanSRVIntervalMS`` and assert that the final topology description
 only contains one server: ``localhost.test.build.10gen.cc.`` at port ``27017``.
+
+10. Test that SRV polling is done correctly for rawsrv URIs
+-----------------------------------------------------------
+
+Connect to ``mongodb+rawsrv://_customname._tcp.test3.test.build.10gen.cc/``,
+mock the addition of the following DNS record::
+
+    _customname._tcp.test3.test.build.10gen.cc.  86400  IN SRV  27018  localhost.test.build.10gen.cc.
+
+Wait until ``2*rescanSRVIntervalMS`` and assert that the final topology description
+contains two servers: ``localhost.test.build.10gen.cc.`` at port ``27017`` and port ``27018``.


### PR DESCRIPTION
DRIVERS-521

Introduces a new URI scheme ``mongodb+rawsrv`` to be used in initial DNS seedlist discovery and subsequent SRV polling. ``mongodb+rawsrv`` functions identically to ``mongodb+srv`` but does not automatically prepend ``_mongodb._tcp`` service name and protocol to the SRV lookup. Instead, it uses the service name and protocol provided by the user in the initial URI.

Updates initial DNS seedlist discovery and SRV polling specs to describe new scheme. Adds spec tests for valid and invalid ``mongodb+rawsrv`` URI schemes and a prose test for SRV polling with ``mongodb+rawsrv``.

Prototype in Go is available [here](https://github.com/benjirewis/mongo-go-driver/tree/rawServiceName). [Here](https://spruce.mongodb.com/version/613249103066157f45794be2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) is a patch of that implementation passing all tests.