### PR TITLE
DRIVERS-521 Allow custom service names with srvServiceName URI option

### DIFF
--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -10,8 +10,8 @@ Initial DNS Seedlist Discovery
 :Authors: Derick Rethans
 :Status: Draft
 :Type: Standards
-:Last Modified: 2019-04-15
-:Version: 1.4.0
+:Last Modified: 2021-09-xx
+:Version: 1.4.1
 :Spec Lead: Matt Broadstone
 :Advisory Group: \A. Jesse Jiryu Davis
 :Approver(s): Bernie Hackett, David Golden, Jeff Yemin, Matt Broadstone, A. Jesse Jiryu Davis
@@ -65,11 +65,13 @@ Seedlist Discovery
 ------------------
 
 In this preprocessing step, the driver will query the DNS server for SRV
-records on ``{hostname}.{domainname}``, prefixed with ``_mongodb._tcp.``:
-``_mongodb._tcp.{hostname}.{domainname}``. This DNS query is expected to
-respond with one or more SRV records. From the DNS result, the driver now MUST
-behave the same as if an ``mongodb://`` URI was provided with all the host
-names and port numbers that were returned as part of the DNS SRV query result.
+records on ``{hostname}.{domainname}``, prefixed with the SRV service name
+and protocol. The SRV service name is provided in the ``srvServiceName`` URI option and
+defaults to ``mongodb``. The protocol is always ``tcp``. After prefixing, the URI
+should look like: ``_{srvServiceName}._tcp.{hostname}.{domainname}``. This DNS query
+is expected to respond with one or more SRV records. From the DNS result, the driver
+now MUST behave the same as if an ``mongodb://`` URI was provided with all the host names
+and port numbers that were returned as part of the DNS SRV query result.
 
 The priority and weight fields in returned SRV records MUST be ignored.
 
@@ -273,6 +275,10 @@ SRV records.
 
 ChangeLog
 =========
+
+2021-09-xx - 1.4.1
+    Clarify that service name only defaults to ``mongodb``, and should be
+    defined by the ``srvServiceName`` URI option.
 
 2021-04-15 - 1.4.0
     Adding in behaviour for load balancer mode.

--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -11,7 +11,7 @@ Initial DNS Seedlist Discovery
 :Status: Draft
 :Type: Standards
 :Last Modified: 2021-09-xx
-:Version: 1.4.1
+:Version: 1.5.0
 :Spec Lead: Matt Broadstone
 :Advisory Group: \A. Jesse Jiryu Davis
 :Approver(s): Bernie Hackett, David Golden, Jeff Yemin, Matt Broadstone, A. Jesse Jiryu Davis
@@ -276,7 +276,7 @@ SRV records.
 ChangeLog
 =========
 
-2021-09-xx - 1.4.1
+2021-09-xx - 1.5.0
     Clarify that service name only defaults to ``mongodb``, and should be
     defined by the ``srvServiceName`` URI option.
 

--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -69,9 +69,9 @@ records on ``{hostname}.{domainname}``, prefixed with the SRV service name
 and protocol. The SRV service name is provided in the ``srvServiceName`` URI option and
 defaults to ``mongodb``. The protocol is always ``tcp``. After prefixing, the URI
 should look like: ``_{srvServiceName}._tcp.{hostname}.{domainname}``. This DNS query
-is expected to respond with one or more SRV records. The driver MUST use all the host
-names and port numbers that were returned as part of the DNS SRV query result in the same
-way as a ``mongodb://`` URI.
+is expected to respond with one or more SRV records. The driver MUST add all the host
+names and port numbers that were returned as part of the DNS SRV query result to the
+seedlist.
 
 The priority and weight fields in returned SRV records MUST be ignored.
 

--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -69,9 +69,9 @@ records on ``{hostname}.{domainname}``, prefixed with the SRV service name
 and protocol. The SRV service name is provided in the ``srvServiceName`` URI option and
 defaults to ``mongodb``. The protocol is always ``tcp``. After prefixing, the URI
 should look like: ``_{srvServiceName}._tcp.{hostname}.{domainname}``. This DNS query
-is expected to respond with one or more SRV records. From the DNS result, the driver
-now MUST behave the same as if an ``mongodb://`` URI was provided with all the host names
-and port numbers that were returned as part of the DNS SRV query result.
+is expected to respond with one or more SRV records. The driver MUST use all the host
+names and port numbers that were returned as part of the DNS SRV query result in the same
+way as a ``mongodb://`` URI.
 
 The priority and weight fields in returned SRV records MUST be ignored.
 

--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -10,7 +10,7 @@ Initial DNS Seedlist Discovery
 :Authors: Derick Rethans
 :Status: Draft
 :Type: Standards
