### PR TITLE
DRIVERS-2226: bump minServerVersion to 4.2 for bulkwrite-update*let tests

### DIFF
--- a/source/crud/tests/unified/bulkWrite-updateMany-let.json
+++ b/source/crud/tests/unified/bulkWrite-updateMany-let.json
@@ -142,7 +142,7 @@
       "description": "BulkWrite updateMany with let option unsupported (server-side error)",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
+          "minServerVersion": "4.2.0",
           "maxServerVersion": "4.9"
         }
       ],

--- a/source/crud/tests/unified/bulkWrite-updateMany-let.yml
+++ b/source/crud/tests/unified/bulkWrite-updateMany-let.yml
@@ -61,7 +61,7 @@ tests:
 
   - description: "BulkWrite updateMany with let option unsupported (server-side error)"
     runOnRequirements:
-      - minServerVersion: "3.6.0"
+      - minServerVersion: "4.2.0"
         maxServerVersion: "4.9"
     operations:
       - object: *collection0

--- a/source/crud/tests/unified/bulkWrite-updateOne-let.json
+++ b/source/crud/tests/unified/bulkWrite-updateOne-let.json
@@ -144,7 +144,7 @@
       "description": "BulkWrite updateOne with let option unsupported (server-side error)",
       "runOnRequirements": [
         {
-          "minServerVersion": "3.6.0",
+          "minServerVersion": "4.2.0",
           "maxServerVersion": "4.9"
         }
       ],

--- a/source/crud/tests/unified/bulkWrite-updateOne-let.yml
+++ b/source/crud/tests/unified/bulkWrite-updateOne-let.yml
@@ -61,7 +61,7 @@ tests:
 
   - description: "BulkWrite updateOne with let option unsupported (server-side error)"
     runOnRequirements:
-      - minServerVersion: "3.6.0"
+      - minServerVersion: "4.2.0"
         maxServerVersion: "4.9"
     operations:
       - object: *collection0


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2226

Successful patch from the Node driver - https://spruce.mongodb.com/version/622618297742ae6d299817b2/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC