### PR TITLE
DRIVERS-2234 Run a ping after initializing a MongoClient in DNS seedlist tests.

### DIFF
--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -114,8 +114,7 @@ These YAML and JSON files contain the following fields:
 - ``error``: indicates that the parsing of the URI, or the resolving or
   contents of the SRV or TXT records included errors.
 - ``comment``: a comment to indicate why a test would fail.
-- ``ping``: if true, the test runner should run a "ping" operation after
-  initializing a MongoClient.
+- ``ping``: if false, the test runner should not run a "ping" operation.
 
 .. _`Connection String`: ../../connection-string/connection-string-spec.rst
 .. _`URI options`: ../../uri-options/uri-options.rst
@@ -124,7 +123,7 @@ For each YAML file:
 
 - Create a MongoClient initialized with the ``mongodb+srv``
   connection string.
-- Run run a "ping" operation if ``ping`` in the test file is true.
+- Run a "ping" operation unless ``ping`` is false or ``error`` is true.
 
 Assertions:
 
@@ -155,10 +154,10 @@ Assertions:
 
 - If ``ping`` is not specified or ``true``, drivers MUST verify that running a
   "ping" operation using the initialized MongoClient succeeds. If ``ping`` is
-   is ``false``, drivers MUST NOT run a "ping" operation.
-  **Note:** These tests are expected to be run against MongoDB databases with
-  and without authentication enabled. The "ping" operation does not require
-  authentication so should succeed with URIs that contain no userinfo (i.e.
-  no username and password). Tests with URIs that contain userinfo always set
-  ``ping`` to ``false`` because some drivers will fail handshake on a connection
-  if userinfo is provided but incorrect.
+  ``false``, drivers MUST NOT run a "ping" operation.
+    **Note:** These tests are expected to be run against MongoDB databases with
+    and without authentication enabled. The "ping" operation does not require
+    authentication so should succeed with URIs that contain no userinfo (i.e.
+    no username and password). Tests with URIs that contain userinfo always set
+    ``ping`` to ``false`` because some drivers will fail handshake on a
+    connection if userinfo is provided but incorrect.

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -118,27 +118,35 @@ These YAML and JSON files contain the following fields:
 .. _`Connection String`: ../../connection-string/connection-string-spec.rst
 .. _`URI options`: ../../uri-options/uri-options.rst
 
-For each file, create a MongoClient initialized with the ``mongodb+srv``
-connection string.
+For each YAML file:
 
-If ``seeds`` is specified, drivers SHOULD verify that the set of hosts in the
-client's initial seedlist matches the list in ``seeds``. If ``numSeeds`` is
-specified, drivers SHOULD verify that the size of that set matches ``numSeeds``.
+- Create a MongoClient initialized with the ``mongodb+srv``
+  connection string.
+- Run run a ping operation.
 
-If ``hosts`` is specified, drivers MUST verify that the set of
-ServerDescriptions in the client's TopologyDescription eventually matches the
-list in ``hosts``. If ``numHosts`` is specified, drivers MUST verify that the
-size of that set matches ``numHosts``.
+Assertions:
 
-If ``options`` is specified, drivers MUST verify each of the values under
-``options`` match the MongoClient's parsed value for that option. There may be
-other options parsed by the MongoClient as well, which a test does not verify.
+- If ``seeds`` is specified, drivers SHOULD verify that the set of hosts in the
+  client's initial seedlist matches the list in ``seeds``. If ``numSeeds`` is
+  specified, drivers SHOULD verify that the size of that set matches
+  ``numSeeds``.
 
-If ``parsed_options`` is specified, drivers MUST verify that each of the values
-under ``parsed_options`` match the MongoClient's parsed value for that option.
-Supported values include, but are not limited to, ``user`` and ``password``
-(parsed from ``UserInfo``) and ``auth_database`` (parsed from
-``Auth database``).
+- If ``hosts`` is specified, drivers MUST verify that the set of
+  ServerDescriptions in the client's TopologyDescription eventually matches the
+  list in ``hosts``. If ``numHosts`` is specified, drivers MUST verify that the
+  size of that set matches ``numHosts``.
 
-If ``error`` is specified and ``true``, drivers MUST verify that an error has
-been thrown.
+- If ``options`` is specified, drivers MUST verify each of the values under
+  ``options`` match the MongoClient's parsed value for that option. There may be
+  other options parsed by the MongoClient as well, which a test does not verify.
+
+- If ``parsed_options`` is specified, drivers MUST verify that each of the
+  values under ``parsed_options`` match the MongoClient's parsed value for that
+  option. Supported values include, but are not limited to, ``user`` and
+  ``password`` (parsed from ``UserInfo``) and ``auth_database`` (parsed from
+  ``Auth database``).
+
+- If ``error`` is specified and ``true``, drivers MUST verify that initializing
+  the MongoClient throws an error. If ``error`` is not specified or is
+  ``false``, both initializing the MongoClient and running a ping operation must
+  succeed without throwing any errors.

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -114,6 +114,8 @@ These YAML and JSON files contain the following fields:
 - ``error``: indicates that the parsing of the URI, or the resolving or
   contents of the SRV or TXT records included errors.
 - ``comment``: a comment to indicate why a test would fail.
