### PR TITLE
DRIVERS-555 Increase CSOT test timeouts

### DIFF
--- a/source/client-side-operations-timeout/etc/templates/global-timeoutMS.yml.template
+++ b/source/client-side-operations-timeout/etc/templates/global-timeoutMS.yml.template
@@ -22,7 +22,7 @@ tests:
   # For each operation, we execute two tests:
   #
   # 1. timeoutMS can be configured to a non-zero value on a MongoClient and is inherited by the operation. Each test
-  # constructs a client entity with timeoutMS=50 and configures a fail point to block the operation for 60ms so
+  # constructs a client entity with timeoutMS=250 and configures a fail point to block the operation for 350ms so
   # execution results in a timeout error.
   #
   # 2. timeoutMS can be set to 0 for a MongoClient. Each test constructs a client entity with timeoutMS=0 and
@@ -39,7 +39,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -57,11 +57,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["{{operation.command_name}}"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: {{operation.operation_name}}
         object: *{{operation.object}}
         {% if operation.arguments|length > 0 -%}

--- a/source/client-side-operations-timeout/etc/templates/global-timeoutMS.yml.template
+++ b/source/client-side-operations-timeout/etc/templates/global-timeoutMS.yml.template
@@ -57,6 +57,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["{{operation.command_name}}"]

--- a/source/client-side-operations-timeout/etc/templates/retryability-timeoutMS.yml.template
+++ b/source/client-side-operations-timeout/etc/templates/retryability-timeoutMS.yml.template
@@ -46,7 +46,7 @@ tests:
   # because the second attempt should take it over the 100ms limit. This test only runs on 4.4+ because it uses the
   # blockConnection option in failCommand.
   #
-  # 2. operation is retried multiple times if timeoutMS is set to a non-zero value - Client timeoutMS=20 and the
+  # 2. operation is retried multiple times if timeoutMS is set to a non-zero value - Client timeoutMS=100 and the
   # operation fails with a retryable error twice. Drivers should send the original operation and two retries, the
   # second of which should succeed.
   #
@@ -70,7 +70,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["{{operation.command_name}}"]
               blockConnection: true
@@ -104,7 +104,7 @@ tests:
       - name: {{operation.operation_name}}
         object: *{{operation.object}}
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           {% for arg in operation.arguments -%}
           {{arg}}
           {% endfor %}

--- a/source/client-side-operations-timeout/tests/README.rst
+++ b/source/client-side-operations-timeout/tests/README.rst
@@ -229,7 +229,7 @@ timeoutMS is refreshed for each handshake command
            configureFailPoint: "failCommand",
            mode: "alwaysOn",
            data: {
-               failCommands: ["isMaster", "saslContinue"],
+               failCommands: ["hello", "isMaster", "saslContinue"],
                blockConnection: true,
                blockTimeMS: 15,
                appName: "refreshTimeoutBackgroundPoolTest"

--- a/source/client-side-operations-timeout/tests/bulkWrite.json
+++ b/source/client-side-operations-timeout/tests/bulkWrite.json
@@ -64,8 +64,17 @@
                   "update"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 120
               }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
             }
           }
         },
@@ -92,7 +101,7 @@
                 }
               }
             ],
