### PR TITLE
DRIVERS-2309 test `create`, `createIndexes`, and `collMod` in FLE

### DIFF
--- a/source/client-side-encryption/etc/test-templates/create-and-createIndexes.yml.template
+++ b/source/client-side-encryption/etc/test-templates/create-and-createIndexes.yml.template
@@ -1,0 +1,58 @@
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+
+data: []
+tests:
+  - description: "create is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+        validator:
+          unencrypted_string: "foo"
+    - name: assertCollectionExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "unencryptedCollection"
+  - description: "createIndexes is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "unencryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+    - name: assertIndexExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "unencryptedCollection"
+        index: name

--- a/source/client-side-encryption/etc/test-templates/fle2-validatorAndPartialFieldExpression.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-validatorAndPartialFieldExpression.yml.template
@@ -1,0 +1,168 @@
+# This test requires libmongocrypt 1.5.0-alpha2.
+runOn:
+    # Require server version 6.0.0 to get behavior added in SERVER-64911.
+    - minServerVersion: "6.0.0"
+      # FLE 2 Encrypted collections are not supported on standalone.
+      topology: [ "replicaset", "sharded" ]
+
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+data: []
+tests:
+  - description: "create with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {{ yamlfile ("encryptedFields.json") }}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          unencrypted_string: "foo"
+    - name: assertCollectionExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+  - description: "create with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {{ yamlfile ("encryptedFields.json") }}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          encryptedIndexed: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "collMod with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {{ yamlfile ("encryptedFields.json") }}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            unencrypted_string: "foo"
+  - description: "collMod with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {{ yamlfile ("encryptedFields.json") }}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            encryptedIndexed: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "createIndexes with a partialFilterExpression on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {{ yamlfile ("encryptedFields.json") }}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                unencrypted_string: "foo"
+    - name: assertIndexExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+        index: name
+  - description: "createIndexes with a partialFilterExpression on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {{ yamlfile ("encryptedFields.json") }}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                encryptedIndexed: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"

