### PR TITLE
DRIVERS-1357 Add SOCKS5 proxy support spec

### DIFF
--- a/source/socks5-support/socks5.rst
+++ b/source/socks5-support/socks5.rst
@@ -1,0 +1,185 @@
+==============
+SOCKS5 Support
+==============
+
+:Spec Title: SOCKS5 Support
+:Spec Version: 1.0.0
+:Author: Anna Henningsen
+:Advisors: TODO
+:Status: Draft
+:Type: Standards
+:Minimum Server Version: N/A
+:Last Modified: 2021-11-19
+
+.. contents::
+
+--------
+
+Abstract
+========
+
+This specification defines driver behaviour when connecting to MongoDB services
+through a SOCKS5 proxy.
+
+META
+====
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in `RFC 2119 <https://www.ietf.org/rfc/rfc2119.txt>`__.
+
+Specification
+=============
+
+
+Terms
+-----
+
+SOCKS5
+^^^^^^
+
+The SOCKS protocol, version 5, as defined in `RFC1928 <https://datatracker.ietf.org/doc/html/rfc1928>`__,
+restricted to either no authentication or username/password authentication
+as defined in `RFC1929 <https://datatracker.ietf.org/doc/html/rfc1929>`__.
+
+
+MongoClient Configuration
+-------------------------
+
+proxyHost
+^^^^^^^^^
+
+To specify to the driver to connect using a SOCKS5 proxy, a connection string
+option of :code:`proxyHost=host` MUST be added to the connection string
+or passed through an equivalent :code:`MongoClient` option.
+This option specifies a domain name or IPv4 or IPv6 address on which
+a SOCKS5 proxy is listening.
+This option MUST only be configurable at the level of a :code:`MongoClient`.
+
+proxyPort
+^^^^^^^^^
+
+To specify to the driver to connect using a SOCKS5 proxy listening
+on a non-default port, a connection string option of :code:`proxyPort=port`
+MUST be added to the connection string or passed through an
+equivalent :code:`MongoClient` option.
+This option specifies a TCP port number. The default for this option
+MUST be :code:`1080`.
+This option MUST only be configurable at the level of a :code:`MongoClient`.
+Drivers MUST ignore this option if :code:`proxyHost` was not specified.
+
+proxyUsername
+^^^^^^^^^^^^^
+
+To specify to the driver to connect using a SOCKS5 proxy requiring
+username/password authentication, a connection string option of
+:code:`proxyUsername=username` MUST be added to the connection string
+or passed through an equivalent :code:`MongoClient` option.
+This option specifies a string of non-zero length. Drivers MUST ignore
+this option if it specifies a zero-length string, or if
+:code:`proxyHost` was not specified. Drivers MUST error if this option
+was specified and :code:`proxyHost` was not specified.
+
+proxyPassword
+^^^^^^^^^^^^^
+
+To specify to the driver to connect using a SOCKS5 proxy requiring
+username/password authentication, a connection string option of
+:code:`proxyPassword=username` MUST be added to the connection string
+or passed through an equivalent :code:`MongoClient` option.
+This option specifies a string of non-zero length. Drivers MUST ignore
+this option if it specifies a zero-length string, or if
+:code:`proxyHost` was not specified. Drivers MUST error if this option
+was specified and :code:`proxyHost` was not specified.
+
+Connection Pooling
+------------------------
+
+Connection Establishment
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+When establishing a new outgoing TCP connection, drivers MUST perform
+the following steps if :code:`proxyHost`
+was specified:
+
+#. Connect to the SOCKS5 proxy host, using :code:`proxyHost` and :code:`proxyPort` as specified.
+
+#. Perform a SOCKS5 handshake as specified in RFC1928.
+
+    If :code:`proxyUsername` and :code:`proxyPassword` were passed,
+    drivers MUST indicate in the handshake that both "no authentication"
+    and "username/password authentication" are supported. Otherwise,
+    drivers MUST indicate support for "no authentication" only.
+
+    Drivers MUST NOT attempt to perform DNS A or AAAA record resolution
+    of the destination hostname and instead pass the hostname to the
+    proxy as-is.
+
+#. Continue with connection establishment as if the connection was one
+   to the destination host.
+
+Drivers MUST use the SOCKS5 proxy for connections to MongoDB services
+and client-side field-level encryption KMS servers.
+
+Drivers SHOULD use the SOCKS5 proxy for all other outgoing TCP connections
+as well, if they create any.
+
+Drivers MUST treat a connection failure when connecting to the SOCKS5
+proxy or a SOCKS5 handshake or authentication failure the same as a
+network error (e.g. `ECONNREFUSED`).
+
+Events
+------
+
+SOCKS5 proxies are fully transparent to connection monitoring events.
+In particular, in :code:`CommandStartedEvent`, :code:`CommandSucceededEvent`, and
+:code:`CommandFailedEvent`, the driver SHOULD NOT reference the SOCKS5
+proxy as part of the :code:`connectionId` field or other fields.
+
+Q&A
+---
+
+Why not include DNS requests in the set of proxied network communication?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+While SOCKS5 as a protocol does support UDP forwarding, using this feature has a number
+of downsides. Notably, only a subset of SOCKS5 client libraries and SOCKS5 server
+implementations support UDP forwarding (e.g. the OpenSSH client’s dynamic
+forwarding feature does not). This would also considerably increase implementation
+complexity in drivers that do not use DNS libraries in which the driver is
+in control of how the UDP packets are sent and received.
+
+Why not support other proxy protocols, such as Socks4/Socks4a, HTTP Connect proxies, etc.?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+SOCKS5 is a powerful, standardized and widely used proxy protocol. It is likely that
+almost all users which require tunneling/proxying of some sort will be able to use it,
+and those who require another protocol or a more advanced setup like proxy chaining,
+can work around that by using a local SOCKS5 intermediate proxy.
+
+Why are the connection string parameters generic, with no explicit mention of SOCKS5?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the case that future changes will enable drivers using other proxy protocols,
+keeping the option names generic allows their re-use.
+In that case, another option would specify the protocol and SOCKS5 would be the
+implied default. However, since there is no reason to believe that such additions
+will be made in the forseeable future, no option for specifying the proxy protocol
+is introduced here.
+
+Why is support for authentication methods limited to no authentication and username/password authentication?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This matches the set of authentication methods most commonly implemented by SOCKS5
+client libraries and thus reduces implementation complexity for drivers.
+This advantage is sufficient to ignore the possible advantages that would
+come with enabling other authentication methods.
+
+Design Rationales
+-----------------
+
+Alternative Designs
+-------------------
+
+Change Log
+==========

