### PR TITLE
DRIVERS-2370 Remove createKey in favor of createDataKey

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -2349,7 +2349,7 @@ Changelog
 
    Date, Description
    22-06-27, Remove ``createKey``.
-   24-06-22, Clean up kmsProviders to use more TypeScript-like type definitions.
+   22-06-24, Clean up kmsProviders to use more TypeScript-like type definitions.
    22-06-23, Make ``RewrapManyDataKeyResult.bulkWriteResult`` optional.
    22-06-16, Change ``QueryType`` to a string.
    22-06-15, Clarify description of date fields in key documents.

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -10,8 +10,8 @@ Client Side Encryption
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 4.2 (CSFLE), 6.0 (Queryable Encryption)
-:Last Modified: 2022-06-23
-:Version: 1.8.1
+:Last Modified: 2022-06-27
+:Version: 1.9.0
 
 .. _lmc-c-api: https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h.in
 
@@ -740,9 +740,6 @@ ClientEncryption
 
       // Creates a new key document and inserts into the key vault collection.
       // Returns the _id of the created document as a UUID (BSON binary subtype 0x04).
-      createKey(kmsProvider: String, opts: Optional<DataKeyOpts>): Binary;
-
-      // An alias function equivalent to createKey.
       createDataKey(kmsProvider: String, opts: Optional<DataKeyOpts>): Binary;
 
       // Decrypts multiple data keys and (re-)encrypts them with a new masterKey, or with their current masterKey if a new one is not given.
@@ -2219,13 +2216,6 @@ key vault collection. Using ``RewrapManyDataKeyResult`` allows new fields to be
 added in the future and more easily deprecate the wrapped ``BulkWriteResult`` if
 necessary.
 
-Why is there both a createKey and a createDataKey function in ClientEncryption?
--------------------------------------------------------------------------------
-
-``createDataKey`` existed before ``createKey``, but ``createKey`` was added for
-parity with the mongosh interface. ``createDataKey`` remains for backwards
-compatibility.
-
 Why does ClientEncryption have key management functions when Drivers can use existing CRUD operations instead?
 --------------------------------------------------------------------------------------------------------------
 
@@ -2322,6 +2312,7 @@ Changelog
    :align: left
 
    Date, Description
+   22-06-27, Remove ``createKey``.
    22-06-23, Make ``RewrapManyDataKeyResult.bulkWriteResult`` optional.
    22-06-16, Change ``QueryType`` to a string.
    22-06-15, Clarify description of date fields in key documents.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1820,7 +1820,7 @@ The command should be equivalent to:
 5. Using ``client_encryption``, create a data key with a ``local`` KMS provider and the keyAltName "def".
 
 Case 1: createDataKey()
-```````````````````
+```````````````````````
 
 1. Use ``client_encryption`` to create a new local data key with a keyAltName "abc" and assert the operation does not fail.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1785,6 +1785,8 @@ Use ``clientEncryption`` to decrypt ``payload``. Assert the returned value equal
 13. Unique Index on keyAltNames
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The following setup must occur before running each of the following test cases.
+
 Setup
 `````
 
@@ -1817,7 +1819,7 @@ The command should be equivalent to:
 
 5. Using ``client_encryption``, create a data key with a ``local`` KMS provider and the keyAltName "def".
 
-Case 1: createKey()
+Case 1: createDataKey()
 ```````````````````
 
 1. Use ``client_encryption`` to create a new local data key with a keyAltName "abc" and assert the operation does not fail.

