### PR TITLE
DRIVERS-2224 Fix load-balanced DNS seedlist discovery tests for new dedicated lb port.

### DIFF
--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -14,8 +14,9 @@ replica set name ``repl0``.
 
 The tests in the ``load-balanced`` directory MUST be executed against a
 load-balanced sharded cluster with the mongos servers running on localhost ports
-27017 and 27018 (corresponding to the script in `drivers-evergreen-tools`_). The
-load balancers, shard servers, and config servers may run on any open ports.
+27017 and 27018 and ``--loadBalancerPort`` 27050 and 27051, respectively
+(corresponding to the script in `drivers-evergreen-tools`_). The load balancers,
+shard servers, and config servers may run on any open ports.
 
 .. _`drivers-evergreen-tools`: https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/run-load-balancer.sh
 
@@ -56,7 +57,9 @@ these tests::
   _mongodb._tcp.test19.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
   _mongodb._tcp.test20.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
   _mongodb._tcp.test21.test.build.10gen.cc.   86400  IN SRV  27017  localhost.test.build.10gen.cc.
-  _customname._tcp.test22.test.build.10gen.cc 86400  IN SRV  27017  localhost.test.build.10gen.cc
+  _customname._tcp.test22.test.build.10gen.cc 86400  IN SRV  27017  localhost.test.build.10gen.cc.
+  _mongodb._tcp.test23.test.build.10gen.cc.   86400  IN SRV  8000   localhost.test.build.10gen.cc.
+  _mongodb._tcp.test24.test.build.10gen.cc.   86400  IN SRV  8000   localhost.test.build.10gen.cc.
 
   Record                                    TTL    Class   Text
   test5.test.build.10gen.cc.                86400  IN TXT  "replicaSet=repl0&authSource=thisDB"
@@ -68,12 +71,18 @@ these tests::
   test11.test.build.10gen.cc.               86400  IN TXT  "replicaS" "et=rep" "l0"
   test20.test.build.10gen.cc.               86400  IN TXT  "loadBalanced=true"
   test21.test.build.10gen.cc.               86400  IN TXT  "loadBalanced=false"
+  test24.test.build.10gen.cc.               86400  IN TXT  "loadBalanced=true"
 
-Note that ``test4`` is omitted deliberately to test what happens with no SRV
-record. ``test9`` is missing because it was deleted during the development of
-the tests. The missing ``test.`` sub-domain in the SRV record target for
-``test12`` is deliberate. ``test22`` is used to test a custom service name
-(``customname``).
+Notes:
+
+- ``test4`` is omitted deliberately to test what happens with no SRV record.
+- ``test9`` is missing because it was deleted during the development of the
+  tests.
+- The missing ``test.`` sub-domain in the SRV record target for ``test12`` is
+  deliberate.
+- ``test22`` is used to test a custom service name (``customname``).
+- ``test23`` and ``test24`` point to port 8000 (HAProxy) and are used for
+  load-balanced tests.
 
 In our tests we have used ``localhost.test.build.10gen.cc`` as the domain, and
 then configured ``localhost.test.build.10gen.cc`` to resolve to 127.0.0.1.

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?directConnection=false",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.yml
@@ -1,12 +1,12 @@
-# The TXT record for test20.test.build.10gen.cc contains loadBalanced=true.
+# The TXT record for test24.test.build.10gen.cc contains loadBalanced=true.
 # DRIVERS-1721 introduced this test as passing.
-uri: "mongodb+srv://test20.test.build.10gen.cc/?directConnection=false"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?directConnection=false"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
     # In LB mode, the driver does not do server discovery, so the hostname does
-    # not get resolved to localhost:27017.
-    - localhost.test.build.10gen.cc:27017
+    # not get resolved to localhost:8000.
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     ssl: true

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-replicaSet-errors.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-replicaSet-errors.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-replicaSet-errors.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-replicaSet-errors.yml
@@ -1,5 +1,5 @@
-# The TXT record for test20.test.build.10gen.cc contains loadBalanced=true.
-uri: "mongodb+srv://test20.test.build.10gen.cc/?replicaSet=replset"
+# The TXT record for test24.test.build.10gen.cc contains loadBalanced=true.
+uri: "mongodb+srv://test24.test.build.10gen.cc/?replicaSet=replset"
 seeds: []
 hosts: []
 error: true

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.yml
@@ -1,10 +1,10 @@
-uri: "mongodb+srv://test20.test.build.10gen.cc/"
+uri: "mongodb+srv://test24.test.build.10gen.cc/"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
     # In LB mode, the driver does not do server discovery, so the hostname does
-    # not get resolved to localhost:27017.
-    - localhost.test.build.10gen.cc:27017
+    # not get resolved to localhost:8000.
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     ssl: true

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.json
@@ -1,5 +1,5 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1",
   "seeds": [],
   "hosts": [],
   "error": true,

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-conflicts_with_loadBalanced-true-txt.yml
@@ -1,4 +1,4 @@
-uri: "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=1"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=1"
 seeds: []
 hosts: []
 error: true

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0",
+  "uri": "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.yml
@@ -1,9 +1,9 @@
 # loadBalanced=true (TXT) is permitted because srvMaxHosts is non-positive
-uri: "mongodb+srv://test20.test.build.10gen.cc/?srvMaxHosts=0"
+uri: "mongodb+srv://test24.test.build.10gen.cc/?srvMaxHosts=0"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     srvMaxHosts: 0

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.json
@@ -1,10 +1,10 @@
 {
-  "uri": "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
+  "uri": "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0",
   "seeds": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "hosts": [
-    "localhost.test.build.10gen.cc:27017"
+    "localhost.test.build.10gen.cc:8000"
   ],
   "options": {
     "loadBalanced": true,

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.yml
@@ -1,9 +1,9 @@
 # loadBalanced=true is permitted because srvMaxHosts is non-positive
-uri: "mongodb+srv://test3.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0"
+uri: "mongodb+srv://test23.test.build.10gen.cc/?loadBalanced=true&srvMaxHosts=0"
 seeds:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 hosts:
-    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:8000
 options:
     loadBalanced: true
     srvMaxHosts: 0


### PR DESCRIPTION
Currently the `mongo-orchestration` changes made with [DRIVERS-1983](https://jira.mongodb.org/browse/DRIVERS-1983) break some initial DNS seedlist discovery load-balanced tests because the driver must now connect to the load balancer to work correctly when in load-balanced mode. See this [comment](https://jira.mongodb.org/browse/GODRIVER-2292?focusedCommentId=4355123&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4355123) for more details about the test failures.

[BUILD-14668](https://jira.mongodb.org/browse/BUILD-14668) adds two new SRV records:
* `_mongodb._tcp.test23.test.build.10gen.cc.   86400  IN SRV  8000   localhost.test.build.10gen.cc.`
* `_mongodb._tcp.test24.test.build.10gen.cc.   86400  IN SRV  8000   localhost.test.build.10gen.cc.`

and one new TXT record:

* `test24.test.build.10gen.cc. 86400  IN TXT  "loadBalanced=true"`

This PR updates the `initial-dns-seedlist-discovery/load-balancer` spec tests to use those new recods to work with the new/updated DNS SRV records and document the SRV record updates in the README.

Note! This PR MUST NOT be merged until [BUILD-14668](https://jira.mongodb.org/browse/BUILD-14668) is complete.