### PR TITLE
DRIVERS-1995 Skip failing test on Server Version 5.3

### DIFF
--- a/source/change-streams/tests/unified/change-streams.json
+++ b/source/change-streams/tests/unified/change-streams.json
@@ -621,6 +621,15 @@
     },
     {
       "description": "Test new structure in ns document MUST NOT err",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "maxServerVersion": "5.2"
+        },
+        {
+          "minServerVersion": "6.0"
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",

--- a/source/change-streams/tests/unified/change-streams.json
+++ b/source/change-streams/tests/unified/change-streams.json
@@ -624,7 +624,7 @@
       "runOnRequirements": [
         {
           "minServerVersion": "3.6",
-          "maxServerVersion": "5.2"
+          "maxServerVersion": "5.2.99"
         },
         {
           "minServerVersion": "6.0"

--- a/source/change-streams/tests/unified/change-streams.yml
+++ b/source/change-streams/tests/unified/change-streams.yml
@@ -336,7 +336,7 @@ tests:
   - description: "Test new structure in ns document MUST NOT err"
     runOnRequirements:
       - minServerVersion: "3.6"
-        maxServerVersion: "5.2"
+        maxServerVersion: "5.2.99"
       - minServerVersion: "6.0"
     operations:
       - name: createChangeStream

--- a/source/change-streams/tests/unified/change-streams.yml
+++ b/source/change-streams/tests/unified/change-streams.yml
@@ -334,6 +334,10 @@ tests:
           newField: "newFieldValue"
 
   - description: "Test new structure in ns document MUST NOT err"
+    runOnRequirements:
+      - minServerVersion: "3.6"
+        maxServerVersion: "5.2"
+      - minServerVersion: "6.0"
     operations:
       - name: createChangeStream
         object: *collection0


### PR DESCRIPTION
[SERVER-65497](https://jira.mongodb.org/browse/SERVER-65497) fixed this test for 6.0 but not yet for 5.3.

We made these changes in https://github.com/mongodb/mongo-python-driver/pull/924 to pass the `rapid` tests.


