### PR TITLE
DRIVERS-2350 clarify prose test 14

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1888,8 +1888,8 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
 
 Configure ``encryptedClient`` with "retryReads=false".
 Register a listener for CommandSucceeded events on ``encryptedClient``.
-The listener must store the most recent CommandStartedEvent reply for the "aggregate" command.
-The listener must store the most recent CommandFailedEvent error for the "aggregate" command.
+The listener must store the most recent ``CommandStartedEvent`` reply for the "aggregate" command.
+The listener must store the most recent ``CommandFailedEvent`` error for the "aggregate" command.
 
 Case 1: Command Error
 `````````````````````
@@ -1913,7 +1913,7 @@ Use ``setupClient`` to configure the following failpoint:
 
 Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
 
-Expect an exception to be thrown from the command error. Expect a CommandFailedEvent.
+Expect an exception to be thrown from the command error. Expect a ``CommandFailedEvent``.
 
 Case 2: Network Error
 `````````````````````
@@ -1938,7 +1938,7 @@ Use ``setupClient`` to configure the following failpoint:
 
 Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
 
-Expect an exception to be thrown from the network error. Expect a CommandFailedEvent.
+Expect an exception to be thrown from the network error. Expect a ``CommandFailedEvent``.
 
 Case 3: Decrypt Error
 `````````````````````
@@ -1948,7 +1948,7 @@ Use ``encryptedClient`` to insert the document ``{ "encrypted": <malformedCipher
 Use ``encryptedClient`` to run an aggregate on ``db.decryption_events`` with an empty pipeline.
 
 Expect an exception to be thrown from the decryption error.
-Expect a CommandSucceededEvent. Expect the CommandSucceededEvent.reply to contain BSON binary for the field ``cursor.firstBatch.encrypted``.
+Expect a ``CommandSucceededEvent``. Expect the ``CommandSucceededEvent.reply`` to contain BSON binary for the field ``cursor.firstBatch.encrypted``.
 
 Case 4: Decrypt Success
 ```````````````````````
@@ -1958,4 +1958,4 @@ Use ``encryptedClient`` to insert the document ``{ "encrypted": <ciphertext> }``
 Use ``encryptedClient`` to run an aggregate on ``db.decryption_events`` with an empty pipeline.
 
 Expect no exception.
-Expect a CommandSucceededEvent. Expect the CommandSucceededEvent.reply to contain BSON binary for the field ``cursor.firstBatch.encrypted``.
+Expect a ``CommandSucceededEvent``. Expect the ``CommandSucceededEvent.reply`` to contain BSON binary for the field ``cursor.firstBatch.encrypted``.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1945,7 +1945,7 @@ Case 3: Decrypt Error
 
 Use ``encryptedClient`` to insert the document ``{ "encrypted": <malformedCiphertext> }`` into ``db.decryption_events``.
 
-Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
+Use ``encryptedClient`` to run an aggregate on ``db.decryption_events`` with an empty pipeline.
 
 Expect an exception to be thrown from the decryption error.
 Expect a CommandSucceededEvent. Expect the CommandSucceededEvent.reply to contain BSON binary for the field ``cursor.firstBatch.encrypted``.
@@ -1955,7 +1955,7 @@ Case 4: Decrypt Success
 
 Use ``encryptedClient`` to insert the document ``{ "encrypted": <ciphertext> }`` into ``db.decryption_events``.
 
-Use ``encryptedClient`` to run an aggregate on ``db.decryption_events``.
+Use ``encryptedClient`` to run an aggregate on ``db.decryption_events`` with an empty pipeline.
 
 Expect no exception.
 Expect a CommandSucceededEvent. Expect the CommandSucceededEvent.reply to contain BSON binary for the field ``cursor.firstBatch.encrypted``.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1888,7 +1888,7 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
 
 Configure ``encryptedClient`` with "retryReads=false".
 Register a listener for CommandSucceeded events on ``encryptedClient``.
-The listener must store the most recent ``CommandStartedEvent`` reply for the "aggregate" command.
+The listener must store the most recent ``CommandSucceededEvent`` reply for the "aggregate" command.
 The listener must store the most recent ``CommandFailedEvent`` error for the "aggregate" command.
 
 Case 1: Command Error


### PR DESCRIPTION
# Summary

This is a follow-up to prose test 14 added in DRIVERS-2350.

- Clarify that an empty pipeline is used in case 3 and case 4.
- Format `CommandStartedEvent`, `CommandFailedEvent`, and `CommandSucceededEvent`.
- Replace incorrect reference to `CommandStartedEvent` with `CommandSucceededEvent`.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **Not applicable? This is a test clarification.**
- [ ] Update changelog. **Not applicable? This is a test clarification.**
- [ ] Make sure there are generated JSON files from the YAML test files. **Not applicable**
- [ ] Test changes in at least one language driver. **Not applicable**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **Not applicable**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

