### PR TITLE
DRIVERS-555 Fix capped collection test on MMAPv1

### DIFF
--- a/source/unified-test-format/tests/valid-pass/collectionData-createOptions.json
+++ b/source/unified-test-format/tests/valid-pass/collectionData-createOptions.json
@@ -34,7 +34,7 @@
       "databaseName": "database0",
       "createOptions": {
         "capped": true,
-        "size": 512
+        "size": 4096
       },
       "documents": [
         {
@@ -60,7 +60,7 @@
           },
           "expectResult": {
             "capped": true,
-            "maxSize": 512
+            "maxSize": 4096
           }
         }
       ]

--- a/source/unified-test-format/tests/valid-pass/collectionData-createOptions.yml
+++ b/source/unified-test-format/tests/valid-pass/collectionData-createOptions.yml
@@ -24,7 +24,8 @@ initialData:
     databaseName: *database0Name
     createOptions:
       capped: true
-      size: &cappedSize 512
+      # With MMAPv1, the size field cannot be less than 4096.
+      size: &cappedSize 4096
     documents:
       - { _id: 1, x: 11 }
 


### PR DESCRIPTION
Please complete the following before merging:
- [ ] ~Bump spec version and last modified date.~
- [ ] ~Update changelog.~
- [X] Make sure there are generated JSON files from the YAML test files.
- [X] Test changes in at least one language driver.
- [X] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

Explanation:
> If the size field is less than or equal to 4096, then the collection will have a cap of 4096 bytes.

https://www.mongodb.com/docs/manual/core/capped-collections/#create-a-capped-collection

Testing this change in Python here: https://github.com/mongodb/mongo-python-driver/pull/990