### PR TITLE
Use 6.0.0-rc4 in `csfle` download example

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -351,6 +351,8 @@ for information on "disabling" csfle and setting csfle search paths.
 
       $ python3 mongodl.py --component=csfle --version=6.0.0-rc4 --out=./csfle/
 
+   Other versions of `csfle` are available. Please use the `--list` option to see versions.
+
 .. _mongodl: https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/mongodl.py
 .. _drivers-evergreen-tools: https://github.com/mongodb-labs/drivers-evergreen-tools/
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -349,7 +349,7 @@ for information on "disabling" csfle and setting csfle search paths.
 
    .. code-block:: shell
 
-      $ python3 mongodl.py --component=csfle --version=5.3.1 --out=./csfle/
+      $ python3 mongodl.py --component=csfle --version=6.0.0-rc4 --out=./csfle/
 
 .. _mongodl: https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/mongodl.py
 .. _drivers-evergreen-tools: https://github.com/mongodb-labs/drivers-evergreen-tools/


### PR DESCRIPTION
5.3.1 does not have all of FLE 2.0 functionality. Per [slack](https://mongodb.slack.com/archives/CFPHLTRMK/p1652192975727899) it may not load correctly on macOS.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date.
- [ ] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

