### PR TITLE
DRIVERS-2006: Remove srvMaxHosts tests expecting an error for invalid values

### DIFF
--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-invalid_integer.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-invalid_integer.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=-1",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not greater than or equal to zero"
-}

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-invalid_integer.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-invalid_integer.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=-1"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not greater than or equal to zero

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-invalid_type.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-invalid_type.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=foo",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not an integer"
-}

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-invalid_type.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-invalid_type.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0&srvMaxHosts=foo"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not an integer

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-invalid_integer.json
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-invalid_integer.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not greater than or equal to zero"
-}

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-invalid_integer.yml
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-invalid_integer.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=-1"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not greater than or equal to zero

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-invalid_type.json
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-invalid_type.json
@@ -1,7 +1,0 @@
-{
-  "uri": "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo",
-  "seeds": [],
-  "hosts": [],
-  "error": true,
-  "comment": "Should fail because srvMaxHosts is not an integer"
-}

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-invalid_type.yml
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-invalid_type.yml
@@ -1,5 +1,0 @@
-uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo"
-seeds: []
-hosts: []
-error: true
-comment: Should fail because srvMaxHosts is not an integer


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2006

These cases should raise warnings, not errors. Since they are already tested by existing uri-options spec tests, these files can simply be removed.