### PR TITLE
Warning-free build with Sphinx

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -794,12 +794,12 @@ Client Second
 
 .. code:: javascript
 
-   { 
+   {
        "a" : "AWS4-HMAC-SHA256 Credential=AKIAICGVLKOKZVY3X3DA/20191107/us-east-1/sts/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-mongodb-gs2-cb-flag;x-mongodb-server-nonce, Signature=ab62ce1c75f19c4c8b918b2ed63b46512765ed9b8bb5d79b374ae83eeac11f55",
        "d" : "20191107T002607Z"
        "t" : "<security_token>"
    }
-|
+
 Note that `X-AMZ-Security-Token` is required when using temporary credentials. When using regular credentials, it
 MUST be omitted. Each message above will be encoded as BSON V1.1 objects and sent to the peer as the value of
 ``payload``. Therefore, the SASL conversation would appear as:
@@ -813,7 +813,7 @@ Client First
        "mechanism" : "MONGODB-AWS" 
        "payload" : new BinData(0, "NAAAAAVyACAAAAAAWj0lSjp8M0BMKGU+QVAzRSpWfk0hJigqO1V+b0FaVz4QcABuAAAAAA==")
    }
-|
+
 Server First
 
 .. code:: javascript
@@ -824,7 +824,7 @@ Server First
        "payload" : new BinData(0, "ZgAAAAVzAEAAAAAAWj0lSjp8M0BMKGU+QVAzRSpWfk0hJigqO1V+b0FaVz5Rj7x9UOBHJLvPgvgPS9sSzZUWgAPTy8HBbI1cG1WJ9gJoABIAAABzdHMuYW1hem9uYXdzLmNvbQAA"),
        "ok" : 1.0
    }
-|
+
 Client Second:
 
 .. code:: javascript
@@ -834,10 +834,9 @@ Client Second:
        "conversationId" : 1,
        "payload" : new BinData(0, "LQEAAAJhAAkBAABBV1M0LUhNQUMtU0hBMjU2IENyZWRlbnRpYWw9QUtJQUlDR1ZMS09LWlZZM1gzREEvMjAxOTExMTIvdXMtZWFzdC0xL3N0cy9hd3M0X3JlcXVlc3QsIFNpZ25lZEhlYWRlcnM9Y29udGVudC1sZW5ndGg7Y29udGVudC10eXBlO2hvc3Q7eC1hbXotZGF0ZTt4LW1vbmdvZGItZ3MyLWNiLWZsYWc7eC1tb25nb2RiLXNlcnZlci1ub25jZSwgU2lnbmF0dXJlPThhMTI0NGZjODYyZTI5YjZiZjc0OTFmMmYwNDE5NDY2ZGNjOTFmZWU1MTJhYTViM2ZmZjQ1NDY3NDEwMjJiMmUAAmQAEQAAADIwMTkxMTEyVDIxMDEyMloAAA==")
    }
-|
 
 In response to the Server First message, drivers MUST send an ``authorization header``. Drivers MUST follow the
-`Signature Version 4 Signing Process <https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html>`_ to
+`Signature Version 4 Signing Process <https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html>`__ to
 calculate the signature for the ``authorization header``. The required and optional headers and their associated
 values drivers MUST use for the canonical request (see `Summary of Signing Steps
 <https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html>`_) are specified in the table
@@ -846,19 +845,17 @@ below. The following pseudocode shows the construction of the Authorization head
 .. code:: javascript
 
     Authorization: algorithm Credential=access key ID/credential scope, SignedHeaders=SignedHeaders, Signature=signature
-|
 
 The following example shows a finished Authorization header.
 
 .. code:: javascript
 
     Authorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7    
-|
 
 The following diagram is a summary of the steps drivers MUST follow to calculate the signature.
 
 .. image:: includes/calculating_a_signature.png
-|
+
 ======================== ======================================================================================================
 Name                     Value       
 ======================== ======================================================================================================
@@ -868,8 +865,8 @@ Content-Type*            application/x-www-form-urlencoded
 Content-Length*          43
 Host*                    Host field from Server First Message
 Region                   Derived from Host - see `Region Calculation`_ below
-X-Amz-Date*              See `Amazon Documentation <https://docs.aws.amazon.com/general/latest/gr/sigv4_elements.html>`_
-X-Amz-Security-Token*    Optional, see `Amazon Documentation <https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html?shortFooter=true>`_
+X-Amz-Date*              See `Amazon Documentation <https://docs.aws.amazon.com/general/latest/gr/sigv4_elements.html>`__
+X-Amz-Security-Token*    Optional, see `Amazon Documentation <https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html?shortFooter=true>`__
 X-MongoDB-Server-Nonce*  Base64 string of server nonce
 X-MongoDB-GS2-CB-Flag*   ASCII lower-case character ‘n’ or ‘y’ or ‘p’
 X-MongoDB-Optional-Data* Optional data, base64 encoded representation of the optional object provided by the client
