### PR TITLE
Update estimatedDocumentCount test

### DIFF
--- a/source/atlas-data-lake-testing/tests/estimatedDocumentCount.json
+++ b/source/atlas-data-lake-testing/tests/estimatedDocumentCount.json
@@ -15,8 +15,25 @@
         {
           "command_started_event": {
             "command": {
-              "count": "driverdata"
-            }
+              "aggregate": "driverdata",
+              "pipeline": [
+                {
+                  "$collStats": {
+                    "count": {}
+                  }
+                },
+                {
+                  "$group": {
+                    "_id": 1,
+                    "n": {
+                      "$sum": "$count"
+                    }
+                  }
+                }
+              ]
+            },
+            "commandName": "aggregate",
+            "databaseName": "test"
           }
         }
       ]

--- a/source/atlas-data-lake-testing/tests/estimatedDocumentCount.yml
+++ b/source/atlas-data-lake-testing/tests/estimatedDocumentCount.yml
@@ -13,4 +13,9 @@ tests:
       -
         command_started_event:
           command:
-            count: *collection_name
+            aggregate: *collection_name
+            pipeline:
+              - $collStats: { count: {} }
+              - $group: { _id: 1, n: { $sum: $count }}
+          commandName: aggregate
+          databaseName: *database_name


### PR DESCRIPTION
Atlas Data Lake has bumped its maxWireVersion to 13, which
triggers a change in driver behavior to use aggregate instead
of count command for the estimatedDocumentCount helper.

DRIVERS-1991