### PR TITLE
DRIVERS-1958: Do not expect readConcern for pre-4.2 servers

### DIFF
--- a/source/crud/tests/unified/aggregate-write-readPreference.json
+++ b/source/crud/tests/unified/aggregate-write-readPreference.json
@@ -181,6 +181,7 @@
       "description": "Aggregate with $out omits read preference for pre-5.0 server",
       "runOnRequirements": [
         {
+          "minServerVersion": "4.2",
           "maxServerVersion": "4.4.99",
           "serverless": "forbid"
         }

--- a/source/crud/tests/unified/aggregate-write-readPreference.yml
+++ b/source/crud/tests/unified/aggregate-write-readPreference.yml
@@ -87,7 +87,11 @@ tests:
 
   - description: "Aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
-      - maxServerVersion: "4.4.99"
+      # MongoDB 4.2 introduced support for read concerns and write stages.
+      # Pre-4.2 servers may allow a "local" read concern anyway, but some
+      # drivers may avoid inheriting a client-level read concern for pre-4.2.
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.4.99"
         serverless: "forbid"
     operations:
       - object: *collection0

--- a/source/crud/tests/unified/db-aggregate-write-readPreference.json
+++ b/source/crud/tests/unified/db-aggregate-write-readPreference.json
@@ -158,6 +158,7 @@
       "description": "Database-level aggregate with $out omits read preference for pre-5.0 server",
       "runOnRequirements": [
         {
+          "minServerVersion": "4.2",
           "maxServerVersion": "4.4.99",
           "serverless": "forbid"
         }

--- a/source/crud/tests/unified/db-aggregate-write-readPreference.yml
+++ b/source/crud/tests/unified/db-aggregate-write-readPreference.yml
@@ -81,7 +81,11 @@ tests:
 
   - description: "Database-level aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
-      - maxServerVersion: "4.4.99"
+      # MongoDB 4.2 introduced support for read concerns and write stages.
+      # Pre-4.2 servers may allow a "local" read concern anyway, but some
+      # drivers may avoid inheriting a client-level read concern for pre-4.2.
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.4.99"
         serverless: "forbid"
     operations:
       - object: *database0


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1958

aggregate-write-readPreference tests use client-level readConcern and writeConcern options to assert that they are still inherited and passed in the aggregate command; however, readConcern is generally not supported for write stages in server versions prior to 4.2.

Note: I realized this was an issue after merging the PHPLIB work for https://github.com/mongodb/specifications/pull/1062 (DRIVERS-823), as we had test failures on MongoDB 3.6 and 4.0 (libmongoc correctly does not inherit a client-level read concern when assembling a command destined for a pre-4.2 server). Tagging @jyemin and @benjirewis are reviewers as Java and Go appear to be the only other drivers that have implemented that ticket thus far.

FWIW, I also verified that MongoDB 4.0 does allow a "local" RC to be specified. If drivers weren't experiencing test failures here, it's likely that they're just passing that inherited value along to the server and it's being silently ignored ("local" is the default, so there is no significance):

```
rs0:PRIMARY> db.foo.runCommand({aggregate:"foo",pipeline:[{$match:{x:1}},{$out:"bar"}],readConcern:{level:"local"},cursor:{}})
{
	"cursor" : {
		"firstBatch" : [ ],
		"id" : NumberLong(0),
		"ns" : "test.foo"
	},
	"ok" : 1,
	"operationTime" : Timestamp(1634741761, 3),
	"$clusterTime" : {
		"clusterTime" : Timestamp(1634741761, 3),
		"signature" : {
			"hash" : BinData(0,"AAAAAAAAAAAAAAAAAAAAAAAAAAA="),
			"keyId" : NumberLong(0)
		}
	}
}
rs0:PRIMARY> db.foo.runCommand({aggregate:"foo",pipeline:[{$match:{x:1}},{$out:"bar"}],readConcern:{level:"majority"},cursor:{}})
{
	"operationTime" : Timestamp(1634741761, 3),
	"ok" : 0,
	"errmsg" : "$out cannot be used with a 'majority' read concern level",
	"code" : 72,
	"codeName" : "InvalidOptions",
	"$clusterTime" : {
		"clusterTime" : Timestamp(1634741761, 3),
		"signature" : {
			"hash" : BinData(0,"AAAAAAAAAAAAAAAAAAAAAAAAAAA="),
			"keyId" : NumberLong(0)
		}
	}
}
```