### PR TITLE
DRIVERS-2272 Fix errorContains in badQueries and types tests

### DIFF
--- a/source/client-side-encryption/etc/test-templates/badQueries.yml.template
+++ b/source/client-side-encryption/etc/test-templates/badQueries.yml.template
@@ -476,7 +476,12 @@ tests:
           filter: { }
           update: { $set : { "encrypted_string": [1,2] }}
         result:
-          errorContains: "Cannot encrypt element of type array"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot encrypt element of type array because schema requires that type is one of: [ string ]"
+          # After it is:
+          # "Cannot encrypt element of type: array"
+          # Only check for the common prefix.
+          errorContains: "Cannot encrypt element of type"
   - description: "an insert with encrypted field on _id errors"
     clientOptions:
       autoEncryptOpts:
@@ -500,7 +505,12 @@ tests:
         arguments:
           document: { encrypted_string: [ "123", "456"] }
         result:
-          errorContains: "Cannot encrypt element of type array"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot encrypt element of type array because schema requires that type is one of: [ string ]"
+          # After it is:
+          # "Cannot encrypt element of type: array"
+          # Only check for the common prefix.
+          errorContains: "Cannot encrypt element of type"
   - description: "an insert with a Timestamp(0,0) value in the top-level fails"
     clientOptions:
       autoEncryptOpts:

--- a/source/client-side-encryption/etc/test-templates/types.yml.template
+++ b/source/client-side-encryption/etc/test-templates/types.yml.template
@@ -146,7 +146,12 @@ tests:
         arguments:
           document: &doc4 { _id: 1, encrypted_double: {"$numberDouble": "1.23"} }
         result:
-            errorContains: "Cannot use deterministic encryption for element of type: double"
+            # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+            # "Cannot use deterministic encryption for element of type: double"
+            # After it is:
+            # "Cannot encrypt element of type: double"
+            # Only check for the common suffix.
+            errorContains: "element of type: double"
   - description: "type=decimal"
     clientOptions:
       autoEncryptOpts:
@@ -159,7 +164,12 @@ tests:
         arguments:
           document: &doc5 { _id: 1, encrypted_decimal: {"$numberDecimal": "1.23"} }
         result:
-            errorContains: "Cannot use deterministic encryption for element of type: decimal"
+            # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+            # "Cannot use deterministic encryption for element of type: decimal"
+            # After it is:
+            # "Cannot encrypt element of type: decimal"
+            # Only check for the common suffix.
+            errorContains: "element of type: decimal"
   - description: "type=binData"
     clientOptions:
       autoEncryptOpts:
@@ -254,7 +264,12 @@ tests:
         arguments:
           document: &doc8 { _id: 1, encrypted_javascriptWithScope: {"$code": "var x = 1;", "$scope": {} } }
         result:
-          errorContains: "Cannot use deterministic encryption for element of type: javascriptWithScope"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot use deterministic encryption for element of type: javascriptWithScope"
+          # After it is:
+          # "Cannot encrypt element of type: javascriptWithScope"
+          # Only check for the common suffix.
+          errorContains: "element of type: javascriptWithScope"
   - description: "type=object"
     clientOptions:
       autoEncryptOpts:
@@ -267,7 +282,12 @@ tests:
         arguments:
           document: &doc9 { _id: 1, encrypted_object: {} }
         result:
-          errorContains: "Cannot use deterministic encryption for element of type: object"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot use deterministic encryption for element of type: object"
+          # After it is:
+          # "Cannot encrypt element of type: object"
+          # Only check for the common suffix.
+          errorContains: "element of type: object"
   - description: "type=timestamp"
     clientOptions:
       autoEncryptOpts:
@@ -442,7 +462,12 @@ tests:
         arguments:
           document: &doc17 { _id: 1, encrypted_array: [] }
         result:
-          errorContains: "Cannot use deterministic encryption for element of type: array"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot use deterministic encryption for element of type: array"
+          # After it is:
+          # "Cannot encrypt element of type: array"
+          # Only check for the common suffix.
+          errorContains: "element of type: array"
   - description: "type=bool"
     clientOptions:
       autoEncryptOpts:
@@ -455,7 +480,12 @@ tests:
         arguments:
           document: &doc18 { _id: 1, encrypted_bool: true }
         result:
-          errorContains: "Cannot use deterministic encryption for element of type: bool"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot use deterministic encryption for element of type: bool"
+          # After it is:
+          # "Cannot encrypt element of type: bool"
+          # Only check for the common suffix.
+          errorContains: "element of type: bool"
   - description: "type=null"
     clientOptions:
       autoEncryptOpts:

--- a/source/client-side-encryption/tests/badQueries.json
+++ b/source/client-side-encryption/tests/badQueries.json
@@ -1318,7 +1318,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot encrypt element of type array"
+            "errorContains": "Cannot encrypt element of type"
           }
         }
       ]
@@ -1387,7 +1387,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot encrypt element of type array"
+            "errorContains": "Cannot encrypt element of type"
           }
         }
       ]

--- a/source/client-side-encryption/tests/badQueries.yml
+++ b/source/client-side-encryption/tests/badQueries.yml
@@ -476,7 +476,12 @@ tests:
           filter: { }
           update: { $set : { "encrypted_string": [1,2] }}
         result:
