### PR TITLE
DRIVERS-2356 Reduce expected removeKeyAltName operations to a single findOneAndUpdate

### DIFF
--- a/source/client-side-encryption/tests/unified/removeKeyAltName.json
+++ b/source/client-side-encryption/tests/unified/removeKeyAltName.json
@@ -118,11 +118,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "does_not_exist"
+                  "update": [
+                    {
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "does_not_exist"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "does_not_exist"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
-                  },
+                  ],
                   "writeConcern": {
                     "w": "majority"
                   }
@@ -239,11 +264,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "does_not_exist"
+                  "update": [
+                    {
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "does_not_exist"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "does_not_exist"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
-                  },
+                  ],
                   "writeConcern": {
                     "w": "majority"
                   }
@@ -378,11 +428,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "alternate_name"
+                  "update": [
+                    {
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "alternate_name"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "alternate_name"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
-                  },
+                  ],
                   "writeConcern": {
                     "w": "majority"
                   }
@@ -501,11 +576,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "alternate_name"
+                  "update": [
+                    {
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "alternate_name"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "alternate_name"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
                     }
-                  },
+                  ],
                   "writeConcern": {
                     "w": "majority"
                   }
@@ -525,42 +625,36 @@
                       }
                     }
                   },
-                  "update": {
-                    "$pull": {
-                      "keyAltNames": "local_key"
-                    }
-                  },
-                  "writeConcern": {
-                    "w": "majority"
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "databaseName": "keyvault",
-                "command": {
-                  "update": "datakeys",
-                  "updates": [
+                  "update": [
                     {
-                      "q": {
-                        "_id": {
-                          "$binary": {
-                            "base64": "bG9jYWxrZXlsb2NhbGtleQ==",
-                            "subType": "04"
-                          }
-                        }
-                      },
-                      "u": {
-                        "$unset": {
-                          "keyAltNames": true
+                      "$set": {
+                        "keyAltNames": {
+                          "$cond": [
+                            {
+                              "$eq": [
+                                "$keyAltNames",
+                                [
+                                  "local_key"
+                                ]
+                              ]
+                            },
+                            "$$REMOVE",
+                            {
+                              "$filter": {
+                                "input": "$keyAltNames",
+                                "cond": {
+                                  "$ne": [
+                                    "$$this",
+                                    "local_key"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
                         }
                       }
                     }
-                  ],
-                  "writeConcern": {
-                    "w": "majority"
-                  }
+                  ]
                 }
               }
             }

--- a/source/client-side-encryption/tests/unified/removeKeyAltName.yml
+++ b/source/client-side-encryption/tests/unified/removeKeyAltName.yml
@@ -58,7 +58,7 @@ tests:
               command:
                 findAndModify: *collection0Name
                 query: { _id: *non_existent_id }
-                update: { $pull: { keyAltNames: does_not_exist } }
+                update: [{ $set: { keyAltNames: { $cond: [{ $eq: [$keyAltNames, [does_not_exist]] }, $$REMOVE, { $filter: { input: $keyAltNames, cond: { $ne: [$$this, does_not_exist] } } }] } } }]
                 writeConcern: { w: majority }
     outcome:
       - collectionName: *collection0Name
@@ -82,7 +82,7 @@ tests:
               command:
                 findAndModify: *collection0Name
                 query: { _id: *local_key_id }
-                update: { $pull: { keyAltNames: does_not_exist } }
+                update: [{ $set: { keyAltNames: { $cond: [{ $eq: [$keyAltNames, [does_not_exist]] }, $$REMOVE, { $filter: { input: $keyAltNames, cond: { $ne: [$$this, does_not_exist] } } }] } } }]
                 writeConcern: { w: majority }
     outcome:
       - collectionName: *collection0Name
@@ -113,7 +113,7 @@ tests:
               command:
                 findAndModify: *collection0Name
                 query: { _id: *local_key_id }
-                update: { $pull: { keyAltNames: alternate_name } }
+                update: [{ $set: { keyAltNames: { $cond: [{ $eq: [$keyAltNames, [alternate_name]] }, $$REMOVE, { $filter: { input: $keyAltNames, cond: { $ne: [$$this, alternate_name] } } }] } } }]
                 writeConcern: { w: majority }
           - commandStartedEvent: { commandName: find }
 
@@ -147,19 +147,11 @@ tests:
               command:
                 findAndModify: *collection0Name
                 query: { _id: *local_key_id }
-                update: { $pull: { keyAltNames: alternate_name } }
+                update: [{ $set: { keyAltNames: { $cond: [{ $eq: [$keyAltNames, [alternate_name]] }, $$REMOVE, { $filter: { input: $keyAltNames, cond: { $ne: [$$this, alternate_name] } } }] } } }]
                 writeConcern: { w: majority }
           - commandStartedEvent:
               databaseName: *database0Name
               command:
                 findAndModify: *collection0Name
                 query: { _id: *local_key_id }
-                update: { $pull: { keyAltNames: local_key } }
-                writeConcern: { w: majority }
-          # The keyAltNames field should be unset if it would otherwise be empty to preserve keyAltNames unique index invariants.
-          - commandStartedEvent:
-              databaseName: *database0Name
-              command:
-                update: *collection0Name
-                updates: [{ q: { _id: *local_key_id }, u: { $unset: { keyAltNames: true } } }]
-                writeConcern: { w: majority }
+                update: [{ $set: { keyAltNames: { $cond: [{ $eq: [$keyAltNames, [local_key]] }, $$REMOVE, { $filter: { input: $keyAltNames, cond: { $ne: [$$this, local_key] } } }] } } }]


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] ~Bump spec version and last modified date.~ N/A
- [x] ~Update changelog.~ N/A
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

## Description

This PR updates the unified spec tests for `removeKeyAltName()` to expect only a single `findOneAndUpdate()` operation that handles conditionally unsetting the `keyAltNames` field if it would otherwise be empty by using an aggregation pipeline rather than an additional and separate `updateOne()` operation. See DRIVERS-2356 for more information.