### PR TITLE
DRIVERS-1385 Always specify error labels at the top level

### DIFF
--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -3,14 +3,14 @@ Retryable Writes
 ================
 
 :Spec Title: Retryable Writes
-:Spec Version: 1.6.1
+:Spec Version: 1.6.2
 :Author: Jeremy Mikola
 :Lead: \A. Jesse Jiryu Davis
 :Advisors: Robert Stam, Esha Maharishi, Samantha Ritter, and Kaloian Manassiev
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: 2021-04-26
+:Last Modified: 2021-11-02
 
 .. contents::
 
@@ -798,6 +798,9 @@ inconsistent with the server and potentially confusing to developers.
 
 Changes
 =======
+
+2021-11-02: Clarify that error labels are only specified in a top-level field of
+an error.
 
 2021-04-26: Replaced deprecated terminology
 

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -3,7 +3,7 @@ Retryable Writes
 ================
 
 :Spec Title: Retryable Writes
-:Spec Version: 1.6.2
+:Spec Version: 1.7.0
 :Author: Jeremy Mikola
 :Lead: \A. Jesse Jiryu Davis
 :Advisors: Robert Stam, Esha Maharishi, Samantha Ritter, and Kaloian Manassiev

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -213,8 +213,6 @@ Determining Retryable Errors
 When connected to a MongoDB instance that supports retryable writes (versions 3.6+),
 the driver MUST treat all errors with the RetryableWriteError label as retryable.
 This error label can be found in the top-level "errorLabels" field of the error.
