### PR TITLE
DRIVERS-2191 Remove use of example.com in Client Side Encryption prose tests

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -687,12 +687,12 @@ Configure with KMS providers as follows:
             "tenantId": <set from environment>,
             "clientId": <set from environment>,
             "clientSecret": <set from environment>,
-            "identityPlatformEndpoint": "example.com:443"
+            "identityPlatformEndpoint": "doesnotexist.invalid:443"
          },
          "gcp": {
             "email": <set from environment>,
             "privateKey": <set from environment>,
-            "endpoint": "example.com:443"
+            "endpoint": "doesnotexist.invalid:443"
          },
          "kmip": {
             "endpoint": "doesnotexist.local:5698"
@@ -775,10 +775,10 @@ Test cases
       {
         region: "us-east-1",
         key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
-        endpoint: "example.com"
+        endpoint: "doesnotexist.invalid"
       }
 
-   Expect this to fail with an exception with a message containing the string: "parse error"
+   Expect this to fail with a network exception indicating failure to resolve "doesnotexist.invalid".
 
 7. Call `client_encryption.createDataKey()` with "azure" as the provider and the following masterKey:
 
@@ -791,7 +791,7 @@ Test cases
 
    Expect this to succeed. Use the returned UUID of the key to explicitly encrypt and decrypt the string "test" to validate it works.
 
-   Call ``client_encryption_invalid.createDataKey()`` with the same masterKey. Expect this to fail with an exception with a message containing the string: "parse error".
+   Call ``client_encryption_invalid.createDataKey()`` with the same masterKey. Expect this to fail with a network exception indicating failure to resolve "doesnotexist.invalid".
 
 8. Call `client_encryption.createDataKey()` with "gcp" as the provider and the following masterKey:
 
@@ -807,7 +807,7 @@ Test cases
 
    Expect this to succeed. Use the returned UUID of the key to explicitly encrypt and decrypt the string "test" to validate it works.
 
-   Call ``client_encryption_invalid.createDataKey()`` with the same masterKey. Expect this to fail with an exception with a message containing the string: "parse error".
+   Call ``client_encryption_invalid.createDataKey()`` with the same masterKey. Expect this to fail with a network exception indicating failure to resolve "doesnotexist.invalid".
 
 9. Call `client_encryption.createDataKey()` with "gcp" as the provider and the following masterKey:
 
@@ -818,7 +818,7 @@ Test cases
         "location": "global",
         "keyRing": "key-ring-csfle",
         "keyName": "key-name-csfle",
-        "endpoint": "example.com:443"
+        "endpoint": "doesnotexist.invalid:443"
       }
 
    Expect this to fail with an exception with a message containing the string: "Invalid KMS response".


### PR DESCRIPTION
# Summary
Replace use of "example.com" in Client Side Encryption prose tests with "doesnotexist.invalid".
- Test expectations in "Custom Endpoint Test" Cases 6, 7, and 8 change from parsing errors to DNS resolution errors.
- The error expectation for Case 9 has not changed from "Invalid KMS response". The error comes from the response to the oauth request. The oauth request is still sent to a valid endpoint, but requests permissions to an [invalid scope](https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt-kms-ctx.c#L1305-L1311).

Here is a PoC of the updated tests with the C driver: https://github.com/mongodb/mongo-c-driver/pull/942 with passing Client Side Encryption tests.

# Motivation & Background
See DRIVERS-2191 for a repro. Sending AWS signed requests to example.com has been recently (as of 02/04/2022) observed to frequently return an HTTP 404, rather than the expected 200.

There is no reason to use "example.com". The tests only need to assert that the passed endpoint is used.

For precedence, Case 10 uses "doesnotexist.local" and expects `to fail with a network exception indicating failure to resolve "doesnotexist.local".`.

Using "doesnotexist.invalid" agrees with [RFC 2606](https://www.rfc-editor.org/rfc/rfc2606.html#section-2):

> ".invalid" is intended for use in online construction of domain names that are sure to be invalid and which it is obvious at a glance are invalid.