-:Last Modified: 2021-09-xx
+:Last Modified: 2021-09-15
 :Version: 1.5.0
 :Spec Lead: Matt Broadstone
 :Advisory Group: \A. Jesse Jiryu Davis
@@ -276,7 +276,7 @@ SRV records.
 ChangeLog
 =========
 
-2021-09-xx - 1.5.0
+2021-09-15 - 1.5.0
     Clarify that service name only defaults to ``mongodb``, and should be
     defined by the ``srvServiceName`` URI option.
 

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
@@ -1,7 +1,8 @@
 {
   "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
   ],
   "hosts": [
     "localhost:27017",
@@ -9,6 +10,7 @@
     "localhost:27019"
   ],
   "options": {
+    "ssl": true,
     "srvServiceName": "customname"
   }
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname",
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname",
   "seeds": [
     "localhost.test.build.10gen.cc:27017"
   ],
@@ -9,7 +9,6 @@
     "localhost:27019"
   ],
   "options": {
-    "ssl": true,
     "srvServiceName": "customname"
   }
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
@@ -1,0 +1,15 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true,
+    "srvServiceName": "customname"
+  }
+}

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
@@ -1,9 +1,11 @@
 uri: "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname"
 seeds:
     - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
 hosts:
     - localhost:27017
     - localhost:27018
     - localhost:27019
 options:
+    ssl: true
     srvServiceName: "customname"

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
@@ -1,4 +1,4 @@
-uri: "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname"
+uri: "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname"
 seeds:
     - localhost.test.build.10gen.cc:27017
 hosts:
@@ -6,5 +6,4 @@ hosts:
     - localhost:27018
     - localhost:27019
 options:
-    ssl: true
     srvServiceName: "customname"

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
@@ -1,0 +1,10 @@
+uri: "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    ssl: true
+    srvServiceName: "customname"

--- a/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
+++ b/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
@@ -9,8 +9,8 @@ Polling SRV Records for mongos Discovery
 :Author: Derick Rethans
 :Status: Accepted
 :Type: Standards
-:Last Modified: 2018-11-29
-:Version: 1.0
+:Last Modified: 2021-09-xx
+:Version: 1.0.1
 :Spec Lead: David Golden
 
 .. contents::
@@ -79,8 +79,10 @@ rescan is similar, but not identical to the behaviour of initial seedlist
 discovery.  Periodic scan MUST follow these rules:
 
 - The driver will query the DNS server for SRV records on
-  ``{hostname}.{domainname}``, prefixed with ``_mongodb._tcp.``:
-  ``_mongodb._tcp.{hostname}.{domainname}``.
+  ``{hostname}.{domainname}``, prefixed with the SRV service name
+  and protocol. The SRV service name is provided in the ``srvServiceName`` URI option and
+  defaults to ``mongodb``. The protocol is always ``tcp``. After prefixing, the URI
+  should look like: ``_{srvServiceName}._tcp.{hostname}.{domainname}``..
 
 - A driver MUST verify that the host names returned through SRV records have
   the same parent ``{domainname}``. When this verification fails, a driver:
@@ -227,4 +229,6 @@ No future work is expected.
 Changelog
 =========
 
-No changes yet.
+2021-09-xx - 1.0.1
+    Clarify that service name only defaults to ``mongodb``, and should be
+    defined by the ``srvServiceName`` URI option.

--- a/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
+++ b/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
@@ -10,7 +10,7 @@ Polling SRV Records for mongos Discovery
 :Status: Accepted
 :Type: Standards
 :Last Modified: 2021-09-xx
-:Version: 1.0.1
+:Version: 1.1.0
 :Spec Lead: David Golden
 
 .. contents::
@@ -82,7 +82,7 @@ discovery.  Periodic scan MUST follow these rules:
   ``{hostname}.{domainname}``, prefixed with the SRV service name
   and protocol. The SRV service name is provided in the ``srvServiceName`` URI option and
   defaults to ``mongodb``. The protocol is always ``tcp``. After prefixing, the URI
-  should look like: ``_{srvServiceName}._tcp.{hostname}.{domainname}``..
+  should look like: ``_{srvServiceName}._tcp.{hostname}.{domainname}``.
 
 - A driver MUST verify that the host names returned through SRV records have
   the same parent ``{domainname}``. When this verification fails, a driver:
@@ -229,6 +229,6 @@ No future work is expected.
 Changelog
 =========
 
-2021-09-xx - 1.0.1
+2021-09-xx - 1.1.0
     Clarify that service name only defaults to ``mongodb``, and should be
     defined by the ``srvServiceName`` URI option.

