### PR TITLE
Clarify that old drivers should default to OP_QUERY handshakes

### DIFF
--- a/source/message/OP_MSG.rst
+++ b/source/message/OP_MSG.rst
@@ -10,9 +10,9 @@ OP_MSG
 :Informed: Bryan Reinero, Chris Hendel, drivers@
 :Status: Approved
 :Type: Standards
-:Last Modified: 2021-04-20
+:Last Modified: 2021-12-16
 :Minimum Server Version: 3.6
-:Version: 1.3
+:Version: 1.3.1
 
 
 
@@ -54,10 +54,10 @@ Usage
 MongoDB drivers SHOULD perform the MongoDB handshake using ``OP_MSG`` if an API
 version was declared on the client, but MAY decide to use ``OP_QUERY``.
 
-If no API version was declared, drivers that support MongoDB 3.4 and earlier
-MUST perform the handshake using ``OP_QUERY`` to determine if the node supports
-``OP_MSG``. Drivers that only support MongoDB 3.6 and newer MAY default to using
-``OP_MSG``.
+If no API version was declared, drivers that have historically supported MongoDB
+3.4 and earlier MUST perform the handshake using ``OP_QUERY`` to determine if the
+node supports ``OP_MSG``. Drivers that have only ever supported MongoDB 3.6 and
+newer MAY default to using ``OP_MSG``.
 
 If the node supports ``OP_MSG``, any and all messages MUST use ``OP_MSG``,
 optionally compressed with ``OP_COMPRESSED``.
@@ -621,6 +621,7 @@ Q & A
 Changelog
 =========
 
+- 2021-12-16 Clarify that old drivers should default to OP_QUERY handshakes
 - 2021-04-20 Suggest using OP_MSG for initial handshake when using versioned API
 - 2021-04-06 Updated to use hello and not writable primary
 - 2017-11-12 Specify read preferences for OP_MSG with direct connection


### PR DESCRIPTION
The original intention of this paragraph was to allow newer drivers published after MongoDB 3.6 to avoid implementing OP_QUERY purely for an initial handshake. Drivers that have historically supported pre-3.6 servers should continue to use OP_QUERY to ensure that meaningful error messages are raised when connecting to an old server instead of a silently dropped connection due to an unrecognized protocol.

----

Note: I skipped making a DRIVERS ticket for this to reduce overhead. If someone feels one is necessary I can do so.