### PR TITLE
DRIVERS-2302 add missing test setup step

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1592,6 +1592,8 @@ Drop and create the collection ``db.explicit_encryption`` using ``encryptedField
 
 Drop and create the collection ``keyvault.datakeys``.
 
+Insert ``key1Document`` in ``keyvault.datakeys`` with majority write concern.
+
 Create a MongoClient named ``keyVaultClient``.
 
 Create a ClientEncryption object named ``clientEncryption`` with these options:


### PR DESCRIPTION
# Summary
- Insert `key1Document` in the `keyvault.datakeys` collection in the `Explicit Encryption` test setup.

# Background & Motivation

Inserting `key1Document` was [in the Go implementation](https://github.com/kevinAlbs/mongo-go-driver/pull/3/files#diff-55617555c17bae6fadeb3e9a0c0e3a10837496998c75937eba67712b871f58eeR101) but was missed when writing the setup steps.

Majority write concern must be used since the driver uses [majority read concern to find key documents](https://github.com/mongodb/specifications/blob/d1458823bd810014df9da16d3a5354d2269ab865/source/client-side-encryption/client-side-encryption.rst#key-vault-collection). 

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **Not applicable? This is a test setup step fix**
- [ ] Update changelog. **Not applicable? This is a test setup step fix**
- [ ] Make sure there are generated JSON files from the YAML test files. **Not applicable. Only affects prose tests. **
- [x] Test changes in at least one language driver. **Tested in Go and C**
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

