### PR TITLE
DRIVERS-2266 remove string assertion from CSFLE Custom Endpoint test case 5

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -756,17 +756,7 @@ Test cases
 
    Expect this to fail with a socket connection error.
 
-5. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
-
-   .. code:: javascript
-
-      {
-        region: "us-east-1",
-        key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
-        endpoint: "kms.us-east-2.amazonaws.com"
-      }
-
-   Expect this to fail with an exception with a message containing the string: "us-east-1"
+5. This test case has been removed.
 
 6. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -766,7 +766,7 @@ Test cases
         endpoint: "kms.us-east-2.amazonaws.com"
       }
 
-   Expect this to fail with an exception with a message containing the string: "us-east-1"
+   Expect this to fail with an exception.
 
 6. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -756,7 +756,17 @@ Test cases
 
    Expect this to fail with a socket connection error.
 
-5. This test case has been removed.
+5. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
+
+   .. code:: javascript
+
+      {
+        region: "us-east-1",
+        key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
+        endpoint: "kms.us-east-2.amazonaws.com"
+      }
+
+   Expect this to fail with an exception with a message containing the string: "us-east-1"
 
 6. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
 


### PR DESCRIPTION
# Summary
Remove string assertion from CSFLE "Custom Endpoint" test case 5.

# Background and Motivation
The current HTTP reply from AWS does not include the invalid region in the error message.

AFAICT, it looks like the error message has changed from AWS. I do not have the full response prior to the change.
But to see the current error response with the AWS CLI, run the following:

```bash
# KEK_ID is from the Client-Side Encryption test README.
KEK_ID="arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
# DEK is a random 96 byte blob
DEK="CpLBnghcm8fhhj5fSDOQIOZFLBVSOsTEuYsnrhDc7IoSANLmCWcL+Q7+Ei+QfKLVhItmJSvL3WNHqMTBG/g7FdqqDXUnxxGxk/JC+xD2VNawpBj1erCXcZ2X0G+1dgPy"
# Use the AWS CLI to encrypt. Use `--debug` to print out the raw HTTP request and response.
aws --profile csfle --debug kms --endpoint-url "https://kms.us-east-2.amazonaws.com:443" --region us-east-1 encrypt --key-id="$KEK_ID" --plaintext="$DEK"
```

Prints `{"__type":"InvalidSignatureException","message":"Credential should be scoped to a valid region. "}`

Drivers [parse the endpoint](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#masterkey) to get the port number
> The value of endpoint or keyVaultEndpoint is a host name with optional port number separated by a colon. E.g. "kms.us-east-1.amazonaws.com" or "kms.us-east-1.amazonaws.com:443". It is assumed that the host name is not an IP address or IP literal. Though drivers MUST NOT inspect the value of "endpoint" that a user sets when creating a data key, a driver will inspect it when connecting to KMS to determine a port number if present.
