### PR TITLE
DRIVERS-1713 Fix change stream errors test on 3.6

### DIFF
--- a/source/change-streams/tests/unified/change-streams-errors.json
+++ b/source/change-streams/tests/unified/change-streams-errors.json
@@ -49,6 +49,13 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "The watch helper must not throw a custom exception when executed against a single server topology, but instead depend on a server error",

--- a/source/change-streams/tests/unified/change-streams-errors.yml
+++ b/source/change-streams/tests/unified/change-streams-errors.yml
@@ -26,6 +26,11 @@ createEntities:
       database: *globalDatabase0
       collectionName: *collection0
 
+initialData:
+  - collectionName: *collection0
+    databaseName: *database0
+    documents: []
+
 tests:
   - description: "The watch helper must not throw a custom exception when executed against a single server topology, but instead depend on a server error"
     runOnRequirements:


### PR DESCRIPTION
DRIVERS-1713

Discovered when updating the Rust tests that the first test in `change-streams-errors.yml` fails with a different error code on server version 3.6 if the database doesn't exist.  Not sure why this didn't show up in previous test runs.