### PR TITLE
DRIVERS-2284 fix command_started_event field names

### DIFF
--- a/source/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.json
@@ -102,8 +102,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -111,8 +111,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -120,8 +120,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -129,8 +129,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -138,8 +138,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -147,8 +147,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -156,8 +156,8 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -165,8 +165,8 @@
             "command": {
               "create": "encryptedCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -182,8 +182,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -282,8 +282,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -291,8 +291,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -300,8 +300,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -309,8 +309,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -318,8 +318,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -327,8 +327,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -336,8 +336,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -345,8 +345,8 @@
             "command": {
               "create": "encryptedCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -362,8 +362,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -502,8 +502,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -511,8 +511,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -520,8 +520,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -529,8 +529,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -538,8 +538,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -547,8 +547,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -556,8 +556,8 @@
             "command": {
               "create": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -565,8 +565,8 @@
             "command": {
               "create": "encryptedCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -582,8 +582,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         },
         {
@@ -591,8 +591,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -600,8 +600,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -609,8 +609,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -618,8 +618,8 @@
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         }
       ]
@@ -732,8 +732,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -741,8 +741,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -750,8 +750,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -759,8 +759,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -768,8 +768,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -777,8 +777,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -786,8 +786,8 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -795,8 +795,8 @@
             "command": {
               "create": "encryptedCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -812,8 +812,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -879,8 +879,8 @@
                 "name": "plaintextCollection"
               }
             },
-            "commandName": "listCollections",
-            "databaseName": "default"
+            "command_name": "listCollections",
+            "database_name": "default"
           }
         },
         {
@@ -888,8 +888,8 @@
             "command": {
               "drop": "plaintextCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -897,8 +897,8 @@
             "command": {
               "create": "plaintextCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         }
       ]
@@ -994,8 +994,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1003,8 +1003,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1012,8 +1012,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1021,8 +1021,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1030,8 +1030,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1039,8 +1039,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1048,8 +1048,8 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1057,8 +1057,8 @@
             "command": {
               "create": "encryptedCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1074,8 +1074,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -1186,8 +1186,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1195,8 +1195,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1204,8 +1204,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1213,8 +1213,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1222,8 +1222,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1231,8 +1231,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1240,8 +1240,8 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1249,8 +1249,8 @@
             "command": {
               "create": "encryptedCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1266,8 +1266,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         }
       ]
@@ -1315,8 +1315,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1324,8 +1324,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1333,8 +1333,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1342,8 +1342,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         }
       ]
@@ -1511,8 +1511,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1520,8 +1520,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1529,8 +1529,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1538,8 +1538,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1547,8 +1547,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1556,8 +1556,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1565,8 +1565,8 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1574,8 +1574,8 @@
             "command": {
               "create": "encryptedCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1591,8 +1591,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         },
         {
@@ -1600,8 +1600,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1609,8 +1609,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1618,8 +1618,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1627,8 +1627,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         }
       ]
@@ -1779,8 +1779,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1788,8 +1788,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1797,8 +1797,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1806,8 +1806,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1815,8 +1815,8 @@
             "command": {
               "create": "encryptedCollection.esc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1824,8 +1824,8 @@
             "command": {
               "create": "encryptedCollection.ecc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1833,8 +1833,8 @@
             "command": {
               "create": "encryptedCollection.ecoc"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1842,8 +1842,8 @@
             "command": {
               "create": "encryptedCollection"
             },
-            "commandName": "create",
-            "databaseName": "default"
+            "command_name": "create",
+            "database_name": "default"
           }
         },
         {
@@ -1859,8 +1859,8 @@
                 }
               ]
             },
-            "commandName": "createIndexes",
-            "databaseName": "default"
+            "command_name": "createIndexes",
+            "database_name": "default"
           }
         },
         {
@@ -1871,8 +1871,8 @@
                 "name": "encryptedCollection"
               }
             },