-            "timeoutMS": 100
+            "timeoutMS": 200
           },
           "expectError": {
             "isTimeoutError": true
@@ -103,6 +112,15 @@
         {
           "client": "client",
           "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "find",
+                "databaseName": "test",
+                "command": {
+                  "find": "coll"
+                }
+              }
+            },
             {
               "commandStartedEvent": {
                 "commandName": "insert",

--- a/source/client-side-operations-timeout/tests/bulkWrite.yml
+++ b/source/client-side-operations-timeout/tests/bulkWrite.yml
@@ -30,7 +30,7 @@ initialData:
 
 tests:
   # Test that drivers do not refresh timeoutMS between commands. This is done by running a bulkWrite that will require
-  # two commands with timeoutMS=100 and blocking each command for 60ms. The server should take over 100ms total, so the
+  # two commands with timeoutMS=200 and blocking each command for 120ms. The server should take over 200ms total, so the
   # bulkWrite should fail with a timeout error.
   - description: "timeoutMS applied to entire bulkWrite, not individual commands"
     operations:
@@ -44,7 +44,12 @@ tests:
             data:
               failCommands: ["insert", "update"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 120
+      # Do an operation without a timeout to ensure the servers are discovered.
+      - name: find
+        object: *collection
+        arguments:
+          filter: { _id : 1 }
       - name: bulkWrite
         object: *collection
         arguments:
@@ -54,12 +59,17 @@ tests:
             - replaceOne:
                 filter: { _id: 1 }
                 replacement: { x: 1 }
-          timeoutMS: 100
+          timeoutMS: 200
         expectError:
           isTimeoutError: true
     expectEvents:
       - client: *client
         events:
+          - commandStartedEvent:
+              commandName: find
+              databaseName: *databaseName
+              command:
+                find: *collectionName
           - commandStartedEvent:
               commandName: insert
               databaseName: *databaseName

--- a/source/client-side-operations-timeout/tests/command-execution.json
+++ b/source/client-side-operations-timeout/tests/command-execution.json
@@ -40,11 +40,12 @@
               "mode": "alwaysOn",
               "data": {
                 "failCommands": [
+                  "hello",
                   "isMaster"
                 ],
                 "appName": "reduceMaxTimeMSTest",
                 "blockConnection": true,
-                "blockTimeMS": 10
+                "blockTimeMS": 20
               }
             }
           }
@@ -59,7 +60,8 @@
                   "id": "client",
                   "useMultipleMongoses": false,
                   "uriOptions": {
-                    "appName": "reduceMaxTimeMSTest"
+                    "appName": "reduceMaxTimeMSTest",
+                    "w": 1
                   },
                   "observeEvents": [
                     "commandStartedEvent"
@@ -86,7 +88,7 @@
                   "database": "database",
                   "collectionName": "timeoutColl",
                   "collectionOptions": {
-                    "timeoutMS": 20
+                    "timeoutMS": 60
                   }
                 }
               }
@@ -135,7 +137,7 @@
                 "command": {
                   "insert": "timeoutColl",
                   "maxTimeMS": {
-                    "$$lte": 20
+                    "$$lte": 60
                   }
                 }
               }
@@ -157,11 +159,12 @@
               "mode": "alwaysOn",
               "data": {
                 "failCommands": [
+                  "hello",
                   "isMaster"
                 ],
                 "appName": "rttTooHighTest",
                 "blockConnection": true,
-                "blockTimeMS": 10
+                "blockTimeMS": 20
               }
             }
           }
