### PR TITLE
DRIVERS-1767: test all json files with a schemaVersion against their corresponding schema

### DIFF
--- a/.github/workflows/check_schema_version.sh
+++ b/.github/workflows/check_schema_version.sh
@@ -1,0 +1,32 @@
+#! /usr/bin/env bash
+
+# Collect error codes so we can see all the invalid json files in one run
+exitCode=0
+
+# $1 - takes a single argument of the path to the JSON file containing a schemaVersion key at the top level.
+function get_schema_version() {
+  node << EOF
+    const { readFileSync } = require('fs')
+    console.log(JSON.parse(readFileSync("./$1")).schemaVersion)
+EOF
+}
+
+function get_all_schemaVersion_defining_files () {
+  # look for all json files with 'schemaVersion": "[1-9]'
+  grep --include='*.json' --files-with-matches --recursive --word-regexp --regexp='schemaVersion": "[1-9]' source | \
+  # Remove the known invalid test files from 'unified-test-format/tests/invalid'
+  grep --word-regexp --invert-match 'unified-test-format/tests/invalid' | \
+  # sort the result!
+  sort
+}
+
+for testFile in $(get_all_schemaVersion_defining_files)
+do
+    schemaVersion=$(get_schema_version "$testFile")
+    if ! ajvCheck=$(ajv -s "source/unified-test-format/schema-$schemaVersion.json" -d "$testFile"); then
+      exitCode=1
+    fi
+    echo "$ajvCheck using schema v$schemaVersion"
+done
+
+exit $exitCode

--- a/.github/workflows/check_schema_version.sh
+++ b/.github/workflows/check_schema_version.sh
@@ -7,13 +7,14 @@ exitCode=0
 function get_schema_version() {
   node << EOF
     const { readFileSync } = require('fs')
-    console.log(JSON.parse(readFileSync("./$1")).schemaVersion)
+    const { load } = require('js-yaml')
+    console.log(load(readFileSync("./$1", { encoding: 'utf-8' })).schemaVersion)
 EOF
 }
 
 function get_all_schemaVersion_defining_files () {
-  # look for all json files with 'schemaVersion": "[1-9]'
-  grep --include='*.json' --files-with-matches --recursive --word-regexp --regexp='schemaVersion": "[1-9]' source | \
+  # look for all yaml files with "schemaVersion: ["'][1-9]"
+  grep --include=*.{yml,yaml} --files-with-matches --recursive --word-regexp --regexp="schemaVersion: [\"'][1-9]" source | \
   # Remove the known invalid test files from 'unified-test-format/tests/invalid'
   grep --word-regexp --invert-match 'unified-test-format/tests/invalid' | \
   # sort the result!

--- a/.github/workflows/unified-test-format-schema-check.yml
+++ b/.github/workflows/unified-test-format-schema-check.yml
@@ -21,7 +21,9 @@ jobs:
         with:
           node-version: lts/*
       - name: Install dependencies
-        run: npm install -g ajv-cli
+        run: |
+          npm install -g ajv-cli
+          npm install js-yaml
       - name: Check unified format test files against schema
         working-directory: source/unified-test-format/tests
         run: make

--- a/.github/workflows/unified-test-format-schema-check.yml
+++ b/.github/workflows/unified-test-format-schema-check.yml
@@ -13,16 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.x
       - name: Set up npm
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: lts/*
       - name: Install dependencies
-        run: |
-          npm install -g ajv-cli
+        run: npm install -g ajv-cli
       - name: Check unified format test files against schema
-        run: |
-          cd source/unified-test-format/tests && make
+        working-directory: source/unified-test-format/tests
+        run: make
+      - name: Check all unified tests schema version is valid
+        run: bash .github/workflows/check_schema_version.sh

--- a/source/load-balancers/tests/cursors.json
+++ b/source/load-balancers/tests/cursors.json
@@ -1,6 +1,6 @@
 {
   "description": "cursors are correctly pinned to connections for load-balanced clusters",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "topologies": [

--- a/source/load-balancers/tests/cursors.yml
+++ b/source/load-balancers/tests/cursors.yml
@@ -1,6 +1,6 @@
 description: cursors are correctly pinned to connections for load-balanced clusters
 
-schemaVersion: '1.3'
+schemaVersion: '1.4'
 
 runOnRequirements:
   - topologies: [ load-balanced ]

--- a/source/load-balancers/tests/sdam-error-handling.json
+++ b/source/load-balancers/tests/sdam-error-handling.json
@@ -1,6 +1,6 @@
 {
   "description": "state change errors are correctly handled",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "topologies": [

--- a/source/load-balancers/tests/sdam-error-handling.yml
+++ b/source/load-balancers/tests/sdam-error-handling.yml
@@ -1,6 +1,6 @@
 description: state change errors are correctly handled
 
-schemaVersion: '1.3'
+schemaVersion: '1.4'
 
 runOnRequirements:
   - topologies: [ load-balanced ]

--- a/source/load-balancers/tests/transactions.json
+++ b/source/load-balancers/tests/transactions.json
@@ -1,6 +1,6 @@
 {
   "description": "transactions are correctly pinned to connections for load-balanced clusters",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "topologies": [

--- a/source/load-balancers/tests/transactions.yml
+++ b/source/load-balancers/tests/transactions.yml
@@ -1,6 +1,6 @@
 description: transactions are correctly pinned to connections for load-balanced clusters
 
-schemaVersion: '1.3'
+schemaVersion: '1.4'
 
 runOnRequirements:
   - topologies: [ load-balanced ]


### PR DESCRIPTION
I've made a script here that will grep for all json files that have a schemaVersion, and use that value in an `ajv` command to check that its a valid schema.

You can see what a failure looks like in the first commit's CI.

This uncovered missed version changes in: 
- `source/load-balancers/tests/cursors.yml`
- `source/load-balancers/tests/sdam-error-handling.yml`
- `source/load-balancers/tests/transactions.yml`

So we may want to change the ticket to drivers changes needed, but the impact might be non-existent if these tests have been sync-ed and no issues reported thus far.

Additionally made some drive-by improvements of the ci file, updated action/node/python versions simply to not let those run out of date. 

https://jira.mongodb.org/browse/DRIVERS-1767