### PR TITLE
DRIVERS-2287 Clarify interaction of bypassAutoEncryption and csfle search paths

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -915,8 +915,11 @@ Setting Search Paths
 --------------------
 
 For the user-facing API the driver MUST append the literal string
-:ts:`"$SYSTEM"` to the search paths for the `libmongocrypt_handle`. For purposes
-of testing, a driver may use a different set of search paths.
+:ts:`"$SYSTEM"` to the search paths for the `libmongocrypt_handle` if
+`bypassAutoEncryption` is not set to |true|, and MUST NOT append to the search
+path if it is set to |true| or if the libmongocrypt_ instance is used
+for explicit encryption only (i.e. on the ClientEncryption class).
+For purposes of testing, a driver may use a different set of search paths.
 
 
 .. rubric:: Explaination


### PR DESCRIPTION
Picking the behavior of _not_ setting csfle search paths when `bypassAutoEncryption` was passed, because:
- Creating a mongocrypt_t instance with an unnecessary csfle library may conflict with the creation of a mongocrypt_t instance that is supposed to use the csfle library but from another path
- It seems like `bypassAutoEncryption` could be implemented by using a `ClientEncryption` instance rather than a separate libmongocrypt handle (on what at least the Python and Node.js bindings call `AutoEncrypter`), in which case the csfle library should probably never be loaded