### PR TITLE
DRIVERS-2387 Skip StaleShardVersion resume test on >= 6.1

### DIFF
--- a/source/change-streams/tests/unified/change-streams-resume-errorLabels.json
+++ b/source/change-streams/tests/unified/change-streams-resume-errorLabels.json
@@ -1480,7 +1480,7 @@
       "description": "change stream resumes after StaleShardVersion",
       "runOnRequirements": [
         {
-          "maxServerVersion": "5.99"
+          "maxServerVersion": "6.0.99"
         }
       ],
       "operations": [

--- a/source/change-streams/tests/unified/change-streams-resume-errorLabels.json
+++ b/source/change-streams/tests/unified/change-streams-resume-errorLabels.json
@@ -1478,6 +1478,11 @@
     },
     {
       "description": "change stream resumes after StaleShardVersion",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "5.99"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/change-streams/tests/unified/change-streams-resume-errorLabels.yml
+++ b/source/change-streams/tests/unified/change-streams-resume-errorLabels.yml
@@ -743,6 +743,9 @@ tests:
               databaseName: *database0
 
   - description: change stream resumes after StaleShardVersion
+    runOnRequirements:
+      # StaleShardVersion is obsolete as of 6.0 and is no longer marked as resumable.
+      - maxServerVersion: "5.99"
     operations:
       - name: failPoint
         object: testRunner

--- a/source/change-streams/tests/unified/change-streams-resume-errorLabels.yml
+++ b/source/change-streams/tests/unified/change-streams-resume-errorLabels.yml
@@ -744,8 +744,8 @@ tests:
 
   - description: change stream resumes after StaleShardVersion
     runOnRequirements:
-      # StaleShardVersion is obsolete as of 6.0 and is no longer marked as resumable.
-      - maxServerVersion: "5.99"
+      # StaleShardVersion is obsolete as of 6.1 and is no longer marked as resumable.
+      - maxServerVersion: "6.0.99"
     operations:
       - name: failPoint
         object: testRunner


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. (N/A)
- [ ] Update changelog. (N/A)
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

DRIVERS-2387

Skips the `change stream resumes after StaleShardVersion` test on > 6.0.99. `StaleShardVersion` was removed (see [SERVER-64449](https://jira.mongodb.org/browse/SERVER-64449)) in 6.1.0 and is therefore not marked resumable by the server. `StaleShardVersion` was obsoleted by `StaleConfig`, but adding tests for the resumability of that error is non-trivial (see DRIVERS-2392), so I think we can just skip the `StaleShardVersion` test on 6.1.0+ for now.
