### PR TITLE
DRIVERS-2180 Clarify Kerberos on Windows credentials passing

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -450,7 +450,7 @@ source
 	MUST be "$external". Defaults to ``$external``.
 
 password
-	MAY be specified.
+	MAY be specified. If omitted, drivers MUST NOT pass the username without password to SSPI on Windows, and instead use the default credentials.
 
 mechanism
 	MUST be "GSSAPI"

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -450,7 +450,7 @@ source
 	MUST be "$external". Defaults to ``$external``.
 
 password
-	MAY be specified. If omitted, drivers MUST NOT pass the username without password to SSPI on Windows, and instead use the default credentials.
+	MAY be specified. If omitted, drivers MUST NOT pass the username without password to SSPI on Windows and instead use the default credentials.
 
 mechanism
 	MUST be "GSSAPI"


### PR DESCRIPTION
See DRIVERS-2180 for context, and https://github.com/mongodb-js/kerberos/pull/141 for the corresponding Node.js bugfix PR.