### PR TITLE
Add missing rationale for key management API and fix RST syntax

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -667,7 +667,7 @@ A collection supporting FLE 2 requires an index and three additional collections
 .. _drop: https://www.mongodb.com/docs/manual/reference/command/drop
 
 Create Collection Helper
-````````````````````````
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 Drivers MUST support a BSON document option named ``encryptedFields`` for any
 `create`_ command helpers (e.g. ``Database.createCollection()``). This option
@@ -694,7 +694,7 @@ If the collection namespace has an associated ``encryptedFields``, then do the f
 - Create the the index ``{"__safeContent__": 1}`` on collection ``collectionName``.
 
 Drop Collection Helper
-``````````````````````
+^^^^^^^^^^^^^^^^^^^^^^
 
 Drivers MUST support a BSON document option named ``encryptedFields`` for any
 `drop`_ command helpers (e.g. ``Database.dropCollection()``,

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -2197,6 +2197,14 @@ Why is there both a createKey and a createDataKey function in ClientEncryption?
 parity with the mongosh interface. ``createDataKey`` remains for backwards
 compatibility.
 
+Why does ClientEncryption have key management functions when Drivers can use existing CRUD operations instead?
+--------------------------------------------------------------------------------------------------------------
+
+The key management functions are added for parity with mongosh to reduce
+friction between conducting operations using mongosh and a Driver. Their
+inclusion assumes their value for users outweighs their cost of implementation
+and maintenance.
+
 Future work
 ===========
 


### PR DESCRIPTION
### Description

This adds a block of rationale that was missing from https://github.com/mongodb/specifications/pull/1229.

As a drive-by fix, this PR also fixes the section title style that currently breaks HTML formatting on Github.

### RST Syntax Checking

Because this issue is not being detected by `rstcheck`, I used `rst2html`:

```
rst2html --halt=none client-side-encryption.rst > /dev/null
```

This yielded the following set of warnings:

~~~
client-side-encryption.rst:87: (ERROR/3) Unknown interpreted text role "ref".
client-side-encryption.rst:245: (ERROR/3) Unknown interpreted text role "ref".
client-side-encryption.rst:642: (ERROR/3) Unknown interpreted text role "ref".
client-side-encryption.rst:644: (ERROR/3) Unknown interpreted text role "ref".
client-side-encryption.rst:669: (SEVERE/4) Title level inconsistent:

Create Collection Helper
````````````````````````
client-side-encryption.rst:696: (SEVERE/4) Title level inconsistent:

Drop Collection Helper
``````````````````````
client-side-encryption.rst:1112: (ERROR/3) Unknown directive type "index".

.. index:: csfle
client-side-encryption.rst:1751: (ERROR/3) Unknown directive type "toctree".

.. toctree::
   :maxdepth: 2

   ./tests/README


client-side-encryption.rst:1382: (ERROR/3) Unknown target name: "why does clientencryption have key management functions when drivers can use existing crud operations instead?".
~~~

The warnings regarding "unknown interpreted text role" and "unknown directive type" appear to be due to Sphinx-specific directives, thus I have elected to ignore them.

Also, for future reference, using triple `~~~` allowed me to escape the RST code block above that would otherwise have been confused by the backticks in the section title style.