### PR TITLE
DRIVERS-2285 Add `wallTime` field to change stream events

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -9,8 +9,8 @@ Change Streams
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: 2022-04-13
-:Version: 1.14
+:Last Modified: 2022-05-17
+:Version: 1.15
 
 .. contents::
 
@@ -203,6 +203,12 @@ If an aggregate command with a ``$changeStream`` stage completes successfully, t
      * pre-image is unavailable, this will be explicitly set to null.
      */
     fullDocumentBeforeChange: Document | null;
+
+    /**
+     * The wall time from the mongod that the change event originated from.
+     * Populated for server versions 6.0 and above.
+     */
+    wallTime: Optional<Datetime>;
   }
 
   class UpdateDescription {
@@ -998,4 +1004,6 @@ Changelog
 +------------+------------------------------------------------------------+
 | 2022-04-13 | Support returning point-in-time pre and post-images with   |
 |            | ``fullDocumentBeforeChange`` and ``fullDocument``.         |
++------------+------------------------------------------------------------+
+| 2022-05-17 | Added ``wallTime`` to ``ChangeStreamDocument``.            |
 +------------+------------------------------------------------------------+

--- a/source/change-streams/tests/unified/change-streams.json
+++ b/source/change-streams/tests/unified/change-streams.json
@@ -1748,6 +1748,48 @@
           ]
         }
       ]
+    },
+    {
+      "description": "Test wallTime field is set in a change event",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "6.0.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": 1
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "insert",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "wallTime": {
+              "$$exists": true
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/source/change-streams/tests/unified/change-streams.yml
+++ b/source/change-streams/tests/unified/change-streams.yml
@@ -904,3 +904,24 @@ tests:
                 pipeline: [ { $changeStream: {} } ]
               commandName: aggregate
               databaseName: *database0
+
+  - description: "Test wallTime field is set in a change event"
+    runOnRequirements:
+      - minServerVersion: "6.0.0"
+    operations:
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { "_id": 1, "a": 1 }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "insert"
+          ns:
+            db: *database0
+            coll: *collection0
+          wallTime: { $$exists: true }


### PR DESCRIPTION
DRIVERS-2285

This adds the `wallTime` field now that it will always be populated in server versions 6.0+.  https://github.com/mongodb/mongo-rust-driver/pull/658 is the (very small) Rust PoC for this change.