### PR TITLE
DRIVERS-1353 fix AWS cases KMS TLS Options Tests

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1343,19 +1343,43 @@ following masterKey:
 
 Expect an error indicating TLS handshake failed.
 
-Call `client_encryption_with_tls.createDataKey()` with "aws" as the provider and
-the same masterKey.
+Call `client_encryption_with_tls.createDataKey()` with "aws" as the provider and the
+following masterKey:
+
+.. code:: javascript
+
+   {
+      region: "us-east-1",
+      key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+      endpoint: "127.0.0.1:8002"
+   }
 
 Expect an error from libmongocrypt with a message containing the string: "parse
 error". This implies TLS handshake succeeded.
 
-Call `client_encryption_expired.createDataKey()` with "aws" as the provider and
-the same masterKey.
+Call `client_encryption_expired.createDataKey()` with "aws" as the provider and the
+following masterKey:
+
+.. code:: javascript
+
+   {
+      region: "us-east-1",
+      key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+      endpoint: "127.0.0.1:8000"
+   }
 
 Expect an error indicating TLS handshake failed due to an expired certificate.
 
-Call `client_encryption_invalid_hostname.createDataKey()` with "aws" as the provider and
-the same masterKey.
+Call `client_encryption_invalid_hostname.createDataKey()` with "aws" as the provider and the
+following masterKey:
+
+.. code:: javascript
+
+   {
+      region: "us-east-1",
+      key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+      endpoint: "127.0.0.1:8001"
+   }
 
 Expect an error indicating TLS handshake failed due to an invalid hostname.
 


### PR DESCRIPTION
Port 8002 should be used for client_encryption_no_tls and client_encryption_with_tls.
Port 8000 should be used for client_encryption_expired.
Port 8001 should be used for client_encryption_invalid_hostname

The AWS test cases require specifying the endpoint through the masterKey document. The C PoC had tested this behavior [here](https://github.com/mongodb/mongo-c-driver/pull/881/files#diff-d363a5539f2fbabfadf2d7cc6cdb96a203fb63f2caa31bae731c3e12d97b204cR2862-R2920), but I wrote the test cases incorrectly.