### PR TITLE
test: add retryable write label to handshake tests

### DIFF
--- a/source/retryable-writes/tests/unified/handshakeError.json
+++ b/source/retryable-writes/tests/unified/handshakeError.json
@@ -181,7 +181,10 @@
                   "saslContinue",
                   "ping"
                 ],
-                "errorCode": 91
+                "errorCode": 91,
+                "errorLabels": [
+                  "RetryableWriteError"
+                ]
               }
             }
           }

--- a/source/retryable-writes/tests/unified/handshakeError.yml
+++ b/source/retryable-writes/tests/unified/handshakeError.yml
@@ -94,7 +94,7 @@ tests:
             data:
               failCommands: [saslContinue, ping]
               errorCode: 91 # ShutdownInProgress
-
+              errorLabels: ["RetryableWriteError"]
       - name: runCommand
         object: *database0
         arguments:


### PR DESCRIPTION
Adds the "RetryableWriteError" label to handshake error unified tests that expect the write to be retryable.