### PR TITLE
DRIVERS-521 Use test22 for custom service name endpoint

### DIFF
--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -24,29 +24,30 @@ these tests::
   localhost.test.build.10gen.cc.            86400  IN A    127.0.0.1
   localhost.sub.test.build.10gen.cc.        86400  IN A    127.0.0.1
 
-  Record                                    TTL    Class   Port   Target
-  _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test1.test.build.10gen.cc.  86400  IN SRV  27018  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test2.test.build.10gen.cc.  86400  IN SRV  27018  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test2.test.build.10gen.cc.  86400  IN SRV  27019  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test3.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test5.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test6.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test7.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test8.test.build.10gen.cc.  86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test10.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test11.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test12.test.build.10gen.cc. 86400  IN SRV  27017  localhost.build.10gen.cc.
-  _mongodb._tcp.test13.test.build.10gen.cc. 86400  IN SRV  27017  test.build.10gen.cc.
-  _mongodb._tcp.test14.test.build.10gen.cc. 86400  IN SRV  27017  localhost.not-test.build.10gen.cc.
-  _mongodb._tcp.test15.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.not-build.10gen.cc.
-  _mongodb._tcp.test16.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.not-10gen.cc.
-  _mongodb._tcp.test17.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.not-cc.
-  _mongodb._tcp.test18.test.build.10gen.cc. 86400  IN SRV  27017  localhost.sub.test.build.10gen.cc.
-  _mongodb._tcp.test19.test.build.10gen.cc. 86400  IN SRV  27017  localhost.evil.build.10gen.cc.
-  _mongodb._tcp.test19.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test20.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _mongodb._tcp.test21.test.build.10gen.cc. 86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  Record                                      TTL    Class   Port   Target
+  _mongodb._tcp.test1.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test1.test.build.10gen.cc.    86400  IN SRV  27018  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test2.test.build.10gen.cc.    86400  IN SRV  27018  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test2.test.build.10gen.cc.    86400  IN SRV  27019  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test3.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test5.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test6.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test7.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test8.test.build.10gen.cc.    86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test10.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test11.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test12.test.build.10gen.cc.   86400  IN SRV  27017  localhost.build.10gen.cc.
+  _mongodb._tcp.test13.test.build.10gen.cc.   86400  IN SRV  27017  test.build.10gen.cc.
+  _mongodb._tcp.test14.test.build.10gen.cc.   86400  IN SRV  27017  localhost.not-test.build.10gen.cc.
+  _mongodb._tcp.test15.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.not-build.10gen.cc.
+  _mongodb._tcp.test16.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.not-10gen.cc.
+  _mongodb._tcp.test17.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.not-cc.
+  _mongodb._tcp.test18.test.build.10gen.cc.   86400  IN SRV  27017  localhost.sub.test.build.10gen.cc.
+  _mongodb._tcp.test19.test.build.10gen.cc.   86400  IN SRV  27017  localhost.evil.build.10gen.cc.
+  _mongodb._tcp.test19.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test20.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test21.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _customname._tcp.test22.test.build.10gen.cc 86400  IN SRV  27017  localhost.test.build.10gen.cc
 
   Record                                    TTL    Class   Text
   test5.test.build.10gen.cc.                86400  IN TXT  "replicaSet=repl0&authSource=thisDB"
@@ -62,7 +63,8 @@ these tests::
 Note that ``test4`` is omitted deliberately to test what happens with no SRV
 record. ``test9`` is missing because it was deleted during the development of
 the tests. The missing ``test.`` sub-domain in the SRV record target for
-``test12`` is deliberate.
+``test12`` is deliberate. ``test22`` is used to test a custom service name
+(``customname``).
 
 In our tests we have used ``localhost.test.build.10gen.cc`` as the domain, and
 then configured ``localhost.test.build.10gen.cc`` to resolve to 127.0.0.1.

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname",
+  "uri": "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname",
   "seeds": [
     "localhost.test.build.10gen.cc:27017",
     "localhost.test.build.10gen.cc:27018"

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
@@ -1,4 +1,4 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname"
+uri: "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname"
 seeds:
     - localhost.test.build.10gen.cc:27017
     - localhost.test.build.10gen.cc:27018

--- a/source/uri-options/tests/srv-service-name-option.json
+++ b/source/uri-options/tests/srv-service-name-option.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "SRV URI with custom srvServiceName",
-      "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname",
+      "uri": "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname",
       "valid": true,
       "warning": false,
       "hosts": null,

--- a/source/uri-options/tests/srv-service-name-option.yml
+++ b/source/uri-options/tests/srv-service-name-option.yml
@@ -1,6 +1,6 @@
 tests:
     - description: "SRV URI with custom srvServiceName"
-      uri: "mongodb+srv://test1.test.build.10gen.cc/?srvServiceName=customname"
+      uri: "mongodb+srv://test22.test.build.10gen.cc/?srvServiceName=customname"
       valid: true
       warning: false
       hosts: ~


### PR DESCRIPTION
DRIVERS-521

Switches endpoint of `srvServiceName` URI options spec tests from `test1` to `test22`. Because `_mongodb._tcp.test1.test.build.10gen.cc` and `_customname._tcp.test1.test.build.10gen.cc` had the same value after SRV lookup, the new spec tests did not really assess whether drivers were appending the custom service name correctly. Since `_mongdb._tcp.test22.test.build.10gen.cc` does not exist, drivers must append a custom service name correctly to successfully hit the endpoint.