-            "commandName": "listCollections",
-            "databaseName": "default"
+            "command_name": "listCollections",
+            "database_name": "default"
           }
         },
         {
@@ -1880,8 +1880,8 @@
             "command": {
               "drop": "encryptedCollection"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1889,8 +1889,8 @@
             "command": {
               "drop": "encryptedCollection.esc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1898,8 +1898,8 @@
             "command": {
               "drop": "encryptedCollection.ecc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         },
         {
@@ -1907,8 +1907,8 @@
             "command": {
               "drop": "encryptedCollection.ecoc"
             },
-            "commandName": "drop",
-            "databaseName": "default"
+            "command_name": "drop",
+            "database_name": "default"
           }
         }
       ]

--- a/source/client-side-encryption/tests/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.yml
@@ -68,47 +68,47 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -116,8 +116,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
   - description: "default state collection names are applied"
     clientOptions:
@@ -183,47 +183,47 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -231,8 +231,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
   - description: "drop removes all state collections"
     clientOptions:
@@ -323,47 +323,47 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -371,30 +371,30 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
         # events from dropCollection ... begin
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
   - description: "encryptedFieldsMap with cyclic entries does not loop"
     clientOptions:
@@ -469,47 +469,47 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -517,8 +517,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
   - description: "CreateCollection without encryptedFields."
     clientOptions:
@@ -561,19 +561,19 @@ tests:
             command:
               listCollections: 1
               filter: { name: "plaintextCollection" }
-            commandName: listCollections
-            databaseName: *database_name
+            command_name: listCollections
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "plaintextCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         - command_started_event:
             command:
               create: "plaintextCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
   - description: "CreateCollection from encryptedFieldsMap."
     clientOptions:
       autoEncryptOpts:
@@ -634,47 +634,47 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -682,8 +682,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
   - description: "CreateCollection from encryptedFields."
     clientOptions:
@@ -756,47 +756,47 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         # State collections are created first.
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Data collection is created after.
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -804,8 +804,8 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
 
   - description: "DropCollection from encryptedFieldsMap"
@@ -836,23 +836,23 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
   - description: "DropCollection from encryptedFields"
     clientOptions:
@@ -961,45 +961,45 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1007,30 +1007,30 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
         # events from dropCollection ... begin
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
 
   - description: "DropCollection from remote encryptedFields"
@@ -1130,45 +1130,45 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end
         # events from createCollection ... begin
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection"
-            commandName: create
-            databaseName: *database_name
+            command_name: create
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1176,34 +1176,34 @@ tests:
               indexes:
                 - name: __safeContent___1
                   key: { __safeContent__: 1 }
-            commandName: createIndexes
-            databaseName: *database_name
+            command_name: createIndexes
+            database_name: *database_name
         # events from createCollection ... end
         # events from dropCollection ... begin
         - command_started_event:
             command:
               listCollections: 1
               filter: { name: "encryptedCollection" }
-            commandName: listCollections
-            databaseName: *database_name
+            command_name: listCollections
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.esc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
-            commandName: drop
-            databaseName: *database_name
+            command_name: drop
+            database_name: *database_name
         # events from dropCollection ... end


### PR DESCRIPTION
# Summary
- Replace `commandName` / `databaseName` with `command_name` / `database_name` in the `fle2-CreateCollection` test.

# Background & Motivation

`commandName` and `databaseName` is used in the Unified Test Format [expectedCommandEvent](https://github.com/mongodb/specifications/blob/de75e99fb7e53e3b436c6b69b3deb893e5f6b5d1/source/unified-test-format/unified-test-format.rst#expectedcommandevent)

The Client-Side Encryption specification tests are based on the [Transactions Test Format](https://github.com/mongodb/specifications/tree/de75e99fb7e53e3b436c6b69b3deb893e5f6b5d1/source/transactions/tests#test-format). I did not find a description of the field names for `commandName` / `command_name` or `databaseName` / `database_name`. All of the transaction tests use `command_name` and `database_name`.

---

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **Not applicable? This is a test file fix.**
- [ ] Update changelog. **Not applicable? This is a test file fix.**
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **The updated fle2-CreateCollection test was validated in the [Go driver implementation here](https://github.com/mongodb/mongo-go-driver/pull/913).**
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

