### PR TITLE
DRIVERS-555 Forbid serverless on collectionData test

### DIFF
--- a/source/unified-test-format/tests/valid-pass/collectionData-createOptions.json
+++ b/source/unified-test-format/tests/valid-pass/collectionData-createOptions.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.9",
   "runOnRequirements": [
     {
-      "minServerVersion": "3.6"
+      "minServerVersion": "3.6",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/unified-test-format/tests/valid-pass/collectionData-createOptions.yml
+++ b/source/unified-test-format/tests/valid-pass/collectionData-createOptions.yml
@@ -4,6 +4,8 @@ schemaVersion: "1.9"
 
 runOnRequirements:
   - minServerVersion: "3.6"
+    # Capped collections cannot be created on serverless instances.
+    serverless: forbid
 
 createEntities:
   - client:


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [n/a Bump spec version and last modified date.
- n/a Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

Forbids `serverless` on the `collectionData` test because it attempts to create a capped collection which are not allowed on serverless topologies.