--- a/source/socks5-support/socks5.rst
+++ b/source/socks5-support/socks5.rst
@@ -92,7 +92,7 @@ proxyPassword
 
 To specify to the driver to connect using a SOCKS5 proxy requiring
 username/password authentication, a connection string option of
-:code:`proxyPassword=username` MUST be added to the connection string
+:code:`proxyPassword=password` MUST be added to the connection string
 or passed through an equivalent :code:`MongoClient` option.
 This option specifies a string of non-zero length. Drivers MUST ignore
 this option if it specifies a zero-length string. Drivers MUST error

--- a/source/socks5-support/socks5.rst
+++ b/source/socks5-support/socks5.rst
@@ -5,8 +5,8 @@ SOCKS5 Support
 :Spec Title: SOCKS5 Support
 :Spec Version: 1.0.0
 :Author: Anna Henningsen
-:Advisors: TODO
-:Status: Draft
+:Advisors: Neal Beeken
+:Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
 :Last Modified: 2021-12-14

--- a/source/socks5-support/socks5.rst
+++ b/source/socks5-support/socks5.rst
@@ -18,6 +18,12 @@ SOCKS5 Support
 Abstract
 ========
 
+SOCKS5 is a standardized protocol for connecting to network services through
+a separate proxy server. It can be used for connecting to hosts that would
+otherwise be unreachable from the local network by connecting to a proxy
+server, which receives the intended target host’s address from the client
+and then connects to that address.
+
 This specification defines driver behaviour when connecting to MongoDB services
 through a SOCKS5 proxy.
 

