### PR TITLE
DRIVERS-2228 Fix runOnRequirements for `estimatedDocumentCount` stable API tests, add test for views

### DIFF
--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -759,7 +759,7 @@ with no query filter, skip, limit, or other options that would alter the
 results. The only supported options are listed in the
 ``EstimatedDocumentCountOptions`` type defined above.
 
-Drivers MUST document that, due to an oversight in versions 5.0.0-5.0.7 of
+Drivers MUST document that, due to an oversight in versions 5.0.0-5.0.8 of
 MongoDB, the ``count`` command, which estimatedDocumentCount uses in its
 implementation, was not included in v1 of the Stable API, and so users of the
 Stable API with estimatedDocumentCount are recommended to upgrade their server
@@ -783,7 +783,7 @@ document the following:
 - The new release is fixing estimatedDocumentCount on views by reverting back to
   using ``count`` in its implementation.
 - Due to an oversight, the ``count`` command was omitted from the Stable API in
-  server versions 5.0.0 - 5.0.7 and 5.1.0 - 5.3.1, so users of the Stable API
+  server versions 5.0.0 - 5.0.8 and 5.1.0 - 5.3.1, so users of the Stable API
   with estimatedDocumentCount are recommended to upgrade their MongoDB clusters
   to 5.0.9 or 5.3.2 (if on Atlas) or set ``apiStrict: false`` when constructing
   their MongoClients.

--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -763,7 +763,7 @@ Drivers MUST document that, due to an oversight in versions 5.0.0-5.0.7 of
 MongoDB, the ``count`` command, which estimatedDocumentCount uses in its
 implementation, was not included in v1 of the Stable API, and so users of the
 Stable API with estimatedDocumentCount are recommended to upgrade their server
-version to 5.0.8+ or set ``apiStrict: false`` to avoid encountering errors.
+version to 5.0.9+ or set ``apiStrict: false`` to avoid encountering errors.
 
 Drivers MUST document that the ``count`` server command is used to implement
 estimatedDocumentCount and that users can find more information via
@@ -785,7 +785,7 @@ document the following:
 - Due to an oversight, the ``count`` command was omitted from the Stable API in
   server versions 5.0.0 - 5.0.7 and 5.1.0 - 5.3.1, so users of the Stable API
   with estimatedDocumentCount are recommended to upgrade their MongoDB clusters
-  to 5.0.8 or 5.3.2 (if on Atlas) or set ``apiStrict: false`` when constructing
+  to 5.0.9 or 5.3.2 (if on Atlas) or set ``apiStrict: false`` when constructing
   their MongoClients.
 
 ~~~~~~~~~~~~~~

--- a/source/crud/tests/unified/estimatedDocumentCount.json
+++ b/source/crud/tests/unified/estimatedDocumentCount.json
@@ -34,6 +34,13 @@
         "database": "database0",
         "collectionName": "coll1"
       }
+    },
+    {
+      "collection": {
+        "id": "collection0View",
+        "database": "database0",
+        "collectionName": "coll0view"
+      }
     }
   ],
   "initialData": [
@@ -54,6 +61,23 @@
           "x": 33
         }
       ]
