### PR TITLE
DRIVERS-2371 add required contention factor to prose tests

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1656,6 +1656,7 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
    class EncryptOpts {
       keyId : <key1ID>
       algorithm: "Indexed",
+      contentionFactor: 0
    }
 
 Store the result in ``insertPayload``.
@@ -1669,7 +1670,8 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
    class EncryptOpts {
       keyId : <key1ID>
       algorithm: "Indexed",
-      queryType: "equality"
+      queryType: "equality",
+      contentionFactor: 0
    }
 
 Store the result in ``findPayload``.
@@ -1704,7 +1706,8 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
    class EncryptOpts {
       keyId : <key1ID>
       algorithm: "Indexed",
-      queryType: "equality"
+      queryType: "equality",
+      contentionFactor: 0
    }
 
 Store the result in ``findPayload``.
@@ -1760,6 +1763,7 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
    class EncryptOpts {
       keyId : <key1ID>
       algorithm: "Indexed",
+      contentionFactor: 0
    }
 
 Store the result in ``payload``.


### PR DESCRIPTION
# Summary
- Update "explicit encryption" prose tests to include required contentionFactor option

# Background & Motivation
[MONGOCRYPT-447](https://jira.mongodb.org/browse/MONGOCRYPT-447) makes contentionFactor a required option when the algorithm is "Indexed".

Drivers require libmongocrypt with MONGOCRYPT-477 to run these tests. MONGOCRYPT-477 is planned in the 1.5.0 stable release. 1.5.0 is not yet released, but libmongocrypt can be downloaded from this [upload-all task](https://evergreen.mongodb.com/task/libmongocrypt_publish_snapshot_upload_all_b1d9dd9811d8c15dc294ab3d5dcb71364833f28d_22_06_27_20_02_56).

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **N/A? Test changes only**
- [ ] Update changelog. **N/A? Test changes only**
- [ ] Make sure there are generated JSON files from the YAML test files. **N/A? Prose test changes only**
- [x] Test changes in at least one language driver. **Tested in [C](https://github.com/mongodb/mongo-c-driver/compare/master...kevinAlbs:mongo-c-driver:M447-require_cf?expand=1)**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **C does not test CSFLE with sharded**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

