### PR TITLE
DRIVERS-2260 Add CSFLE spec test for auto encryption on a collection …

### DIFF
--- a/source/client-side-encryption/etc/test-templates/noSchema.yml.template
+++ b/source/client-side-encryption/etc/test-templates/noSchema.yml.template
@@ -1,0 +1,37 @@
+# Test auto encryption on a collection with no jsonSchema configured.
+# This is a regression test for MONGOCRYPT-378/PYTHON-3188.
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "unencrypted"
+
+tests:
+  - description: "Insert on an unencrypted collection"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+    operations:
+      - name: insertOne
+        arguments:
+          document: &doc0 { _id: 1 }
+    expectations:
+      # Auto encryption will request the collection info.
+      - command_started_event:
+          command:
+            listCollections: 1
+            filter:
+              name: *collection_name
+          command_name: listCollections
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - *doc0
+            ordered: true
+          command_name: insert
+    outcome:
+      collection:
+        # Outcome is checked using a separate MongoClient without auto encryption.
+        data:
+          - *doc0

--- a/source/client-side-encryption/tests/noSchema.json
+++ b/source/client-side-encryption/tests/noSchema.json
@@ -1,0 +1,67 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "unencrypted",
+  "tests": [
+    {
+      "description": "Insert on an unencrypted collection",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "aws": {}
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "unencrypted"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "unencrypted",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true
+            },
+            "command_name": "insert"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/source/client-side-encryption/tests/noSchema.yml
+++ b/source/client-side-encryption/tests/noSchema.yml
@@ -1,0 +1,37 @@
+# Test auto encryption on a collection with no jsonSchema configured.
+# This is a regression test for MONGOCRYPT-378/PYTHON-3188.
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "unencrypted"
+
+tests:
+  - description: "Insert on an unencrypted collection"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          aws: {} # Credentials filled in from environment.
+    operations:
+      - name: insertOne
+        arguments:
+          document: &doc0 { _id: 1 }
+    expectations:
+      # Auto encryption will request the collection info.
+      - command_started_event:
+          command:
+            listCollections: 1
+            filter:
+              name: *collection_name
+          command_name: listCollections
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - *doc0
+            ordered: true
+          command_name: insert
+    outcome:
+      collection:
+        # Outcome is checked using a separate MongoClient without auto encryption.
+        data:
+          - *doc0


### PR DESCRIPTION
…with no jsonSchema

# Background & Motivation

MONGOCRYPT-378 introduced [a regression](https://github.com/mongodb/libmongocrypt/pull/282) that only applied to collections with no local or remote jsonSchema configured. This was resolved and tested within libmongocrypt. This PR adds an integration test for the missing coverage.

The new test was run with the Go driver in https://github.com/mongodb/mongo-go-driver/pull/903.