+- ``ping``: if true, the test runner should run a "ping" operation after
+  initializing a MongoClient.
 
 .. _`Connection String`: ../../connection-string/connection-string-spec.rst
 .. _`URI options`: ../../uri-options/uri-options.rst
@@ -122,7 +124,7 @@ For each YAML file:
 
 - Create a MongoClient initialized with the ``mongodb+srv``
   connection string.
-- Run run a ping operation.
+- Run run a ping operation if ``ping`` in the test file is true.
 
 Assertions:
 
@@ -150,3 +152,11 @@ Assertions:
   the MongoClient throws an error. If ``error`` is not specified or is
   ``false``, both initializing the MongoClient and running a ping operation must
   succeed without throwing any errors.
+
+- If ``ping`` is specified and ``true``, drivers MUST verify that running a
+  "ping" operation using the initialized MongoClient succeeds. If ``ping`` is
+  not specified or ``false, drivers MUST NOT run a "ping" operation. Note that
+  these tests are intended to be run against MongoDB databases with and without
+  authentication enabled. The "ping" operation does not require authentication
+  so should succeed, even though the test URIs do not include authentication
+  information.

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -155,6 +155,7 @@ Assertions:
 - If ``ping`` is not specified or ``true``, drivers MUST verify that running a
   "ping" operation using the initialized MongoClient succeeds. If ``ping`` is
   ``false``, drivers MUST NOT run a "ping" operation.
