### PR TITLE
DRIVERS-1030: Implicit sessions allocate underlying server session after connection checkout

### DIFF
--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -1109,7 +1109,7 @@ ensure that they close any explicit client sessions and any unexhausted cursors.
     * In the parent, return the ClientSession to the pool, create a new ClientSession, and assert its lsid is the same.
     * In the child, return the ClientSession to the pool, create a new ClientSession, and assert its lsid is different.
 
-13. To confirm that implicit sessions are only obtained after a successful connection checkout
+13. To confirm that implicit sessions only allocate their server session after a successful connection checkout
 
     * Create a MongoClient with maxPoolSize=1, and attach a command succeeded listener
     * Initiate 3 concurrent operations, e.g. collection.insertOne(doc)
@@ -1310,4 +1310,4 @@ Change log
 :2021-04-08: Updated to use hello and legacy hello
 :2021-04-08: Adding in behaviour for load balancer mode.
 :2020-05-26: Simplify logic for determining sessions support
-:2022-01-19: Implicit sessions MUST be obtained after connection checkout succeeds
+:2022-01-19: Implicit sessions MUST obtain server session after connection checkout succeeds

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -1262,7 +1262,7 @@ sessions will be automatically cleaned up by the server after the
 configured ``logicalSessionTimeoutMinutes``.
 
 
-Why must driver's wait to consume a server session until after a connection is checked out?
+Why must drivers wait to consume a server session until after a connection is checked out?
 -----------------------------------------------------------------------------------------------------
 The problem that may occur is when the number of concurrent application requests are larger than the number of available connections,
 the driver may generate many more implicit sessions than connections.

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -3,7 +3,7 @@ Driver Sessions Specification
 =============================
 
 :Spec Title: Driver Sessions Specification (See the registry of specs)
-:Spec Version: 1.8.0
+:Spec Version: 1.9.0
 :Author: Robert Stam
 :Spec Lead: A\. Jesse Jiryu Davis
 :Advisory Group: Jeremy Mikola, Jeff Yemin, Samantha Ritter
@@ -12,7 +12,7 @@ Driver Sessions Specification
 :Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
 :Type: Standards
 :Minimum Server Version: 3.6 (The minimum server version this spec applies to)
-:Last Modified: 2021-04-12
+:Last Modified: 2022-01-28
 
 .. contents::
 
@@ -1310,4 +1310,4 @@ Change log
 :2021-04-08: Updated to use hello and legacy hello
 :2021-04-08: Adding in behaviour for load balancer mode.
 :2020-05-26: Simplify logic for determining sessions support
-:2022-01-19: Implicit sessions MUST obtain server session after connection checkout succeeds
+:2022-01-28: Implicit sessions MUST obtain server session after connection checkout succeeds

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -1111,9 +1111,11 @@ ensure that they close any explicit client sessions and any unexhausted cursors.
 
 13. To confirm that implicit sessions are only obtained after a successful connection checkout
 
-    * Create a MongoClient with a maxPoolSize of 1
-    * Run 3 operations in parallel
-    * Assert that the session count never rises above 1
+    * Create a MongoClient with maxPoolSize=1, and attach a command succeeded listener
+    * Initiate 3 concurrent operations, e.g. collection.insertOne(doc)
+    * Wait for all operations to complete
+    * Assert that all commands contain the same lsid
+
 
 Tests that only apply to drivers that have not implemented OP_MSG and are still using OP_QUERY
 ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1030

The language change is on the light side but the undertaking for this change is likely large for most drivers. I could use some discussion guidance on more rigorous prose tests to reccomend to drivers. 

The key pain point we're trying to solve is that connection pool size is the true to limit to how many concurrent operations can happen against a particular node, by obtaining implicit sessions after we've checkedOut we can be sure we're not creating a larger than necessary pool of sessions.

I looked at Transactions and LB and to my knowledge there isn't an impact to those specs, transactions are using explicit sessions, and LB will behave the same it has the continued concern of using the same connection related to a given session. 