### PR TITLE
DRIVERS-2373 remove unnecessary use of on-demand credentials in CSE unified spec tests

### DIFF
--- a/source/client-side-encryption/tests/unified/addKeyAltName.json
+++ b/source/client-side-encryption/tests/unified/addKeyAltName.json
@@ -22,7 +22,11 @@
           "keyVaultClient": "client0",
           "keyVaultNamespace": "keyvault.datakeys",
           "kmsProviders": {
-            "local": {}
+            "local": {
+              "key": {
+                "$$placeholder": 1
+              }
+            }
           }
         }
       }

--- a/source/client-side-encryption/tests/unified/addKeyAltName.yml
+++ b/source/client-side-encryption/tests/unified/addKeyAltName.yml
@@ -16,7 +16,7 @@ createEntities:
         keyVaultClient: *client0
         keyVaultNamespace: keyvault.datakeys
         kmsProviders:
-          local: {}
+          local: { key: { $$placeholder: 1 } }
   - database:
       id: &database0 database0
       client: *client0

--- a/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.json
+++ b/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.json
@@ -24,7 +24,14 @@
           "keyVaultClient": "client0",
           "keyVaultNamespace": "keyvault.datakeys",
           "kmsProviders": {
-            "aws": {}
+            "aws": {
+              "accessKeyId": {
+                "$$placeholder": 1
+              },
+              "secretAccessKey": {
+                "$$placeholder": 1
+              }
+            }
           }
         }
       }

--- a/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
+++ b/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
@@ -18,7 +18,7 @@ createEntities:
         keyVaultClient: *client0
         keyVaultNamespace: keyvault.datakeys
         kmsProviders:
-          aws: {}
+          aws: { accessKeyId: { $$placeholder: 1 }, secretAccessKey: { $$placeholder: 1 } }
 
 tests:
   - description: create data key without required master key fields

--- a/source/client-side-encryption/tests/unified/deleteKey.json
+++ b/source/client-side-encryption/tests/unified/deleteKey.json
@@ -22,7 +22,11 @@
           "keyVaultClient": "client0",
           "keyVaultNamespace": "keyvault.datakeys",
           "kmsProviders": {
-            "local": {}
+            "local": {
+              "key": {
+                "$$placeholder": 1
+              }
+            }
           }
         }
       }

--- a/source/client-side-encryption/tests/unified/deleteKey.yml
+++ b/source/client-side-encryption/tests/unified/deleteKey.yml
@@ -16,7 +16,7 @@ createEntities:
         keyVaultClient: *client0
         keyVaultNamespace: keyvault.datakeys
         kmsProviders:
-          local: {}
+          local: { key: { $$placeholder: 1 } }
   - database:
       id: &database0 database0
       client: *client0

--- a/source/client-side-encryption/tests/unified/getKey.json
+++ b/source/client-side-encryption/tests/unified/getKey.json
@@ -22,7 +22,11 @@
           "keyVaultClient": "client0",
           "keyVaultNamespace": "keyvault.datakeys",
           "kmsProviders": {
-            "local": {}
+            "local": {
+              "key": {
+                "$$placeholder": 1
+              }
+            }
           }
         }
       }

--- a/source/client-side-encryption/tests/unified/getKey.yml
+++ b/source/client-side-encryption/tests/unified/getKey.yml
@@ -16,7 +16,7 @@ createEntities:
         keyVaultClient: *client0
         keyVaultNamespace: keyvault.datakeys
         kmsProviders:
-          local: {}
+          local: { key: { $$placeholder: 1 } }
   - database:
       id: &database0 database0
       client: *client0

--- a/source/client-side-encryption/tests/unified/getKeyByAltName.json
+++ b/source/client-side-encryption/tests/unified/getKeyByAltName.json
@@ -22,7 +22,11 @@
           "keyVaultClient": "client0",
           "keyVaultNamespace": "keyvault.datakeys",
           "kmsProviders": {
-            "local": {}
+            "local": {
+              "key": {
+                "$$placeholder": 1
+              }
+            }
           }
         }
       }

--- a/source/client-side-encryption/tests/unified/getKeyByAltName.yml
+++ b/source/client-side-encryption/tests/unified/getKeyByAltName.yml
@@ -16,7 +16,7 @@ createEntities:
         keyVaultClient: *client0
         keyVaultNamespace: keyvault.datakeys
         kmsProviders:
-          local: {}
+          local: { key: { $$placeholder: 1 } }
   - database:
       id: &database0 database0
       client: *client0

--- a/source/client-side-encryption/tests/unified/removeKeyAltName.json
+++ b/source/client-side-encryption/tests/unified/removeKeyAltName.json
@@ -22,7 +22,11 @@
           "keyVaultClient": "client0",
           "keyVaultNamespace": "keyvault.datakeys",
           "kmsProviders": {
-            "local": {}
+            "local": {
+              "key": {
+                "$$placeholder": 1
+              }
+            }
           }
         }
       }

--- a/source/client-side-encryption/tests/unified/removeKeyAltName.yml
+++ b/source/client-side-encryption/tests/unified/removeKeyAltName.yml
@@ -16,7 +16,7 @@ createEntities:
         keyVaultClient: *client0
         keyVaultNamespace: keyvault.datakeys
         kmsProviders:
-          local: {}
+          local: { key: { $$placeholder: 1 } }
   - database:
       id: &database0 database0
       client: *client0

--- a/source/unified-test-format/tests/valid-pass/kmsProviders-unconfigured_kms.json
+++ b/source/unified-test-format/tests/valid-pass/kmsProviders-unconfigured_kms.json
@@ -4,6 +4,9 @@
   "runOnRequirements": [
     {
       "csfle": true
+    },
+    {
+      "skipReason": "DRIVERS-2280: waiting on driver support for on-demand credentials"
     }
   ],
   "createEntities": [

--- a/source/unified-test-format/tests/valid-pass/kmsProviders-unconfigured_kms.json
+++ b/source/unified-test-format/tests/valid-pass/kmsProviders-unconfigured_kms.json
@@ -4,9 +4,6 @@
   "runOnRequirements": [
     {
       "csfle": true
-    },
-    {
-      "skipReason": "DRIVERS-2280: waiting on driver support for on-demand credentials"
     }
   ],
   "createEntities": [
@@ -35,6 +32,7 @@
   "tests": [
     {
       "description": "",
+      "skipReason": "DRIVERS-2280: waiting on driver support for on-demand credentials",
       "operations": []
     }
   ]

--- a/source/unified-test-format/tests/valid-pass/kmsProviders-unconfigured_kms.yml
+++ b/source/unified-test-format/tests/valid-pass/kmsProviders-unconfigured_kms.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.8"
 
 runOnRequirements:
   - csfle: true
+  - skipReason: "DRIVERS-2280: waiting on driver support for on-demand credentials"
 
 createEntities:
   - client:

--- a/source/unified-test-format/tests/valid-pass/kmsProviders-unconfigured_kms.yml
+++ b/source/unified-test-format/tests/valid-pass/kmsProviders-unconfigured_kms.yml
@@ -5,7 +5,6 @@ schemaVersion: "1.8"
 
 runOnRequirements:
   - csfle: true
-  - skipReason: "DRIVERS-2280: waiting on driver support for on-demand credentials"
 
 createEntities:
   - client:
@@ -24,4 +23,5 @@ createEntities:
 
 tests:
   - description: ""
+    skipReason: "DRIVERS-2280: waiting on driver support for on-demand credentials"
     operations: []


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] ~Bump spec version and last modified date.~ N/A
- [x] ~Update changelog.~ N/A
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

## Description

This PR resolves DRIVERS-2373.