### PR TITLE
DRIVERS-2355 Clarify that driver tests < 6.0 should use mongocryptd

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -330,6 +330,11 @@ Using ``crypt_shared``
 On platforms where crypt_shared_ is available, drivers should prefer to test
 with the ``crypt_shared`` library instead of spawning mongocryptd.
 
+crypt_shared_ is released alongside the server.
+crypt_shared_ is only available in versions 6.0 and above.
+Drivers SHOULD prefer testing a version of crypt_shared_ that matches the server version being tested.
+Driver tests on server versions less than 6.0 SHOULD use mongocryptd.
+
 Drivers MUST continue to run all tests with mongocryptd on at least one
 platform for all tested server versions.
 


### PR DESCRIPTION
# Summary
- Clarify that driver tests < 6.0 should use mongocryptd

# Background & Motivation

The goal of DRIVERS-2355 is to use a consistent version for crypt_shared and the server. Meeting that goal prohibits testing with crypt_shared on < 6.0 servers.

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **N/A. Test clarification**
- [ ] Update changelog. **N/A. Test clarification**
- [ ] Make sure there are generated JSON files from the YAML test files. **N/A. Test clarification**
- [ ] Test changes in at least one language driver. **N/A. Test clarification**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **N/A. Test clarification**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

