### PR TITLE
DRIVERS-1560 Further clarify KMS TLS tests

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1028,14 +1028,14 @@ run the following commands from the ``.evergreen/csfle`` directory:
 
    . ./activate_venv.sh
    python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/expired.pem --port 8000 &
-      python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001
+   python -u kms_http_server.py --ca_file ../x509gen/ca.pem --cert_file ../x509gen/wrong-host.pem --port 8001 &
 
 Setup
 `````
 
 For both tests, do the following:
 
-#. Start a ``mongod`` process with **server version 4.1.9 or later** with TLS disabled (we are not concerned with TLS interactions between the driver and the ``mongod`` process).
+#. Start a ``mongod`` process with **server version 4.1.9 or later**.
 
 #. Create a ``MongoClient`` for key vault operations.
 


### PR DESCRIPTION
DRIVERS-1560

After the [C# implementation](https://jira.mongodb.org/browse/CSHARP-3467), @DmitryLukyanov noticed some ambiguities in the description of the KMS TLS prose tests for cert verification. 

Gives an example of starting both KMS mock servers at once. Clarifies that the `mongod` process should be started without SSL (TLS) since we are not concerned with TLS interactions between the driver and the server. Splits the creation of `client_encrypted` and the configuration of `keyVaultNamespace` into separate setup steps. Clarifies that drivers may inspect other fields of the error besides the message if the language of implementation has a single, generic error message for certificate validation failure.