+    },
+    {
+      "collectionName": "coll0view",
+      "databaseName": "edc-tests",
+      "documents": [],
+      "createOptions": {
+        "viewOn": "coll0",
+        "pipeline": [
+          {
+            "$match": {
+              "_id": {
+                "$gt": 1
+              }
+            }
+          }
+        ]
+      }
     }
   ],
   "tests": [
@@ -254,6 +278,32 @@
               "commandStartedEvent": {
                 "command": {
                   "count": "coll0"
+                },
+                "commandName": "count",
+                "databaseName": "edc-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "estimatedDocumentCount works correctly on views",
+      "operations": [
+        {
+          "name": "estimatedDocumentCount",
+          "object": "collection0View",
+          "expectResult": 2
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0view"
                 },
                 "commandName": "count",
                 "databaseName": "edc-tests"

--- a/source/crud/tests/unified/estimatedDocumentCount.json
+++ b/source/crud/tests/unified/estimatedDocumentCount.json
@@ -1,6 +1,6 @@
 {
   "description": "estimatedDocumentCount",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.9",
   "createEntities": [
     {
       "client": {

--- a/source/crud/tests/unified/estimatedDocumentCount.json
+++ b/source/crud/tests/unified/estimatedDocumentCount.json
@@ -1,6 +1,6 @@
 {
   "description": "estimatedDocumentCount",
-  "schemaVersion": "1.9",
+  "schemaVersion": "1.0",
   "createEntities": [
     {
       "client": {
@@ -61,23 +61,6 @@
           "x": 33
         }
       ]
-    },
-    {
-      "collectionName": "coll0view",
-      "databaseName": "edc-tests",
-      "documents": [],
-      "createOptions": {
-        "viewOn": "coll0",
-        "pipeline": [
-          {
-            "$match": {
-              "_id": {
-                "$gt": 1
-              }
-            }
-          }
-        ]
-      }
     }
   ],
   "tests": [
@@ -289,7 +272,36 @@
     },
     {
       "description": "estimatedDocumentCount works correctly on views",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.4.0"
+        }
+      ],
       "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "coll0view"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database0",
+          "arguments": {
+            "collection": "coll0view",
+            "viewOn": "coll0",
+            "pipeline": [
+              {
+                "$match": {
+                  "_id": {
+                    "$gt": 1
+                  }
+                }
+              }
+            ]
+          }
+        },
         {
           "name": "estimatedDocumentCount",
           "object": "collection0View",
@@ -300,6 +312,34 @@
         {
           "client": "client0",
           "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "drop": "coll0view"
+                },
+                "commandName": "drop",
+                "databaseName": "edc-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "create": "coll0view",
+                  "viewOn": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "_id": {
+                          "$gt": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "commandName": "create",
+                "databaseName": "edc-tests"
+              }
+            },
             {
               "commandStartedEvent": {
                 "command": {

--- a/source/crud/tests/unified/estimatedDocumentCount.yml
+++ b/source/crud/tests/unified/estimatedDocumentCount.yml
@@ -1,6 +1,6 @@
 description: "estimatedDocumentCount"
 
-schemaVersion: "1.9"
+schemaVersion: "1.0"
 
 createEntities:
   - client:
@@ -33,13 +33,6 @@ initialData:
       - { _id: 1, x: 11 }
       - { _id: 2, x: 22 }
       - { _id: 3, x: 33 }
-  - collectionName: *collection0ViewName
-    databaseName: *database0Name
-    documents: []
-    createOptions:
-      viewOn: *collection0Name
-      pipeline:
-        - { $match: { _id: { $gt: 1 } } }
 
 tests:
   - description: "estimatedDocumentCount always uses count"
@@ -148,13 +141,39 @@ tests:
               databaseName: *database0Name
 
   - description: "estimatedDocumentCount works correctly on views"
+    # viewOn option was added to the create command in 3.4
+    runOnRequirements:
+      - minServerVersion: "3.4.0"
     operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0ViewName
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0ViewName
+          viewOn: *collection0Name
+          pipeline: &pipeline
+            - { $match: { _id: { $gt: 1 } } }
       - name: estimatedDocumentCount
         object: *collection0View
         expectResult: 2
     expectEvents:
       - client: *client0
         events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0ViewName
+              commandName: drop
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0ViewName
+                viewOn: *collection0Name
+                pipeline: *pipeline
+              commandName: create
+              databaseName: *database0Name
           - commandStartedEvent:
               command:
                 count: *collection0ViewName

--- a/source/crud/tests/unified/estimatedDocumentCount.yml
+++ b/source/crud/tests/unified/estimatedDocumentCount.yml
@@ -1,6 +1,6 @@
 description: "estimatedDocumentCount"
 
-schemaVersion: "1.0"
+schemaVersion: "1.9"
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/estimatedDocumentCount.yml
+++ b/source/crud/tests/unified/estimatedDocumentCount.yml
@@ -21,6 +21,10 @@ createEntities:
       id: &collection1 collection1
       database: *database0
       collectionName: &collection1Name coll1
+  - collection:
+      id: &collection0View collection0View
+      database: *database0
+      collectionName: &collection0ViewName coll0view
 
 initialData:
   - collectionName: *collection0Name
@@ -29,6 +33,13 @@ initialData:
       - { _id: 1, x: 11 }
       - { _id: 2, x: 22 }
       - { _id: 3, x: 33 }
+  - collectionName: *collection0ViewName
+    databaseName: *database0Name
+    documents: []
+    createOptions:
+      viewOn: *collection0Name
+      pipeline:
+        - { $match: { _id: { $gt: 1 } } }
 
 tests:
   - description: "estimatedDocumentCount always uses count"
@@ -133,5 +144,19 @@ tests:
           - commandStartedEvent:
               command:
                 count: *collection0Name
+              commandName: count
+              databaseName: *database0Name
+
+  - description: "estimatedDocumentCount works correctly on views"
+    operations:
+      - name: estimatedDocumentCount
+        object: *collection0View
+        expectResult: 2
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0ViewName
               commandName: count
               databaseName: *database0Name

--- a/source/versioned-api/tests/crud-api-version-1-strict.json
+++ b/source/versioned-api/tests/crud-api-version-1-strict.json
@@ -615,7 +615,7 @@
       "description": "estimatedDocumentCount appends declared API version",
       "runOnRequirements": [
         {
-          "minServerVersion": "5.0.8",
+          "minServerVersion": "5.0.9",
           "maxServerVersion": "5.0.99"
         },
         {

--- a/source/versioned-api/tests/crud-api-version-1-strict.yml
+++ b/source/versioned-api/tests/crud-api-version-1-strict.yml
@@ -231,7 +231,7 @@ tests:
   - description: "estimatedDocumentCount appends declared API version"
     # See: https://jira.mongodb.org/browse/SERVER-63850
     runOnRequirements:
-      - minServerVersion: "5.0.8"
+      - minServerVersion: "5.0.9"
         maxServerVersion: "5.0.99"
       - minServerVersion: "5.3.2"
     operations:

--- a/source/versioned-api/tests/crud-api-version-1.json
+++ b/source/versioned-api/tests/crud-api-version-1.json
@@ -607,7 +607,7 @@
       "description": "estimatedDocumentCount appends declared API version",
       "runOnRequirements": [
         {
-          "minServerVersion": "5.0.8",
+          "minServerVersion": "5.0.9",
           "maxServerVersion": "5.0.99"
         },
         {

--- a/source/versioned-api/tests/crud-api-version-1.yml
+++ b/source/versioned-api/tests/crud-api-version-1.yml
@@ -225,7 +225,7 @@ tests:
   - description: "estimatedDocumentCount appends declared API version"
     # See: https://jira.mongodb.org/browse/SERVER-63850
     runOnRequirements:
-      - minServerVersion: "5.0.8"
+      - minServerVersion: "5.0.9"
         maxServerVersion: "5.0.99"
       - minServerVersion: "5.3.2"
     operations:


### PR DESCRIPTION
DRIVERS-2228

This is a follow up to the previous PR (#1187) which corrects the server version that the addition of `count` to the stable API was backported to. It also adds a test for `estimatedDocumentCount` on views.