--- a/source/socks5-support/socks5.rst
+++ b/source/socks5-support/socks5.rst
@@ -9,7 +9,7 @@ SOCKS5 Support
 :Status: Draft
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-11-19
+:Last Modified: 2021-12-14
 
 .. contents::
 

--- a/source/socks5-support/socks5.rst
+++ b/source/socks5-support/socks5.rst
@@ -66,7 +66,8 @@ equivalent :code:`MongoClient` option.
 This option specifies a TCP port number. The default for this option
 MUST be :code:`1080`.
 This option MUST only be configurable at the level of a :code:`MongoClient`.
-Drivers MUST ignore this option if :code:`proxyHost` was not specified.
+Drivers MUST error if this option was specified and :code:`proxyHost`
+was not specified.
 
 proxyUsername
 ^^^^^^^^^^^^^
@@ -76,9 +77,9 @@ username/password authentication, a connection string option of
 :code:`proxyUsername=username` MUST be added to the connection string
 or passed through an equivalent :code:`MongoClient` option.
 This option specifies a string of non-zero length. Drivers MUST ignore
-this option if it specifies a zero-length string, or if
-:code:`proxyHost` was not specified. Drivers MUST error if this option
-was specified and :code:`proxyHost` was not specified.
+this option if it specifies a zero-length string. Drivers MUST error
+if this option was specified and :code:`proxyHost` was not specified
+or :code:`proxyPassword` was not specified.
 
 proxyPassword
 ^^^^^^^^^^^^^
@@ -88,9 +89,9 @@ username/password authentication, a connection string option of
 :code:`proxyPassword=username` MUST be added to the connection string
 or passed through an equivalent :code:`MongoClient` option.
 This option specifies a string of non-zero length. Drivers MUST ignore
-this option if it specifies a zero-length string, or if
-:code:`proxyHost` was not specified. Drivers MUST error if this option
-was specified and :code:`proxyHost` was not specified.
+this option if it specifies a zero-length string. Drivers MUST error
+if this option was specified and :code:`proxyHost` was not specified
+or :code:`proxyUsername` was not specified.
 
 Connection Pooling
 ------------------------
@@ -119,7 +120,10 @@ was specified:
    to the destination host.
 
 Drivers MUST use the SOCKS5 proxy for connections to MongoDB services
-and client-side field-level encryption KMS servers.
+and `client-side field-level encryption KMS servers <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#kms-provider>`__.
+
+Drivers MUST NOT use the SOCKS5 proxy for connections to
+:code:`mongocryptd` processes spawned for automatic client-side field-level encryption.
 
 Drivers SHOULD use the SOCKS5 proxy for all other outgoing TCP connections
 as well, if they create any.

