### PR TITLE
DRIVERS-2279 Don't use explicit session in dirty implicit session test

### DIFF
--- a/source/sessions/tests/driver-sessions-dirty-session-errors.json
+++ b/source/sessions/tests/driver-sessions-dirty-session-errors.json
@@ -448,7 +448,6 @@
           "name": "insertOne",
           "object": "collection0",
           "arguments": {
-            "session": "session0",
             "document": {
               "_id": 2
             }

--- a/source/sessions/tests/driver-sessions-dirty-session-errors.yml
+++ b/source/sessions/tests/driver-sessions-dirty-session-errors.yml
@@ -195,7 +195,6 @@ tests:
       - name: insertOne
         object: *collection0
         arguments:
-          session: *session0
           document: { _id: 2 }
         expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
       - *find_with_implicit_session


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2279

Noticed while working on https://jira.mongodb.org/browse/PYTHON-3160.