### PR TITLE
DRIVERS-2343 Reapply updates to FLE 2 find payloads

### DIFF
--- a/source/client-side-encryption/etc/test-templates/fle2-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Delete.yml.template
@@ -71,7 +71,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }

--- a/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-jsonSchema.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-jsonSchema.yml.template
@@ -72,7 +72,7 @@ tests:
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/source/client-side-encryption/etc/test-templates/fle2-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-FindOneAndUpdate.yml.template
@@ -70,7 +70,7 @@ tests:
                 "encryptedIndexed": { 
                   "$eq": {
                     "$binary": {
-                        "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                        "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                         "subType": "06"
                     }
                   }
@@ -172,7 +172,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }

--- a/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Indexed.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Indexed.yml.template
@@ -68,7 +68,7 @@ tests:
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/source/client-side-encryption/etc/test-templates/fle2-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Update.yml.template
@@ -74,7 +74,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }
@@ -179,7 +179,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }

--- a/source/client-side-encryption/tests/legacy/fle2-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Delete.json
@@ -225,7 +225,7 @@
                     "encryptedIndexed": {
                       "$eq": {
                         "$binary": {
-                          "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                          "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                           "subType": "06"
                         }
                       }

--- a/source/client-side-encryption/tests/legacy/fle2-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Delete.yml
@@ -71,7 +71,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.json
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.json
@@ -230,7 +230,7 @@
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
@@ -72,7 +72,7 @@ tests:
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.json
@@ -230,7 +230,7 @@
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }
@@ -490,7 +490,7 @@
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.yml
@@ -70,7 +70,7 @@ tests:
                 "encryptedIndexed": { 
                   "$eq": {
                     "$binary": {
-                        "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                        "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                         "subType": "06"
                     }
                   }
@@ -172,7 +172,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.json
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.json
@@ -226,7 +226,7 @@
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.yml
@@ -68,7 +68,7 @@ tests:
                 "encryptedIndexed": {
                   "$eq": {
                     "$binary": {
-                      "base64": "BYkAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsSY20AAAAAAAAAAAAA",
+                      "base64": "BbEAAAAFZAAgAAAAAPGmZcUzdE/FPILvRSyAScGvZparGI2y9rJ/vSBxgCujBXMAIAAAAACi1RjmndKqgnXy7xb22RzUbnZl1sOZRXPOC0KcJkAxmQVjACAAAAAAWuidNu47c9A4Clic3DvFhn1AQJVC+FJtoE5bGZuz6PsFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                       "subType": "06"
                     }
                   }

--- a/source/client-side-encryption/tests/legacy/fle2-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Update.json
@@ -232,7 +232,7 @@
                     "encryptedIndexed": {
                       "$eq": {
                         "$binary": {
-                          "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                          "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                           "subType": "06"
                         }
                       }
@@ -496,7 +496,7 @@
                     "encryptedIndexed": {
                       "$eq": {
                         "$binary": {
-                          "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                          "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                           "subType": "06"
                         }
                       }

--- a/source/client-side-encryption/tests/legacy/fle2-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Update.yml
@@ -74,7 +74,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }
@@ -179,7 +179,7 @@ tests:
                     "encryptedIndexed": { 
                       "$eq": {
                         "$binary": {
-                            "base64": "BYkAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcSY20AAAAAAAAAAAAA",
+                            "base64": "BbEAAAAFZAAgAAAAAPtVteJQAlgb2YMa/+7YWH00sbQPyt7L6Rb8OwBdMmL2BXMAIAAAAAAd44hgVKnEnTFlwNVC14oyc9OZOTspeymusqkRQj57nAVjACAAAAAA19X9v9NlWidu/wR5/C/7WUV54DfL5CkNmT5WYrhxdDcFZQAgAAAAAOuac/eRLYakKX6B0vZ1r3QodOQFfjqJD+xlGiPu4/PsEmNtAAAAAAAAAAAAAA==",
                             "subType": "06"
                         }
                       }


### PR DESCRIPTION
This reverts commit cd34149ca1510ff2ec59e72ea9958c6855df9f3f.

# Background & Motivation

Drivers require libmongocrypt with MONGOCRYPT-433 to run these tests. MONGOCRYPT-433 is planned in the 1.5.0 stable release.

## Caveats
MongoDB Atlas is still running 6.0.0-rc7. Drivers using libmongocrypt 1.5.0 stable will receive the `BSON field 'root.e' is an unknown field.` using MongoDB Atlas until Atlas upgrades to 6.0.0-rc8 or newer. Since, libmongocrypt 1.5.0 stable is planned soon, this PR proposes proceeding with this caveat.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **N/A. Test changes only**
- [ ] Update changelog. **N/A. Test changes only**
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested in C**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). *C does not run CSFLE tests against sharded clusters*

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

