### PR TITLE
DRIVERS-2310 Include encryptFields in expected FLE2 test command

### DIFF
--- a/source/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.json
@@ -943,7 +943,24 @@
           "name": "createCollection",
           "object": "database",
           "arguments": {
-            "collection": "encryptedCollection"
+            "collection": "encryptedCollection",
+            "encryptedFields": {
+              "escCollection": "encryptedCollection.esc",
+              "eccCollection": "encryptedCollection.ecc",
+              "ecocCollection": "encryptedCollection.ecoc",
+              "fields": [
+                {
+                  "path": "firstName",
+                  "bsonType": "string",
+                  "keyId": {
+                    "$binary": {
+                      "subType": "04",
+                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                    }
+                  }
+                }
+              ]
+            }
           }
         },
         {

--- a/source/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.json
@@ -1017,24 +1017,7 @@
           "name": "createCollection",
           "object": "database",
           "arguments": {
-            "collection": "encryptedCollection",
-            "encryptedFields": {
-              "escCollection": "encryptedCollection.esc",
-              "eccCollection": "encryptedCollection.ecc",
-              "ecocCollection": "encryptedCollection.ecoc",
-              "fields": [
-                {
-                  "path": "firstName",
-                  "bsonType": "string",
-                  "keyId": {
-                    "$binary": {
-                      "subType": "04",
-                      "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
-                    }
-                  }
-                }
-              ]
-            }
+            "collection": "encryptedCollection"
           }
         },
         {

--- a/source/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.json
@@ -163,7 +163,24 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -343,7 +360,27 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    },
+                    "queries": {
+                      "queryType": "equality",
+                      "contention": {
+                        "$numberLong": "0"
+                      }
+                    }
+                  }
+                ]
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -563,7 +600,27 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    },
+                    "queries": {
+                      "queryType": "equality",
+                      "contention": {
+                        "$numberLong": "0"
+                      }
+                    }
+                  }
+                ]
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -793,7 +850,24 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1072,7 +1146,24 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1264,7 +1355,24 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1589,7 +1697,24 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1857,7 +1982,24 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection"
+              "create": "encryptedCollection",
+              "encryptedFields": {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                  {
+                    "path": "firstName",
+                    "bsonType": "string",
+                    "keyId": {
+                      "$binary": {
+                        "subType": "04",
+                        "base64": "AAAAAAAAAAAAAAAAAAAAAA=="
+                      }
+                    }
+                  }
+                ]
+              }
             },
             "command_name": "create",
             "database_name": "default"

--- a/source/client-side-encryption/tests/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.yml
@@ -13,7 +13,7 @@ tests:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields0 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -107,6 +107,7 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection"
+              encryptedFields: *encrypted_fields0
             command_name: create
             database_name: *database_name
         # Index on __safeContents__ is then created.
@@ -125,7 +126,7 @@ tests:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields1 {
                 "fields": [
                     {
                         "path": "firstName",
@@ -222,6 +223,7 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection"
+              encryptedFields: *encrypted_fields1
             command_name: create
             database_name: *database_name
         # Index on __safeContents__ is then created.
@@ -240,7 +242,7 @@ tests:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields2 {
                 "fields": [
                     {
                         "path": "firstName",
@@ -362,6 +364,7 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection"
+              encryptedFields: *encrypted_fields2
             command_name: create
             database_name: *database_name
         # Index on __safeContents__ is then created.
@@ -404,7 +407,7 @@ tests:
         encryptedFieldsMap:
           # encryptedCollection has encryptedCollection.esc as the escCollection.
           # encryptedCollection.esc has encryptedCollection as the escCollection.
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields3 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -508,6 +511,7 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection"
+              encryptedFields: *encrypted_fields3
             command_name: create
             database_name: *database_name
         # Index on __safeContents__ is then created.
@@ -580,7 +584,7 @@ tests:
         kmsProviders:
           aws: {} # Credentials filled in from environment.
         encryptedFieldsMap:
-          default.encryptedCollection: {
+          default.encryptedCollection: &encrypted_fields4 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -685,6 +689,7 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection"
+              encryptedFields: *encrypted_fields4
             command_name: create
             database_name: *database_name
         # Index on __safeContents__ is then created.
@@ -724,7 +729,7 @@ tests:
         object: database
         arguments:
           collection: "encryptedCollection"
-          encryptedFields: {
+          encryptedFields: &encrypted_fields5 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -807,6 +812,7 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection"
+              encryptedFields: *encrypted_fields5
             command_name: create
             database_name: *database_name
         # Index on __safeContents__ is then created.
@@ -936,7 +942,7 @@ tests:
         object: database
         arguments:
           collection: "encryptedCollection"
-          encryptedFields: {
+          encryptedFields: &encrypted_fields6 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -1010,6 +1016,7 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection"
+              encryptedFields: *encrypted_fields6
             command_name: create
             database_name: *database_name
         # Index on __safeContents__ is then created.
@@ -1074,7 +1081,7 @@ tests:
         object: database
         arguments:
           collection: "encryptedCollection"
-          encryptedFields: {
+          encryptedFields: &encrypted_fields7 {
                 "escCollection": "encryptedCollection.esc",
                 "eccCollection": "encryptedCollection.ecc",
                 "ecocCollection": "encryptedCollection.ecoc",
@@ -1179,6 +1186,7 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection"
+              encryptedFields: *encrypted_fields7
             command_name: create
             database_name: *database_name
         # Index on __safeContents__ is then created.

--- a/source/client-side-encryption/tests/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.yml
@@ -602,6 +602,18 @@ tests:
         object: database
         arguments:
           collection: "encryptedCollection"
+          encryptedFields: {
+                "escCollection": "encryptedCollection.esc",
+                "eccCollection": "encryptedCollection.ecc",
+                "ecocCollection": "encryptedCollection.ecoc",
+                "fields": [
+                    {
+                        "path": "firstName",
+                        "bsonType": "string",
+                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
+                    }
+                ]
+            }
       - name: assertCollectionExists
         object: testRunner
         arguments:

--- a/source/client-side-encryption/tests/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.yml
@@ -606,18 +606,6 @@ tests:
         object: database
         arguments:
           collection: "encryptedCollection"
-          encryptedFields: {
-                "escCollection": "encryptedCollection.esc",
-                "eccCollection": "encryptedCollection.ecc",
-                "ecocCollection": "encryptedCollection.ecoc",
-                "fields": [
-                    {
-                        "path": "firstName",
-                        "bsonType": "string",
-                        "keyId": { "$binary": { "subType": "04", "base64": "AAAAAAAAAAAAAAAAAAAAAA==" }}
-                    }
-                ]
-            }
       - name: assertCollectionExists
         object: testRunner
         arguments:


### PR DESCRIPTION
In the “CreateCollection from encryptedFieldsMap”, it makes sense
to also assert on the encryptedFields option that ends up being
passed to the server.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