-          errorContains: "Cannot encrypt element of type array"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot encrypt element of type array because schema requires that type is one of: [ string ]"
+          # After it is:
+          # "Cannot encrypt element of type: array"
+          # Only check for the common prefix.
+          errorContains: "Cannot encrypt element of type"
   - description: "an insert with encrypted field on _id errors"
     clientOptions:
       autoEncryptOpts:
@@ -500,7 +505,12 @@ tests:
         arguments:
           document: { encrypted_string: [ "123", "456"] }
         result:
-          errorContains: "Cannot encrypt element of type array"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot encrypt element of type array because schema requires that type is one of: [ string ]"
+          # After it is:
+          # "Cannot encrypt element of type: array"
+          # Only check for the common prefix.
+          errorContains: "Cannot encrypt element of type"
   - description: "an insert with a Timestamp(0,0) value in the top-level fails"
     clientOptions:
       autoEncryptOpts:

--- a/source/client-side-encryption/tests/types.json
+++ b/source/client-side-encryption/tests/types.json
@@ -504,7 +504,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: double"
+            "errorContains": "element of type: double"
           }
         }
       ]
@@ -551,7 +551,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: decimal"
+            "errorContains": "element of type: decimal"
           }
         }
       ]
@@ -883,7 +883,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: javascriptWithScope"
+            "errorContains": "element of type: javascriptWithScope"
           }
         }
       ]
@@ -928,7 +928,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: object"
+            "errorContains": "element of type: object"
           }
         }
       ]
@@ -1547,7 +1547,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: array"
+            "errorContains": "element of type: array"
           }
         }
       ]
@@ -1592,7 +1592,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot use deterministic encryption for element of type: bool"
+            "errorContains": "element of type: bool"
           }
         }
       ]

--- a/source/client-side-encryption/tests/types.yml
+++ b/source/client-side-encryption/tests/types.yml
@@ -146,7 +146,12 @@ tests:
         arguments:
           document: &doc4 { _id: 1, encrypted_double: {"$numberDouble": "1.23"} }
         result:
-            errorContains: "Cannot use deterministic encryption for element of type: double"
+            # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+            # "Cannot use deterministic encryption for element of type: double"
+            # After it is:
+            # "Cannot encrypt element of type: double"
+            # Only check for the common suffix.
+            errorContains: "element of type: double"
   - description: "type=decimal"
     clientOptions:
       autoEncryptOpts:
@@ -159,7 +164,12 @@ tests:
         arguments:
           document: &doc5 { _id: 1, encrypted_decimal: {"$numberDecimal": "1.23"} }
         result:
-            errorContains: "Cannot use deterministic encryption for element of type: decimal"
+            # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+            # "Cannot use deterministic encryption for element of type: decimal"
+            # After it is:
+            # "Cannot encrypt element of type: decimal"
+            # Only check for the common suffix.
+            errorContains: "element of type: decimal"
   - description: "type=binData"
     clientOptions:
       autoEncryptOpts:
@@ -254,7 +264,12 @@ tests:
         arguments:
           document: &doc8 { _id: 1, encrypted_javascriptWithScope: {"$code": "var x = 1;", "$scope": {} } }
         result:
-          errorContains: "Cannot use deterministic encryption for element of type: javascriptWithScope"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot use deterministic encryption for element of type: javascriptWithScope"
+          # After it is:
+          # "Cannot encrypt element of type: javascriptWithScope"
+          # Only check for the common suffix.
+          errorContains: "element of type: javascriptWithScope"
   - description: "type=object"
     clientOptions:
       autoEncryptOpts:
@@ -267,7 +282,12 @@ tests:
         arguments:
           document: &doc9 { _id: 1, encrypted_object: {} }
         result:
-          errorContains: "Cannot use deterministic encryption for element of type: object"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot use deterministic encryption for element of type: object"
+          # After it is:
+          # "Cannot encrypt element of type: object"
+          # Only check for the common suffix.
+          errorContains: "element of type: object"
   - description: "type=timestamp"
     clientOptions:
       autoEncryptOpts:
@@ -442,7 +462,12 @@ tests:
         arguments:
           document: &doc17 { _id: 1, encrypted_array: [] }
         result:
-          errorContains: "Cannot use deterministic encryption for element of type: array"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot use deterministic encryption for element of type: array"
+          # After it is:
+          # "Cannot encrypt element of type: array"
+          # Only check for the common suffix.
+          errorContains: "element of type: array"
   - description: "type=bool"
     clientOptions:
       autoEncryptOpts:
@@ -455,7 +480,12 @@ tests:
         arguments:
           document: &doc18 { _id: 1, encrypted_bool: true }
         result:
-          errorContains: "Cannot use deterministic encryption for element of type: bool"
+          # DRIVERS-2272: The expected error message changed in mongocryptd 6.0. Before it was:
+          # "Cannot use deterministic encryption for element of type: bool"
+          # After it is:
+          # "Cannot encrypt element of type: bool"
+          # Only check for the common suffix.
+          errorContains: "element of type: bool"
   - description: "type=null"
     clientOptions:
       autoEncryptOpts:


### PR DESCRIPTION
mongocryptd 6.0 changed the error message.

Here is a [passing test run with the Go driver](https://github.com/mongodb/mongo-go-driver/pull/906).