### PR TITLE
DRIVERS-2395: Add test that read is not retried in a transaction

### DIFF
--- a/source/transactions/tests/unified/do-not-retry-read-in-transaction.json
+++ b/source/transactions/tests/unified/do-not-retry-read-in-transaction.json
@@ -86,7 +86,10 @@
             "session": "session0"
           },
           "expectError": {
-            "isError": true
+            "isError": true,
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
           }
         }
       ],

--- a/source/transactions/tests/unified/do-not-retry-read-in-transaction.json
+++ b/source/transactions/tests/unified/do-not-retry-read-in-transaction.json
@@ -3,9 +3,15 @@
   "schemaVersion": "1.4",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.0",
+      "minServerVersion": "4.0.0",
       "topologies": [
-        "replicaset",
+        "single",
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.2.0",
+      "topologies": [
         "sharded",
         "load-balanced"
       ]

--- a/source/transactions/tests/unified/do-not-retry-read-in-transaction.json
+++ b/source/transactions/tests/unified/do-not-retry-read-in-transaction.json
@@ -1,0 +1,107 @@
+{
+  "description": "do not retry read in a transaction",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ],
+        "uriOptions": {
+          "retryReads": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "retryable-read-in-transaction-test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "find does not retry in a transaction",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "session": "session0"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll",
+                  "filter": {},
+                  "startTransaction": true
+                },
+                "commandName": "find",
+                "databaseName": "retryable-read-in-transaction-test"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/transactions/tests/unified/do-not-retry-read-in-transaction.yml
+++ b/source/transactions/tests/unified/do-not-retry-read-in-transaction.yml
@@ -1,0 +1,62 @@
+description: "do not retry read in a transaction"
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "4.0"
+    topologies: [replicaset, sharded, load-balanced]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent]
+      uriOptions: { retryReads: true }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName retryable-read-in-transaction-test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName coll
+  - session:
+      id: &session0 session0
+      client: *client0
+
+tests:
+  - description: "find does not retry in a transaction"
+    operations:
+
+      - name: startTransaction
+        object: *session0
+
+      - name: failPoint # fail the following find command
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [find]
+              closeConnection: true
+
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+          session: *session0
+        expectError:
+          isError: true
+
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collectionName
+                filter: {}
+                startTransaction: true
+              commandName: find
+              databaseName: *databaseName

--- a/source/transactions/tests/unified/do-not-retry-read-in-transaction.yml
+++ b/source/transactions/tests/unified/do-not-retry-read-in-transaction.yml
@@ -3,8 +3,10 @@ description: "do not retry read in a transaction"
 schemaVersion: "1.4"
 
 runOnRequirements:
-  - minServerVersion: "4.0"
-    topologies: [replicaset, sharded, load-balanced]
+  - minServerVersion: "4.0.0"
+    topologies: [ single, replicaset ]
+  - minServerVersion: "4.2.0"
+    topologies: [ sharded, load-balanced ]
 
 createEntities:
   - client:

--- a/source/transactions/tests/unified/do-not-retry-read-in-transaction.yml
+++ b/source/transactions/tests/unified/do-not-retry-read-in-transaction.yml
@@ -51,7 +51,7 @@ tests:
           session: *session0
         expectError:
           isError: true
-
+          errorLabelsContain: ["TransientTransactionError"]
     expectEvents:
       - client: *client0
         events:


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [N/A] Bump spec version and last modified date.
- [N/A] Update changelog.
- [Done] Make sure there are generated JSON files from the YAML test files.
- [Done] Test changes in at least one language driver.
- [Done] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

Though the requirement is in the retryable reads spec, the test seemed more appropriate in the transactions spec.  Happy to move if there is strong disagreement.

DRIVERS-2395