### PR TITLE
remove note about contentionFactor default

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -915,7 +915,6 @@ contentionFactor
 ^^^^^^^^^^^^^^^^
 contentionFactor only applies when algorithm is "Indexed".
 It is an error to set contentionFactor when algorithm is not "Indexed".
-If contentionFactor is not supplied, it defaults to a value of 0.
 
 queryType
 ^^^^^^^^^


### PR DESCRIPTION
The default value is applied in libmongocrypt, not the driver.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **Not applicable? Small clarification.**
- [ ] Update changelog. **Not applicable? Small clarification.**
- [ ] Make sure there are generated JSON files from the YAML test files. **Not applicable. No test changes.**
- [ ] Test changes in at least one language driver. **Not applicable. No functional changes.**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **Not applicable. No functional changes.**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

