### PR TITLE
DRIVERS-2377 Support GCP attached service accounts when using GCP KMS

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -525,7 +525,7 @@ Automatic Credentials
 .. versionadded:: 1.9.0 2022/06/22
 
 If the ``aws`` or ``gcp`` provider properties of a KMSProviders_ are present and
-empty map/object, the driver MUST be able to populate an AWSKMSOptions_ or
+are an empty map/object, the driver MUST be able to populate an AWSKMSOptions_ or
 GCPKMSOptions_ object on-demand if-and-only-if AWS or GCP credentials are
 needed.
 

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -534,7 +534,8 @@ needed.
 libmongocrypt_ will interpret an empty KMSProviders_ map properties as a request
 by the user to lazily load the credentials for the respective `KMS provider`_.
 libmongocrypt_ will call back to the driver to fill an empty KMS provider
-property only once the associated credentials are needed.
+property only once the associated credentials are needed by entering
+``MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS`` state.
 
 Once requested, drivers MUST create a new KMSProviders_ :math:`P` according to
 the following process:

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -480,9 +480,9 @@ accept arbitrary strings at runtime for forward-compatibility.
 .. code:: typescript
 
    interface KMSProviders {
-      aws?: AWSKMSOptions | { /* Empty. (See "Automatic AWS Credentials") */ };
+      aws?: AWSKMSOptions | { /* Empty. (See "Automatic Credentials") */ };
       azure?: AzureKMSOptions;
-      gcp?: GCPKMSOptions;
+      gcp?: GCPKMSOptions | { /* Empty. (See "Automatic Credentials") */ };
       local?: LocalKMSOptions;
       kmip?: KMIPKMSOptions;
    };
@@ -504,11 +504,17 @@ accept arbitrary strings at runtime for forward-compatibility.
       identityPlatformEndpoint?: string; // Defaults to login.microsoftonline.com
    };
 
-   interface GCPKMSOptions {
+   type GCPKMSOptions = GCPKMSCredentials | GCPKMSAccessToken
+
+   interface GCPKMSCredentials {
       email: string;
       privateKey: byte[] | string; // May be passed as a base64 encoded string.
       endpoint?: string; // Defaults to oauth2.googleapis.com
    };
+
+   interface GCPKMSAccessToken {
+      accessToken: string;
+   }
 
    interface LocalKMSOptions {
       key: byte[96] | string; // The master key used to encrypt/decrypt data keys. May be passed as a base64 encoded string.

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -535,7 +535,7 @@ libmongocrypt_ will interpret an empty KMSProviders_ map properties as a request
 by the user to lazily load the credentials for the respective `KMS provider`_.
 libmongocrypt_ will call back to the driver to fill an empty KMS provider
 property only once the associated credentials are needed by entering
-``MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS`` state.
+the ``MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS`` state.
 
 Once requested, drivers MUST create a new KMSProviders_ :math:`P` according to
 the following process:

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2012,3 +2012,72 @@ the environment.
 .. _Automatic AWS Credentials: ../client-side-encryption.rst#automatic-aws-credentials
 .. _ClientEncryption: ../client-side-encryption.rst#clientencryption
 .. _auth-aws: ../../auth/auth.rst#obtaining-credentials
+
+16. On-demand GCP Credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Refer: `Automatic GCP Credentials`_.
+
+For these cases, create a ClientEncryption_ object :math:`C` with the following
+options:
+
+.. code-block:: typescript
+
+   ClientEncryptionOpts {
+      keyVaultClient: <setupClient>,
+      keyVaultNamespace: "keyvault.datakeys",
+      kmsProviders: { "gcp": {} },
+   }
+
+Case 1: Failure
+```````````````
+
+Do not run this test case in an environment with a GCP service account is
+attached (e.g. any `GCE equivalent runtime
+<https://google.aip.dev/auth/4115>`_). This may be run in an AWS EC2 instance.
+
+Attempt to create a datakey with :math:`C` using the ``"gcp"`` KMS provider and
+following ``DataKeyOpts``:
+
+.. code-block:: typescript
+
+   class DataKeyOpts {
+      masterKey: {
+         "projectId": "devprod-drivers",
+         "location": "global",
+         "keyRing": "key-ring-csfle",
+         "keyName": "key-name-csfle"
+      }
+   }
+
+Expect the attempt to obtain ``"gcp"`` credentials from the environment to fail.
+
+Case 2: Success
+```````````````
+
+This test case must run in a Google Compute Engine (GCE) Virtual Machine with a
+service account attached. See `drivers-evergreen-tools/.evergreen/csfle/gcpkms
+<https://github.com/mongodb-labs/drivers-evergreen-tools/blob/master/.evergreen/csfle/gcpkms>`_
+for scripts to create a GCE instance for testing. The Evergreen task SHOULD set a
+``batchtime`` of 14 days to reduce how often this test case runs.
+
+Attempt to create a datakey with :math:`C` using the ``"gcp"`` KMS provider and
+following ``DataKeyOpts``:
+
+.. code-block:: typescript
+
+   class DataKeyOpts {
+      masterKey: {
+         "projectId": "devprod-drivers",
+         "location": "global",
+         "keyRing": "key-ring-csfle",
+         "keyName": "key-name-csfle"
+      }
+   }
+
+This should successfully load and use the GCP credentials of the service account
+attached to the virtual machine.
+
+Expect the key to be successfully created.
+
+.. _Automatic GCP Credentials: ../client-side-encryption.rst#automatic-gcp-credentials


### PR DESCRIPTION
# Scope
- Support GCP attached service accounts when using GCP KMS.

# Background & Motivation

See [DBX Scope: Support attached service accounts for GCP KMS](https://docs.google.com/document/d/1RTDp5QMg_ayYnR_T7S9SriE19doNALwqIHNxlWerFeE/edit?usp=sharing).

This follows a similar pattern as the "aws" credentials for CSFLE added in DRIVERS-2280.

Support of the ``GCE_METADATA_HOST`` environment variable is not mentioned in https://google.aip.dev/auth/4115. It is implemented in the GCP SDKs I checked: (e.g. [Go](https://pkg.go.dev/cloud.google.com/go/compute/metadata#Client.Get) and [Python](https://github.com/googleapis/google-auth-library-python/blob/6f49d1fa1dff62c5f2ed0cf198507568f5c4296f/google/auth/compute_engine/_metadata.py#L35-L39)). I found it useful for development to test with a mock server. It may be useful for diagnosing bugs in the future.

Please see the https://github.com/mongodb/mongo-go-driver/pull/1029 for a PoC implementation in the Go driver. The PoC implementation is tested on with a GCE environment created with scripts in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/216.

---
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files. **N/A. Only prose tests added**
- [x] Test changes in at least one language driver. **Tested in [Go](https://github.com/mongodb/mongo-go-driver/pull/1029)**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **N/A. New test and behavior is independent of topology and server version. Tests are run against latest server**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