@@ -176,7 +179,8 @@
                   "id": "client",
                   "useMultipleMongoses": false,
                   "uriOptions": {
-                    "appName": "rttTooHighTest"
+                    "appName": "rttTooHighTest",
+                    "w": 1
                   },
                   "observeEvents": [
                     "commandStartedEvent"

--- a/source/client-side-operations-timeout/tests/command-execution.yml
+++ b/source/client-side-operations-timeout/tests/command-execution.yml
@@ -27,7 +27,7 @@ initialData:
 tests:
   - description: "maxTimeMS value in the command is less than timeoutMS"
     operations:
-      # Artificially increase the server RTT to ~10ms.
+      # Artificially increase the server RTT to ~20ms.
       - name: failPoint
         object: testRunner
         arguments:
@@ -36,10 +36,10 @@ tests:
             configureFailPoint: failCommand
             mode: "alwaysOn"
             data:
-              failCommands: ["isMaster"]
+              failCommands: ["hello", "isMaster"]
               appName: &appName reduceMaxTimeMSTest
               blockConnection: true
-              blockTimeMS: 10
+              blockTimeMS: 20
       # Create a client with the app name specified in the fail point. Also create database and collection entities
       # derived from the new client. There are two collection entities: one with no timeoutMS, which is used to run
       # an initial operation, and one with a timeoutMS higher than the fail point's blockTimeMS value.
@@ -52,6 +52,7 @@ tests:
                 useMultipleMongoses: false
                 uriOptions:
                   appName: *appName
+                  w: 1  # Override server's w:majority default to speed up the test.
                 observeEvents:
                   - commandStartedEvent
             - database:
@@ -67,7 +68,7 @@ tests:
                 database: *database
                 collectionName: *timeoutCollectionName
                 collectionOptions:
-                  timeoutMS: &timeoutMS 20
+                  timeoutMS: &timeoutMS 60
       # Do an operation with regularCollection to ensure the servers are discovered.
       - name: insertOne
         object: *regularCollection
@@ -96,7 +97,7 @@ tests:
 
   - description: "command is not sent if RTT is greater than timeoutMS"
     operations:
-      # Artificially increase the server RTT to ~10ms.
+      # Artificially increase the server RTT to ~20ms.
       - name: failPoint
         object: testRunner
         arguments:
@@ -105,10 +106,10 @@ tests:
             configureFailPoint: failCommand
             mode: "alwaysOn"
             data:
-              failCommands: ["isMaster"]
+              failCommands: ["hello", "isMaster"]
               appName: &appName rttTooHighTest
               blockConnection: true
-              blockTimeMS: 10
+              blockTimeMS: 20
       # Create a client with the app name specified in the fail point. Also create database and collection entities
       # derived from the new client. There is one collection entity with no timeoutMS and another with a timeoutMS
       # that's lower than the fail point's blockTimeMS value.
@@ -121,6 +122,7 @@ tests:
                 useMultipleMongoses: false
                 uriOptions:
                   appName: *appName
+                  w: 1  # Override server's w:majority default to speed up the test.
                 observeEvents:
                   - commandStartedEvent
             - database:

--- a/source/client-side-operations-timeout/tests/error-transformations.json
+++ b/source/client-side-operations-timeout/tests/error-transformations.json
@@ -27,7 +27,7 @@
       "client": {
         "id": "client",
         "uriOptions": {
-          "timeoutMS": 50
+          "timeoutMS": 250
         },
         "useMultipleMongoses": false,
         "observeEvents": [

--- a/source/client-side-operations-timeout/tests/error-transformations.yml
+++ b/source/client-side-operations-timeout/tests/error-transformations.yml
@@ -16,7 +16,7 @@ createEntities:
   - client:
       id: &client client
       uriOptions:
-        timeoutMS: 50
+        timeoutMS: 250
       useMultipleMongoses: false
       observeEvents:
         - commandStartedEvent

--- a/source/client-side-operations-timeout/tests/global-timeoutMS.json
+++ b/source/client-side-operations-timeout/tests/global-timeoutMS.json
@@ -38,7 +38,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -71,14 +71,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "listDatabases"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -217,7 +217,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -250,14 +250,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "listDatabases"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -390,7 +390,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -423,14 +423,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "aggregate"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -569,7 +569,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -602,14 +602,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "aggregate"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -762,7 +762,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -795,14 +795,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "listCollections"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -941,7 +941,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -974,14 +974,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "listCollections"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -1120,7 +1120,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -1153,14 +1153,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "ping"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -1305,7 +1305,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -1338,14 +1338,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "aggregate"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -1484,7 +1484,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -1517,14 +1517,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "aggregate"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -1663,7 +1663,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -1696,14 +1696,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "count"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -1842,7 +1842,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -1875,14 +1875,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "aggregate"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -2021,7 +2021,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -2054,14 +2054,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "count"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -2194,7 +2194,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -2227,14 +2227,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "distinct"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -2375,7 +2375,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -2408,14 +2408,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "find"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -2554,7 +2554,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -2587,14 +2587,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "find"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -2733,7 +2733,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -2766,14 +2766,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "listIndexes"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -2906,7 +2906,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -2939,14 +2939,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "listIndexes"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -3079,7 +3079,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -3112,14 +3112,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "aggregate"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -3258,7 +3258,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -3291,14 +3291,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "insert"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -3441,7 +3441,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -3474,14 +3474,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "insert"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -3628,7 +3628,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -3661,14 +3661,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "delete"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -3807,7 +3807,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -3840,14 +3840,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "delete"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -3986,7 +3986,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -4019,14 +4019,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "update"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -4171,7 +4171,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -4204,14 +4204,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "update"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -4360,7 +4360,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -4393,14 +4393,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "update"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -4549,7 +4549,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -4582,14 +4582,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "findAndModify"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -4728,7 +4728,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -4761,14 +4761,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "findAndModify"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -4913,7 +4913,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -4946,14 +4946,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "findAndModify"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -5102,7 +5102,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -5135,14 +5135,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "insert"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -5297,7 +5297,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -5330,14 +5330,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "createIndexes"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -5482,7 +5482,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -5515,14 +5515,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "dropIndexes"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }
@@ -5665,7 +5665,7 @@
                 "client": {
                   "id": "client",
                   "uriOptions": {
-                    "timeoutMS": 50
+                    "timeoutMS": 250
                   },
                   "useMultipleMongoses": false,
                   "observeEvents": [
@@ -5698,14 +5698,14 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 1
+                "times": 2
               },
               "data": {
                 "failCommands": [
                   "dropIndexes"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 60
+                "blockTimeMS": 350
               }
             }
           }

--- a/source/client-side-operations-timeout/tests/global-timeoutMS.yml
+++ b/source/client-side-operations-timeout/tests/global-timeoutMS.yml
@@ -56,6 +56,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["listDatabases"]
@@ -153,6 +156,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["listDatabases"]
@@ -246,6 +252,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
@@ -343,6 +352,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
@@ -440,6 +452,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["listCollections"]
@@ -537,6 +552,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["listCollections"]
@@ -634,6 +652,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["ping"]
@@ -733,6 +754,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
@@ -830,6 +854,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
@@ -927,6 +954,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["count"]
@@ -1024,6 +1054,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
@@ -1121,6 +1154,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["count"]
@@ -1214,6 +1250,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["distinct"]
@@ -1313,6 +1352,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["find"]
@@ -1410,6 +1452,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["find"]
@@ -1507,6 +1552,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["listIndexes"]
@@ -1600,6 +1648,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["listIndexes"]
@@ -1693,6 +1744,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
@@ -1790,6 +1844,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["insert"]
@@ -1887,6 +1944,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["insert"]
@@ -1986,6 +2046,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["delete"]
@@ -2083,6 +2146,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["delete"]
@@ -2180,6 +2246,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["update"]
@@ -2279,6 +2348,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["update"]
@@ -2378,6 +2450,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["update"]
@@ -2477,6 +2552,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["findAndModify"]
@@ -2574,6 +2652,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["findAndModify"]
@@ -2673,6 +2754,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["findAndModify"]
@@ -2772,6 +2856,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["insert"]
@@ -2873,6 +2960,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["createIndexes"]
@@ -2972,6 +3062,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["dropIndexes"]
@@ -3071,6 +3164,9 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
+            # Use "times: 2" to workaround a quirk in Python on Windows where
+            # socket I/O can timeout ~20ms earlier than expected. With
+            # "times: 1" the retry would succeed within the remaining ~20ms.
             mode: { times: 2 }
             data:
               failCommands: ["dropIndexes"]

--- a/source/client-side-operations-timeout/tests/global-timeoutMS.yml
+++ b/source/client-side-operations-timeout/tests/global-timeoutMS.yml
@@ -22,7 +22,7 @@ tests:
   # For each operation, we execute two tests:
   #
   # 1. timeoutMS can be configured to a non-zero value on a MongoClient and is inherited by the operation. Each test
-  # constructs a client entity with timeoutMS=50 and configures a fail point to block the operation for 60ms so
+  # constructs a client entity with timeoutMS=250 and configures a fail point to block the operation for 350ms so
   # execution results in a timeout error.
   #
   # 2. timeoutMS can be set to 0 for a MongoClient. Each test constructs a client entity with timeoutMS=0 and
@@ -38,7 +38,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -56,11 +56,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["listDatabases"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: listDatabases
         object: *client
         arguments:
@@ -135,7 +135,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -153,11 +153,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["listDatabases"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: listDatabaseNames
         object: *client
         
@@ -228,7 +228,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -246,11 +246,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: createChangeStream
         object: *client
         arguments:
@@ -325,7 +325,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -343,11 +343,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: aggregate
         object: *database
         arguments:
@@ -422,7 +422,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -440,11 +440,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["listCollections"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: listCollections
         object: *database
         arguments:
@@ -519,7 +519,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -537,11 +537,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["listCollections"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: listCollectionNames
         object: *database
         arguments:
@@ -616,7 +616,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -634,11 +634,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["ping"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: runCommand
         object: *database
         arguments:
@@ -715,7 +715,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -733,11 +733,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: createChangeStream
         object: *database
         arguments:
@@ -812,7 +812,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -830,11 +830,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: aggregate
         object: *collection
         arguments:
@@ -909,7 +909,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -927,11 +927,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["count"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: count
         object: *collection
         arguments:
@@ -1006,7 +1006,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1024,11 +1024,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: countDocuments
         object: *collection
         arguments:
@@ -1103,7 +1103,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1121,11 +1121,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["count"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: estimatedDocumentCount
         object: *collection
         
@@ -1196,7 +1196,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1214,11 +1214,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["distinct"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: distinct
         object: *collection
         arguments:
@@ -1295,7 +1295,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1313,11 +1313,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["find"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: find
         object: *collection
         arguments:
@@ -1392,7 +1392,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1410,11 +1410,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["find"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: findOne
         object: *collection
         arguments:
@@ -1489,7 +1489,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1507,11 +1507,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["listIndexes"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: listIndexes
         object: *collection
         
@@ -1582,7 +1582,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1600,11 +1600,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["listIndexes"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: listIndexNames
         object: *collection
         
@@ -1675,7 +1675,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1693,11 +1693,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: createChangeStream
         object: *collection
         arguments:
@@ -1772,7 +1772,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1790,11 +1790,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["insert"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: insertOne
         object: *collection
         arguments:
@@ -1869,7 +1869,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1887,11 +1887,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["insert"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: insertMany
         object: *collection
         arguments:
@@ -1968,7 +1968,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -1986,11 +1986,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["delete"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: deleteOne
         object: *collection
         arguments:
@@ -2065,7 +2065,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2083,11 +2083,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["delete"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: deleteMany
         object: *collection
         arguments:
@@ -2162,7 +2162,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2180,11 +2180,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["update"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: replaceOne
         object: *collection
         arguments:
@@ -2261,7 +2261,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2279,11 +2279,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["update"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: updateOne
         object: *collection
         arguments:
@@ -2360,7 +2360,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2378,11 +2378,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["update"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: updateMany
         object: *collection
         arguments:
@@ -2459,7 +2459,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2477,11 +2477,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["findAndModify"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: findOneAndDelete
         object: *collection
         arguments:
@@ -2556,7 +2556,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2574,11 +2574,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["findAndModify"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: findOneAndReplace
         object: *collection
         arguments:
@@ -2655,7 +2655,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2673,11 +2673,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["findAndModify"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: findOneAndUpdate
         object: *collection
         arguments:
@@ -2754,7 +2754,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2772,11 +2772,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["insert"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: bulkWrite
         object: *collection
         arguments:
@@ -2855,7 +2855,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2873,11 +2873,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["createIndexes"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: createIndex
         object: *collection
         arguments:
@@ -2954,7 +2954,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -2972,11 +2972,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["dropIndexes"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: dropIndex
         object: *collection
         arguments:
@@ -3053,7 +3053,7 @@ tests:
             - client:
                 id: &client client
                 uriOptions:
-                  timeoutMS: 50
+                  timeoutMS: 250
                 useMultipleMongoses: false
                 observeEvents:
                   - commandStartedEvent
@@ -3071,11 +3071,11 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 1 }
+            mode: { times: 2 }
             data:
               failCommands: ["dropIndexes"]
               blockConnection: true
-              blockTimeMS: 60
+              blockTimeMS: 350
       - name: dropIndexes
         object: *collection
         

--- a/source/client-side-operations-timeout/tests/retryability-timeoutMS.json
+++ b/source/client-side-operations-timeout/tests/retryability-timeoutMS.json
@@ -77,7 +77,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -137,7 +137,7 @@
           "name": "insertOne",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "document": {
               "x": 1
             }
@@ -294,7 +294,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -356,7 +356,7 @@
           "name": "insertMany",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "documents": [
               {
                 "x": 1
@@ -517,7 +517,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -575,7 +575,7 @@
           "name": "deleteOne",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {}
           }
         }
@@ -728,7 +728,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -789,7 +789,7 @@
           "name": "replaceOne",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {},
             "replacement": {
               "x": 1
@@ -948,7 +948,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -1011,7 +1011,7 @@
           "name": "updateOne",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {},
             "update": {
               "$set": {
@@ -1174,7 +1174,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -1232,7 +1232,7 @@
           "name": "findOneAndDelete",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {}
           }
         }
@@ -1385,7 +1385,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -1446,7 +1446,7 @@
           "name": "findOneAndReplace",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {},
             "replacement": {
               "x": 1
@@ -1605,7 +1605,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -1668,7 +1668,7 @@
           "name": "findOneAndUpdate",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {},
             "update": {
               "$set": {
@@ -1831,7 +1831,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -1897,7 +1897,7 @@
           "name": "bulkWrite",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "requests": [
               {
                 "insertOne": {
@@ -2066,7 +2066,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -2124,7 +2124,7 @@
           "name": "listDatabases",
           "object": "client",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {}
           }
         }
@@ -2277,7 +2277,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -2332,7 +2332,7 @@
           "name": "listDatabaseNames",
           "object": "client",
           "arguments": {
-            "timeoutMS": 250
+            "timeoutMS": 500
           }
         }
       ],
@@ -2483,7 +2483,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -2541,7 +2541,7 @@
           "name": "createChangeStream",
           "object": "client",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "pipeline": []
           }
         }
@@ -2694,7 +2694,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -2759,7 +2759,7 @@
           "name": "aggregate",
           "object": "database",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "pipeline": [
               {
                 "$listLocalSessions": {}
@@ -2926,7 +2926,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -2984,7 +2984,7 @@
           "name": "listCollections",
           "object": "database",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {}
           }
         }
@@ -3137,7 +3137,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -3195,7 +3195,7 @@
           "name": "listCollectionNames",
           "object": "database",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {}
           }
         }
@@ -3348,7 +3348,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -3406,7 +3406,7 @@
           "name": "createChangeStream",
           "object": "database",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "pipeline": []
           }
         }
@@ -3559,7 +3559,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -3617,7 +3617,7 @@
           "name": "aggregate",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "pipeline": []
           }
         }
@@ -3770,7 +3770,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -3828,7 +3828,7 @@
           "name": "count",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {}
           }
         }
@@ -3981,7 +3981,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -4039,7 +4039,7 @@
           "name": "countDocuments",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {}
           }
         }
@@ -4192,7 +4192,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -4247,7 +4247,7 @@
           "name": "estimatedDocumentCount",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250
+            "timeoutMS": 500
           }
         }
       ],
@@ -4398,7 +4398,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -4457,7 +4457,7 @@
           "name": "distinct",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "fieldName": "x",
             "filter": {}
           }
@@ -4612,7 +4612,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -4670,7 +4670,7 @@
           "name": "find",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {}
           }
         }
@@ -4823,7 +4823,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -4881,7 +4881,7 @@
           "name": "findOne",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "filter": {}
           }
         }
@@ -5034,7 +5034,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -5089,7 +5089,7 @@
           "name": "listIndexes",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250
+            "timeoutMS": 500
           }
         }
       ],
@@ -5240,7 +5240,7 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 2
+                "times": 4
               },
               "data": {
                 "failCommands": [
@@ -5298,7 +5298,7 @@
           "name": "createChangeStream",
           "object": "collection",
           "arguments": {
-            "timeoutMS": 250,
+            "timeoutMS": 500,
             "pipeline": []
           }
         }

--- a/source/client-side-operations-timeout/tests/retryability-timeoutMS.yml
+++ b/source/client-side-operations-timeout/tests/retryability-timeoutMS.yml
@@ -46,7 +46,7 @@ tests:
   # because the second attempt should take it over the 100ms limit. This test only runs on 4.4+ because it uses the
   # blockConnection option in failCommand.
   #
-  # 2. operation is retried multiple times if timeoutMS is set to a non-zero value - Client timeoutMS=20 and the
+  # 2. operation is retried multiple times if timeoutMS is set to a non-zero value - Client timeoutMS=100 and the
   # operation fails with a retryable error twice. Drivers should send the original operation and two retries, the
   # second of which should succeed.
   #
@@ -69,7 +69,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["insert"]
               blockConnection: true
@@ -100,7 +100,7 @@ tests:
       - name: insertOne
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           document: { x: 1 }
           
     expectEvents:
@@ -175,7 +175,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["insert"]
               blockConnection: true
@@ -207,7 +207,7 @@ tests:
       - name: insertMany
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           documents:
             - { x: 1 }
           
@@ -284,7 +284,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["delete"]
               blockConnection: true
@@ -315,7 +315,7 @@ tests:
       - name: deleteOne
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           
     expectEvents:
@@ -390,7 +390,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["update"]
               blockConnection: true
@@ -422,7 +422,7 @@ tests:
       - name: replaceOne
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           replacement: { x: 1 }
           
@@ -499,7 +499,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["update"]
               blockConnection: true
@@ -531,7 +531,7 @@ tests:
       - name: updateOne
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           update: { $set: { x: 1 } }
           
@@ -608,7 +608,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["findAndModify"]
               blockConnection: true
@@ -639,7 +639,7 @@ tests:
       - name: findOneAndDelete
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           
     expectEvents:
@@ -714,7 +714,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["findAndModify"]
               blockConnection: true
@@ -746,7 +746,7 @@ tests:
       - name: findOneAndReplace
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           replacement: { x: 1 }
           
@@ -823,7 +823,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["findAndModify"]
               blockConnection: true
@@ -855,7 +855,7 @@ tests:
       - name: findOneAndUpdate
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           update: { $set: { x: 1 } }
           
@@ -932,7 +932,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["insert"]
               blockConnection: true
@@ -965,7 +965,7 @@ tests:
       - name: bulkWrite
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           requests:
             - insertOne:
                 document: { _id: 1 }
@@ -1044,7 +1044,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["listDatabases"]
               blockConnection: true
@@ -1075,7 +1075,7 @@ tests:
       - name: listDatabases
         object: *client
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           
     expectEvents:
@@ -1150,7 +1150,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["listDatabases"]
               blockConnection: true
@@ -1179,7 +1179,7 @@ tests:
       - name: listDatabaseNames
         object: *client
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           
     expectEvents:
       - client: *client
@@ -1252,7 +1252,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
@@ -1283,7 +1283,7 @@ tests:
       - name: createChangeStream
         object: *client
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           pipeline: []
           
     expectEvents:
@@ -1358,7 +1358,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
@@ -1389,7 +1389,7 @@ tests:
       - name: aggregate
         object: *database
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           pipeline: [ { $listLocalSessions: {} }, { $limit: 1 } ]
           
     expectEvents:
@@ -1464,7 +1464,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["listCollections"]
               blockConnection: true
@@ -1495,7 +1495,7 @@ tests:
       - name: listCollections
         object: *database
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           
     expectEvents:
@@ -1570,7 +1570,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["listCollections"]
               blockConnection: true
@@ -1601,7 +1601,7 @@ tests:
       - name: listCollectionNames
         object: *database
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           
     expectEvents:
@@ -1676,7 +1676,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
@@ -1707,7 +1707,7 @@ tests:
       - name: createChangeStream
         object: *database
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           pipeline: []
           
     expectEvents:
@@ -1782,7 +1782,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
@@ -1813,7 +1813,7 @@ tests:
       - name: aggregate
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           pipeline: []
           
     expectEvents:
@@ -1888,7 +1888,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["count"]
               blockConnection: true
@@ -1919,7 +1919,7 @@ tests:
       - name: count
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           
     expectEvents:
@@ -1994,7 +1994,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
@@ -2025,7 +2025,7 @@ tests:
       - name: countDocuments
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           
     expectEvents:
@@ -2100,7 +2100,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["count"]
               blockConnection: true
@@ -2129,7 +2129,7 @@ tests:
       - name: estimatedDocumentCount
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           
     expectEvents:
       - client: *client
@@ -2202,7 +2202,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["distinct"]
               blockConnection: true
@@ -2234,7 +2234,7 @@ tests:
       - name: distinct
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           fieldName: x
           filter: {}
           
@@ -2311,7 +2311,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["find"]
               blockConnection: true
@@ -2342,7 +2342,7 @@ tests:
       - name: find
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           
     expectEvents:
@@ -2417,7 +2417,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["find"]
               blockConnection: true
@@ -2448,7 +2448,7 @@ tests:
       - name: findOne
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           filter: {}
           
     expectEvents:
@@ -2523,7 +2523,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["listIndexes"]
               blockConnection: true
@@ -2552,7 +2552,7 @@ tests:
       - name: listIndexes
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           
     expectEvents:
       - client: *client
@@ -2625,7 +2625,7 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 2 }
+            mode: { times: 4 }
             data:
               failCommands: ["aggregate"]
               blockConnection: true
@@ -2656,7 +2656,7 @@ tests:
       - name: createChangeStream
         object: *collection
         arguments:
-          timeoutMS: 250
+          timeoutMS: 500
           pipeline: []
           
     expectEvents:


### PR DESCRIPTION
This change makes the tests more reliable in Python and Go.

Please complete the following before merging:
- [ ] Bump spec version and last modified date.
- [ ] Update changelog.
- [X] Make sure there are generated JSON files from the YAML test files.
- [X] Test changes in at least one language driver.
- [X] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

Tested in python here: https://github.com/mongodb/mongo-python-driver/pull/954