### PR TITLE
DRIVERS-2360 Add assertions that addKeyAltName() added keyAltName without failure

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1833,11 +1833,11 @@ Case 2: addKeyAltName()
 
 2. Use ``client_encryption`` to add a keyAltName "abc" to the key created in Step 1 and assert the operation does not fail.
 
-3. Repeat Step 2 and assert the operation does not fail.
+3. Repeat Step 2, assert the operation does not fail, and assert the returned key document contains the keyAltName "abc" added in Step 2.
 
 4. Use ``client_encryption`` to add a keyAltName "def" to the key created in Step 1 and assert the operation fails due to a duplicate key server error (error code 11000).
 
-5. Use ``client_encryption`` to add a keyAltName "def" to the existing key and assert the operation does not fail.
+5. Use ``client_encryption`` to add a keyAltName "def" to the existing key, assert the operation does not fail, and assert the returned key document contains the keyAltName "def" added during Setup.
 
 14. Decryption Events
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] ~Bump spec version and last modified date.~ N/A
- [x] ~Update changelog.~ N/A
- [x] ~Make sure there are generated JSON files from the YAML test files.~ N/A
- [x] Test changes in at least [one language driver](https://github.com/mongodb/mongo-c-driver/pull/1041).
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

## Description

This PR resolves DRIVERS-2360. The description of some steps in CSE Prose Test 13 have been adjusted to ensure the "does not fail" operations are succeeding due to actually adding a keyAltName as intended by the test, not because there was no matching document.