+
     **Note:** These tests are expected to be run against MongoDB databases with
     and without authentication enabled. The "ping" operation does not require
     authentication so should succeed with URIs that contain no userinfo (i.e.

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -153,9 +153,9 @@ Assertions:
   ``false``, both initializing the MongoClient and running a ping operation must
   succeed without throwing any errors.
 
-- If ``ping`` is specified and ``true``, drivers MUST verify that running a
+- If ``ping`` is not specified or ``true``, drivers MUST verify that running a
   "ping" operation using the initialized MongoClient succeeds. If ``ping`` is
-  not specified or is ``false``, drivers MUST NOT run a "ping" operation.
+   is ``false``, drivers MUST NOT run a "ping" operation.
   **Note:** These tests are expected to be run against MongoDB databases with
   and without authentication enabled. The "ping" operation does not require
   authentication so should succeed with URIs that contain no userinfo (i.e.

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -124,7 +124,7 @@ For each YAML file:
 
 - Create a MongoClient initialized with the ``mongodb+srv``
   connection string.
-- Run run a ping operation if ``ping`` in the test file is true.
+- Run run a "ping" operation if ``ping`` in the test file is true.
 
 Assertions:
 
@@ -155,8 +155,8 @@ Assertions:
 
 - If ``ping`` is specified and ``true``, drivers MUST verify that running a
   "ping" operation using the initialized MongoClient succeeds. If ``ping`` is
-  not specified or ``false, drivers MUST NOT run a "ping" operation. Note that
-  these tests are intended to be run against MongoDB databases with and without
-  authentication enabled. The "ping" operation does not require authentication
-  so should succeed, even though the test URIs do not include authentication
-  information.
+  not specified or is ``false``, drivers MUST NOT run a "ping" operation.
+  **Note:** These tests are expected to be run against MongoDB databases with
+  and without authentication enabled. The "ping" operation does not require
+  authentication so should succeed, even though the test URIs do not have
+  correct authentication information.

--- a/source/initial-dns-seedlist-discovery/tests/README.rst
+++ b/source/initial-dns-seedlist-discovery/tests/README.rst
@@ -158,5 +158,7 @@ Assertions:
   not specified or is ``false``, drivers MUST NOT run a "ping" operation.
   **Note:** These tests are expected to be run against MongoDB databases with
   and without authentication enabled. The "ping" operation does not require
-  authentication so should succeed, even though the test URIs do not have
-  correct authentication information.
+  authentication so should succeed with URIs that contain no userinfo (i.e.
+  no username and password). Tests with URIs that contain userinfo always set
+  ``ping`` to ``false`` because some drivers will fail handshake on a connection
+  if userinfo is provided but incorrect.

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.json
@@ -10,5 +10,6 @@
     "loadBalanced": true,
     "ssl": true,
     "directConnection": false
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-directConnection.yml
@@ -11,3 +11,4 @@ options:
     loadBalanced: true
     ssl: true
     directConnection: false
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.json
@@ -9,5 +9,6 @@
   "options": {
     "loadBalanced": true,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/loadBalanced-true-txt.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     loadBalanced: true
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.json
@@ -10,5 +10,6 @@
     "loadBalanced": true,
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero-txt.yml
@@ -8,3 +8,4 @@ options:
     loadBalanced: true
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.json
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.json
@@ -10,5 +10,6 @@
     "loadBalanced": true,
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.yml
+++ b/source/initial-dns-seedlist-discovery/tests/load-balanced/srvMaxHosts-zero.yml
@@ -8,3 +8,4 @@ options:
     loadBalanced: true
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/direct-connection-false.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/direct-connection-false.json
@@ -11,5 +11,6 @@
   "options": {
     "ssl": true,
     "directConnection": false
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/direct-connection-false.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/direct-connection-false.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     ssl: true
     directConnection: false
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.json
@@ -17,6 +17,6 @@
     "password": "$4to@L8=MC",
     "db": "mydb?"
   },
-  "ping": true,
+  "ping": false,
   "comment": "Encoded user, pass, and DB parse correctly"
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.json
@@ -17,5 +17,6 @@
     "password": "$4to@L8=MC",
     "db": "mydb?"
   },
+  "ping": true,
   "comment": "Encoded user, pass, and DB parse correctly"
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.yml
@@ -12,5 +12,8 @@ parsed_options:
     user: "b*b@f3tt="
     password: "$4to@L8=MC"
     db: "mydb?"
-ping: true
+# Don't run a ping for URIs that include userinfo. Ping doesn't require authentication, so missing
+# userinfo isn't a problem, but some drivers will fail handshake on a connection if userinfo is
+# provided but incorrect.
+ping: false
 comment: Encoded user, pass, and DB parse correctly

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.yml
@@ -12,4 +12,5 @@ parsed_options:
     user: "b*b@f3tt="
     password: "$4to@L8=MC"
     db: "mydb?"
+ping: true
 comment: Encoded user, pass, and DB parse correctly

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/loadBalanced-false-txt.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/loadBalanced-false-txt.json
@@ -11,5 +11,6 @@
   "options": {
     "loadBalanced": false,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/loadBalanced-false-txt.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/loadBalanced-false-txt.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     loadBalanced: false
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/longer-parent-in-return.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/longer-parent-in-return.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "ssl": true
   },
+  "ping": true,
   "comment": "Is correct, as returned host name shared the URI root \"test.build.10gen.cc\"."
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/longer-parent-in-return.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/longer-parent-in-return.yml
@@ -8,4 +8,5 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true
 comment: Is correct, as returned host name shared the URI root "test.build.10gen.cc".

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/one-result-default-port.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/one-result-default-port.json
@@ -11,5 +11,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/one-result-default-port.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/one-result-default-port.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record-multiple-strings.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record-multiple-strings.json
@@ -11,5 +11,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record-multiple-strings.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record-multiple-strings.yml
@@ -8,3 +8,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "authSource": "thisDB",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/one-txt-record.yml
@@ -9,3 +9,4 @@ options:
     replicaSet: repl0
     authSource: thisDB
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.json
@@ -12,5 +12,6 @@
   "options": {
     "ssl": true,
     "srvServiceName": "customname"
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srv-service-name.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     ssl: true
     srvServiceName: "customname"
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-equal_to_srv_records.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-equal_to_srv_records.json
@@ -13,5 +13,6 @@
   "options": {
     "srvMaxHosts": 2,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-equal_to_srv_records.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-equal_to_srv_records.yml
@@ -14,3 +14,4 @@ hosts:
 options:
     srvMaxHosts: 2
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-greater_than_srv_records.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-greater_than_srv_records.json
@@ -12,5 +12,6 @@
   "options": {
     "srvMaxHosts": 3,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-greater_than_srv_records.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-greater_than_srv_records.yml
@@ -13,3 +13,4 @@ hosts:
 options:
     srvMaxHosts: 3
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-less_than_srv_records.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-less_than_srv_records.json
@@ -9,5 +9,6 @@
   "options": {
     "srvMaxHosts": 1,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-less_than_srv_records.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-less_than_srv_records.yml
@@ -13,3 +13,4 @@ hosts:
 options:
     srvMaxHosts: 1
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero-txt.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero-txt.json
@@ -13,5 +13,6 @@
     "replicaSet": "repl0",
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero-txt.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero-txt.yml
@@ -13,3 +13,4 @@ options:
     replicaSet: repl0
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero.json
@@ -13,5 +13,6 @@
     "replicaSet": "repl0",
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/srvMaxHosts-zero.yml
@@ -13,3 +13,4 @@ options:
     replicaSet: repl0
     srvMaxHosts: 0
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/two-results-default-port.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/two-results-default-port.json
@@ -12,5 +12,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/two-results-default-port.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/two-results-default-port.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/two-results-nonstandard-port.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/two-results-nonstandard-port.json
@@ -12,5 +12,6 @@
   "options": {
     "replicaSet": "repl0",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/two-results-nonstandard-port.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/two-results-nonstandard-port.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     replicaSet: repl0
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-ssl-option.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-ssl-option.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "authSource": "thisDB",
     "ssl": false
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-ssl-option.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-ssl-option.yml
@@ -9,3 +9,4 @@ options:
     replicaSet: repl0
     authSource: thisDB
     ssl: false
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-uri-option.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-uri-option.json
@@ -12,5 +12,6 @@
     "replicaSet": "repl0",
     "authSource": "otherDB",
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-uri-option.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/txt-record-with-overridden-uri-option.yml
@@ -9,3 +9,4 @@ options:
     replicaSet: repl0
     authSource: otherDB
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-admin-database.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-admin-database.json
@@ -15,5 +15,6 @@
   },
   "parsed_options": {
     "auth_database": "adminDB"
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-admin-database.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-admin-database.yml
@@ -11,3 +11,4 @@ options:
     ssl: true
 parsed_options:
     auth_database: adminDB
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.json
@@ -13,5 +13,6 @@
     "user": "auser",
     "password": "apass"
   },
+  "ping": true,
   "comment": "Should preserve auth credentials"
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.json
@@ -17,6 +17,6 @@
     "user": "auser",
     "password": "apass"
   },
-  "ping": true,
+  "ping": false,
   "comment": "Should preserve auth credentials"
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.json
@@ -9,6 +9,10 @@
     "localhost:27018",
     "localhost:27019"
   ],
+  "options": {
+    "replicaSet": "repl0",
+    "ssl": true
+  },
   "parsed_options": {
     "user": "auser",
     "password": "apass"

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.yml
@@ -9,4 +9,5 @@ hosts:
 parsed_options:
     user: auser
     password: apass
+ping: true
 comment: Should preserve auth credentials

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.yml
@@ -12,5 +12,8 @@ options:
 parsed_options:
     user: auser
     password: apass
-ping: true
+# Don't run a ping for URIs that include userinfo. Ping doesn't require authentication, so missing
+# userinfo isn't a problem, but some drivers will fail handshake on a connection if userinfo is
+# provided but incorrect.
+ping: false
 comment: Should preserve auth credentials

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-auth.yml
@@ -6,6 +6,9 @@ hosts:
     - localhost:27017
     - localhost:27018
     - localhost:27019
+options:
+    replicaSet: repl0
+    ssl: true
 parsed_options:
     user: auser
     password: apass

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-equal_to_srv_records.json
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-equal_to_srv_records.json
@@ -12,5 +12,6 @@
   "options": {
     "srvMaxHosts": 2,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-equal_to_srv_records.yml
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-equal_to_srv_records.yml
@@ -11,3 +11,4 @@ hosts:
 options:
     srvMaxHosts: 2
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-greater_than_srv_records.json
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-greater_than_srv_records.json
@@ -11,5 +11,6 @@
   "options": {
     "srvMaxHosts": 3,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-greater_than_srv_records.yml
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-greater_than_srv_records.yml
@@ -10,3 +10,4 @@ hosts:
 options:
     srvMaxHosts: 3
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-less_than_srv_records.json
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-less_than_srv_records.json
@@ -5,5 +5,6 @@
   "options": {
     "srvMaxHosts": 1,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-less_than_srv_records.yml
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-less_than_srv_records.yml
@@ -8,3 +8,4 @@ numHosts: 1
 options:
     srvMaxHosts: 1
     ssl: true
+ping: true

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-zero.json
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-zero.json
@@ -11,5 +11,6 @@
   "options": {
     "srvMaxHosts": 0,
     "ssl": true
-  }
+  },
+  "ping": true
 }

--- a/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-zero.yml
+++ b/source/initial-dns-seedlist-discovery/tests/sharded/srvMaxHosts-zero.yml
@@ -9,3 +9,4 @@ hosts:
 options:
     srvMaxHosts: 0
     ssl: true
+ping: true


### PR DESCRIPTION
[DRIVERS-2234](https://jira.mongodb.org/browse/DRIVERS-2234)

Currently, the initial DNS seedlist discovery spec test runner description requires creating a MongoClient initialized with the URI specified in the test and asserting that either the host lists match the expected values or that an error was thrown/returned. However, it does not specify to run an operation or create a connection, which can lead to incorrectly configured tests passing. Some drivers (e.g. the Go driver) do create connections, which exposes test misconfigurations.

Update the initial DNS seedlist discovery spec test runner description to require running a Ping operation with the created MongoClient in the no-error test cases.