### PR TITLE
fix(DRIVERS-1983): update direct connection details

### DIFF
--- a/source/load-balancers/load-balancers.rst
+++ b/source/load-balancers/load-balancers.rst
@@ -325,8 +325,9 @@ MAY also close the connection associated with the transaction when the transacti
 Conversely, those services must abort a transaction when the connection associated with the
 transaction is closed.
 
-Any applications that connect directly to services and not through the load balancer MUST also
-supply the :code:`loadBalanced=true` option to the driver they use to connect.
+Any applications that connect directly to services and not through the load balancer MUST connect
+via the regular service port as they normally would and not the port specified by the
+`loadBalancerPort` option. The `loadBalanced=true` URI option MUST be omitted in this case.
 
 
 Q&A


### PR DESCRIPTION
Services now enable load balancing by the `--loadBalancerPort` option which requires the v1 or v2 proxy protocol to be enabled in the load balancer. Drivers wishing to bypass the load balancer and connect directly must do so now on the original service port without enabling load balancer mode. This PR updates the downstream wording to reflect this.