### PR TITLE
Clarify description of date fields of key documents

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -10,8 +10,8 @@ Client Side Encryption
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 4.2 (CSFLE), 6.0 (Queryable Encryption)
-:Last Modified: 2022-06-09
-:Version: 1.7.4
+:Last Modified: 2022-06-15
+:Version: 1.7.5
 
 .. _lmc-c-api: https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h.in
 
@@ -1505,8 +1505,8 @@ Data keys are stored in the MongoDB key vault collection with the following sche
 version      Int64            A numeric identifier for the schema version of this document. Implicitly 0 if unset.
 keyAltNames  Array of strings Alternate names to search for keys by. Used for a per-document key scenario in support of GDPR scenarios.
 keyMaterial  BinData          Encrypted data key material, BinData type General
-creationDate Date             The datetime the wrapped key was imported into the Key Database.
-updateDate   Date             The datetime the wrapped key was last modified. On initial import, this value will be set to creationDate.
+creationDate Date             The datetime the wrapped data key material was imported into the Key Database.
+updateDate   Date             The datetime the wrapped data key material was last modified. On initial import, this value will be set to creationDate.
 status       Int              0 = enabled, 1 = disabled
 masterKey    Document         Per provider master key definition, see below
 ============ ================ ==========================================================================================================
@@ -2310,6 +2310,7 @@ Changelog
    :align: left
 
    Date, Description
+   22-06-15, Clarify description of date fields in key documents.
    22-06-08, Add ``Queryable Encryption`` to abstract.
    22-06-02, Rename ``FLE 2`` to ``Queryable Encryption``
    22-05-31, Rename ``csfle`` to ``crypt_shared``


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [x] ~Make sure there are generated JSON files from the YAML test files.~ N/A
- [x] ~Test changes in at least one language driver.~ N/A
- [x] ~Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~ N/A

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

## Description

Unlike [ClientEncryption.createKey()](https://github.com/mongodb/specifications/blob/f9cbedafe53faffd62f15bcb2e952d1e016934e9/source/client-side-encryption/tests/unified/createKey.yml#L61) and [ClientEncryption.rewrapManyDataKey()](https://github.com/mongodb/specifications/blob/f9cbedafe53faffd62f15bcb2e952d1e016934e9/source/client-side-encryption/tests/unified/rewrapManyDataKey.yml#L148), the unified spec tests for [ClientEncryption.addKeyAltName()](https://github.com/mongodb/specifications/blob/f9cbedafe53faffd62f15bcb2e952d1e016934e9/source/client-side-encryption/tests/unified/addKeyAltName.yml#L55) and [ClientEncryption.removeKeyAltName()](https://github.com/mongodb/specifications/blob/f9cbedafe53faffd62f15bcb2e952d1e016934e9/source/client-side-encryption/tests/unified/removeKeyAltName.yml#L56) do not update the `updateDate` field of the modified key document(s).

This was motivated by the description of the `updateDate` field in the [Client Side Encryption spec](https://github.com/mongodb/specifications/blob/f9cbedafe53faffd62f15bcb2e952d1e016934e9/source/client-side-encryption/client-side-encryption.rst#key-vault-collection-schema-for-data-keys):
> The datetime the wrapped key was last modified. On initial import, this value will be set to creationDate.

"The wrapped key" was interpreted as referring to the encrypted data key material, _not_ the key document.

To reduce opportunity for this confusion, this PR adjusts the descriptions of the `creationDate` and `updateDate` fields by substituting "wrapped key" with "wrapped data key material". This adjustment consequently equates the term "wrapped data key" with "encrypted data key material", leaving no room for confusion with the key document itself.