### PR TITLE
[DRIVERS-2280] New on-demand credential loading for AWS in CSE

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -927,6 +927,8 @@ mechanism_properties
 		Drivers MUST allow the user to specify an AWS session token for authentication with temporary credentials.
 
 
+.. _obtaining-credentials:
+
 Obtaining Credentials
 `````````````````````
 Drivers will need AWS IAM credentials (an access key, a secret access key and optionally a session token) to complete the steps in the `Signature Version 4 Signing Process 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

This documents and prescribes new behavior for lazily loading AWS credentials for CSE using the same logic that is used in the Auth spec. This is based on the semantics (as I understand them) that were implemented in the Java driver (Refer: [JAVA-4499](https://jira.mongodb.org/browse/JAVA-4499)).

Implementing automated tests is an open question as this is a very environment-sensitivie behavior. It may be easiest to implement in terms of DRIVERS-2011.

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [x] ~~Make sure there are generated JSON files from the YAML test files.~~ (N/A)
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

