### PR TITLE
DRIVERS-2348 add IndexKeyId

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -11,7 +11,7 @@ Client Side Encryption
 :Type: Standards
 :Minimum Server Version: 4.2 (CSFLE), 6.0 (Queryable Encryption)
 :Last Modified: 2022-06-09
-:Version: 1.7.4
+:Version: 1.8.0
 
 .. _lmc-c-api: https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h.in
 
@@ -944,6 +944,7 @@ EncryptOpts
 
    class EncryptOpts {
       keyId : Optional<Binary>
+      indexKeyId : Optional<Binary>
       keyAltName: Optional<String>
       algorithm: String,
       contentionFactor: Optional<Int64>,
@@ -956,6 +957,14 @@ identified by \_id or by alternate name. Exactly one is required.
 keyId
 ^^^^^
 Identifies a data key by \_id. The value is a UUID (binary subtype 4).
+
+indexKeyId
+^^^^^^^^^^
+Identifies a data key by \_id. The value is a UUID (binary subtype 4).
+It is an error to set indexKeyId when algorithm is not "Indexed".
+If indexKeyId is not set, it defaults to the value of keyId.
+The IndexKeyId must match the keyId set in encryptedFields for correctness.
+See `Why is IndexKeyId needed?`_.
 
 keyAltName
 ^^^^^^^^^^
@@ -2302,6 +2311,15 @@ key vault collection, the key management functions may be overloaded to take an
 explicit session parameter as described in the
 `Drivers Sessions Specification <../sessions/driver-sessions.rst>`__.
 
+Why is IndexKeyId needed?
+-------------------------
+
+Queryable Encryption supports two keys for an encrypted value: UserKey and IndexKey.
+- The UserKey encrypts user data. 
+- The IndexKey is used to derive tokens for indexing. It must match the "keyId" in encryptedFields for correct query results.
+
+Adding an EncryptOpts.indexKeyId enables multiple values with different UserKey to be inserted on the same field.
+
 Changelog
 =========
 
@@ -2310,6 +2328,7 @@ Changelog
    :align: left
 
    Date, Description
+   22-06-14, Add ``IndexKeyId``.
    22-06-08, Add ``Queryable Encryption`` to abstract.
    22-06-02, Rename ``FLE 2`` to ``Queryable Encryption``
    22-05-31, Rename ``csfle`` to ``crypt_shared``

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1613,15 +1613,16 @@ Test Setup
 
 Load the file `encryptedFields.json <https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields.json>`_ as ``encryptedFields``.
 
-Load the file `key1-document.json <https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/keys/key1-document.json>`_ as ``key1Document``.
+Load the file `key1-document.json <https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/keys/key1-document.json>`_ as ``key1Document``
+and `key2-document.json <https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/keys/key2-document.json>`_ as ``key2Document``.
 
-Read the ``"_id"`` field of ``key1Document`` as ``key1ID``.
+Read the ``"_id"`` field of ``key1Document`` as ``key1ID`` and the ``"_id"`` field of ``key2Document`` as ``key2ID``.
 
 Drop and create the collection ``db.explicit_encryption`` using ``encryptedFields`` as an option. See `FLE 2 CreateCollection() and Collection.Drop() <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#fle-2-createcollection-and-collection-drop>`_.
 
 Drop and create the collection ``keyvault.datakeys``.
 
-Insert ``key1Document`` in ``keyvault.datakeys`` with majority write concern.
+Insert ``key1Document`` and ``key2Document`` in ``keyvault.datakeys`` with majority write concern.
 
 Create a MongoClient named ``keyVaultClient``.
 
@@ -1781,6 +1782,39 @@ Use ``clientEncryption`` to encrypt the value "encrypted unindexed value" with t
 Store the result in ``payload``.
 
 Use ``clientEncryption`` to decrypt ``payload``. Assert the returned value equals "encrypted unindexed value".
+
+Case 6: IndexKeyId works
+````````````````````````
+
+Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with these ``EncryptOpts``:
+
+.. code:: typescript
+
+   class EncryptOpts {
+      keyId : <key2ID>,
+      indexKeyId : <key1ID>
+      algorithm: "Indexed",
+   }
+
+Store the result in ``insertPayload``.
+
+Use ``encryptedClient`` to insert the document ``{ "encryptedIndexed": <insertPayload> }`` into ``db.explicit_encryption``.
+
+Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with these ``EncryptOpts``:
+
+.. code:: typescript
+
+   class EncryptOpts {
+      keyId : <key1ID>
+      algorithm: "Indexed",
+      queryType: Equality
+   }
+
+Store the result in ``findPayload``.
+
+Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{ "encryptedIndexed": <findPayload> }``.
+
+Assert one document is returned containing the field ``{ "encryptedIndexed": "encrypted indexed value" }``.
 
 13. Unique Index on keyAltNames
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary
- Add `EncryptOpts.indexKeyId`.
- Add prose test "case 6: IndexKeyId works".

# Background & Motivation

The test "case 6: IndexKeyId works" is expected to fail if the IndexKeyID option is not passed to libmongocrypt with `mongocrypt_ctx_setopt_index_key_id`. libmongocrypt defaults the IndexKeyID to [the keyID set in `mongocrypt_ctx_setopt_key_id`](https://github.com/mongodb/libmongocrypt/blob/1ed14540db29fe52dd0ccc1208b949b8addac3fd/src/mongocrypt-ctx-encrypt.c#L1636-L1642). If the IndexKeyID is not overridden, the test will fail to find the inserted document.

A mistaken insert with an incorrect IndexKeyId results in incorrect query results and non-obvious errors. [SERVER-67263](https://jira.mongodb.org/browse/SERVER-67263) tracks a request to reject incorrect IndexKeyId from being inserted.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files. *Not applicable. Only prose tests were modified*.
- [x] Test changes in at least one language driver. *Tested in [Go](https://github.com/mongodb/mongo-go-driver/pull/986)*
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

