### PR TITLE
DRIVERS-2404 Fix Azure and KMIP key material for RewrapManyDataKey

### DIFF
--- a/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.json
+++ b/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.json
@@ -1,5 +1,5 @@
 {
-  "description": "createDataKey-provider-invalid",
+  "description": "createDataKey-kms_providers-invalid",
   "schemaVersion": "1.8",
   "runOnRequirements": [
     {

--- a/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
+++ b/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
@@ -1,4 +1,4 @@
-description: createDataKey-provider-invalid
+description: createDataKey-kms_providers-invalid
 
 schemaVersion: "1.8"
 

--- a/source/client-side-encryption/tests/unified/rewrapManyDataKey.json
+++ b/source/client-side-encryption/tests/unified/rewrapManyDataKey.json
@@ -128,7 +128,7 @@
           ],
           "keyMaterial": {
             "$binary": {
-              "base64": "AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEGkNTybTc7Eyif0f+qqE0lAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDB2j78AeuIQxcRh8cQIBEIB7vj9buHEaT7XHFIsKBJiyzZRmNnjvqMK5LSdzonKdx97jlqauvPvTDXSsdQDcspUs5oLrGmAXpbFResscxmbwZoKgUtWiuIOpeAcYuszCiMKt15s1WIMLDXUhYtfCmhRhekvgHnRAaK4HJMlGE+lKJXYI84E0b86Cd/g+",
+              "base64": "pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==",
               "subType": "00"
             }
           },
@@ -196,7 +196,7 @@
           ],
           "keyMaterial": {
             "$binary": {
-              "base64": "VoI9J8HusQ3u2gT9i8Awgg/6W4/igvLwRzn3SRDGx0Dl/1ayDMubphOw0ONPVKfuvS6HL3e4gAoCJ/uEz2KLFTVsEqYCpMhfAhgXxm8Ena8vDcOkCzFX+euvN/N2ES3wpzAD18b3qIH0MbBwKJP82d5GQ4pVfGnPW8Ujp9aO1qC/s0EqNqYyzJ1SyzhV9lAjHHGIENYJx+bBrekg2EeZBA==",
+              "base64": "CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==",
               "subType": "00"
             }
           },

--- a/source/client-side-encryption/tests/unified/rewrapManyDataKey.json
+++ b/source/client-side-encryption/tests/unified/rewrapManyDataKey.json
@@ -1,5 +1,5 @@
 {
-  "description": "rewrapManyDataKey-kms_providers",
+  "description": "rewrapManyDataKey",
   "schemaVersion": "1.8",
   "runOnRequirements": [
     {

--- a/source/client-side-encryption/tests/unified/rewrapManyDataKey.yml
+++ b/source/client-side-encryption/tests/unified/rewrapManyDataKey.yml
@@ -2,7 +2,7 @@
 # commands sort the resulting documents in ascending order by the single-element
 # keyAltNames array to ensure alphabetic order by original KMS provider as
 # defined in initialData.
-description: rewrapManyDataKey-kms_providers
+description: rewrapManyDataKey
 
 schemaVersion: "1.8"
 

--- a/source/client-side-encryption/tests/unified/rewrapManyDataKey.yml
+++ b/source/client-side-encryption/tests/unified/rewrapManyDataKey.yml
@@ -50,7 +50,7 @@ initialData:
           region: us-east-1
       - _id: &azure_key_id { $binary: { base64: YXp1cmVhenVyZWF6dXJlYQ==, subType: "04" } }
         keyAltNames: ["azure_key"]
-        keyMaterial: { $binary: { base64: AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEGkNTybTc7Eyif0f+qqE0lAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDB2j78AeuIQxcRh8cQIBEIB7vj9buHEaT7XHFIsKBJiyzZRmNnjvqMK5LSdzonKdx97jlqauvPvTDXSsdQDcspUs5oLrGmAXpbFResscxmbwZoKgUtWiuIOpeAcYuszCiMKt15s1WIMLDXUhYtfCmhRhekvgHnRAaK4HJMlGE+lKJXYI84E0b86Cd/g+, subType: "00" } }
+        keyMaterial: { $binary: { base64: pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==, subType: "00" } }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
@@ -72,7 +72,7 @@ initialData:
           keyName: key-name-csfle
       - _id: &kmip_key_id { $binary: { base64: a21pcGttaXBrbWlwa21pcA==, subType: "04" } }
         keyAltNames: ["kmip_key"]
-        keyMaterial: { $binary: { base64: VoI9J8HusQ3u2gT9i8Awgg/6W4/igvLwRzn3SRDGx0Dl/1ayDMubphOw0ONPVKfuvS6HL3e4gAoCJ/uEz2KLFTVsEqYCpMhfAhgXxm8Ena8vDcOkCzFX+euvN/N2ES3wpzAD18b3qIH0MbBwKJP82d5GQ4pVfGnPW8Ujp9aO1qC/s0EqNqYyzJ1SyzhV9lAjHHGIENYJx+bBrekg2EeZBA==, subType: "00" } }
+        keyMaterial: { $binary: { base64: CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==, subType: "00" } }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] ~Bump spec version and last modified date.~ N/A
- [x] ~Update changelog.~ N/A
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in [at least one language driver](https://github.com/mongodb/mongo-c-driver/pull/1079).
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

## Description

Resolves DRIVERS-2404.

As a drive-by fix, also updates the descriptions of some CSE tests to be consistent with their filenames.