### PR TITLE
DRIVERS-2352 use a string for QueryType

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -11,7 +11,7 @@ Client Side Encryption
 :Type: Standards
 :Minimum Server Version: 4.2 (CSFLE), 6.0 (Queryable Encryption)
 :Last Modified: 2022-06-09
-:Version: 1.7.4
+:Version: 1.8.0
 
 .. _lmc-c-api: https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h.in
 
@@ -938,16 +938,12 @@ EncryptOpts
 
 .. code:: typescript
 
-   enum QueryType {
-      Equality
-   }
-
    class EncryptOpts {
       keyId : Optional<Binary>
       keyAltName: Optional<String>
       algorithm: String,
       contentionFactor: Optional<Int64>,
-      queryType: Optional<QueryType>
+      queryType: Optional<String>
    }
 
 Explicit encryption requires a key and algorithm. Keys are either
@@ -981,6 +977,9 @@ It is an error to set contentionFactor when algorithm is not "Indexed".
 
 queryType
 ^^^^^^^^^
+One of the strings:
+- "equality"
+
 queryType only applies when algorithm is "Indexed".
 It is an error to set queryType when algorithm is not "Indexed".
 
@@ -2232,6 +2231,16 @@ friction between conducting operations using mongosh and a Driver. Their
 inclusion assumes their value for users outweighs their cost of implementation
 and maintenance.
 
+Why are the QueryType and Algorithm options a String?
+-----------------------------------------------------
+
+Using an enum to represent QueryType was considered and rejected in
+`DRIVERS-2352 <https://jira.mongodb.org/browse/DRIVERS-2352>`_.
+
+A string value helps with future compatibility. When new values of QueryType
+and IndexType are added in libmongocrypt, users would only need to upgrade
+libmongocrypt, and not the driver, to use the new values.
+
 Future work
 ===========
 
@@ -2310,6 +2319,7 @@ Changelog
    :align: left
 
    Date, Description
+   22-06-15, Change ``QueryType`` to a string.
    22-06-08, Add ``Queryable Encryption`` to abstract.
    22-06-02, Rename ``FLE 2`` to ``Queryable Encryption``
    22-05-31, Rename ``csfle`` to ``crypt_shared``

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1669,7 +1669,7 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
    class EncryptOpts {
       keyId : <key1ID>
       algorithm: "Indexed",
-      queryType: Equality
+      queryType: "equality"
    }
 
 Store the result in ``findPayload``.
@@ -1704,7 +1704,7 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
    class EncryptOpts {
       keyId : <key1ID>
       algorithm: "Indexed",
-      queryType: Equality
+      queryType: "equality"
    }
 
 Store the result in ``findPayload``.
@@ -1720,7 +1720,7 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
    class EncryptOpts {
       keyId : <key1ID>
       algorithm: "Indexed",
-      queryType: Equality,
+      queryType: "equality",
       contentionFactor: 10
    }
 


### PR DESCRIPTION
# Summary

- Change `EncryptOpts.QueryType` from an enum to a string.

# Background & Motivation

String values helps with forward compatibility When new values of QueryType and IndexType are added in libmongocrypt, users would only need to upgrade libmongocrypt, and not the driver, to use the new values. See [DRIVERS-2352](https://jira.mongodb.org/browse/DRIVERS-2352) for the motivation.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files. **Not applicable. No specification tests have changed**.
- [x] Test changes in at least one language driver. *Tested in [Go](https://github.com/mongodb/mongo-go-driver/pull/988/files)*
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

