### PR TITLE
Skip "listIndexes pins the cursor to a connection" on serverless

### DIFF
--- a/source/load-balancers/tests/cursors.json
+++ b/source/load-balancers/tests/cursors.json
@@ -996,6 +996,11 @@
     },
     {
       "description": "listIndexes pins the cursor to a connection",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "createIndex",

--- a/source/load-balancers/tests/cursors.yml
+++ b/source/load-balancers/tests/cursors.yml
@@ -398,6 +398,8 @@ tests:
           - connectionCheckedInEvent: {}
 
   - description: listIndexes pins the cursor to a connection
+    runOnRequirements:
+      - serverless: forbid
     operations:
       # There is an automatic index on _id so we create two more indexes to force multiple batches with batchSize=2.
       - name: createIndex


### PR DESCRIPTION
Server team is investigating a bug which this test appears to have uncovered
when running in serverless environment.  While it's being investigated,
skipping this test on serverless.

DRIVERS-1882