### PR TITLE
Fix CODEOWNERS rule for unowned specs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Unowned specs
-/ @mongodb/dbx-spec-reviewers-unowned
+* @mongodb/dbx-spec-reviewers-unowned
 
 # APM
 /source/command-monitoring/ @mongodb/dbx-spec-owners-apm


### PR DESCRIPTION
Fixes this error:
![Screen Shot 2022-03-23 at 12 22 49 PM](https://user-images.githubusercontent.com/5015933/159780043-28d8e9f8-be67-4b07-bd8f-00bc69f35a61.png)
