### PR TITLE
DRIVERS-1393 listCollectionNames should use authorizedCollections argument

### DIFF
--- a/source/enumerate-collections.rst
+++ b/source/enumerate-collections.rst
@@ -271,6 +271,11 @@ MongoDB 4.0 introduced a ``nameOnly`` boolean option to the ``listCollections``
 database command, which limits the command result to only include collection
 names. NOTE: ``nameOnly`` is applied before any filter is applied.
 
+MongoDB 4.0 also added an ``authorizedCollections`` boolean option to the ``listCollections``
+command, which can be used to limit the command result to only include collections
+the user is authorized to use. Drivers MUST always specify ``authorizedCollections``
+as true when they intend to access collection names from the ``listCollections`` command.
+
 Example return::
 
     [
@@ -284,11 +289,12 @@ Example return::
 
 
 Server version between 2.7.6 (inclusive) and 4.0 (exclusive) do not support
-the ``nameOnly`` option for the ``listCollections`` command and will ignore it 
-without raising an error. Therefore, drivers MUST always specify the ``nameOnly`` 
-option when they only intend to access collection names from the ``listCollections`` 
-command result, except drivers MUST NOT set ``nameOnly`` if a filter
-specifies any keys other than ``name``.
+the ``nameOnly`` and ``authorizedCollections`` options for the ``listCollections``
+command and will ignore it without raising an error. Therefore, drivers MUST
+always specify the ``nameOnly`` and ``authorizedCollections`` options when they
+only intend to access collection names from the ``listCollections`` command
+result, except drivers MUST NOT set ``nameOnly`` if a filter specifies any
+keys other than ``name``.
 
 Getting Full Collection Information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -433,6 +439,9 @@ The shell implements the first algorithm for falling back if the
 
 Version History
 ===============
+Version 0.6.2 Changes
+    - Support ``authorizedCollections`` option in ``listCollections`` command.
+
 Version 0.6.1 Changes
     - Update to use secondaryOk.
 
@@ -449,7 +458,7 @@ Version 0.5 Changes
     - Clarify that ``nameOnly`` must not be used with filters other than ``name``.
 
 Version 0.4 Changes
-    - SPEC-1066: Support ``nameOnly`` option in ``listCollections`` command. 
+    - SPEC-1066: Support ``nameOnly`` option in ``listCollections`` command.
 
 Version 0.3.1 Changes
 

--- a/source/enumerate-collections.rst
+++ b/source/enumerate-collections.rst
@@ -273,8 +273,8 @@ names. NOTE: ``nameOnly`` is applied before any filter is applied.
 
 MongoDB 4.0 also added an ``authorizedCollections`` boolean option to the ``listCollections``
 command, which can be used to limit the command result to only include collections
-the user is authorized to use. Drivers MUST always specify ``authorizedCollections``
-as true when they intend to access collection names from the ``listCollections`` command.
+the user is authorized to use. Drivers MAY allow users to set the ``authorizedCollections``
+option on the ``listCollectionNames`` method.
 
 Example return::
 
@@ -289,12 +289,11 @@ Example return::
 
 
 Server version between 2.7.6 (inclusive) and 4.0 (exclusive) do not support
-the ``nameOnly`` and ``authorizedCollections`` options for the ``listCollections``
-command and will ignore it without raising an error. Therefore, drivers MUST
-always specify the ``nameOnly`` and ``authorizedCollections`` options when they
-only intend to access collection names from the ``listCollections`` command
-result, except drivers MUST NOT set ``nameOnly`` if a filter specifies any
-keys other than ``name``.
+the ``nameOnly`` option for the ``listCollections`` command and will ignore it
+without raising an error. Therefore, drivers MUST always specify the ``nameOnly``
+option when they only intend to access collection names from the ``listCollections``
+command result, except drivers MUST NOT set ``nameOnly`` if a filter
+specifies any keys other than ``name``.
 
 Getting Full Collection Information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -348,7 +347,8 @@ Example return (a cursor which returns documents, not a simple array)::
 When returning this information as a cursor, a driver SHOULD use the
 method name ``listCollections`` or an idiomatic variant.
 
-Drivers MAY allow ``nameOnly`` option to be passed when executing the ``listCollections`` command for this method.
+Drivers MAY allow the ``nameOnly`` and ``authorizedCollections`` options
+to be passed when executing the ``listCollections`` command for this method.
 
 Returning a List of Collection Objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -368,7 +368,8 @@ Example return (in PHP, but abbreviated)::
       [5] => class MongoCollection#11 { }
     }
 
