### PR TITLE
test: remove duplicate tls option test

### DIFF
--- a/source/uri-options/tests/tls-options.json
+++ b/source/uri-options/tests/tls-options.json
@@ -45,15 +45,6 @@
       }
     },
     {
-      "description": "Invalid tlsAllowInvalidCertificates causes a warning",
-      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=invalid",
-      "valid": true,
-      "warning": true,
-      "hosts": null,
-      "auth": null,
-      "options": {}
-    },
-    {
       "description": "tlsAllowInvalidHostnames is parsed correctly",
       "uri": "mongodb://example.com/?tlsAllowInvalidHostnames=true",
       "valid": true,

--- a/source/uri-options/tests/tls-options.yml
+++ b/source/uri-options/tests/tls-options.yml
@@ -37,14 +37,6 @@ tests:
         options:
             tlsAllowInvalidCertificates: true
     -
-        description: "Invalid tlsAllowInvalidCertificates causes a warning"
-        uri: "mongodb://example.com/?tlsAllowInvalidCertificates=invalid"
-        valid: true
-        warning: true
-        hosts: ~
-        auth: ~
-        options: {}
-    -
         description: "tlsAllowInvalidHostnames is parsed correctly"
         uri: "mongodb://example.com/?tlsAllowInvalidHostnames=true"
         valid: true


### PR DESCRIPTION
I came across this duplicate test while fixing up the node driver uri spec runner. It's a minor thing, but it does mess with our IDE test runner tooling.