@@ -952,14 +949,14 @@ An example URI for authentication with MONGODB-AWS using AWS IAM credentials pas
 .. code:: javascript
 
    "mongodb://<access_key>:<secret_key>@mongodb.example.com/?authMechanism=MONGODB-AWS"
-|
-Users MAY have obtained temporary credentials through an `AssumeRole <https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html>`_ 
-request. If so, then in addition to a username and password, users MAY also provide an ``AWS_SESSION_TOKEN`` as a ``mechanism_property``. 
+
+Users MAY have obtained temporary credentials through an `AssumeRole <https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html>`_
+request. If so, then in addition to a username and password, users MAY also provide an ``AWS_SESSION_TOKEN`` as a ``mechanism_property``.
 
 .. code:: javascript
 
    "mongodb://<access_key>:<secret_key>@mongodb.example.com/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:<security_token>"
-|
+
 Environment variables
 _____________________
 AWS Lambda runtimes set several `environment variables <https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime>`_ during initialization. To support AWS Lambda runtimes Drivers MUST check a subset of these variables, i.e., ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, and ``AWS_SESSION_TOKEN``, for the access key ID, secret access key and session token, respectively if AWS credentials are not explicitly provided in the URI. The ``AWS_SESSION_TOKEN`` may or may not be set. However, if ``AWS_SESSION_TOKEN`` is set Drivers MUST use its value as the session token.
@@ -990,22 +987,26 @@ If the environment variable ``AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`` is unset,
 .. code:: html
 
     http://169.254.169.254/latest/meta-data/iam/security-credentials/<role-name>
+
 with the required header,
 
 .. code:: html
 
     X-aws-ec2-metadata-token: <secret-token>
+
 to access the EC2 instance's metadata. Drivers MUST obtain the role name from querying the URI
 
 .. code:: html
 
     http://169.254.169.254/latest/meta-data/iam/security-credentials/
+
 The role name request also requires the header ``X-aws-ec2-metadata-token``. Drivers MUST use v2 of the EC2 Instance Metadata Service (`IMDSv2 <https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/>`_) to access the secret token. In other words, Drivers MUST
 
 * Start a session with a simple HTTP PUT request to IMDSv2.
 	* The URL is ``http://169.254.169.254/latest/api/token``.
 	* The required header is ``X-aws-ec2-metadata-token-ttl-seconds``. Its value is the number of seconds the secret token should remain valid with a max of six hours (`21600` seconds).
 * Capture the secret token IMDSv2 returned as a response to the PUT request. This token is the value for the header ``X-aws-ec2-metadata-token``.
+
 The curl recipe below demonstrates the above. It retrieves a secret token that's valid for 30 seconds. It then uses that token to access the EC2 instance's credentials:
 
 .. code:: shell-session
@@ -1013,11 +1014,13 @@ The curl recipe below demonstrates the above. It retrieves a secret token that's
     $ TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
     $ ROLE_NAME=`curl http://169.254.169.254/latest/meta-data/iam/security-credentials/ -H "X-aws-ec2-metadata-token: $TOKEN"`
     $ curl http://169.254.169.254/latest/meta-data/iam/security-credentials/$ROLE_NAME -H "X-aws-ec2-metadata-token: $TOKEN"
+
 Drivers can test this process using the mock EC2 server in `mongo-enterprise-modules <https://github.com/10gen/mongo-enterprise-modules/blob/master/jstests/external_auth/lib/ec2_metadata_http_server.py>`_. The script must be run with `python3`:
 
 .. code:: shell-session
 
 	python3 ec2_metadata_http_server.py
