### PR TITLE
DRIVERS-1915: Change stream support for point-in-time pre and post-images

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -361,11 +361,11 @@ Driver API
 
   class ChangeStreamOptions {
     /**
-     * Allowed values: 'updateLookup', 'whenAvailable', 'required'.
+     * Allowed values: 'default', 'updateLookup', 'whenAvailable', 'required'.
      *
-     * The default is to not send a value. By default, the change notification
-     * for partial updates will include a delta describing the changes to the
-     * document.
+     * The default is to not send a value, which is equivalent to 'default'. By
+     * default, the change notification for partial updates will include a delta
+     * describing the changes to the document.
      *
      * When set to 'updateLookup', the change notification for partial updates
      * will include both a delta describing the changes to the document as well

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -189,17 +189,17 @@ If an aggregate command with a ``$changeStream`` stage completes successfully, t
      * document was deleted since the updated happened, it will be null.
      *
      * Contains the point-in-time post-image of the modified document if the
-     * post-image is available and either "required" or "whenAvailable" was
-     * specified for the "fullDocument" option when creating the change stream.
-     * A post-image is always available for "insert" and "replace" events.
+     * post-image is available and either 'required' or 'whenAvailable' was
+     * specified for the 'fullDocument' option when creating the change stream.
+     * A post-image is always available for 'insert' and 'replace' events.
      */
     fullDocument: Document | null;
 
     /**
      * Contains the pre-image of the modified or deleted document if the
-     * pre-image is available for the change event and either "required" or
-     * "whenAvailable" was specified for the "fullDocumentBeforeChange" option
-     * when creating the change stream. If "whenAvailable" was specified but the
+     * pre-image is available for the change event and either 'required' or
+     * 'whenAvailable' was specified for the 'fullDocumentBeforeChange' option
+     * when creating the change stream. If 'whenAvailable' was specified but the
      * pre-image is unavailable, this will be explicitly set to null.
      */
     fullDocumentBeforeChange: Document | null;
@@ -997,5 +997,5 @@ Changelog
 | 2022-03-25 | Do not error when parsing change stream event documents.   |
 +------------+------------------------------------------------------------+
 | 2022-04-08 | Support returning point-in-time pre and post-images with   |
-|            | fullDocumentBeforeChange and fullDocument.                 |
+|            | ``fullDocumentBeforeChange`` and ``fullDocument``.         |
 +------------+------------------------------------------------------------+

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -9,7 +9,7 @@ Change Streams
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: 2022-04-08
+:Last Modified: 2022-04-13
 :Version: 1.14
 
 .. contents::
@@ -996,6 +996,6 @@ Changelog
 +------------+------------------------------------------------------------+
 | 2022-03-25 | Do not error when parsing change stream event documents.   |
 +------------+------------------------------------------------------------+
-| 2022-04-08 | Support returning point-in-time pre and post-images with   |
+| 2022-04-13 | Support returning point-in-time pre and post-images with   |
 |            | ``fullDocumentBeforeChange`` and ``fullDocument``.         |
 +------------+------------------------------------------------------------+

--- a/source/change-streams/tests/unified/change-streams-pre_and_post_images.json
+++ b/source/change-streams/tests/unified/change-streams-pre_and_post_images.json
@@ -1,0 +1,826 @@
+{
+  "description": "change-streams-pre_and_post_images",
+  "schemaVersion": "1.0",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.0.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "ignoreCommandMonitoringEvents": [
+          "collMod",
+          "insert",
+          "update",
+          "getMore",
+          "killCursors"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "change-stream-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "change-stream-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocument": {
+              "_id": 1,
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocument:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocument": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocument": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "whenAvailable"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": null
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "whenAvailable"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "required"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectError": {
+            "isClientError": false
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "required"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "database0",
+          "arguments": {
+            "commandName": "collMod",
+            "command": {
+              "collMod": "test",
+              "changeStreamPreAndPostImages": {
+                "enabled": false
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "fullDocumentBeforeChange": "off"
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "change-stream-tests",
+              "coll": "test"
+            },
+            "updateDescription": {
+              "$$type": "object"
+            },
+            "fullDocumentBeforeChange": {
+              "$$exists": false
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "test",
+                  "pipeline": [
+                    {
+                      "$changeStream": {
+                        "fullDocumentBeforeChange": "off"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/change-streams/tests/unified/change-streams-pre_and_post_images.yml
+++ b/source/change-streams/tests/unified/change-streams-pre_and_post_images.yml
@@ -160,15 +160,6 @@ tests:
                 pipeline:
                   - $changeStream: { fullDocument: "required" }
 
-
-
-
-
-
-
-
-
-
   - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled"
     operations:
       - name: runCommand

--- a/source/change-streams/tests/unified/change-streams-pre_and_post_images.yml
+++ b/source/change-streams/tests/unified/change-streams-pre_and_post_images.yml
@@ -1,0 +1,359 @@
+description: "change-streams-pre_and_post_images"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "6.0.0"
+    topologies: [ replicaset, sharded-replicaset, load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+      ignoreCommandMonitoringEvents: [ collMod, insert, update, getMore, killCursors ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name change-stream-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &enablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: true }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &disablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: false }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+
+
+
+
+
+
+
+
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }

--- a/source/change-streams/tests/unified/change-streams-pre_and_post_images.yml
+++ b/source/change-streams/tests/unified/change-streams-pre_and_post_images.yml
@@ -1,6 +1,6 @@
 description: "change-streams-pre_and_post_images"
 
-schemaVersion: "1.0"
+schemaVersion: "1.3"
 
 runOnRequirements:
   - minServerVersion: "6.0.0"

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -2,7 +2,7 @@ SCHEMA=../schema-1.7.json
 
 .PHONY: all invalid valid-fail valid-pass versioned-api load-balancers gridfs transactions crud collection-management sessions command-monitoring HAS_AJV
 
-all: invalid valid-fail valid-pass versioned-api load-balancers gridfs transactions crud collection-management sessions command-monitoring
+all: invalid valid-fail valid-pass versioned-api load-balancers gridfs transactions change-streams crud collection-management sessions command-monitoring
 
 invalid: HAS_AJV
 	@# Redirect stdout to hide expected validation errors
@@ -25,6 +25,9 @@ gridfs: HAS_AJV
 
 transactions: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../transactions/tests/unified/*.yml" --valid
+
+change-streams: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../change-streams/tests/unified/*.yml" --valid
 
 crud: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../crud/tests/unified/*.yml" --valid


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1915

POC: https://github.com/mongodb/mongo-php-library/pull/911

Note: testing may require starting mongod with `--setParameter featureFlagChangeStreamPreAndPostImages=true` if the "latest" server build does not include [SERVER-52282](https://jira.mongodb.org/browse/SERVER-52282).