### PR TITLE
feat(DRIVERS-1108): add service host to mech props

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -465,6 +465,9 @@ mechanism_properties
 	SERVICE_REALM
 		Drivers MAY allow the user to specify a different realm for the service. This might be necessary to support cross-realm authentication where the user exists in one realm and the service in another.
 
+	SERVICE_HOST
+		Drivers MAY allow the user to specify a different host for the service. This is stored in the service principal name instead of the standard host name. This is generally used for cases where the initial role is being created from localhost but the actual service host would differ.
+
 Hostname Canonicalization
 `````````````````````````
 

--- a/source/auth/tests/connection-string.json
+++ b/source/auth/tests/connection-string.json
@@ -80,7 +80,7 @@
     },
     {
       "description": "should accept generic mechanism property (GSSAPI)",
-      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true",
+      "uri": "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com",
       "valid": true,
       "credential": {
         "username": "user@DOMAIN.COM",
@@ -89,7 +89,8 @@
         "mechanism": "GSSAPI",
         "mechanism_properties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true
+          "CANONICALIZE_HOST_NAME": true,
+          "SERVICE_HOST": "example.com"
         }
       }
     },

--- a/source/auth/tests/connection-string.yml
+++ b/source/auth/tests/connection-string.yml
@@ -64,7 +64,7 @@ tests:
                 SERVICE_NAME: "mongodb"
     -
         description: "should accept generic mechanism property (GSSAPI)"
-        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true"
+        uri: "mongodb://user%40DOMAIN.COM@localhost/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com"
         valid: true
         credential:
             username: "user@DOMAIN.COM"
@@ -74,6 +74,7 @@ tests:
             mechanism_properties:
                 SERVICE_NAME: "other"
                 CANONICALIZE_HOST_NAME: true
+                SERVICE_HOST: "example.com"
     -
         description: "should accept the password (GSSAPI)"
         uri: "mongodb://user%40DOMAIN.COM:password@localhost/?authMechanism=GSSAPI&authSource=$external"

--- a/source/connection-string/tests/valid-auth.json
+++ b/source/connection-string/tests/valid-auth.json
@@ -284,7 +284,7 @@
     },
     {
       "description": "Escaped username (GSSAPI)",
-      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI",
+      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI",
       "valid": true,
       "warning": false,
       "hosts": [
@@ -303,7 +303,8 @@
         "authmechanism": "GSSAPI",
         "authmechanismproperties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true
+          "CANONICALIZE_HOST_NAME": true,
+          "SERVICE_HOST": "example.com"
         }
       }
     },

--- a/source/connection-string/tests/valid-auth.yml
+++ b/source/connection-string/tests/valid-auth.yml
@@ -222,7 +222,7 @@ tests:
             authmechanism: "MONGODB-X509"
     -
         description: "Escaped username (GSSAPI)"
-        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI"
+        uri: "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authMechanism=GSSAPI"
         valid: true
         warning: false
         hosts:
@@ -238,7 +238,8 @@ tests:
             authmechanism: "GSSAPI"
             authmechanismproperties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: true
+                CANONICALIZE_HOST_NAME: true,
+                SERVICE_HOST: "example.com"
     -
         description: "At-signs in options aren't part of the userinfo"
         uri: "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset"

--- a/source/uri-options/tests/auth-options.json
+++ b/source/uri-options/tests/auth-options.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "Valid auth options are parsed correctly (GSSAPI)",
-      "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external",
+      "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authSource=$external",
       "valid": true,
       "warning": false,
       "hosts": null,
@@ -11,7 +11,8 @@
         "authMechanism": "GSSAPI",
         "authMechanismProperties": {
           "SERVICE_NAME": "other",
-          "CANONICALIZE_HOST_NAME": true
+          "CANONICALIZE_HOST_NAME": true,
+          "SERVICE_HOST": "example.com"
         },
         "authSource": "$external"
       }

--- a/source/uri-options/tests/auth-options.yml
+++ b/source/uri-options/tests/auth-options.yml
@@ -1,7 +1,7 @@
 tests:
     -
         description: "Valid auth options are parsed correctly (GSSAPI)"
-        uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external"
+        uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true,SERVICE_HOST:example.com&authSource=$external"
         valid: true
         warning: false
         hosts: ~
@@ -11,6 +11,7 @@ tests:
             authMechanismProperties:
                 SERVICE_NAME: "other"
                 CANONICALIZE_HOST_NAME: true
+                SERVICE_HOST: "example.com"
             authSource: "$external"
     -
         description: "Valid auth options are parsed correctly (SCRAM-SHA-1)"


### PR DESCRIPTION
Updates the auth spec to allow drivers to allow a `SERVICE_HOST` property in their auth mechanism properties, which replaces the default host in the service principal name to the provided attribute.

Node impl: https://github.com/mongodb/node-mongodb-native/pull/3123