### PR TITLE
DRIVERS-2326 Update FLE 2 Collection Management

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -688,7 +688,7 @@ A call to a driver helper ``Collection.Drop(dropOptions)`` must check if the col
 - The value of ``AutoEncryptionOpts.encryptedFieldsMap[<databaseName>.<collectionName>]``.
 - If ``AutoEncryptionOpts.encryptedFieldsMap`` is not null, run a ``listCollections`` command on the database ``databaseName`` with the filter ``{ "name": "<collectionName>" }``. Check the returned ``options`` for the ``encryptedFields`` option.
 
-If the collection namespace has an associated ``encryptedFields``, then do the following operations. If any of the following operations error, the remaining operations are not attempted:
+If the collection namespace has an associated ``encryptedFields``, then do the following operations. If any of the following operations error, the remaining operations are not attempted. A ``namespace not found`` error returned from the server (server error code 26) MUST be ignored:
 
 - Drop the collection with name ``encryptedFields["escCollection"]``.
   If ``encryptedFields["escCollection"]`` is not set, use the collection name ``enxcol_.<collectionName>.esc``.

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -2143,7 +2143,7 @@ Changelog
    :align: left
 
    Date, Description
-   22-05-11, Update create state collections to use clustered collections
+   22-05-11, Update create state collections to use clustered collections. Drop data collection after state collection.
    22-05-03, Add queryType, contentionFactor, and "Indexed" and "Unindexed" to algorithm.
    22-04-29, Add bypassQueryAnalysis option
    22-04-11, Document the usage of the new csfle_ library

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -10,8 +10,8 @@ Client Side Encryption
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 4.2
-:Last Modified: 2022-05-03
-:Version: 1.5.0
+:Last Modified: 2022-05-11
+:Version: 1.6.0
 
 .. _lmc-c-api: https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h.in
 
