### PR TITLE
DRIVERS-1959: Expect either valid:false or warning:true, but not both

### DIFF
--- a/source/uri-options/tests/README.rst
+++ b/source/uri-options/tests/README.rst
@@ -38,6 +38,11 @@ The ``valid`` and ``warning`` fields are boolean in order to keep the tests
 flexible. We are not concerned with asserting the format of specific error or
 warnings messages strings.
 
+Under normal circumstances, it should not be necessary to specify both
+``valid: false`` and ``warning: true``. Typically, a URI test case will either
+yield an error (e.g. options conflict) or a warning (e.g. invalid type or value
+for an option), but not both.
+
 Use as unit tests
 =================
 

--- a/source/uri-options/tests/srv-options.json
+++ b/source/uri-options/tests/srv-options.json
@@ -15,7 +15,7 @@
       "description": "Non-SRV URI with custom srvServiceName",
       "uri": "mongodb://example.com/?srvServiceName=customname",
       "valid": false,
-      "warning": true,
+      "warning": false,
       "hosts": null,
       "auth": null,
       "options": {}
@@ -34,7 +34,7 @@
     {
       "description": "SRV URI with negative integer for srvMaxHosts",
       "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1",
-      "valid": false,
+      "valid": true,
       "warning": true,
       "hosts": null,
       "auth": null,
@@ -43,7 +43,7 @@
     {
       "description": "SRV URI with invalid type for srvMaxHosts",
       "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo",
-      "valid": false,
+      "valid": true,
       "warning": true,
       "hosts": null,
       "auth": null,
@@ -53,7 +53,7 @@
       "description": "Non-SRV URI with srvMaxHosts",
       "uri": "mongodb://example.com/?srvMaxHosts=2",
       "valid": false,
-      "warning": true,
+      "warning": false,
       "hosts": null,
       "auth": null,
       "options": {}
@@ -62,7 +62,7 @@
       "description": "SRV URI with positive srvMaxHosts and replicaSet",
       "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&replicaSet=foo",
       "valid": false,
-      "warning": true,
+      "warning": false,
       "hosts": null,
       "auth": null,
       "options": {}
@@ -71,7 +71,7 @@
       "description": "SRV URI with positive srvMaxHosts and loadBalanced=true",
       "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=true",
       "valid": false,
-      "warning": true,
+      "warning": false,
       "hosts": null,
       "auth": null,
       "options": {}

--- a/source/uri-options/tests/srv-options.yml
+++ b/source/uri-options/tests/srv-options.yml
@@ -10,7 +10,7 @@ tests:
     - description: "Non-SRV URI with custom srvServiceName"
       uri: "mongodb://example.com/?srvServiceName=customname"
       valid: false
-      warning: true
+      warning: false
       hosts: ~
       auth: ~
       options: {}
@@ -24,14 +24,14 @@ tests:
           srvMaxHosts: 2
     - description: "SRV URI with negative integer for srvMaxHosts"
       uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1"
-      valid: false
+      valid: true
       warning: true
       hosts: ~
       auth: ~
       options: {}
     - description: "SRV URI with invalid type for srvMaxHosts"
       uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo"
-      valid: false
+      valid: true
       warning: true
       hosts: ~
       auth: ~
@@ -39,24 +39,24 @@ tests:
     - description: "Non-SRV URI with srvMaxHosts"
       uri: "mongodb://example.com/?srvMaxHosts=2"
       valid: false
-      warning: true
+      warning: false
       hosts: ~
       auth: ~
       options: {}
     # Note: Testing URI validation for srvMaxHosts conflicting with either
-    # loadBalanced=true or # replicaSet specified via TXT records is covered by
+    # loadBalanced=true or replicaSet specified via TXT records is covered by
     # the Initial DNS Seedlist Discovery test suite.
     - description: "SRV URI with positive srvMaxHosts and replicaSet"
       uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&replicaSet=foo"
       valid: false
-      warning: true
+      warning: false
       hosts: ~
       auth: ~
       options: {}
     - description: "SRV URI with positive srvMaxHosts and loadBalanced=true"
       uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=true"
       valid: false
-      warning: true
+      warning: false
       hosts: ~
       auth: ~
       options: {}


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1959

SRV option tests will either raise errors (e.g. using options with non-SRV scheme) or warnings (e.g. invalid value/type), but not both. This corrects a mistake originally introduced in b508f6d2a1819882d40c4e7e73b95fc8ae3bdfe5 (#1069).