+
 To re-direct queries from the EC2 endpoint to the mock server, replace the link-local address (``http://169.254.169.254``) with the IP and port of the mock server (by default, ``http://localhost:8000``). For example, the curl script above becomes:
 
 .. code:: shell-session

--- a/source/auth/tests/mongodb-aws.rst
+++ b/source/auth/tests/mongodb-aws.rst
@@ -17,7 +17,7 @@ For brevity, this section gives the values ``<AccessKeyId>``, ``<SecretAccessKey
   AccessKeyId=AKIAI44QH8DHBEXAMPLE
   SecretAccessKey=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   Token=AQoDYXdzEJr...<remainder of security token>
-|
+
 .. sectnum::
 
 Regular credentials
@@ -28,7 +28,7 @@ Drivers MUST be able to authenticate by providing a valid access key id and secr
 .. code-block:: 
 
   mongodb://<AccessKeyId>:<SecretAccessKey>@localhost/?authMechanism=MONGODB-AWS
-|
+
 EC2 Credentials
 ===============
 
@@ -37,8 +37,8 @@ Drivers MUST be able to authenticate from an EC2 instance via temporary credenti
 .. code-block::
   
   mongodb://localhost/?authMechanism=MONGODB-AWS
-|
-.. note:: No username, password or session token is passed into the URI. Drivers MUST query the EC2 instance endpoint to obtain these credentials. 
+
+.. note:: No username, password or session token is passed into the URI. Drivers MUST query the EC2 instance endpoint to obtain these credentials.
 
 ECS instance
 ============
@@ -48,8 +48,8 @@ Drivers MUST be able to authenticate from an ECS container via temporary credent
 .. code-block::
 
   mongodb://localhost/?authMechanism=MONGODB-AWS
-|
-.. note:: No username, password or session token is passed into the URI. Drivers MUST query the ECS container endpoint to obtain these credentials. 
+
+.. note:: No username, password or session token is passed into the URI. Drivers MUST query the ECS container endpoint to obtain these credentials.
 
 AssumeRole
 ==========
@@ -59,7 +59,7 @@ Drivers MUST be able to authenticate using temporary credentials returned from a
 .. code-block::
 
   mongodb://<AccessKeyId>:<SecretAccessKey>@localhost/?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN:<Token>
-|
+
 AWS Lambda
 ==========
 
@@ -70,7 +70,6 @@ Drivers MUST be able to authenticate via an access key ID, secret access key and
   AWS_ACCESS_KEY_ID
   AWS_SECRET_ACCESS_KEY 
   AWS_SESSION_TOKEN
-|
 
 Sample URIs both with and without optional session tokens set are shown below. Drivers MUST test both cases.
 
@@ -81,7 +80,7 @@ Sample URIs both with and without optional session tokens set are shown below. D
   export AWS_SECRET_ACCESS_KEY="<SecretAccessKey>"
 
   URI="mongodb://localhost/?authMechanism=MONGODB-AWS"
-|
+
 .. code-block:: bash
 
   # with a session token
@@ -90,5 +89,5 @@ Sample URIs both with and without optional session tokens set are shown below. D
   export AWS_SESSION_TOKEN="<Token>"
 
   URI="mongodb://localhost/?authMechanism=MONGODB-AWS"
-|
+
 .. note:: No username, password or session token is passed into the URI. Drivers MUST check the environment variables listed above for these values. If the session token is set Drivers MUST use it.

--- a/source/benchmarking/benchmarking.rst
+++ b/source/benchmarking/benchmarking.rst
@@ -579,7 +579,7 @@ Phases:
 |                                      | (or JSON string for C).              |
 +--------------------------------------+--------------------------------------+
 | Before task                          | Drop the 'corpus' collection.        |
-|                                      |  Create an empty 'corpus' collection |
+|                                      | Create an empty 'corpus' collection  |
 |                                      | with the 'create' command.           |
 |                                      | Construct a Collection object for    |
 |                                      | the 'corpus' collection to use for   |
@@ -620,7 +620,7 @@ Phases:
 |                                      | (or JSON string for C).              |
 +--------------------------------------+--------------------------------------+
 | Before task                          | Drop the 'corpus' collection.        |
-|                                      |  Create an empty 'corpus' collection |
+|                                      | Create an empty 'corpus' collection  |
 |                                      | with the 'create' command.           |
 |                                      | Construct a Collection object for    |
 |                                      | the 'corpus' collection to use for   |
@@ -792,13 +792,13 @@ Phases:
 
 +--------------------------------------+--------------------------------------+
 | Setup                                | Construct a MongoClient object.      |
-|                                      |  Drop the 'perftest' database.  Load |
+|                                      | rop the 'perftest' database.  Load   |
 |                                      | the GRIDFS\_LARGE  file as a string  |
 |                                      | or other language-appropriate type   |
 |                                      | for binary octet data.               |
 +--------------------------------------+--------------------------------------+
 | Before task                          | Drop the default GridFS bucket.      |
-|                                      |  Insert a 1-byte file into the       |
+|                                      | Insert a 1-byte file into the        |
 |                                      | bucket. (This ensures the bucket     |
 |                                      | collections and indices have been    |
 |                                      | created.)                            |
@@ -838,8 +838,8 @@ Phases:
 
 +--------------------------------------+--------------------------------------+
 | Setup                                | Construct a MongoClient object.      |
-|                                      |  Drop the 'perftest' database.       |
-|                                      |  Upload the GRIDFS\_LARGE  file to   |
+|                                      | Drop the 'perftest' database.        |
+|                                      | Upload the GRIDFS\_LARGE  file to    |
 |                                      | the default gridFS bucket with the   |
 |                                      | name "gridfstest".  Record the       |
 |                                      | \_id of the uploaded file.           |
@@ -907,7 +907,7 @@ Phases:
 |                                      |                                      |
 +--------------------------------------+--------------------------------------+
 | Before task                          | Drop the 'corpus' collection.        |
-|                                      |  Create an empty 'corpus' collection |
+|                                      | Create an empty 'corpus' collection  |
 |                                      | with the 'create' command.           |
 +--------------------------------------+--------------------------------------+
 | Do task                              | Do an unordered insert of all        |
@@ -939,12 +939,11 @@ Phases:
 
 +--------------------------------------+--------------------------------------+
 | Setup                                | Construct a MongoClient object.      |
-|                                      |  Drop the 'perftest' database. Drop  |
+|                                      | Drop the 'perftest' database. Drop   |
 |                                      | the 'corpus' collection.  Do an      |
 |                                      | unordered insert of all 500,000      |
 |                                      | documents in the dataset into the    |
 |                                      | 'corpus' collection.                 |
-|                                      |                                      |
 +--------------------------------------+--------------------------------------+
 | Before task                          | Construct whatever objects, threads, |
 |                                      | etc. are required for exporting the  |
@@ -1023,8 +1022,8 @@ Phases:
 
 +--------------------------------------+--------------------------------------+
 | Setup                                | Construct a MongoClient object.      |
-|                                      |  Drop the 'perftest' database.       |
-|                                      |  Construct a temporary directory for |
+|                                      | Drop the 'perftest' database.        |
+|                                      | Construct a temporary directory for  |
 |                                      | holding downloads. Drop the default  |
 |                                      | GridFS bucket in the 'perftest'      |
 |                                      | database.  Upload the 50 file        |

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -802,7 +802,7 @@ For example:
 
 - A client creates a ``ChangeStream``, and calls ``watch``
 - The ``ChangeStream`` sends out the initial ``aggregate`` call, and receives a response
-with no initial values. Because there are no initial values, there is no latest resumeToken.
+  with no initial values. Because there are no initial values, there is no latest resumeToken.
 - The client's network is partitioned from the server, causing the client's ``getMore`` to time out
 - Changes occur on the server.
 - The network is unpartitioned

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -103,9 +103,9 @@ Spec Test Runner
 Before running the tests
 
 - Create a MongoClient ``globalClient``, and connect to the server.
-When executing tests against a sharded cluster, ``globalClient`` must only connect to one mongos. This is because tests
-that set failpoints will only work consistently if both the ``configureFailPoint`` and failing commands are sent to the
-same mongos.
+  When executing tests against a sharded cluster, ``globalClient`` must only connect to one mongos. This is because tests
+  that set failpoints will only work consistently if both the ``configureFailPoint`` and failing commands are sent to the
+  same mongos.
 
 For each YAML file, for each element in ``tests``:
 

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -305,7 +305,7 @@ See `What's the deal with metadataClient, keyVaultClient, and the internal clien
 
 keyVaultClient, metadataClient, and the internal MongoClient
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The following pseudo-code describes the configuration behavior for the three ``MongoClient``s:
+The following pseudo-code describes the configuration behavior for the three ``MongoClient`` objects:
 
 .. code::
 
@@ -816,7 +816,7 @@ MongoClient fails to connect after spawning, the server selection error
 is propagated to the user.
 
 Single-threaded drivers MUST connect with `serverSelectionTryOnce=false <../server-selection/server-selection.rst#serverselectiontryonce>`_
-, connectTimeoutMS=10000, and MUST bypass `cooldownMS <../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`_ when connecting to mongocryptd. See `Why are serverSelectionTryOnce and cooldownMS disabled for single-threaded drivers connecting to mongocryptd?`_.
+, connectTimeoutMS=10000, and MUST bypass `cooldownMS <../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`__ when connecting to mongocryptd. See `Why are serverSelectionTryOnce and cooldownMS disabled for single-threaded drivers connecting to mongocryptd?`_.
 
 If the ClientEncryption is configured with mongocryptdBypassSpawn=true,
 then the driver is not responsible for spawning mongocryptd. If server
@@ -1330,7 +1330,7 @@ Why cache keys?
 We can't re-fetch the key on each operation, the performance goal for
 this project requires us to cache. We do need a revocation mechanism,
 based upon periodic checking from the client. Initially this window will
-not be configurable. See future work: `Make the key caching window configurable`__.
+not be configurable.
 
 Why require including a C library?
 ----------------------------------
@@ -1468,7 +1468,7 @@ Meaning if the first attempt to mongocryptd fails to connect, then the user
 would observe a 5 second delay. This is not configurable in the URI, so this
 must be overriden internally. Since mongocryptd is a local process, there should
 only be a very short delay after spawning mongocryptd for it to start listening
-on sockets. See the SDAM spec description of `cooldownMS <../source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`_.
+on sockets. See the SDAM spec description of `cooldownMS <../source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#cooldownms>`__.
 
 Because single threaded drivers may exceed ``serverSelectionTimeoutMS`` by the
 duration of the topology scan, ``connectTimeoutMS`` is also reduced.

--- a/source/client-side-encryption/subtype6.rst
+++ b/source/client-side-encryption/subtype6.rst
@@ -31,7 +31,7 @@ META
 ====
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”,
 “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this
-document are to be interpreted as described in \`RFC 2119
+document are to be interpreted as described in `RFC 2119
 <https://www.ietf.org/rfc/rfc2119.txt>`_.
 
 Specification

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -549,7 +549,7 @@ The corpus test exhaustively enumerates all ways to encrypt all BSON value types
 
 2. Using ``client``, drop and create the collection ``db.coll`` configured with the included JSON schema `corpus/corpus-schema.json <../corpus/corpus-schema.json>`_.
 
-3. Using ``client``, drop the collection ``keyvault.datakeys``. Insert the documents `corpus/corpus-key-local.json <../corpus/corpus-key-local.json>`_, `corpus/corpus-key-aws.json <../corpus/corpus-key-aws.json>`_, `corpus/corpus-key-azure.json <../corpus/corpus-key-azure.json>`_, `corpus/corpus-key-gcp.json <../corpus/corpus-key-gcp.json>`_, and `corpus/corpus-key-gcp.json <../corpus/corpus-key-kmip.json>`_.
+3. Using ``client``, drop the collection ``keyvault.datakeys``. Insert the documents `corpus/corpus-key-local.json <../corpus/corpus-key-local.json>`_, `corpus/corpus-key-aws.json <../corpus/corpus-key-aws.json>`_, `corpus/corpus-key-azure.json <../corpus/corpus-key-azure.json>`_, `corpus/corpus-key-gcp.json <../corpus/corpus-key-gcp.json>`_, and `corpus/corpus-key-kmip.json <../corpus/corpus-key-kmip.json>`_.
 
 4. Create the following:
 

--- a/source/client-side-operations-timeout/client-side-operations-timeout.rst
+++ b/source/client-side-operations-timeout/client-side-operations-timeout.rst
@@ -31,7 +31,7 @@ META
 
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”,
 “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this
-document are to be interpreted as described in \`RFC 2119
+document are to be interpreted as described in `RFC 2119
 <https://www.ietf.org/rfc/rfc2119.txt>`_.
 
 Specification

--- a/source/collation/collation.rst
+++ b/source/collation/collation.rst
@@ -210,8 +210,8 @@ For example,
 .. code:: typescript
 
 	db.command({
-		create: “myCollection”,
-		collation: {locale: “en_US”}
+		create: "myCollection",
+		collation: {locale: "en_US"}
 	});
 
 -------------
@@ -226,7 +226,7 @@ user will provide BulkWrite operation models as in the following example:
 .. code:: typescript
 
   db.collection.bulkWrite([
-    {insertOne: { … }},
+    {insertOne: { ... }},
 
     {updateOne: { filter: { name: "PING" },
                           update: { $set: { name: "pong" }},

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,0 +1,41 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+
+project = 'MongoDB Specifications'
+copyright = '2022, MongoDB'
+author = 'MongoDB'
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = []
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = []
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['Thumbs.db', '.DS_Store']
+
+# Warn about all missing references
+nitpicky = True
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = []

--- a/source/connection-string/connection-string-spec.rst
+++ b/source/connection-string/connection-string-spec.rst
@@ -43,7 +43,7 @@ General Syntax
 In general we follow URI style conventions, however unlike a URI the
 connection string supports multiple hosts.
 
-.. code:: prettyprint
+.. code:: text
 
   mongodb://username:password@example.com:27017,example2.com:27017,...,example.comN:27017/database?key=value&keyN=valueN
   \_____/   \_______________/ \_________/ \__/  \_______________________________________/ \______/ \_/ \___/
@@ -102,7 +102,7 @@ A host identifier consists of a host and an optional port.
 
 Host
 ~~~~
-Identifies a server address to connect to. It can identify either a hostname, IP address, IP Literal, or UNIX domain socket. For definitions of hostname, IP address and IP Literal formats see `RFC 3986 <http://tools.ietf.org/html/rfc3986#section-3.2.2>`_ .
+Identifies a server address to connect to. It can identify either a hostname, IP address, IP Literal, or UNIX domain socket. For definitions of hostname, IP address and IP Literal formats see `RFC 3986 Section 3.2.2 <http://tools.ietf.org/html/rfc3986#section-3.2.2>`_ .
 
 UNIX domain sockets MUST end in ".sock" and MUST be URL encoded, for example::
 
@@ -120,7 +120,7 @@ This specification does not define how host types should be differentiated (e.g.
 
 Port (optional)
 ~~~~~~~~~~~~~~~
-The port is an integer between 1 and 65535 (inclusive) that identifies the port to connect to. See `RFC 3986 <http://tools.ietf.org/html/rfc3986#section-3.2.3>`_ .
+The port is an integer between 1 and 65535 (inclusive) that identifies the port to connect to. See `RFC 3986 3.2.3 <http://tools.ietf.org/html/rfc3986#section-3.2.3>`_ .
 
 .. _database contains no prohibited characters:
 

--- a/source/driver-bulk-update.rst
+++ b/source/driver-bulk-update.rst
@@ -1,3 +1,4 @@
+=============
 Bulk API Spec
 =============
 
@@ -9,37 +10,37 @@ Bulk API Spec
 .. contents::
 
 Changes from previous versions
-------------------------------
+==============================
 
 Deprecated in favor of the *Driver CRUD API*.
 
 v0.8
-~~~~
+----
 * Removed "Test Case 3: Key validation, no $-prefixed keys allowed" for insert.
 
 v0.7
-~~~~
+----
 * Clarify that "writeConcernErrors" field is plural
 
 v0.6
-~~~~
+----
 * First public version of the specification.
 * Merged in Test Cases from QA tickets
 * Specification cleanup and increased precision
 
 v0.5
-~~~~
+----
 * Specification cleanup and increased precision
 * Suggested Error handling for languages using commonly raising exceptions
 * Narrowed writeConcern reporting requirement
 
 v0.4
-~~~~
+----
 * Renamed nUpdated to nMatched as to reflect that it's the number of matched documents not the number of modified documents.
 
 
 Bulk Operation Builder
-----------------------
+======================
 
 Starting a bulk operation can be done in two ways.
 
@@ -49,7 +50,7 @@ Starting a bulk operation can be done in two ways.
     initializeOrderedBulkOp()       -> Bulk   - Initialize an ordered bulk
 
 Operations Possible On Bulk Instance
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------------------
 Available operations follow the fluent API for insert, update and
 remove.
 
@@ -122,7 +123,7 @@ remove.
     bulk.execute(writeConcern);
 
 Current shell implementation
-----------------------------
+============================
 The shell implementation serves as a guide only. One main difference between the shell implementation and a proper driver implementation 
 is that unordered bulk operations are not optimized by re-ordering the writes; only the execution semantics are kept correct. 
 You can find it here:
@@ -804,6 +805,8 @@ The driver algorithm for merging results, when using write commands, in pseudoco
         "upserted": [],
     }
 
+::
+
     for each server response in all bulk operations' responses:
         if the operation is an update:
             if the response has a non-NULL nModified:
@@ -1237,7 +1240,7 @@ Test Case 2:
         
         .. code:: javascript
 
-            var bigstring = “string of length 16 MiB - 30 bytes”
+            var bigstring = "string of length 16 MiB - 30 bytes"
             batch = initializeUnorderedBulkOp()
             batch.find({key: 1}).upsert().update({$set: {x: bigstring}})
             batch.execute() succeeds.

--- a/source/find_getmore_killcursors_commands.rst
+++ b/source/find_getmore_killcursors_commands.rst
@@ -334,19 +334,19 @@ The command response will be as follows:
       "cursorsKilled": [
         <cursor id 1>
         <cursor id 2>,
-        …
+        ...
         <cursor id n>
       ],
       "cursorsNotFound": [
         <cursor id 1>
         <cursor id 2>,
-        …
+        ...
         <cursor id n>
       ],
       "cursorsAlive": [
         <cursor id 1>
         <cursor id 2>,
-        …
+        ...
         <cursor id n>
       ],
       ok: 1

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,0 +1,17 @@
+MongoDB Specifications
+======================
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Specifications:
+   :glob:
+
+   **/*
+   *
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/source/max-staleness/max-staleness-tests.rst
+++ b/source/max-staleness/max-staleness-tests.rst
@@ -76,7 +76,7 @@ Insert a document and wait one second.
 
 Get the client's ServerDescription for the server.
 It must have a non-zero lastWriteDate.
-Wait another second. [1]
+Wait another second. [1]_
 
 Insert a document and wait one second.
 

--- a/source/ocsp-support/ocsp-support.rst
+++ b/source/ocsp-support/ocsp-support.rst
@@ -153,7 +153,7 @@ as specified in `RFC 6960: 4.1.1
 <https://tools.ietf.org/html/rfc6960#section-4.1.1>`__.
 For convenience, the relevant section has been duplicated below:
 
-.. code:: ASN.1
+.. code::
 
    CertID          ::=     SEQUENCE {
        hashAlgorithm       AlgorithmIdentifier,

--- a/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
+++ b/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
@@ -79,7 +79,7 @@ rescan is similar, but not identical to the behaviour of initial seedlist
 discovery.  Periodic scan MUST follow these rules:
 
 - The driver will query the DNS server for SRV records on
-``{hostname}.{domainname}``, prefixed with the SRV service name and protocol.
+  ``{hostname}.{domainname}``, prefixed with the SRV service name and protocol.
   The SRV service name is provided in the srvServiceName_ URI option and
   defaults to ``mongodb``. The protocol is always ``tcp``. After prefixing, the
   URI should look like: ``_{srvServiceName}._tcp.{hostname}.{domainname}``.

--- a/source/read-write-concern/read-write-concern.rst
+++ b/source/read-write-concern/read-write-concern.rst
@@ -56,7 +56,7 @@ Read Concern
 ------------
 
 For naming and deviation guidance, see the `CRUD specification
-<https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#naming>`_.
+<https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#naming>`__.
 Defined below are the constructs for drivers.
 
 .. code:: typescript
@@ -95,7 +95,7 @@ Defined below are the constructs for drivers.
     level: Optional<ReadConcernLevel | String>
   }
 
-The read concern option is available for the following operations: 
+The read concern option is available for the following operations:
 
 - ``aggregate`` command
 - ``count`` command
@@ -153,7 +153,7 @@ Read Commands
 
 Read commands that support ``ReadConcern`` take a named parameter spelled
 (case-sensitively) ``readConcern``. See command documentation for further
-examples. 
+examples.
 
 If the ``Client``, ``Database``, or ``Collection`` being operated on either
 has no ``ReadConcern`` set, or has the server default ``ReadConcern``
@@ -201,7 +201,7 @@ Via Code
 ``Collection`` levels. Unless specified, the value MUST be inherited from its
 parent and SHOULD NOT be modifiable on an existing ``Client``, ``Database``
 or ``Collection``. In addition, a driver MAY allow it to be specified on a
-per-operation basis in accordance with the CRUD specification. 
+per-operation basis in accordance with the CRUD specification.
 
 For example:
 
@@ -233,7 +233,7 @@ Options
 
 For example:
 
-.. code:: 
+.. code::
 
     mongodb://server:27017/db?readConcernLevel=majority
 
@@ -260,7 +260,7 @@ When a driver sends a write concern document to the server, the structure
 of the write concern document MUST be as follows:
 
 .. code:: typescript
-  
+
   class WriteConcern {
     /**
      * If true, wait for the the write operation to get committed to the
@@ -273,7 +273,7 @@ of the write concern document MUST be as follows:
     /**
      * When an integer, specifies the number of nodes that should acknowledge
      * the write and MUST be greater than or equal to 0.
-     * When a string, indicates tags. "majority" is defined, but users 
+     * When a string, indicates tags. "majority" is defined, but users
      * could specify other custom error modes.
      * When not specified, a driver MUST NOT send "w".
      */
@@ -294,10 +294,10 @@ of the write concern document MUST be as follows:
 When a driver provides a way for the application to specify the write concern,
 the following data structure SHOULD be used. For acceptable naming and
 deviation guidance, see the `CRUD specification
-<https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#naming>`_.
+<https://github.com/mongodb/specifications/blob/master/source/crud/crud.rst#naming>`__.
 
 .. code:: typescript
-  
+
   class WriteConcern {
     /**
      * Corresponds to the "j" field in the WriteConcern document sent to
@@ -349,7 +349,7 @@ this, :javascript:`writeConcern: { }` is not the same as
 :javascript:`writeConcern: {w: 1}`. Sending :javascript:`{w:1}` overrides
 that default. As another example, :javascript:`writeConcern: { }` is not the
 same as :javascript:`writeConcern: {journal: false}`.
-    
+
 
 Inconsistent WriteConcern
 -------------------------
@@ -366,7 +366,7 @@ Unacknowledged WriteConcern
 ---------------------------
 
 An ``Unacknowledged WriteConcern`` is when (``w`` equals 0) AND (``journal``
-is not set or is ``false``). 
+is not set or is ``false``).
 
 These criteria indicates that the user does not care about errors from the server.
 
@@ -376,7 +376,7 @@ Examples:
 
    writeConcern = { w: 0 }; // Unacknowledged
    writeConcern = { w: 0, journal: false }; // Unacknowledged
-   writeConcern = { w: 0, wtimeoutMS: 100 }; // Unacknowledged 
+   writeConcern = { w: 0, wtimeoutMS: 100 }; // Unacknowledged
 
 
 On the Wire
@@ -385,7 +385,7 @@ On the Wire
 OP_INSERT, OP_DELETE, OP_UPDATE
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``WriteConcern`` is implemented by sending the ``getLastError``(GLE) command
+``WriteConcern`` is implemented by sending the ``getLastError`` (GLE) command
 directly after the operation. Drivers SHOULD piggy-back the GLE onto the same
 buffer as the operation. Regardless, GLE MUST be sent on the same connection
 as the initial write operation.
@@ -531,7 +531,7 @@ Drivers SHOULD report writeConcernErrors however they report other server
 errors: by raising an exception, returning "false", or another idiom that is
 consistent with other server errors. Drivers SHOULD report writeConcernErrors
 with a ``WriteConcernError`` defined in the
-`CRUD specification </source/crud/crud.rst#error-handling>`_.
+`CRUD specification </source/crud/crud.rst#error-handling>`__.
 
 Drivers SHOULD NOT parse server replies for "writeConcernError" in generic
 command methods.
@@ -620,7 +620,7 @@ Options
 
 For example:
 
-.. code:: 
+.. code::
 
     mongodb://server:27017/db?w=3
 
@@ -715,9 +715,9 @@ Version History
   - 2017-03-13: reIndex silently ignores writeConcern in MongoDB 3.4 and returns
     an error if writeConcern is included with MongoDB 3.5+. See
     `SERVER-27891 <https://jira.mongodb.org/browse/SERVER-27891>`_.
-  - 2017-11-17 : Added list of commands that support readConcern 
+  - 2017-11-17 : Added list of commands that support readConcern
   - 2017-12-18 : Added "available" to Readconcern level.
-  - 2017-05-29 : Added user management commands to list of commands that write 
+  - 2017-05-29 : Added user management commands to list of commands that write
   - 2019-01-29 : Added section listing all known examples of writeConcernError.
   - 2019-06-07: Clarify language for aggregate and mapReduce commands that write.
   - 2019-10-31: Explicitly define write concern option mappings.

--- a/source/retryable-reads/retryable-reads.rst
+++ b/source/retryable-reads/retryable-reads.rst
@@ -481,7 +481,7 @@ Documentation
 
 3. Driver release notes MUST make it clear to users that they may need to adjust
    custom retry logic to prevent an application from inadvertently retrying for
-   too long (see `Backwards Compatibility<#backwards-compatibility>`__ for
+   too long (see `Backwards Compatibility <#backwards-compatibility>`__ for
    details).
 
 4. Drivers implementing retryability for their generic command runner for read

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -39,7 +39,7 @@ document are to be interpreted as described in
 Conflicting TLS options
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Per the `Connection String spec <https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.rst#repeated-keys>`_,
+Per the `Connection String spec <https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.rst#repeated-keys>`__,
 the behavior of duplicates of most URI options is undefined. However, due
 to the security implications of certain options, drivers MUST raise an
 error to the user during parsing if any of the following circumstances
@@ -98,7 +98,7 @@ SOCKS5 options
 ~~~~~~~~~~~~~~
 
 For URI option validation pertaining to ``proxyHost``, ``proxyPort``,
-``proxyUsername`` and ``proxyPassword```please see the
+``proxyUsername`` and ``proxyPassword`` please see the
 `SOCKS5 support spec`_ for details.
 
 
@@ -176,13 +176,13 @@ pertaining to URI options apply here.
 
    * - directConnection
      - "true" or "false"
-     - defined in `SDAM spec <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#initial-topology-type>`_
+     - defined in `SDAM spec <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#initial-topology-type>`__
      - no
      - Whether to connect to the deployment in Single topology.
 
    * - heartbeatFrequencyMS
      - integer greater than or equal to 500
-     - defined in `SDAM spec <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#heartbeatfrequencyms>`_
+     - defined in `SDAM spec <https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#heartbeatfrequencyms>`__
      - no
      - the interval between regular server monitoring checks
 
@@ -194,14 +194,14 @@ pertaining to URI options apply here.
 
    * - loadBalanced
      - "true" or "false"
-     - defined in `Load Balancer spec <../load-balancers/load-balancers.rst#loadbalanced>`_
+     - defined in `Load Balancer spec <../load-balancers/load-balancers.rst#loadbalanced>`__
      - no
      - Whether the driver is connecting to a load balancer.
 
    * - localThresholdMS
      - non-negative integer; 0 means 0 ms (i.e. the fastest eligible server
        must be selected)
-     - defined in the `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#localthresholdms>`_
+     - defined in the `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#localthresholdms>`__
      - no
      - The amount of time beyond the fastest round trip time that a given
        server’s round trip time can take and still be eligible for server selection
@@ -267,8 +267,8 @@ pertaining to URI options apply here.
      - Default read concern for the client
 
    * - readPreference
-     - any string; currently supported values are defined in the `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#mode>`_, but must be lowercase camelCase, e.g. "primaryPreferred"
-     - defined in `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#mode>`_
+     - any string; currently supported values are defined in the `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#mode>`__, but must be lowercase camelCase, e.g. "primaryPreferred"
+     - defined in `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#mode>`__
      - no
      - Default read preference for the client (excluding tags)
 
@@ -303,13 +303,13 @@ pertaining to URI options apply here.
 
    * - serverSelectionTimeoutMS
      - positive integer; a driver may also accept 0 to be used for a special case, provided that it documents the meaning
-     - defined in `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#serverselectiontimeoutms>`_
+     - defined in `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#serverselectiontimeoutms>`__
      - no
      - A timeout in milliseconds to block for server selection before raising an error
 
    * - serverSelectionTryOnce
      - "true" or "false"
-     - defined in `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#serverselectiontryonce>`_
+     - defined in `server selection spec <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#serverselectiontryonce>`__
      - required for single-threaded drivers
      - Scan the topology only once after a server selection failure instead of repeatedly until the server selection times out
 
@@ -323,7 +323,7 @@ pertaining to URI options apply here.
 
    * - srvMaxHosts
      - non-negative integer; 0 means no maximum
-     - defined in the `Initial DNS Seedlist Discovery spec <../initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst#srvmaxhosts>`_
+     - defined in the `Initial DNS Seedlist Discovery spec <../initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst#srvmaxhosts>`__
      - no
      - The maximum number of SRV results to randomly select when initially
        populating the seedlist or, during SRV polling, adding new hosts to the
@@ -333,7 +333,7 @@ pertaining to URI options apply here.
      - a valid SRV service name according to `RFC 6335 <https://datatracker.ietf.org/doc/html/rfc6335#section-5.1>`_
      - "mongodb"
      - no
-     - the service name to use for SRV lookup in `initial DNS seedlist discovery <../initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst#srvservicename>`_
+     - the service name to use for SRV lookup in `initial DNS seedlist discovery <../initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst#srvservicename>`__
        and `SRV polling <../polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst>`_
 
    * - ssl


### PR DESCRIPTION
These changes allow all specification documents to render with Sphinx (Version 4) without generating errors or warnings. There are(should-be) no changes to the actual meaning of any documents. This is only the minimal changes to get Sphinx to generate the pages.

The current tool, `rstcheck`, is set to only report hard-errors, and only looks for semantic issues that Sphinx does not already report as errors/warnings.