@@ -667,13 +667,13 @@ A call to a driver helper ``CreateCollection(collectionName, collectionOptions)`
 
 If the collection namespace has an associated ``encryptedFields``, then do the following operations. If any of the following operations error, the remaining operations are not attempted:
 
-- Create the collection with name ``encryptedFields["escCollection"]`` using default options.
+- Create the collection with name ``encryptedFields["escCollection"]`` as a clustered collection using the options ``{clusteredIndex: {key: {_id: 1}, unique: true}}``.
   If ``encryptedFields["escCollection"]`` is not set, use the collection name ``enxcol_.<collectionName>.esc``.
   Creating this collection MUST NOT check if the collection namespace is in the ``AutoEncryptionOpts.encryptedFieldsMap``.
-- Create the collection with name ``encryptedFields["eccCollection"]`` using default options.
+- Create the collection with name ``encryptedFields["eccCollection"]`` as a clustered collection using the options ``{clusteredIndex: {key: {_id: 1}, unique: true}}``.
   If ``encryptedFields["eccCollection"]`` is not set, use the collection name ``enxcol_.<collectionName>.ecc``.
   Creating this collection MUST NOT check if the collection namespace is in the ``AutoEncryptionOpts.encryptedFieldsMap``.
-- Create the collection with name ``encryptedFields["ecocCollection"]`` using default options.
+- Create the collection with name ``encryptedFields["ecocCollection"]`` as a clustered collection using the options ``{clusteredIndex: {key: {_id: 1}, unique: true}}``.
   If ``encryptedFields["ecocCollection"]`` is not set, use the collection name ``enxcol_.<collectionName>.ecoc``.
   Creating this collection MUST NOT check if the collection namespace is in the ``AutoEncryptionOpts.encryptedFieldsMap``.
 - Create the collection ``collectionName`` with ``collectionOptions`` and the option ``encryptedFields`` set to the ``encryptedFields``.
@@ -2143,6 +2143,7 @@ Changelog
    :align: left
 
    Date, Description
+   22-05-11, Update create state collections to use clustered collections
    22-05-03, Add queryType, contentionFactor, and "Indexed" and "Unindexed" to algorithm.
    22-04-29, Add bypassQueryAnalysis option
    22-04-11, Document the usage of the new csfle_ library

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -689,13 +689,13 @@ A call to a driver helper ``Collection.Drop(dropOptions)`` must check if the col
 
 If the collection namespace has an associated ``encryptedFields``, then do the following operations. If any of the following operations error, the remaining operations are not attempted:
 
-- Drop the collection ``collectionName``.
 - Drop the collection with name ``encryptedFields["escCollection"]``.
   If ``encryptedFields["escCollection"]`` is not set, use the collection name ``enxcol_.<collectionName>.esc``.
 - Drop the collection with name ``encryptedFields["eccCollection"]``.
   If ``encryptedFields["eccCollection"]`` is not set, use the collection name ``enxcol_.<collectionName>.ecc``.
 - Drop the collection with name ``encryptedFields["ecocCollection"]``.
   If ``encryptedFields["ecocCollection"]`` is not set, use the collection name ``enxcol_.<collectionName>.ecoc``.
+- Drop the collection ``collectionName``.
 
 ClientEncryption
 ----------------

--- a/source/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.json
@@ -136,7 +136,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -145,7 +151,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -154,7 +166,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -333,7 +351,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.esc"
+              "create": "enxcol_.encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -342,7 +366,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc"
+              "create": "enxcol_.encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -351,7 +381,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecoc"
+              "create": "enxcol_.encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -573,7 +609,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.esc"
+              "create": "enxcol_.encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -582,7 +624,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecc"
+              "create": "enxcol_.encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -591,7 +639,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "enxcol_.encryptedCollection.ecoc"
+              "create": "enxcol_.encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -823,7 +877,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -832,7 +892,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -841,7 +907,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1102,7 +1174,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1111,7 +1189,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1120,7 +1204,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1311,7 +1401,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1320,7 +1416,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1329,7 +1431,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1653,7 +1761,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1662,7 +1776,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1671,7 +1791,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1938,7 +2064,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.esc"
+              "create": "encryptedCollection.esc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1947,7 +2079,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecc"
+              "create": "encryptedCollection.ecc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"
@@ -1956,7 +2094,13 @@
         {
           "command_started_event": {
             "command": {
-              "create": "encryptedCollection.ecoc"
+              "create": "encryptedCollection.ecoc",
+              "clusteredIndex": {
+                "key": {
+                  "_id": 1
+                },
+                "unique": true
+              }
             },
             "command_name": "create",
             "database_name": "default"

--- a/source/client-side-encryption/tests/fle2-CreateCollection.json
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.json
@@ -100,15 +100,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -128,6 +119,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -315,15 +315,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -343,6 +334,15 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -573,15 +573,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -601,6 +592,15 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -700,15 +700,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "enxcol_.encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -728,6 +719,15 @@
           "command_started_event": {
             "command": {
               "drop": "enxcol_.encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -841,15 +841,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -869,6 +860,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1138,15 +1138,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1166,6 +1157,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1365,15 +1365,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1393,6 +1384,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1529,15 +1529,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1557,6 +1548,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1725,15 +1725,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1753,6 +1744,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -1849,15 +1849,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -1877,6 +1868,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -2028,15 +2028,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -2056,6 +2047,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"
@@ -2164,15 +2164,6 @@
         {
           "command_started_event": {
             "command": {
-              "drop": "encryptedCollection"
-            },
-            "command_name": "drop",
-            "database_name": "default"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "drop": "encryptedCollection.esc"
             },
             "command_name": "drop",
@@ -2192,6 +2183,15 @@
           "command_started_event": {
             "command": {
               "drop": "encryptedCollection.ecoc"
+            },
+            "command_name": "drop",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "drop": "encryptedCollection"
             },
             "command_name": "drop",
             "database_name": "default"

--- a/source/client-side-encryption/tests/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.yml
@@ -67,11 +67,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -83,6 +78,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -186,11 +186,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -202,6 +197,11 @@ tests:
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -330,11 +330,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -346,6 +341,11 @@ tests:
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -389,11 +389,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "enxcol_.encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -405,6 +400,11 @@ tests:
         - command_started_event:
             command:
               drop: "enxcol_.encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -480,11 +480,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -496,6 +491,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -649,11 +649,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -665,6 +660,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -775,11 +775,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -791,6 +786,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -859,11 +859,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -875,6 +870,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -984,11 +984,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -1000,6 +995,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -1041,11 +1041,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -1057,6 +1052,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -1157,11 +1157,6 @@ tests:
         # events from dropCollection ... begin
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -1173,6 +1168,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end
@@ -1220,11 +1220,6 @@ tests:
             database_name: *database_name
         - command_started_event:
             command:
-              drop: "encryptedCollection"
-            command_name: drop
-            database_name: *database_name
-        - command_started_event:
-            command:
               drop: "encryptedCollection.esc"
             command_name: drop
             database_name: *database_name
@@ -1236,6 +1231,11 @@ tests:
         - command_started_event:
             command:
               drop: "encryptedCollection.ecoc"
+            command_name: drop
+            database_name: *database_name
+        - command_started_event:
+            command:
+              drop: "encryptedCollection"
             command_name: drop
             database_name: *database_name
         # events from dropCollection ... end

--- a/source/client-side-encryption/tests/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/fle2-CreateCollection.yml
@@ -91,16 +91,19 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -207,16 +210,19 @@ tests:
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -348,16 +354,19 @@ tests:
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "enxcol_.encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -495,16 +504,19 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -661,16 +673,19 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -784,16 +799,19 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         # Data collection is created after.
@@ -989,16 +1007,19 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
@@ -1159,16 +1180,19 @@ tests:
         - command_started_event:
             command:
               create: "encryptedCollection.esc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:
             command:
               create: "encryptedCollection.ecoc"
+              clusteredIndex: {key: {_id: 1}, unique: true}
             command_name: create
             database_name: *database_name
         - command_started_event:


### PR DESCRIPTION
The FLE 2 secondary collections benefit from being clustered collections
on _id. This reduces the write amplification by 50%.

@kevinAlbs, Unfortunately, I do not know how to write the drivers tests so I need help from someone to update the tests.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested in [C](https://github.com/mongodb/mongo-c-driver/pull/993) and [Go](https://github.com/kevinAlbs/mongo-go-driver/pull/5)**
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

