### PR TITLE
DRIVERS-1096: Split showRecordId/returnKey into separate test

### DIFF
--- a/source/command-monitoring/tests/unified/find.json
+++ b/source/command-monitoring/tests/unified/find.json
@@ -123,7 +123,11 @@
               }
             },
             "sort": {
-              "_id": 1
+              "x": -1
+            },
+            "projection": {
+              "_id": 0,
+              "x": 1
             },
             "skip": 2,
             "comment": "test",
@@ -136,9 +140,7 @@
             "maxTimeMS": 6000,
             "min": {
               "_id": 0
-            },
-            "returnKey": false,
-            "showRecordId": false
+            }
           }
         }
       ],
@@ -156,7 +158,11 @@
                     }
                   },
                   "sort": {
-                    "_id": 1
+                    "x": -1
+                  },
+                  "projection": {
+                    "_id": 0,
+                    "x": 1
                   },
                   "skip": 2,
                   "comment": "test",
@@ -169,9 +175,7 @@
                   "maxTimeMS": 6000,
                   "min": {
                     "_id": 0
-                  },
-                  "returnKey": false,
-                  "showRecordId": false
+                  }
                 },
                 "commandName": "find",
                 "databaseName": "command-monitoring-tests"
@@ -186,12 +190,74 @@
                     "ns": "command-monitoring-tests.test",
                     "firstBatch": [
                       {
-                        "_id": 4,
-                        "x": 44
+                        "x": 33
                       },
                       {
-                        "_id": 5,
-                        "x": 55
+                        "x": 22
+                      }
+                    ]
+                  }
+                },
+                "commandName": "find"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A successful find with showRecordId and returnKey",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "sort": {
+              "_id": 1
+            },
+            "showRecordId": true,
+            "returnKey": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "test",
+                  "showRecordId": true,
+                  "returnKey": true
+                },
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
+              }
+            },
+            {
+              "commandSucceededEvent": {
+                "reply": {
+                  "ok": 1,
+                  "cursor": {
+                    "id": 0,
+                    "ns": "command-monitoring-tests.test",
+                    "firstBatch": [
+                      {
+                        "_id": 1
+                      },
+                      {
+                        "_id": 2
+                      },
+                      {
+                        "_id": 3
+                      },
+                      {
+                        "_id": 4
+                      },
+                      {
+                        "_id": 5
                       }
                     ]
                   }

--- a/source/command-monitoring/tests/unified/find.yml
+++ b/source/command-monitoring/tests/unified/find.yml
@@ -63,15 +63,14 @@ tests:
         object: *collection
         arguments:
           filter: { _id: { $gt: 1 } }
-          sort: { _id: 1 }
+          sort: { x: -1 }
+          projection: { _id: 0, x: 1 }
           skip: 2
           comment: "test"
           hint: { _id: 1 }
           max: { _id: 6 }
           maxTimeMS: 6000
           min: { _id: 0 }
-          returnKey: false
-          showRecordId: false
     expectEvents:
       - client: *client
         events:
@@ -79,15 +78,14 @@ tests:
               command:
                 find: *collectionName
                 filter: { _id: { $gt: 1 } }
-                sort: { _id: 1 }
+                sort: { x: -1 }
+                projection: { _id: 0, x: 1 }
                 skip: 2
                 comment: "test"
                 hint: { _id: 1 }
                 max: { _id: 6 }
                 maxTimeMS: 6000
                 min: { _id: 0 }
-                returnKey: false
-                showRecordId: false
               commandName: find
               databaseName: *databaseName
           - commandSucceededEvent:
@@ -97,8 +95,41 @@ tests:
                   id: 0
                   ns: *namespace
                   firstBatch:
-                    - { _id: 4, x: 44 }
-                    - { _id: 5, x: 55 }
+                    - { x: 33 }
+                    - { x: 22 }
+              commandName: find
+
+  - description: "A successful find with showRecordId and returnKey"
+    operations:
+      - name: find
+        object: *collection
+        arguments:
+          filter: { }
+          sort: { _id: 1 }
+          showRecordId: true
+          returnKey: true
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collectionName
+                showRecordId: true
+                returnKey: true
+              commandName: find
+              databaseName: *databaseName
+          - commandSucceededEvent:
+              reply:
+                ok: 1
+                cursor:
+                  id: 0
+                  ns: *namespace
+                  firstBatch:
+                    - { _id: 1 }
+                    - { _id: 2 }
+                    - { _id: 3 }
+                    - { _id: 4 }
+                    - { _id: 5 }
               commandName: find
 
   - description: "A successful find with a getMore"


### PR DESCRIPTION
Java driver is failing the `A successful find with options` test because it only include showRecordId and returnKey in the command if the value is true (the booleans are not nullable).  I switched up the tests a bit so that Java (and perhaps other drivers) will pass them.

DRIVERS-1096

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ n/a] Bump spec version and last modified date.
- [ n/a] Update changelog.
- [ x] Make sure there are generated JSON files from the YAML test files.
- [ x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

