### PR TITLE
DRIVERS-1953 LB txns have exclusive connection

### DIFF
--- a/source/load-balancers/load-balancers.rst
+++ b/source/load-balancers/load-balancers.rst
@@ -3,13 +3,13 @@ Load Balancer Support
 =====================
 
 :Spec Title: Load Balancer Support
-:Spec Version: 1.0.0
+:Spec Version: 1.0.1
 :Author: Durran Jordan
 :Advisors: Jeff Yemin, Divjot Arora, Andy Schwerin, Cory Mintz
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 5.0
-:Last Modified: 2021-04-06
+:Last Modified: 2021-12-22
 
 .. contents::
 
@@ -235,6 +235,8 @@ to a single connection ensures that all commands in the transaction target the s
 service behind the load balancer. The rules for pinning to a connection and releasing
 a pinned connection are the same as those for server pinning in non-load balanced sharded
 transactions as described in `When to unpin <../transactions/transactions.rst#when-to-unpin>`__.
+Drivers MUST NOT use the same connection for two concurrent transactions run under different
+sessions from the same client.
 
 Connection Tracking
 ^^^^^^^^^^^^^^^^^^^
@@ -423,4 +425,5 @@ be supported.
 Change Log
 ==========
 
+- 2021-12-22: Clarify that pinned connections in transactions are exclusive.
 - 2021-10-14: Note that ``loadBalanced=true`` conflicts with ``srvMaxHosts``.


### PR DESCRIPTION
# Scope
- Clarify that load balanced transactions must have exclusive access to pinned connection.

# Background & Rationale

The `all operations go to the same mongos` test in https://github.com/mongodb/specifications/blob/master/source/load-balancers/tests/transactions.yml asserts this behavior. It runs multiple insert operations within a transaction and asserts only one `connectionCheckedOutEvent`.

I surveyed drivers here: [spreadsheet](https://docs.google.com/spreadsheets/d/1KYdZECD9NZRePk9U07ThUlUCE1QQBlIUZvpn-Nc-eZc/edit?usp=sharing). This found that Ruby pins to a `ServiceID` rather than a connection. I was unable to determine for the Node driver.

If a transaction does not have exclusive access to a load balanced connection, it may be unable to make progress if it cannot check out another connection to the same ServiceID. Consider this scenario:
- Client configured with a `MaxPoolSize=10`.
- 1 connection goes to ServiceID `A`. 9 go to ServiceID `B`.
- Transaction pins to ServiceID `A`.
- Separate thread runs a long operation with the one connection for ServiceID `A`.
- Transaction cannot make progress until long operation checks connection back in.
