### PR TITLE
DRIVERS-1991 Fix data lake tests which use legacy test format

### DIFF
--- a/source/atlas-data-lake-testing/tests/estimatedDocumentCount.json
+++ b/source/atlas-data-lake-testing/tests/estimatedDocumentCount.json
@@ -32,8 +32,8 @@
                 }
               ]
             },
-            "commandName": "aggregate",
-            "databaseName": "test"
+            "command_name": "aggregate",
+            "database_name": "test"
           }
         }
       ]

--- a/source/atlas-data-lake-testing/tests/estimatedDocumentCount.yml
+++ b/source/atlas-data-lake-testing/tests/estimatedDocumentCount.yml
@@ -17,5 +17,5 @@ tests:
             pipeline:
               - $collStats: { count: {} }
               - $group: { _id: 1, n: { $sum: $count }}
-          commandName: aggregate
-          databaseName: *database_name
+          command_name: aggregate
+          database_name: *database_name


### PR DESCRIPTION
The data lake tests currently use the legacy CRUD v2 (same as the legacy transactions) test format where commandName and databaseName should be named command_name and database_name.