### PR TITLE
DRIVERS-2307 use topology, not topologies

### DIFF
--- a/source/client-side-encryption/etc/test-templates/fle2-Compact.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Compact.yml.template
@@ -1,6 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
-    topologies: [ "replicaset", "sharded" ]
+    # FLE 2 Encrypted collections are not supported on standalone.
+    topology: [ "replicaset", "sharded" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-Compact.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Compact.json
@@ -2,7 +2,7 @@
   "runOn": [
     {
       "minServerVersion": "6.0.0",
-      "topologies": [
+      "topology": [
         "replicaset",
         "sharded"
       ]

--- a/source/client-side-encryption/tests/legacy/fle2-Compact.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Compact.yml
@@ -1,6 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
-    topologies: [ "replicaset", "sharded" ]
+    # FLE 2 Encrypted collections are not supported on standalone.
+    topology: [ "replicaset", "sharded" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []


### PR DESCRIPTION
# Summary

- Use "topology", not "topologies" in fle2-Compact test.

# Background & Motivation
"topologies" is used in the [Unified Test Format](https://github.com/mongodb/specifications/blob/7f37c9325b423223edf54d795afed444e6989b98/source/unified-test-format/unified-test-format.rst#runonrequirement). "topology" is consistent with the [legacy transaction test format](https://github.com/mongodb/specifications/tree/7f37c9325b423223edf54d795afed444e6989b98/source/transactions/tests#test-format). The CSFLE legacy specification tests are based off of the legacy transactions test format.


<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **Test fix. Not applicable**
- [ ] Update changelog. **Test fix. Not applicable**
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested with [C driver here](https://github.com/mongodb/mongo-c-driver/pull/1006)**
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **Tested with [C driver here](https://github.com/mongodb/mongo-c-driver/pull/1006)**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

