### PR TITLE
DRIVERS-2290 Correct ROR in YML

### DIFF
--- a/source/crud/tests/unified/bulkWrite-comment.yml
+++ b/source/crud/tests/unified/bulkWrite-comment.yml
@@ -153,7 +153,7 @@ tests:
   - description: 'BulkWrite with comment - pre 4.4'
     runOnRequirements:
       - minServerVersion: "3.4.0"
-      - maxServerVersion: "4.2.99"
+        maxServerVersion: "4.2.99"
     operations:
       - object: *collection0
         name: bulkWrite

--- a/source/crud/tests/unified/deleteMany-comment.yml
+++ b/source/crud/tests/unified/deleteMany-comment.yml
@@ -75,7 +75,7 @@ tests:
   - description: "deleteMany with comment - pre 4.4"
     runOnRequirements:
       - minServerVersion: "3.4.0"
-      - maxServerVersion: "4.2.99"
+        maxServerVersion: "4.2.99"
     operations:
       - name: deleteMany
         object: *collection0

--- a/source/crud/tests/unified/deleteOne-comment.yml
+++ b/source/crud/tests/unified/deleteOne-comment.yml
@@ -76,7 +76,7 @@ tests:
   - description: "deleteOne with comment - pre 4.4"
     runOnRequirements:
       - minServerVersion: "3.4.0"
-      - maxServerVersion: "4.2.99"
+        maxServerVersion: "4.2.99"
     operations:
       - name: deleteOne
         object: *collection0

--- a/source/crud/tests/unified/insertMany-comment.yml
+++ b/source/crud/tests/unified/insertMany-comment.yml
@@ -71,7 +71,7 @@ tests:
   - description: "insertMany with comment - pre 4.4"
     runOnRequirements:
       - minServerVersion: "3.4.0"
-      - maxServerVersion: "4.2.99"
+        maxServerVersion: "4.2.99"
     operations:
       - name: insertMany
         object: *collection0

--- a/source/crud/tests/unified/insertOne-comment.yml
+++ b/source/crud/tests/unified/insertOne-comment.yml
@@ -70,7 +70,7 @@ tests:
   - description: "insertOne with comment - pre 4.4"
     runOnRequirements:
       - minServerVersion: "3.4.0"
-      - maxServerVersion: "4.2.99"
+        maxServerVersion: "4.2.99"
     operations:
       - name: insertOne
         object: *collection0

--- a/source/crud/tests/unified/replaceOne-comment.yml
+++ b/source/crud/tests/unified/replaceOne-comment.yml
@@ -79,7 +79,7 @@ tests:
   - description: "ReplaceOne with comment - pre 4.4"
     runOnRequirements:
       - minServerVersion: "3.4.0"
-      - maxServerVersion: "4.2.99"
+        maxServerVersion: "4.2.99"
     operations:
       - name: replaceOne
         object: *collection0

--- a/source/crud/tests/unified/updateMany-comment.yml
+++ b/source/crud/tests/unified/updateMany-comment.yml
@@ -78,7 +78,7 @@ tests:
   - description: "UpdateMany with comment - pre 4.4"
     runOnRequirements:
       - minServerVersion: "3.4.0"
-      - maxServerVersion: "4.2.99"
+        maxServerVersion: "4.2.99"
     operations:
       - name: updateMany
         object: *collection0

--- a/source/crud/tests/unified/updateOne-comment.yml
+++ b/source/crud/tests/unified/updateOne-comment.yml
@@ -78,7 +78,7 @@ tests:
   - description: "UpdateOne with comment - pre 4.4"
     runOnRequirements:
       - minServerVersion: "3.4.0"
-      - maxServerVersion: "4.2.99"
+        maxServerVersion: "4.2.99"
     operations:
       - name: updateOne
         object: *collection0


### PR DESCRIPTION
[DRIVERS-2290](https://jira.mongodb.org/browse/DRIVERS-2290)

Correct ROR YAML object array from two objects to one.  The separation is causes [this failure](https://github.com/mongodb/specifications/runs/6178549023?check_suite_focus=true).