-Drivers MUST specify the ``nameOnly`` option when executing the ``listCollections`` command for this method,
+Drivers MAY allow the ``nameOnly`` and ``authorizedCollections`` options
+to be passed when executing the ``listCollections`` command for this method,
 except drivers MUST NOT set ``nameOnly`` if a filter specifies any keys other than ``name``.
 
 Replica Sets

--- a/source/enumerate-collections.rst
+++ b/source/enumerate-collections.rst
@@ -368,7 +368,7 @@ Example return (in PHP, but abbreviated)::
       [5] => class MongoCollection#11 { }
     }
 
-Drivers SHOULD specify true for the ``nameOnly`` option when executing the
+Drivers MUST specify true for the ``nameOnly`` option when executing the
 ``listCollections`` command for this method, except drivers MUST NOT set
 ``nameOnly`` if a filter specifies any keys other than ``name``.
 

--- a/source/enumerate-collections.rst
+++ b/source/enumerate-collections.rst
@@ -271,11 +271,6 @@ MongoDB 4.0 introduced a ``nameOnly`` boolean option to the ``listCollections``
 database command, which limits the command result to only include collection
 names. NOTE: ``nameOnly`` is applied before any filter is applied.
 
-MongoDB 4.0 also added an ``authorizedCollections`` boolean option to the ``listCollections``
-command, which can be used to limit the command result to only include collections
-the user is authorized to use. Drivers MAY allow users to set the ``authorizedCollections``
-option on the ``listCollectionNames`` method.
-
 Example return::
 
     [
@@ -294,6 +289,11 @@ without raising an error. Therefore, drivers MUST always specify the ``nameOnly`
 option when they only intend to access collection names from the ``listCollections``
 command result, except drivers MUST NOT set ``nameOnly`` if a filter
 specifies any keys other than ``name``.
+
+MongoDB 4.0 also added an ``authorizedCollections`` boolean option to the ``listCollections``
+command, which can be used to limit the command result to only include collections
+the user is authorized to use. Drivers MAY allow users to set the ``authorizedCollections``
+option on the ``listCollectionNames`` method.
 
 Getting Full Collection Information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -368,9 +368,12 @@ Example return (in PHP, but abbreviated)::
       [5] => class MongoCollection#11 { }
     }
 
-Drivers MAY allow the ``nameOnly`` and ``authorizedCollections`` options
-to be passed when executing the ``listCollections`` command for this method,
-except drivers MUST NOT set ``nameOnly`` if a filter specifies any keys other than ``name``.
+Drivers SHOULD specify true for the ``nameOnly`` option when executing the
+``listCollections`` command for this method, except drivers MUST NOT set
+``nameOnly`` if a filter specifies any keys other than ``name``.
+
+Drivers MAY allow the ``authorizedCollections`` option to be passed when
+executing the ``listCollections`` command for this method
 
 Replica Sets
 ~~~~~~~~~~~~
@@ -440,7 +443,7 @@ The shell implements the first algorithm for falling back if the
 
 Version History
 ===============
-Version 0.6.2 Changes
+Version 0.7.0 Changes
     - Support ``authorizedCollections`` option in ``listCollections`` command.
 
 Version 0.6.1 Changes


### PR DESCRIPTION
A few things to ask/note about this ticket/PR:

1. The proposed changes in this spec may change the behavior of the `listCollectionNames` driver helper to list only the collections that the user has access to, as opposed to returning all collection names (which requires database wide access).
2. That said, should the `authorizedCollections` be forcibly set to true (i.e. even if the user provides the option as false) or just defaulted to true?
    - On the one hand, this is would match the behavior of the `db.getCollectionNames()` shell command, and it is still possible to retrieve all of the collections using `listCollections`.
    - On the other hand, we might not want to change the functionality of `listCollectionNames` and provide the users the option to retrieve all collection names. The Ruby driver plans on using this option.

3. Should I be adding `authorizedCollections` docs to the other parts of the spec, i.e. `listCollections`, `listMongoCollections`, etc, or should I leave it only in `listCollectionNames` since this is the only function that requires it as of now? 

EDIT: Jeremy clarified the answers to these questions in the ticket [DRIVERS-1393](https://jira.mongodb.org/browse/DRIVERS-1393). 
