### PR TITLE
note that 4.2.9 server is required for server selection prose test

### DIFF
--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -281,7 +281,7 @@ Prose Test
 
 Multi-threaded and async drivers MUST also implement the following prose test:
 
-1. Configure a sharded cluster with two mongoses. Use a 4.9.0 or newer server version.
+1. Configure a sharded cluster with two mongoses. Use a 4.2.9 or newer server version.
 
 2. Enable the following failpoint against exactly one of the mongoses::
 

--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -281,7 +281,7 @@ Prose Test
 
 Multi-threaded and async drivers MUST also implement the following prose test:
 
-1. Configure a sharded cluster with two mongoses.
+1. Configure a sharded cluster with two mongoses. Use a 4.9.0 or newer server version.
 
 2. Enable the following failpoint against exactly one of the mongoses::
 

--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -296,7 +296,7 @@ Multi-threaded and async drivers MUST also implement the following prose test:
         },
     }
 
-3. Create a client with both mongoses' adresses in its seed list,
+3. Create a client with both mongoses' addresses in its seed list,
    appName="loadBalancingTest", and command monitoring enabled.
 
 4. Start 10 concurrent threads / tasks that each run 10 `findOne` operations


### PR DESCRIPTION
# Background & Motivation

The "Prose Test" in server-selection-tests.rst specifies configuring a `failCommand` fail point with the `blockTimeMS` option.

~~[SERVER-53512](https://jira.mongodb.org/browse/SERVER-53512)~~ [SERVER-41070](https://jira.mongodb.org/browse/SERVER-41070) added a `failCommand` fail point with `blockTimeMS` in ~~4.9.0~~ 4.2.9.