--- a/source/socks5-support/socks5.rst
+++ b/source/socks5-support/socks5.rst
@@ -125,9 +125,6 @@ and `client-side field-level encryption KMS servers <https://github.com/mongodb/
 Drivers MUST NOT use the SOCKS5 proxy for connections to
 :code:`mongocryptd` processes spawned for automatic client-side field-level encryption.
 
-Drivers SHOULD use the SOCKS5 proxy for all other outgoing TCP connections
-as well, if they create any.
-
 Drivers MUST treat a connection failure when connecting to the SOCKS5
 proxy or a SOCKS5 handshake or authentication failure the same as a
 network error (e.g. `ECONNREFUSED`).

--- a/source/socks5-support/tests/README.rst
+++ b/source/socks5-support/tests/README.rst
@@ -67,7 +67,10 @@ Drivers MUST test the following connection strings:
      - (succeeds)
 
 where :code:`<replicaset>` stands for all hosts in the tests replica set
-and :code:`mappedhost` stands for :code:`localhost:12345`.
+and :code:`mappedhost` stands for :code:`localhost:12345`. For the
+Evergreen task in which TLS is enabled, the required :code:`tls` and
+:code:`tlsCAFile` connection string options are appended to all connection strings
+listed above.
 
 Drivers MUST create a :code:`MongoClient` for each of these connection strings,
 and attempt to run a :code:`hello` command usin each client.

--- a/source/socks5-support/tests/README.rst
+++ b/source/socks5-support/tests/README.rst
@@ -65,6 +65,18 @@ Drivers MUST test the following connection strings:
      - (succeeds)
    * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081`
      - (succeeds)
+   * - :code:`mongodb://localhost/?proxyPort=1080`
+     - (invalid)
+   * - :code:`mongodb://localhost/?proxyUsername=abc`
+     - (invalid)
+   * - :code:`mongodb://localhost/?proxyPassword=def`
+     - (invalid)
+   * - :code:`mongodb://localhost/?proxyPort=1080&proxyUsername=abc&proxyPassword=def`
+     - (invalid)
+   * - :code:`mongodb://localhost/?proxyHost=localhost&proxyUsername=abc`
+     - (invalid)
+   * - :code:`mongodb://localhost/?proxyHost=localhost&proxyPassword=def`
+     - (invalid)
 
 where :code:`<replicaset>` stands for all hosts in the tests replica set
 and :code:`mappedhost` stands for :code:`localhost:12345`. For the
@@ -73,11 +85,12 @@ Evergreen task in which TLS is enabled, the required :code:`tls` and
 listed above.
 
 Drivers MUST create a :code:`MongoClient` for each of these connection strings,
-and attempt to run a :code:`hello` command usin each client.
-The operation must succeed for table entries marked (succeeds) and fail
-for table entries marked (fails) in order to pass the tests.
+and attempt to run a :code:`hello` command using each client.
+The operation must succeed for table entries marked (succeeds), fail
+for table entries marked (fails), and reject the connection string as
+invalid for table entries marked (invalid) in order to pass the tests.
 
-Drivers MUST run variants of this tests in which the proxy options are
+Drivers MUST run variants of these tests in which the proxy options are
 substituted for :code:`MongoClient` options.
 
 Drivers MUST verify for at least one of the connection strings

--- a/source/socks5-support/tests/README.rst
+++ b/source/socks5-support/tests/README.rst
@@ -65,18 +65,6 @@ Drivers MUST test the following connection strings:
      - (succeeds)
    * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081`
      - (succeeds)
-   * - :code:`mongodb://localhost/?proxyPort=1080`
-     - (invalid)
-   * - :code:`mongodb://localhost/?proxyUsername=abc`
-     - (invalid)
-   * - :code:`mongodb://localhost/?proxyPassword=def`
-     - (invalid)
-   * - :code:`mongodb://localhost/?proxyPort=1080&proxyUsername=abc&proxyPassword=def`
-     - (invalid)
-   * - :code:`mongodb://localhost/?proxyHost=localhost&proxyUsername=abc`
-     - (invalid)
-   * - :code:`mongodb://localhost/?proxyHost=localhost&proxyPassword=def`
-     - (invalid)
 
 where :code:`<replicaset>` stands for all hosts in the tests replica set
 and :code:`mappedhost` stands for :code:`localhost:12345`. For the
@@ -86,9 +74,9 @@ listed above.
 
 Drivers MUST create a :code:`MongoClient` for each of these connection strings,
 and attempt to run a :code:`hello` command using each client.
-The operation must succeed for table entries marked (succeeds), fail
-for table entries marked (fails), and reject the connection string as
-invalid for table entries marked (invalid) in order to pass the tests.
+The operation must succeed for table entries marked (succeeds) and fail
+for table entries marked (fails). The connection strings MUST all
+be accepted as valid connection strings.
 
 Drivers MUST run variants of these tests in which the proxy options are
 substituted for :code:`MongoClient` options.

--- a/source/socks5-support/tests/README.rst
+++ b/source/socks5-support/tests/README.rst
@@ -1,0 +1,71 @@
+====================
+SOCKS5 Support Tests
+====================
+
+.. contents::
+
+----
+
+Introduction
+============
+
+This document describes how drivers should test support for SOCKS5 proxies.
+
+Testing Requirements
+====================
+
+For a single server version (at least 5.0), drivers MUST add two
+Evergreen tasks: one with a replica set with TLS enabled, and one
+with TLS disabled. The servers of the replica set may listen on any free ports.
+
+Each task MUST also start up two SOCKS5 proxies: one requiring authentication,
+and one that does not require authentication.
+
+SOCKS5 Proxy Configuration
+--------------------------
+
+Drivers MUST use the ``socks5srv.py`` script in ``drivers-evergreen-tools``
+to run the SOCKS5 proxy servers for Evergreen tasks. This script MUST
+be run after the backing replica set has already been started,
+and MUST be started with ``--map "localhost:12345 to <host>"` where
+``host` is the host:port identifier of an arbitrary member of the replica set.
+The SOCKS5 proxy server requiring authentication MUST be started with
+``--port 1080 --auth username:p4ssw0rd`, the one not requiring authentication
+with `--port 1081``.
+
+Prose Tests
+===========
+
+Drivers MUST test the following connection strings:
+
+.. list-table::
+   :header-rows: 1
+
+   * - SOCKS5 auth required
+     - SOCKS5 auth disabled
+   * - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1080&directConnection=true` (fails)
+     - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1081&directConnection=true` (succeeds)
+   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1080&directConnection=true` (fails)
+     - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081&directConnection=true` (succeeds)
+   * - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1080&proxyUsername=nonexistentuser&proxyPassword=badauth&directConnection=true` (fails)
+     - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1081&proxyUsername=nonexistentuser&proxyPassword=badauth&directConnection=true` (succeeds)
+   * -
+     - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081&proxyUsername=nonexistentuser&proxyPassword=badauth` (succeeds)
+   * - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1080&proxyUsername=username&proxyPassword=p4ssw0rd&directConnection=true` (succeeds)
+     - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1081&directConnection=true` (succeeds)
+   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1080&proxyUsername=username&proxyPassword=p4ssw0rd` (succeeds)
+     - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081` (succeeds)
+
+where :code:`<replicaset>` stands for all hosts in the tests replica set.
+
+Drivers MUST create a :code:`MongoClient` for each of these connection strings,
+and attempt to run a :code:`hello` command against using those clients.
+The operation must succeed for table entries marked (succeeds) and fail
+for table entries marked (fails) in order to pass the tests.
+
+Drivers MUST run variants of this tests in which the proxy options are
+substituted for :code:`MongoClient` options.
+
+Drivers MUST verify for at least one of the connection strings
+marked (succeeds) that command monitoring events do not reference the
+SOCKS5 proxy host where the MongoDB service server/port are referenced.

--- a/source/socks5-support/tests/README.rst
+++ b/source/socks5-support/tests/README.rst
@@ -41,25 +41,34 @@ Drivers MUST test the following connection strings:
 .. list-table::
    :header-rows: 1
 
-   * - SOCKS5 auth required
-     - SOCKS5 auth disabled
-   * - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1080&directConnection=true` (fails)
-     - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1081&directConnection=true` (succeeds)
-   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1080&directConnection=true` (fails)
-     - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081&directConnection=true` (succeeds)
-   * - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1080&proxyUsername=nonexistentuser&proxyPassword=badauth&directConnection=true` (fails)
-     - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1081&proxyUsername=nonexistentuser&proxyPassword=badauth&directConnection=true` (succeeds)
-   * -
-     - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081&proxyUsername=nonexistentuser&proxyPassword=badauth` (succeeds)
-   * - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1080&proxyUsername=username&proxyPassword=p4ssw0rd&directConnection=true` (succeeds)
-     - :code:`mongodb://localhost:12345/?proxyHost=localhost&proxyPort=1081&directConnection=true` (succeeds)
-   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1080&proxyUsername=username&proxyPassword=p4ssw0rd` (succeeds)
-     - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081` (succeeds)
+   * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1080&directConnection=true`
+     - (fails)
+   * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1081&directConnection=true`
+     - (succeeds)
+   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1080&directConnection=true`
+     - (fails)
+   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081&directConnection=true`
+     - (succeeds)
+   * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1080&proxyUsername=nonexistentuser&proxyPassword=badauth&directConnection=true`
+     - (fails)
+   * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1081&proxyUsername=nonexistentuser&proxyPassword=badauth&directConnection=true`
+     - (succeeds)
+   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081&proxyUsername=nonexistentuser&proxyPassword=badauth`
+     - (succeeds)
+   * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1080&proxyUsername=username&proxyPassword=p4ssw0rd&directConnection=true`
+     - (succeeds)
+   * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1081&directConnection=true`
+     - (succeeds)
+   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1080&proxyUsername=username&proxyPassword=p4ssw0rd`
+     - (succeeds)
+   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081`
+     - (succeeds)
 
-where :code:`<replicaset>` stands for all hosts in the tests replica set.
+where :code:`<replicaset>` stands for all hosts in the tests replica set
+and :code:`mappedhost` stands for :code:`localhost:12345`.
 
 Drivers MUST create a :code:`MongoClient` for each of these connection strings,
-and attempt to run a :code:`hello` command against using those clients.
+and attempt to run a :code:`hello` command usin each client.
 The operation must succeed for table entries marked (succeeds) and fail
 for table entries marked (fails) in order to pass the tests.
 

--- a/source/socks5-support/tests/README.rst
+++ b/source/socks5-support/tests/README.rst
@@ -41,6 +41,8 @@ Drivers MUST test the following connection strings:
 .. list-table::
    :header-rows: 1
 
+   * - Connection String
+     - Expected Result
    * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1080&directConnection=true`
      - (fails)
    * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1081&directConnection=true`

--- a/source/socks5-support/tests/README.rst
+++ b/source/socks5-support/tests/README.rst
@@ -47,9 +47,9 @@ Drivers MUST test the following connection strings:
      - (fails)
    * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1081&directConnection=true`
      - (succeeds)
