### PR TITLE
DRIVERS-2350 fix setup for Decryption Events tests

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1874,8 +1874,8 @@ Use ``clientEncryption`` to encrypt the string "hello" with the following ``Encr
 
 Store the result in a variable named ``ciphertext``.
 
-Copy ``ciphertext`` into a variable named ``malformedCiphertext``.
-Change the last byte to 0. This will produce an invalid HMAC tag.
+Copy ``ciphertext`` into a variable named ``malformedCiphertext``. Change the
+last byte to a different value. This will produce an invalid HMAC tag.
 
 Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``:
 


### PR DESCRIPTION
Change the last byte value. The last byte may have started as 0.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **Not applicable? This is a test setup bug fix**
- [ ] Update changelog. **Not applicable? This is a test setup bug fix**
- [ ] Make sure there are generated JSON files from the YAML test files. **Not applicable? This is a test setup bug fix**
- [x] Test changes in at least one language driver **Tested in [C](https://github.com/mongodb/mongo-c-driver/pull/1025/commits/6946bd363a7ff6be3a11a038cbe3f953d6669ea5)**.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