--- a/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
+++ b/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
@@ -9,7 +9,7 @@ Polling SRV Records for mongos Discovery
 :Author: Derick Rethans
 :Status: Accepted
 :Type: Standards
-:Last Modified: 2021-09-xx
+:Last Modified: 2021-09-15
 :Version: 1.1.0
 :Spec Lead: David Golden
 
@@ -229,6 +229,6 @@ No future work is expected.
 Changelog
 =========
 
-2021-09-xx - 1.1.0
+2021-09-15 - 1.1.0
     Clarify that service name only defaults to ``mongodb``, and should be
     defined by the ``srvServiceName`` URI option.

--- a/source/uri-options/tests/srv-service-name-option.json
+++ b/source/uri-options/tests/srv-service-name-option.json
@@ -1,0 +1,24 @@
+{
+  "tests": [
+    {
+      "description": "SRV URI with custom srvServiceName",
+      "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "srvServiceName": "customname"
+      }
+    },
+    {
+      "description": "Non-SRV URI with custom srvServiceName",
+      "uri": "mongodb://example.com/?srvServiceName=customname",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/source/uri-options/tests/srv-service-name-option.json
+++ b/source/uri-options/tests/srv-service-name-option.json
@@ -4,7 +4,7 @@
       "description": "SRV URI with custom srvServiceName",
       "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname",
       "valid": true,
-      "warning": false,
+      "warning": null,
       "hosts": null,
       "auth": null,
       "options": {

--- a/source/uri-options/tests/srv-service-name-option.json
+++ b/source/uri-options/tests/srv-service-name-option.json
@@ -2,9 +2,9 @@
   "tests": [
     {
       "description": "SRV URI with custom srvServiceName",
-      "uri": "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname",
+      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname",
       "valid": true,
-      "warning": null,
+      "warning": false,
       "hosts": null,
       "auth": null,
       "options": {
@@ -15,7 +15,7 @@
       "description": "Non-SRV URI with custom srvServiceName",
       "uri": "mongodb://example.com/?srvServiceName=customname",
       "valid": false,
-      "warning": null,
+      "warning": true,
       "hosts": null,
       "auth": null,
       "options": {}

--- a/source/uri-options/tests/srv-service-name-option.yml
+++ b/source/uri-options/tests/srv-service-name-option.yml
@@ -1,8 +1,8 @@
 tests:
     - description: "SRV URI with custom srvServiceName"
-      uri: "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname"
+      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname"
       valid: true
-      warning: ~
+      warning: false
       hosts: ~
       auth: ~
       options:
@@ -10,7 +10,7 @@ tests:
     - description: "Non-SRV URI with custom srvServiceName"
       uri: "mongodb://example.com/?srvServiceName=customname"
       valid: false
-      warning: ~
+      warning: true
       hosts: ~
       auth: ~
       options: {}

--- a/source/uri-options/tests/srv-service-name-option.yml
+++ b/source/uri-options/tests/srv-service-name-option.yml
@@ -2,7 +2,7 @@ tests:
     - description: "SRV URI with custom srvServiceName"
       uri: "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname"
       valid: true
-      warning: false
+      warning: ~
       hosts: ~
       auth: ~
       options:

--- a/source/uri-options/tests/srv-service-name-option.yml
+++ b/source/uri-options/tests/srv-service-name-option.yml
@@ -1,0 +1,16 @@
+tests:
+    - description: "SRV URI with custom srvServiceName"
+      uri: "mongodb+srv://test3.test.build.10gen.cc/?srvServiceName=customname"
+      valid: true
+      warning: false
+      hosts: ~
+      auth: ~
+      options:
+          srvServiceName: "customname"
+    - description: "Non-SRV URI with custom srvServiceName"
+      uri: "mongodb://example.com/?srvServiceName=customname"
+      valid: false
+      warning: ~
+      hosts: ~
+      auth: ~
+      options: {}

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -11,7 +11,7 @@ URI Options Specification
 :Informed: drivers@
 :Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
 :Type: Standards
-:Last Modified: 2021-9-xx
+:Last Modified: 2021-09-15
 
 
 **Abstract**
@@ -471,7 +471,7 @@ this specification MUST be updated to reflect those changes.
 Changes
 -------
 
-- 2021-09-xx Add srvServiceName option
+- 2021-09-15 Add srvServiceName option
 - 2021-09-13 Fix link to load balancer spec
 - 2021-04-15 Adding in behaviour for load balancer mode.
 - 2021-04-08 Updated to refer to hello and legacy hello

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -282,8 +282,8 @@ pertaining to URI options apply here.
        character DNS query limit is not surpassed
      - "mongodb"
      - no
-     - the service name to use for SRV lookup in `initial DNS seedlist discovery <https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst>`_
-       and `SRV polling <https://github.com/mongodb/specifications/blob/master/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst>`_
+     - the service name to use for SRV lookup in `initial DNS seedlist discovery <../initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst>`_
+       and `SRV polling <../polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst>`_
 
    * - ssl
      - "true" or "false"

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -278,7 +278,8 @@ pertaining to URI options apply here.
      - Amount of time spent attempting to send or receive on a socket before timing out; note that this only applies to application operations, not SDAM
 
    * - srvServiceName
-     - any string
+     - a valid SRV service name according to `RFC 6335 <https://datatracker.ietf.org/doc/html/rfc6335#section-5.1>`_; can be longer than 15 characters as long as the 63 character DNS query limit is
+       not surpassed
      - "mongodb"
      - no
      - the service name to use for SRV lookup in `initial DNS seedlist discovery <https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst>`_

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -278,8 +278,8 @@ pertaining to URI options apply here.
      - Amount of time spent attempting to send or receive on a socket before timing out; note that this only applies to application operations, not SDAM
 
    * - srvServiceName
-     - a valid SRV service name according to `RFC 6335 <https://datatracker.ietf.org/doc/html/rfc6335#section-5.1>`_; can be longer than 15 characters as long as the 63 character DNS query limit is
-       not surpassed
+     - a valid SRV service name according to `RFC 6335 <https://datatracker.ietf.org/doc/html/rfc6335#section-5.1>`_; can be longer than 15 characters as long as the 63 (62 with prepended underscore)
+       character DNS query limit is not surpassed
      - "mongodb"
      - no
      - the service name to use for SRV lookup in `initial DNS seedlist discovery <https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst>`_

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -3,7 +3,7 @@ URI Options Specification
 =========================
 
 :Spec Title: URI Options Specification
-:Spec Version: 1.7.1
+:Spec Version: 1.8.0
 :Author: Sam Rossi
 :Spec Lead: Bernie Hackett
 :Advisory Group: Scott L'Hommedieu
@@ -11,7 +11,7 @@ URI Options Specification
 :Informed: drivers@
 :Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
 :Type: Standards
-:Last Modified: 2021-09-13
+:Last Modified: 2021-9-xx
 
 
 **Abstract**
@@ -70,6 +70,14 @@ The driver MUST report an error if the ``directConnection=true`` URI option
 is specified with an SRV URI, because the URI may resolve to multiple
 hosts. The driver MUST allow specifying ``directConnection=false`` URI
 option with an SRV URI.
+
+Non-SRV URI with srvServiceName URI option
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The driver MUST report an error if the ``srvServiceName`` URI option is
+specified with a non-SRV URI (i.e. ``mongodb://``) because SRV lookup
+only occurs with SRV URIs. The driver MUST allow specifying the ``srvServiceName``
+URI option with an SRV URI.
 
 Multiple seeds with directConnection URI option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -208,7 +216,7 @@ pertaining to URI options apply here.
      - non-negative integer
      - defined in the `Connection Pooling spec`_
      - required for drivers with connection pools
-     - The number of connections the driver should create and maintain in the pool even when no operations are occurring. This count includes connections which are currently checked out. 
+     - The number of connections the driver should create and maintain in the pool even when no operations are occurring. This count includes connections which are currently checked out.
 
    * - readConcernLevel
      - any string (`to allow for forwards compatibility with the server <https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#unknown-levels-and-additional-options-for-string-based-readconcerns>`_)
@@ -268,6 +276,13 @@ pertaining to URI options apply here.
      - no timeout
      - no
      - Amount of time spent attempting to send or receive on a socket before timing out; note that this only applies to application operations, not SDAM
+
+   * - srvServiceName
+     - any string
+     - "mongodb"
+     - no
+     - the service name to use for SRV lookup in `initial DNS seedlist discovery <https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst>`_
+       and `SRV polling <https://github.com/mongodb/specifications/blob/master/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst>`_
 
    * - ssl
      - "true" or "false"
@@ -455,6 +470,7 @@ this specification MUST be updated to reflect those changes.
 Changes
 -------
 
+- 2021-09-xx Add srvServiceName option
 - 2021-09-13 Fix link to load balancer spec
 - 2021-04-15 Adding in behaviour for load balancer mode.
 - 2021-04-08 Updated to refer to hello and legacy hello


### PR DESCRIPTION
DRIVERS-521

Allow the use of custom SRV service names for SRV lookup using a new `srvServiceName` URI option. Clarify that during initial DNS seedlist discovery and SRV polling, the value of `srvServiceName` should be prefixed to the URI and `mongodb` should only be used as a service name if `srvServiceName` is not specified.

Prototype available in Go [here](https://github.com/benjirewis/mongo-go-driver/tree/customServiceName).