### PR TITLE
require testing with mongocryptd

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -328,10 +328,13 @@ Using ``crypt_shared``
 ======================
 
 On platforms where crypt_shared_ is available, drivers should prefer to test
-with the ``crypt_shared`` library instead of spawning mongocryptd, although
-having some tests dedicated to mongocryptd is recommended. Note that some tests
-assert on mongocryptd-related behaviors (e.g. the ``mongocryptdBypassSpawn``
-test).
+with the ``crypt_shared`` library instead of spawning mongocryptd.
+
+Drivers MUST continue to run all tests with mongocryptd on at least one
+platform for all tested server versions.
+
+Note that some tests assert on mongocryptd-related behaviors (e.g. the
+``mongocryptdBypassSpawn`` test).
 
 Drivers under test should load the crypt_shared_ library using either the
 ``cryptSharedLibPath`` public API option (as part of the AutoEncryption


### PR DESCRIPTION
Requiring tests with mongocryptd is motivated by a behavior difference observed in mongocryptd 6.0.0-rc5. C and Ruby are using the "admin" database for commands to mongocryptd. mongocryptd 6.0.0-rc5 expects the database included in "encryptionInformation" to match "$db".

From [this survey](https://docs.google.com/spreadsheets/d/1VMk1UjI33MnHRFcqWf3UoGKSElZyjRdNji_FW5Kmu0U/edit?usp=sharing), I think this only impacts C and Ruby.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **Not applicable? Test changes only**
- [ ] Update changelog. **Not applicable? Test changes only**
- [ ] Make sure there are generated JSON files from the YAML test files. **Not applicable? Test README changes only**
- [x] Test changes in at least one language driver. **Tested in [C](https://github.com/mongodb/mongo-c-driver/pull/1020)**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **C does not currently test CSFLE with sharded or serverless**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