-In a server error response with a writeConcernError field the top level document
-or the writeConcernError document may contain the RetryableWriteError error label.
 
 RetryableWriteError Labels
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/retryable-writes/tests/legacy/bulkWrite-serverErrors.json
+++ b/source/retryable-writes/tests/legacy/bulkWrite-serverErrors.json
@@ -119,12 +119,12 @@
           "failCommands": [
             "insert"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/retryable-writes/tests/legacy/bulkWrite-serverErrors.yml
+++ b/source/retryable-writes/tests/legacy/bulkWrite-serverErrors.yml
@@ -58,10 +58,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["insert"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "bulkWrite"
             arguments:

--- a/source/retryable-writes/tests/legacy/deleteOne-serverErrors.json
+++ b/source/retryable-writes/tests/legacy/deleteOne-serverErrors.json
@@ -75,12 +75,12 @@
           "failCommands": [
             "delete"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/retryable-writes/tests/legacy/deleteOne-serverErrors.yml
+++ b/source/retryable-writes/tests/legacy/deleteOne-serverErrors.yml
@@ -37,10 +37,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["delete"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "deleteOne"
             arguments:

--- a/source/retryable-writes/tests/legacy/findOneAndDelete-serverErrors.json
+++ b/source/retryable-writes/tests/legacy/findOneAndDelete-serverErrors.json
@@ -81,12 +81,12 @@
           "failCommands": [
             "findAndModify"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/retryable-writes/tests/legacy/findOneAndDelete-serverErrors.yml
+++ b/source/retryable-writes/tests/legacy/findOneAndDelete-serverErrors.yml
@@ -37,10 +37,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["findAndModify"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "findOneAndDelete"
             arguments:

--- a/source/retryable-writes/tests/legacy/findOneAndReplace-serverErrors.json
+++ b/source/retryable-writes/tests/legacy/findOneAndReplace-serverErrors.json
@@ -85,12 +85,12 @@
           "failCommands": [
             "findAndModify"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/retryable-writes/tests/legacy/findOneAndReplace-serverErrors.yml
+++ b/source/retryable-writes/tests/legacy/findOneAndReplace-serverErrors.yml
@@ -39,10 +39,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["findAndModify"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "findOneAndReplace"
             arguments:

--- a/source/retryable-writes/tests/legacy/findOneAndUpdate-serverErrors.json
+++ b/source/retryable-writes/tests/legacy/findOneAndUpdate-serverErrors.json
@@ -86,12 +86,12 @@
           "failCommands": [
             "findAndModify"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/retryable-writes/tests/legacy/findOneAndUpdate-serverErrors.yml
+++ b/source/retryable-writes/tests/legacy/findOneAndUpdate-serverErrors.yml
@@ -39,10 +39,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["findAndModify"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "findOneAndUpdate"
             arguments:

--- a/source/retryable-writes/tests/legacy/insertMany-serverErrors.json
+++ b/source/retryable-writes/tests/legacy/insertMany-serverErrors.json
@@ -92,12 +92,12 @@
           "failCommands": [
             "insert"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/retryable-writes/tests/legacy/insertMany-serverErrors.yml
+++ b/source/retryable-writes/tests/legacy/insertMany-serverErrors.yml
@@ -41,10 +41,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["insert"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertMany"
             arguments:

--- a/source/retryable-writes/tests/legacy/insertOne-serverErrors.json
+++ b/source/retryable-writes/tests/legacy/insertOne-serverErrors.json
@@ -761,12 +761,12 @@
           "failCommands": [
             "insert"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11600,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },
@@ -812,12 +812,12 @@
           "failCommands": [
             "insert"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11602,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },
@@ -863,12 +863,12 @@
           "failCommands": [
             "insert"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 189,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },
@@ -914,12 +914,12 @@
           "failCommands": [
             "insert"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },
@@ -965,12 +965,12 @@
           "failCommands": [
             "insert"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/retryable-writes/tests/legacy/insertOne-serverErrors.yml
+++ b/source/retryable-writes/tests/legacy/insertOne-serverErrors.yml
@@ -347,10 +347,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["insert"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 11600
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:
@@ -370,10 +370,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["insert"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 11602
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:
@@ -393,10 +393,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["insert"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 189
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:
@@ -416,10 +416,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["insert"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:
@@ -439,10 +439,10 @@ tests:
             mode: { times: 2 }
             data:
                 failCommands: ["insert"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "insertOne"
             arguments:

--- a/source/retryable-writes/tests/legacy/replaceOne-serverErrors.json
+++ b/source/retryable-writes/tests/legacy/replaceOne-serverErrors.json
@@ -85,12 +85,12 @@
           "failCommands": [
             "update"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/retryable-writes/tests/legacy/replaceOne-serverErrors.yml
+++ b/source/retryable-writes/tests/legacy/replaceOne-serverErrors.yml
@@ -41,10 +41,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["update"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "replaceOne"
             arguments:

--- a/source/retryable-writes/tests/legacy/updateOne-serverErrors.json
+++ b/source/retryable-writes/tests/legacy/updateOne-serverErrors.json
@@ -86,12 +86,12 @@
           "failCommands": [
             "update"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/retryable-writes/tests/legacy/updateOne-serverErrors.yml
+++ b/source/retryable-writes/tests/legacy/updateOne-serverErrors.yml
@@ -41,10 +41,10 @@ tests:
             mode: { times: 1 }
             data:
                 failCommands: ["update"]
+                errorLabels: ["RetryableWriteError"]
                 writeConcernError:
                     code: 91
                     errmsg: Replication is being shut down
-                    errorLabels: ["RetryableWriteError"]
         operation:
             name: "updateOne"
             arguments:

--- a/source/transactions/tests/legacy/error-labels.json
+++ b/source/transactions/tests/legacy/error-labels.json
@@ -963,12 +963,12 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errmsg": "Replication is being shut down",
-            "errorLabels": [
-              "RetryableWriteError"
-            ]
+            "errmsg": "Replication is being shut down"
           }
         }
       },

--- a/source/transactions/tests/legacy/error-labels.yml
+++ b/source/transactions/tests/legacy/error-labels.yml
@@ -590,10 +590,10 @@ tests:
       mode: { times: 2 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 91
             errmsg: Replication is being shut down
-            errorLabels: ["RetryableWriteError"]
 
     operations:
       - name: startTransaction

--- a/source/transactions/tests/legacy/mongos-recovery-token.json
+++ b/source/transactions/tests/legacy/mongos-recovery-token.json
@@ -180,12 +180,12 @@
                 "failCommands": [
                   "commitTransaction"
                 ],
+                "errorLabels": [
+                  "RetryableWriteError"
+                ],
                 "writeConcernError": {
                   "code": 91,
-                  "errmsg": "Replication is being shut down",
-                  "errorLabels": [
-                    "RetryableWriteError"
-                  ]
+                  "errmsg": "Replication is being shut down"
                 }
               }
             }

--- a/source/transactions/tests/legacy/mongos-recovery-token.yml
+++ b/source/transactions/tests/legacy/mongos-recovery-token.yml
@@ -118,10 +118,10 @@ tests:
             mode: { times: 1 }
             data:
               failCommands: ["commitTransaction"]
+              errorLabels: ["RetryableWriteError"]
               writeConcernError:
                 code: 91
                 errmsg: Replication is being shut down
-                errorLabels: ["RetryableWriteError"]
       # The client sees a retryable writeConcernError on the first
       # commitTransaction due to the fail point but it actually succeeds on the
       # server (SERVER-39346). The retry will succeed both on a new mongos and

--- a/source/transactions/tests/legacy/retryable-abort.json
+++ b/source/transactions/tests/legacy/retryable-abort.json
@@ -1556,11 +1556,11 @@
           "failCommands": [
             "abortTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11600,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1673,11 +1673,11 @@
           "failCommands": [
             "abortTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11602,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1790,11 +1790,11 @@
           "failCommands": [
             "abortTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 189,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1907,11 +1907,11 @@
           "failCommands": [
             "abortTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/source/transactions/tests/legacy/retryable-abort.yml
+++ b/source/transactions/tests/legacy/retryable-abort.yml
@@ -1021,9 +1021,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["abortTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 11600
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1096,9 +1096,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["abortTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 11602
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1171,9 +1171,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["abortTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 189
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1246,9 +1246,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["abortTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 91
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:

--- a/source/transactions/tests/legacy/retryable-commit.json
+++ b/source/transactions/tests/legacy/retryable-commit.json
@@ -1855,11 +1855,11 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11600,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -1977,11 +1977,11 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 11602,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2099,11 +2099,11 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 189,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }
@@ -2221,11 +2221,11 @@
           "failCommands": [
             "commitTransaction"
           ],
+          "errorLabels": [
+            "RetryableWriteError"
+          ],
           "writeConcernError": {
             "code": 91,
-            "errorLabels": [
-              "RetryableWriteError"
-            ],
             "errmsg": "Replication is being shut down"
           }
         }

--- a/source/transactions/tests/legacy/retryable-commit.yml
+++ b/source/transactions/tests/legacy/retryable-commit.yml
@@ -1162,9 +1162,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 11600
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1238,9 +1238,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 11602
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1314,9 +1314,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 189
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:
@@ -1390,9 +1390,9 @@ tests:
       mode: { times: 1 }
       data:
           failCommands: ["commitTransaction"]
+          errorLabels: ["RetryableWriteError"]
           writeConcernError:
             code: 91
-            errorLabels: ["RetryableWriteError"]
             errmsg: Replication is being shut down
 
     operations:


### PR DESCRIPTION
Updates spec language and spec tests always to specify error labels at the top level. This behavior is verified in the comments of DRIVERS-1385.