### PR TITLE
DRIVERS-1875 Add BSON corpus test for binary subtype 7

### DIFF
--- a/source/bson-corpus/tests/binary.json
+++ b/source/bson-corpus/tests/binary.json
@@ -51,6 +51,11 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"05\"}}}"
         },
         {
+            "description": "subtype 0x07",
+            "canonical_bson": "1D000000057800100000000773FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"07\"}}}"
+        },
+        {
             "description": "subtype 0x80",
             "canonical_bson": "0F0000000578000200000080FFFF00",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"80\"}}}"


### PR DESCRIPTION
The new test only validates correct subtype number encoding/decoding and binary data encoding/decoding. The binary data itself is not validated. DRIVERS-1875 states the data intended to be stored is "meant to be opaque", so I believe this should satisfy current requirements.