### PR TITLE
DRIVERS-2309 add listCollections events to fle2-CreateCollection

### DIFF
--- a/source/client-side-encryption/tests/legacy/fle2-CreateCollection.json
+++ b/source/client-side-encryption/tests/legacy/fle2-CreateCollection.json
@@ -1472,6 +1472,18 @@
         {
           "command_started_event": {
             "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
               "createIndexes": "encryptedCollection",
               "indexes": [
                 {
@@ -1832,6 +1844,18 @@
         {
           "command_started_event": {
             "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
               "createIndexes": "encryptedCollection",
               "indexes": [
                 {
@@ -2129,6 +2153,18 @@
               }
             },
             "command_name": "create",
+            "database_name": "default"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "encryptedCollection"
+              }
+            },
+            "command_name": "listCollections",
             "database_name": "default"
           }
         },

--- a/source/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
@@ -821,6 +821,13 @@ tests:
               encryptedFields: *encrypted_fields5
             command_name: create
             database_name: *database_name
+        # libmongocrypt requests listCollections to get a schema for the "createIndexes" command.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            command_name: listCollections
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1028,6 +1035,13 @@ tests:
               encryptedFields: *encrypted_fields6
             command_name: create
             database_name: *database_name
+        # libmongocrypt requests listCollections to get a schema for the "createIndexes" command.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            command_name: listCollections
+            database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:
             command:
@@ -1200,6 +1214,13 @@ tests:
               create: "encryptedCollection"
               encryptedFields: *encrypted_fields7
             command_name: create
+            database_name: *database_name
+        # libmongocrypt requests listCollections to get a schema for the "createIndexes" command.
+        - command_started_event:
+            command:
+              listCollections: 1
+              filter: { name: "encryptedCollection" }
+            command_name: listCollections
             database_name: *database_name
         # Index on __safeContents__ is then created.
         - command_started_event:

--- a/source/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
@@ -1,3 +1,4 @@
+# This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.


### PR DESCRIPTION
# Summary

- Add `listCollections` expected event to `fle2-CreateCollection` test for `createIndexes` command.

Tests were run with the [C driver here](https://github.com/mongodb/mongo-c-driver/pull/1009). The tests required the branch of libmongocrypt from https://github.com/mongodb/libmongocrypt/pull/341.

Drivers upgrading libmongocrypt to 1.5.0-alpha2 will need to update the `fle2-CreateCollection` test from this PR. 1.5.0-alpha2 is not yet released. libmongocrypt-1.5.0-alpha2 will contain [MONGOCRYPT-429](https://jira.mongodb.org/browse/MONGOCRYPT-429). I want to merge this before doing the 1.5.0-alpha2 release.

# Background & Motivation

MONGOCRYPT-429 now runs "createIndexes" through query analysis (`mongocryptd` or `csfle` shared library).  The "createIndexes" command sent as part of CreateCollection for FLE 2 will now generate `listCollections` events.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **Not applicable. Test changes only.**
- [ ] Update changelog. **Not applicable. Test changes only.**
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->