-   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1080&directConnection=true`
+   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1080`
      - (fails)
-   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081&directConnection=true`
+   * - :code:`mongodb://<replicaset>/?proxyHost=localhost&proxyPort=1081`
      - (succeeds)
    * - :code:`mongodb://<mappedhost>/?proxyHost=localhost&proxyPort=1080&proxyUsername=nonexistentuser&proxyPassword=badauth&directConnection=true`
      - (fails)

--- a/source/uri-options/tests/proxy-options.json
+++ b/source/uri-options/tests/proxy-options.json
@@ -89,6 +89,51 @@
       "hosts": null,
       "auth": null,
       "options": {}
+    },
+    {
+      "description": "only host present",
+      "uri": "mongodb://localhost/?proxyHost=localhost",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "host and default port present",
+      "uri": "mongodb://localhost/?proxyHost=localhost&proxyPort=1080",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "host and non-default port present",
+      "uri": "mongodb://localhost/?proxyHost=localhost&proxyPort=12345",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "replicaset, host and non-default port present",
+      "uri": "mongodb://rs1,rs2,rs3/?proxyHost=localhost&proxyPort=12345",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "all options present",
+      "uri": "mongodb://rs1,rs2,rs3/?proxyHost=localhost&proxyPort=12345&proxyUsername=asdf&proxyPassword=qwerty",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
     }
   ]
 }

