### PR TITLE
DRIVERS-1999 Add server selection spec test to ensure that RSGhost servers are not selectable

### DIFF
--- a/source/server-selection/tests/server_selection/Unknown/read/ghost.json
+++ b/source/server-selection/tests/server_selection/Unknown/read/ghost.json
@@ -1,0 +1,18 @@
+{
+  "topology_description": {
+    "type": "Unknown",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 5,
+        "type": "RSGhost"
+      }
+    ]
+  },
+  "operation": "read",
+  "read_preference": {
+    "mode": "Nearest"
+  },
+  "suitable_servers": [],
+  "in_latency_window": []
+}

--- a/source/server-selection/tests/server_selection/Unknown/read/ghost.yml
+++ b/source/server-selection/tests/server_selection/Unknown/read/ghost.yml
@@ -1,0 +1,11 @@
+topology_description:
+  type: Unknown
+  servers:
+  - address: a:27017
+    avg_rtt_ms: 5
+    type: RSGhost
+operation: read
+read_preference:
+  mode: Nearest
+suitable_servers: []
+in_latency_window: []

--- a/source/server-selection/tests/server_selection/Unknown/write/ghost.json
+++ b/source/server-selection/tests/server_selection/Unknown/write/ghost.json
@@ -1,0 +1,18 @@
+{
+  "topology_description": {
+    "type": "Unknown",
+    "servers": [
+      {
+        "address": "a:27017",
+        "avg_rtt_ms": 5,
+        "type": "RSGhost"
+      }
+    ]
+  },
+  "operation": "write",
+  "read_preference": {
+    "mode": "Nearest"
+  },
+  "suitable_servers": [],
+  "in_latency_window": []
+}

--- a/source/server-selection/tests/server_selection/Unknown/write/ghost.yml
+++ b/source/server-selection/tests/server_selection/Unknown/write/ghost.yml
@@ -1,0 +1,11 @@
+topology_description:
+  type: Unknown
+  servers:
+  - address: a:27017
+    avg_rtt_ms: 5
+    type: RSGhost
+operation: write
+read_preference:
+  mode: Nearest
+suitable_servers: []
+in_latency_window: []


### PR DESCRIPTION
This is tested by the Python driver here: https://github.com/mongodb/mongo-python-driver/pull/806, see https://spruce.mongodb.com/version/61a803745623432084f4fe64/tasks

Note that in pymongo I needed to update the test runner to handle the RSGhost server type. Other drivers may need to do the same:
```
diff --git a/test/utils_selection_tests.py b/test/utils_selection_tests.py
index 0006f6f6..de10312c 100644
--- a/test/utils_selection_tests.py
+++ b/test/utils_selection_tests.py
@@ -63,7 +63,7 @@ def make_server_description(server, hosts):
         return ServerDescription(clean_node(server['address']), Hello({}))

     hello_response = {'ok': True, 'hosts': hosts}
-    if server_type != "Standalone" and server_type != "Mongos":
+    if server_type not in ("Standalone", "Mongos", "RSGhost", "RSGhost"):
         hello_response['setName'] = "rs"

     if server_type == "RSPrimary":
@@ -72,6 +72,8 @@ def make_server_description(server, hosts):
         hello_response['secondary'] = True
     elif server_type == "Mongos":
         hello_response['msg'] = 'isdbgrid'
+    elif server_type == "RSGhost":
+        hello_response['isreplicaset'] = True

     hello_response['lastWrite'] = {
         'lastWriteDate': make_last_write_date(server)
```