### PR TITLE
DRIVERS-2359 Require server 4.2+ for `csfle: true`

### DIFF
--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3,13 +3,13 @@ Unified Test Format
 ===================
 
 :Spec Title: Unified Test Format
-:Spec Version: 1.9
+:Spec Version: 1.9.1
 :Author: Jeremy Mikola
 :Advisors: Prashant Mital, Isabel Atkinson, Thomas Reggi
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2022-05-16
+:Last Modified: 2022-06-16
 
 .. contents::
 
@@ -420,8 +420,9 @@ The structure of this object is as follows:
   If this field is omitted, there is no authentication requirement.
 
 - ``csfle``: Optional boolean. If true, the tests MUST only run if the driver
-  supports Client-Side Field Level Encryption. If false, tests MUST only run if
-  CSFLE is not enabled. If this field is omitted, there is no CSFLE requirement.
+  supports Client-Side Field Level Encryption and the server is version 4.2.0
+  or higher. If false, tests MUST only run if CSFLE is not enabled. If this
+  field is omitted, there is no CSFLE requirement.
 
 Test runners MAY evaluate these conditions in any order. For example, it may be
 more efficient to evaluate ``serverless`` or ``auth`` before communicating with
@@ -3472,6 +3473,8 @@ spec changes developed in parallel or during the same release cycle.
 
 Change Log
 ==========
+
+:2022-06-16: Require server 4.2+ for ``csfle: true``.
 
 :2022-05-10: Add reference to Client Side Encryption spec under
              `ClientEncryption Operations`_.

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -420,9 +420,9 @@ The structure of this object is as follows:
   If this field is omitted, there is no authentication requirement.
 
 - ``csfle``: Optional boolean. If true, the tests MUST only run if the driver
-  supports Client-Side Field Level Encryption and the server is version 4.2.0
-  or higher. If false, tests MUST only run if CSFLE is not enabled. If this
-  field is omitted, there is no CSFLE requirement.
+  and server support Client-Side Field Level Encryption. A server supports
+  CSFLE if it is version 4.2.0 or higher. If false, tests MUST only run if
+  CSFLE is not enabled. If this field is omitted, there is no CSFLE requirement.
 
 Test runners MAY evaluate these conditions in any order. For example, it may be
 more efficient to evaluate ``serverless`` or ``auth`` before communicating with


### PR DESCRIPTION
# Summary

- Require server 4.2+ for the `csfle: true` `runOnRequirement`.

# Background & Motivation

DRIVERS-2356 changed the implementation of removeKeyAltName to use one findOneAndUpdate operation with an aggregation pipeline. Using an aggregation pipeline for an update was added in MongoDB server 4.2: https://www.mongodb.com/docs/manual/tutorial/update-documents-with-aggregation-pipeline/.

A rejected alternative is to add `minServerVersion: "4.2.0"` to the runOnRequirement in removeKeyAltName.yml.

Client-Side Encryption requires a minimum server support of 4.2 for schema support. [The rationale](https://github.com/mongodb/specifications/blob/7f2ec854d730097494d23cfaf62abc5a0aea4570/source/client-side-encryption/client-side-encryption.rst#why-is-a-4-2-server-required) notes:

> Limiting to 4.2 reduces testing complexity

Adding the server requirement to `csfle` seems aligned to that rationale and may prevent future omissions in tests.

See [slack thread](https://mongodb.slack.com/archives/CFPHLTRMK/p1655330486574449) for additional background.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files. **Not applicable**
- [ ] Test changes in at least one language driver. **Tested locally in [C](https://github.com/mongodb/mongo-c-driver/pull/1040)**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

