### PR TITLE
DRIVERS-2218: Clarify intended bounding of implicit session allocation and rework flaky prose test

### DIFF
--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -504,10 +504,10 @@ include a session ID in a ``KILLCURSORS`` command.
 
 Sessions and Connections
 ========================
-A driver MUST only obtain an implicit session's ``ServerSession`` after it successfully checks out a connection.
+
+To reduce the number of ``ServerSessions`` created, the driver MUST only obtain an implicit session's
+``ServerSession`` after it successfully checks out a connection.
 A driver SHOULD NOT attempt to release the acquired session before connection check in.
-Through both through the pooling mechanism and limiting acquisition to a successful
-connection checkout we can have guaranteed improvement of ``ServerSession`` reuse.
 
 Explicit sessions MAY be changed to allocate a server session similarly.
 
@@ -1155,6 +1155,9 @@ Test Plan
     * Assert the following across at least 5 retries of the above test:
 
       * Drivers MUST assert that exactly one session is used for all operations at least once across the retries of this test.
+
+        * Note that it's possible, although rare, for >1 server session to be used because the session is not released until after the connection is checked in.
+
       * Drivers MUST assert that the number of allocated sessions is strictly less than the number of concurrent operations in every retry of this test. In this instance it would less than (but NOT equal to) 8.
 
 
@@ -1332,8 +1335,6 @@ Why should drivers NOT attempt to release a serverSession before checking back i
 There are a variety of cases, such as, retryable operations or cursor creating operations
 where a ``serverSession`` must remain acquired by the ``ClientSession`` after an operation is attempted.
 Attempting to account for all these scenarios has risks that do not justify the potential guaranteed ``ServerSession`` allocation limiting.
-Drivers SHOULD attempt to release the ``ServerSession`` to the pool at the earliest possible opportunity.
-Drivers SHOULD attempt to reuse ``ServerSession`` as best as possible, concurrency fairness willing.
 
 Change log
 ==========

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -12,7 +12,7 @@ Driver Sessions Specification
 :Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
 :Type: Standards
 :Minimum Server Version: 3.6 (The minimum server version this spec applies to)
-:Last Modified: 2022-03-16
+:Last Modified: 2022-03-24
 
 .. contents::
 

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -1154,8 +1154,8 @@ Test Plan
     * Wait for all operations to complete successfully
     * Assert the following across at least 5 retries of the above test:
 
-        * Drivers MUST assert that exactly one session is used for all operations at least once across the 5 retries of this test.
-        * Drivers MUST assert that the number of allocated sessions is strictly less than the number of concurrent operations in every retry of this test. In this instance it would less than (but NOT equal to) 8.
+      * Drivers MUST assert that exactly one session is used for all operations at least once across the 5 retries of this test.
+      * Drivers MUST assert that the number of allocated sessions is strictly less than the number of concurrent operations in every retry of this test. In this instance it would less than (but NOT equal to) 8.
 
 
 

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -1154,7 +1154,7 @@ Test Plan
     * Wait for all operations to complete successfully
     * Assert the following across at least 5 retries of the above test:
 
-      * Drivers MUST assert that exactly one session is used for all operations at least once across the 5 retries of this test.
+      * Drivers MUST assert that exactly one session is used for all operations at least once across the retries of this test.
       * Drivers MUST assert that the number of allocated sessions is strictly less than the number of concurrent operations in every retry of this test. In this instance it would less than (but NOT equal to) 8.
 
 

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -1325,12 +1325,12 @@ is needed and, known it will be used, after connection checkout succeeds.
 It is still possible that via explicit sessions or cursors, which hold on to the session they started with, a driver could over allocate sessions.
 But those scenarios are extenuating and outside the scope of solving in this spec.
 
-// TODO
+Why should drivers NOT attempt to release a serverSession before checking back in the operation's connection?
+-------------------------------------------------------------------------------------------------------------
+
 There are a variety of cases, such as, retryable operations or cursor creating operations
 where a ``serverSession`` must remain acquired by the ``ClientSession`` after an operation is attempted.
-
 Attempting to account for all these scenarios has risks that do not justify the potential guaranteed ``ServerSession`` allocation limiting.
-
 Drivers SHOULD attempt to release the ``ServerSession`` to the pool at the earliest possible opportunity.
 Drivers SHOULD attempt to reuse ``ServerSession`` as best as possible, concurrency fairness willing.
 

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -809,7 +809,7 @@ instance and have the same lifetime as the ``MongoClient`` instance.
 
 When a new implicit ``ClientSession`` is started it MUST NOT attempt to acquire a server
 session from the server session pool immediately. When a new explicit ``ClientSession`` is started
-it SHOULD attempt to acquire a server session from the server session pool immediately.
+it MAY attempt to acquire a server session from the server session pool immediately.
 See the algorithm below for the steps to follow when attempting to acquire a ``ServerSession`` from the server session pool.
 
 Note that ``ServerSession`` instances acquired from the server session pool might have as
@@ -1158,7 +1158,7 @@ Test Plan
 
         * Note that it's possible, although rare, for >1 server session to be used because the session is not released until after the connection is checked in.
 
-      * Drivers MUST assert that the number of allocated sessions is strictly less than the number of concurrent operations in every retry of this test. In this instance it would less than (but NOT equal to) 8.
+      * Drivers MUST assert that the number of allocated sessions is strictly less than the number of concurrent operations in every retry of this test. In this instance it would be less than (but NOT equal to) 8.
 
 
 
@@ -1332,7 +1332,7 @@ But those scenarios are extenuating and outside the scope of solving in this spe
 Why should drivers NOT attempt to release a serverSession before checking back in the operation's connection?
 -------------------------------------------------------------------------------------------------------------
 
-There are a variety of cases, such as, retryable operations or cursor creating operations
+There are a variety of cases, such as retryable operations or cursor creating operations,
 where a ``serverSession`` must remain acquired by the ``ClientSession`` after an operation is attempted.
 Attempting to account for all these scenarios has risks that do not justify the potential guaranteed ``ServerSession`` allocation limiting.
 

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -1366,4 +1366,4 @@ Change log
 :2021-04-08: Adding in behaviour for load balancer mode.
 :2020-05-26: Simplify logic for determining sessions support
 :2022-01-28: Implicit sessions MUST obtain server session after connection checkout succeeds
-:2022-03-16: ServerSession Pooling is required and clarifies session acquisition bounding
+:2022-03-24: ServerSession Pooling is required and clarifies session acquisition bounding


### PR DESCRIPTION
http://jira.mongodb.org/browse/DRIVERS-2218

* Clarify the purpose and goal of session limiting
* Adjust test 13 to correctly assert the optimal solution
* ~Clean up code snippets and test bullets~ moved to #1158 