--- a/source/client-side-encryption/etc/test-templates/validatorAndPartialFieldExpression.yml.template
+++ b/source/client-side-encryption/etc/test-templates/validatorAndPartialFieldExpression.yml.template
@@ -1,0 +1,166 @@
+# This test requires libmongocrypt 1.5.0-alpha2.
+runOn:
+  # Require server version 6.0.0 to get behavior added in SERVER-64911.
+  - minServerVersion: "6.0.0"
+
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+data: []
+tests:
+  - description: "create with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        schemaMap:
+          "default.encryptedCollection": {{schema('basic')}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          unencrypted_string: "foo"
+    - name: assertCollectionExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+  - description: "create with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        schemaMap:
+          "default.encryptedCollection": {{schema('basic')}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          encrypted_string: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "collMod with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        schemaMap:
+          "default.encryptedCollection": {{schema('basic')}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            unencrypted_string: "foo"
+  - description: "collMod with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        schemaMap:
+          "default.encryptedCollection": {{schema('basic')}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            encrypted_string: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "createIndexes with a partialFilterExpression on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        schemaMap:
+          "default.encryptedCollection": {{schema('basic')}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                unencrypted_string: "foo"
+    - name: assertIndexExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+        index: name
+  - description: "createIndexes with a partialFilterExpression on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+        schemaMap:
+          "default.encryptedCollection": {{schema('basic')}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                encrypted_string: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"

--- a/source/client-side-encryption/tests/legacy/create-and-createIndexes.json
+++ b/source/client-side-encryption/tests/legacy/create-and-createIndexes.json
@@ -1,0 +1,115 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "4.1.10"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "tests": [
+    {
+      "description": "create is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "unencryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "unencryptedCollection",
+            "validator": {
+              "unencrypted_string": "foo"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "unencryptedCollection"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "unencryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "unencryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "unencryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "unencryptedCollection",
+            "index": "name"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/client-side-encryption/tests/legacy/create-and-createIndexes.yml
+++ b/source/client-side-encryption/tests/legacy/create-and-createIndexes.yml
@@ -1,0 +1,58 @@
+runOn:
+  - minServerVersion: "4.1.10"
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+
+data: []
+tests:
+  - description: "create is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+        validator:
+          unencrypted_string: "foo"
+    - name: assertCollectionExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "unencryptedCollection"
+  - description: "createIndexes is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "unencryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "unencryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+    - name: assertIndexExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "unencryptedCollection"
+        index: name

--- a/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.json
+++ b/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.json
@@ -1,0 +1,520 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "6.0.0",
+      "topology": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "tests": [
+    {
+      "description": "create with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "unencrypted_string": "foo"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        }
+      ]
+    },
+    {
+      "description": "create with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "encryptedIndexed": "foo"
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "unencrypted_string": "foo"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "encryptedIndexed": "foo"
+              }
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "unencrypted_string": "foo"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "name"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "encryptedFieldsMap": {
+            "default.encryptedCollection": {
+              "escCollection": "enxcol_.default.esc",
+              "eccCollection": "enxcol_.default.ecc",
+              "ecocCollection": "enxcol_.default.ecoc",
+              "fields": [
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedIndexed",
+                  "bsonType": "string",
+                  "queries": {
+                    "queryType": "equality",
+                    "contention": {
+                      "$numberLong": "0"
+                    }
+                  }
+                },
+                {
+                  "keyId": {
+                    "$binary": {
+                      "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                      "subType": "04"
+                    }
+                  },
+                  "path": "encryptedUnindexed",
+                  "bsonType": "string"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "encryptedIndexed": "foo"
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
@@ -1,0 +1,167 @@
+runOn:
+    # Require server version 6.0.0 to get behavior added in SERVER-64911.
+    - minServerVersion: "6.0.0"
+      # FLE 2 Encrypted collections are not supported on standalone.
+      topology: [ "replicaset", "sharded" ]
+
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+data: []
+tests:
+  - description: "create with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          unencrypted_string: "foo"
+    - name: assertCollectionExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+  - description: "create with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          encryptedIndexed: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "collMod with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            unencrypted_string: "foo"
+  - description: "collMod with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            encryptedIndexed: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "createIndexes with a partialFilterExpression on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                unencrypted_string: "foo"
+    - name: assertIndexExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+        index: name
+  - description: "createIndexes with a partialFilterExpression on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        encryptedFieldsMap:
+          "default.encryptedCollection": {'escCollection': 'enxcol_.default.esc', 'eccCollection': 'enxcol_.default.ecc', 'ecocCollection': 'enxcol_.default.ecoc', 'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedIndexed', 'bsonType': 'string', 'queries': {'queryType': 'equality', 'contention': {'$numberLong': '0'}}}, {'keyId': {'$binary': {'base64': 'q83vqxI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedUnindexed', 'bsonType': 'string'}]}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                encryptedIndexed: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"

--- a/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
@@ -1,3 +1,4 @@
+# This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
     # Require server version 6.0.0 to get behavior added in SERVER-64911.
     - minServerVersion: "6.0.0"

--- a/source/client-side-encryption/tests/legacy/validatorAndPartialFieldExpression.json
+++ b/source/client-side-encryption/tests/legacy/validatorAndPartialFieldExpression.json
@@ -1,0 +1,642 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "6.0.0"
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "tests": [
+    {
+      "description": "create with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "unencrypted_string": "foo"
+            }
+          }
+        },
+        {
+          "name": "assertCollectionExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
+        }
+      ]
+    },
+    {
+      "description": "create with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection",
+            "validator": {
+              "encrypted_string": "foo"
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "unencrypted_string": "foo"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "collMod with a validator on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "collMod": "encryptedCollection",
+              "validator": {
+                "encrypted_string": "foo"
+              }
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an unencrypted field is OK",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "unencrypted_string": "foo"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "assertIndexExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection",
+            "index": "name"
+          }
+        }
+      ]
+    },
+    {
+      "description": "createIndexes with a partialFilterExpression on an encrypted field is an error",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          },
+          "schemaMap": {
+            "default.encryptedCollection": {
+              "properties": {
+                "encrypted_w_altname": {
+                  "encrypt": {
+                    "keyId": "/altname",
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                },
+                "random": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+                  }
+                },
+                "encrypted_string_equivalent": {
+                  "encrypt": {
+                    "keyId": [
+                      {
+                        "$binary": {
+                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "subType": "04"
+                        }
+                      }
+                    ],
+                    "bsonType": "string",
+                    "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+                  }
+                }
+              },
+              "bsonType": "object"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "createCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "encryptedCollection"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "createIndexes": "encryptedCollection",
+              "indexes": [
+                {
+                  "name": "name",
+                  "key": {
+                    "name": 1
+                  },
+                  "partialFilterExpression": {
+                    "encrypted_string": "foo"
+                  }
+                }
+              ]
+            }
+          },
+          "result": {
+            "errorContains": "Comparison to encrypted fields not supported"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/client-side-encryption/tests/legacy/validatorAndPartialFieldExpression.yml
+++ b/source/client-side-encryption/tests/legacy/validatorAndPartialFieldExpression.yml
@@ -1,0 +1,165 @@
+runOn:
+  # Require server version 6.0.0 to get behavior added in SERVER-64911.
+  - minServerVersion: "6.0.0"
+
+database_name: &database_name "default"
+collection_name: &collection_name "default"
+data: []
+tests:
+  - description: "create with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          unencrypted_string: "foo"
+    - name: assertCollectionExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+  - description: "create with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+        validator:
+          encrypted_string: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "collMod with a validator on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            unencrypted_string: "foo"
+  - description: "collMod with a validator on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          collMod: "encryptedCollection"
+          validator:
+            encrypted_string: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"
+  - description: "createIndexes with a partialFilterExpression on an unencrypted field is OK"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                unencrypted_string: "foo"
+    - name: assertIndexExists
+      object: testRunner
+      arguments:
+        database: *database_name
+        collection: "encryptedCollection"
+        index: name
+  - description: "createIndexes with a partialFilterExpression on an encrypted field is an error"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+        schemaMap:
+          "default.encryptedCollection": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+    operations:
+    # Drop to remove a collection that may exist from previous test runs.
+    - name: dropCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: createCollection
+      object: database
+      arguments:
+        collection: "encryptedCollection"
+    - name: runCommand
+      object: database
+      arguments:
+        command:
+          createIndexes: "encryptedCollection"
+          indexes:
+            - name: "name"
+              key: { name: 1 }
+              partialFilterExpression:
+                encrypted_string: "foo"
+      result:
+        errorContains: "Comparison to encrypted fields not supported"

--- a/source/client-side-encryption/tests/legacy/validatorAndPartialFieldExpression.yml
+++ b/source/client-side-encryption/tests/legacy/validatorAndPartialFieldExpression.yml
@@ -1,3 +1,4 @@
+# This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
   # Require server version 6.0.0 to get behavior added in SERVER-64911.
   - minServerVersion: "6.0.0"


### PR DESCRIPTION
# Summary

This contains integration tests for behavior added in [MONGOCRYPT-429](https://jira.mongodb.org/browse/MONGOCRYPT-429). libmongocrypt 1.5.0-alpha2 is required to run these tests expected. There are no driver changes required.

- Test that `create` and `collMod` with a `validator` for encrypted fields are an error.
- Test that `createIndexes` with a `partialFieldExpression` for encrypted fields is an error.
- Test that `create` and `createIndexes` continues to work.

Tests were run with the [Go driver here](https://github.com/kevinAlbs/mongo-go-driver/pull/6) and the [C driver here](https://github.com/mongodb/mongo-c-driver/pull/1005).

Tests are expected fail on `mongocryptd` or `csfle` versions >= 6.0.0-rc0 and <= 6.0.0-rc4. The versions do not include [SERVER-64911](https://jira.mongodb.org/browse/SERVER-64911).

# Background & Motivation

libmongocrypt 1.5.0-alpha2 may be downloaded from [Evergreen here](https://evergreen.mongodb.com/task/libmongocrypt_publish_snapshot_upload_all_bc7f312c5f98e7d697df045d7e56a49abcceeaa6_22_05_04_20_57_02).

DRIVERS-2309 requests running "create", "createIndexes", and "collMod" commands through query analysis (`mongocryptd` or `csfle` shared library).

The "create" and "collMod" commands may contain sensitive data in `validators`:

```js
{
    "create": "encryptedCollection",
    "validator": {
        // "a", "b", and "c" are sensitive.
        "encryptedField": { "$in": [ "a", "b", "c" ]}
    }
}
```

The "createIndexes" field may contain sensitive data in the `partialFilterExpression`:

```js
{
    "createIndexes": "encryptedCollection",
    "indexes": {
        "name": "name",
        "key": { "name": 1 },
        "partialFilterExpression": {
            // "a", "b", and "c" are sensitive.
            "encryptedField": { "$in": [ "a", "b", "c" ]}
        }
    }
}
```

`mongocryptd` versions older than 6.0.0-rc5 return an error on `create` and `createIndexes`:

```
> db.runCommand({create: "foo", jsonSchema: {}})
{
	"ok" : 0,
	"errmsg" : "no such command: 'create'",
	"code" : 59,
	"codeName" : "CommandNotFound"
}
MongoDB Enterprise > db.version()
5.0.5
```

Before MONGOCRYPT-429:
- libmongocrypt would bypass query analysis for `create` and `createIndexes` and send them as-is.
- libmongocrypt would error on `collMod`. 

After MONGOCRYPT-429:
- libmongocrypt checks if `mongocryptd` supports `create` and `createIndexes` by checking the wire version with `isMaster`.
- If query analysis supports `create` and `createIndexes`, both commands are sent to query analysis.
- If query analysis does not support `create` and `createIndexes`, both commands are sent as-is. This is to prevent a backwards break when using `mongocryptd` < 6.0.
- `collMod` is always sent to query analysis.


<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **Not applicable. Test changes only.**
- [ ] Update changelog. **Not applicable. Test changes only.**
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