--- a/source/uri-options/tests/proxy-options.json
+++ b/source/uri-options/tests/proxy-options.json
@@ -53,6 +53,42 @@
       "hosts": null,
       "auth": null,
       "options": {}
+    },
+    {
+      "description": "multiple proxyHost parameters",
+      "uri": "mongodb://localhost/?proxyHost=localhost&proxyHost=localhost2",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "multiple proxyPort parameters",
+      "uri": "mongodb://localhost/?proxyHost=localhost&proxyPort=1234&proxyPort=12345",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "multiple proxyUsername parameters",
+      "uri": "mongodb://localhost/?proxyHost=localhost&proxyUsername=abc&proxyUsername=def&proxyPassword=123",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "multiple proxyPassword parameters",
+      "uri": "mongodb://localhost/?proxyHost=localhost&proxyUsername=abc&proxyPassword=123&proxyPassword=456",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
     }
   ]
 }

--- a/source/uri-options/tests/proxy-options.json
+++ b/source/uri-options/tests/proxy-options.json
@@ -1,0 +1,58 @@
+{
+  "tests": [
+    {
+      "description": "proxyPort without proxyHost",
+      "uri": "mongodb://localhost/?proxyPort=1080",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "proxyUsername without proxyHost",
+      "uri": "mongodb://localhost/?proxyUsername=abc",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "proxyPassword without proxyHost",
+      "uri": "mongodb://localhost/?proxyPassword=def",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "all other proxy options without proxyHost",
+      "uri": "mongodb://localhost/?proxyPort=1080&proxyUsername=abc&proxyPassword=def",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "proxyUsername without proxyPassword",
+      "uri": "mongodb://localhost/?proxyHost=localhost&proxyUsername=abc",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "proxyPassword without proxyUsername",
+      "uri": "mongodb://localhost/?proxyHost=localhost&proxyPassword=def",
+      "valid": false,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/source/uri-options/tests/proxy-options.yml
+++ b/source/uri-options/tests/proxy-options.yml
@@ -47,3 +47,35 @@ tests:
         hosts: ~
         auth: ~
         options: {}
+    -
+        description: "multiple proxyHost parameters"
+        uri: "mongodb://localhost/?proxyHost=localhost&proxyHost=localhost2"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "multiple proxyPort parameters"
+        uri: "mongodb://localhost/?proxyHost=localhost&proxyPort=1234&proxyPort=12345"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "multiple proxyUsername parameters"
+        uri: "mongodb://localhost/?proxyHost=localhost&proxyUsername=abc&proxyUsername=def&proxyPassword=123"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "multiple proxyPassword parameters"
+        uri: "mongodb://localhost/?proxyHost=localhost&proxyUsername=abc&proxyPassword=123&proxyPassword=456"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}

--- a/source/uri-options/tests/proxy-options.yml
+++ b/source/uri-options/tests/proxy-options.yml
@@ -79,3 +79,43 @@ tests:
         hosts: ~
         auth: ~
         options: {}
+    -
+        description: "only host present"
+        uri: "mongodb://localhost/?proxyHost=localhost"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "host and default port present"
+        uri: "mongodb://localhost/?proxyHost=localhost&proxyPort=1080"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "host and non-default port present"
+        uri: "mongodb://localhost/?proxyHost=localhost&proxyPort=12345"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "replicaset, host and non-default port present"
+        uri: "mongodb://rs1,rs2,rs3/?proxyHost=localhost&proxyPort=12345"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "all options present"
+        uri: "mongodb://rs1,rs2,rs3/?proxyHost=localhost&proxyPort=12345&proxyUsername=asdf&proxyPassword=qwerty"
+        valid: true
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}

--- a/source/uri-options/tests/proxy-options.yml
+++ b/source/uri-options/tests/proxy-options.yml
@@ -1,0 +1,49 @@
+tests:
+    -
+        description: "proxyPort without proxyHost"
+        uri: "mongodb://localhost/?proxyPort=1080"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "proxyUsername without proxyHost"
+        uri: "mongodb://localhost/?proxyUsername=abc"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "proxyPassword without proxyHost"
+        uri: "mongodb://localhost/?proxyPassword=def"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "all other proxy options without proxyHost"
+        uri: "mongodb://localhost/?proxyPort=1080&proxyUsername=abc&proxyPassword=def"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "proxyUsername without proxyPassword"
+        uri: "mongodb://localhost/?proxyHost=localhost&proxyUsername=abc"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}
+    -
+        description: "proxyPassword without proxyUsername"
+        uri: "mongodb://localhost/?proxyHost=localhost&proxyPassword=def"
+        valid: false
+        warning: false
+        hosts: ~
+        auth: ~
+        options: {}

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -520,6 +520,7 @@ this specification MUST be updated to reflect those changes.
 Changes
 -------
 