--- a/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.json
+++ b/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.json
@@ -1,5 +1,5 @@
 {
-  "description": "createKey-provider-invalid",
+  "description": "createDataKey-provider-invalid",
   "schemaVersion": "1.8",
   "runOnRequirements": [
     {
@@ -35,7 +35,7 @@
       "description": "create data key without required master key fields",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "aws",
@@ -59,7 +59,7 @@
       "description": "create data key with invalid master key field",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local",
@@ -85,7 +85,7 @@
       "description": "create data key with invalid master key",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "aws",

--- a/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
+++ b/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
@@ -1,4 +1,4 @@
-description: createKey-provider-invalid
+description: createDataKey-provider-invalid
 
 schemaVersion: "1.8"
 
@@ -23,7 +23,7 @@ createEntities:
 tests:
   - description: create data key without required master key fields
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: aws
@@ -37,7 +37,7 @@ tests:
 
   - description: create data key with invalid master key field
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local
@@ -52,7 +52,7 @@ tests:
 
   - description: create data key with invalid master key
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: aws

--- a/source/client-side-encryption/tests/unified/createDataKey.json
+++ b/source/client-side-encryption/tests/unified/createDataKey.json
@@ -1,5 +1,5 @@
 {
-  "description": "createKey",
+  "description": "createDataKey",
   "schemaVersion": "1.8",
   "runOnRequirements": [
     {
@@ -90,7 +90,7 @@
       "description": "create data key with AWS KMS provider",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "aws",
@@ -153,7 +153,7 @@
       "description": "create datakey with Azure KMS provider",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "azure",
@@ -216,7 +216,7 @@
       "description": "create datakey with GCP KMS provider",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "gcp",
@@ -283,7 +283,7 @@
       "description": "create datakey with KMIP KMS provider",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "kmip"
@@ -341,7 +341,7 @@
       "description": "create datakey with local KMS provider",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local"
@@ -396,7 +396,7 @@
       "description": "create datakey with no keyAltName",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local",
@@ -457,7 +457,7 @@
       "description": "create datakey with single keyAltName",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local",
@@ -520,7 +520,7 @@
       "description": "create datakey with multiple keyAltNames",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local",
@@ -619,7 +619,7 @@
       "description": "create datakey with custom key material",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local",
@@ -682,7 +682,7 @@
       "description": "create datakey with invalid custom key material (too short)",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local",

--- a/source/client-side-encryption/tests/unified/createDataKey.yml
+++ b/source/client-side-encryption/tests/unified/createDataKey.yml
@@ -1,4 +1,4 @@
-description: createKey
+description: createDataKey
 
 schemaVersion: "1.8"
 
@@ -38,7 +38,7 @@ initialData:
 tests:
   - description: create data key with AWS KMS provider
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: aws
@@ -67,7 +67,7 @@ tests:
 
   - description: create datakey with Azure KMS provider
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: azure
@@ -96,7 +96,7 @@ tests:
 
   - description: create datakey with GCP KMS provider
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: gcp
@@ -127,7 +127,7 @@ tests:
 
   - description: create datakey with KMIP KMS provider
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: kmip
@@ -152,7 +152,7 @@ tests:
 
   - description: create datakey with local KMS provider
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local
@@ -176,7 +176,7 @@ tests:
 
   - description: create datakey with no keyAltName
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local
@@ -203,7 +203,7 @@ tests:
 
   - description: create datakey with single keyAltName
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local
@@ -229,7 +229,7 @@ tests:
 
   - description: create datakey with multiple keyAltNames
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local
@@ -268,7 +268,7 @@ tests:
 
   - description: create datakey with custom key material
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local
@@ -295,7 +295,7 @@ tests:
 
   - description: create datakey with invalid custom key material (too short)
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local

--- a/source/client-side-encryption/tests/unified/getKeys.json
+++ b/source/client-side-encryption/tests/unified/getKeys.json
@@ -87,7 +87,7 @@
       "description": "getKeys with single key documents",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local",
@@ -160,7 +160,7 @@
       "description": "getKeys with many key documents",
       "operations": [
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local"
@@ -170,7 +170,7 @@
           }
         },
         {
-          "name": "createKey",
+          "name": "createDataKey",
           "object": "clientEncryption0",
           "arguments": {
             "kmsProvider": "local"

--- a/source/client-side-encryption/tests/unified/getKeys.yml
+++ b/source/client-side-encryption/tests/unified/getKeys.yml
@@ -49,7 +49,7 @@ tests:
 
   - description: getKeys with single key documents
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local
@@ -80,12 +80,12 @@ tests:
 
   - description: getKeys with many key documents
     operations:
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local
         expectResult: { $$type: binData }
-      - name: createKey
+      - name: createDataKey
         object: *clientEncryption0
         arguments:
           kmsProvider: local


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

## Description

This PR addresses DRIVERS-2370. All instances of `createKey()` have either been removed or renamed to `createDataKey()`.

Upon reconsideration, it was decided that the engineering effort, subsequent maintenance, and clarity of usage and documentation of adding to all Drivers a new `createKey()` function that is merely an alias to the existing `createDataKey()` function may not be desirable. It was deemed preferable for mongosh, whose interface the Key Management API is aiming to reach parity with, to add `createDataKey()` for parity instead.

Other factors considered was leaving room for further key types to be managed in the key vault collection. Instead of reserving the generic `createKey` for "data keys", `createDataKey()` leaves room for additional `createXKey()` without semantic conflicts. Other Key Management API functions such as `deleteKey()` and `addKeyAltName()` do not require qualifications as their operations may apply regardless of key type (by UUID or by key alternate name).

## CSE Version Number

This PR proposes bumping the CSE spec version to 1.9.0 from 1.8.1 despite removing a public interface entity, which would normally constitute a major version bump per SemVer. This is because this change is intended to be applied as part of initial Key Management API implementation and no Driver has, or is expected to have, publically released a version with the Key Management API yet. If the version number _should_ instead be bumped to 2.0.0 regardless, please indicate so in the review.