+- 2021-12-14 Add SOCKS5 options
 - 2021-11-08 Add maxConnecting option.
 - 2021-10-14 Add srvMaxHosts option. Merge headings discussing URI validation
   for directConnection option.

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -64,7 +64,7 @@ occur:
    value, an error MUST NOT be raised.
 
 
-directConnection URI option with multiple seeds or SRV URI 
+directConnection URI option with multiple seeds or SRV URI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The driver MUST report an error if the ``directConnection=true`` URI option
@@ -92,6 +92,14 @@ For URI option validation in Load Balancer mode (i.e. ``loadBalanced=true``),
 please see the
 `Load Balancer spec <../load-balancers/load-balancers.rst#uri-validation>`_ for
 details.
+
+
+SOCKS5 options
+~~~~~~~~~~~~~~
+
+For URI option validation pertaining to ``proxyHost``, ``proxyPort``,
+``proxyUsername`` and ``proxyPassword```please see the
+`SOCKS5 support spec`_ for details.
 
 
 List of specified options
@@ -227,6 +235,30 @@ pertaining to URI options apply here.
      - defined in the `Connection Pooling spec`_
      - required for drivers with connection pools
      - The number of connections the driver should create and maintain in the pool even when no operations are occurring. This count includes connections which are currently checked out.
+
+   * - proxyHost
+     - any string
+     - defined in the `SOCKS5 support spec`_
+     - no
+     - The IPv4/IPv6 address or domain name of a SOCKS5 proxy server used for connecting to MongoDB services.
+
+   * - proxyPort
+     - non-negative integer
+     - defined in the `SOCKS5 support spec`_
+     - no
+     - The port of the SOCKS5 proxy server specified in ``proxyHost``.
+
+   * - proxyUsername
+     - any string
+     - defined in the `SOCKS5 support spec`_
+     - no
+     - The username for username/password authentication to the SOCKS5 proxy server specified in ``proxyHost``.
+
+   * - proxyPassword
+     - any string
+     - defined in the `SOCKS5 support spec`_
+     - no
+     - The password for username/password authentication to the SOCKS5 proxy server specified in ``proxyHost``.
 
    * - readConcernLevel
      - any string (`to allow for forwards compatibility with the server <https://github.com/mongodb/specifications/blob/master/source/read-write-concern/read-write-concern.rst#unknown-levels-and-additional-options-for-string-based-readconcerns>`_)
@@ -503,3 +535,4 @@ Changes
 - 2019-09-08 Add retryReads option
 
 .. _Connection Pooling spec: https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1
+.. _SOCKS5 support spec: https://github.com/mongodb/specifications/blob/master/source/socks5-support/socks5.rst#mongoclient-configuration


### PR DESCRIPTION
Node.js driver implementation PR: https://github.com/mongodb/node-mongodb-native/pull/3041