### PR TITLE
DRIVERS-2407 update expected error in fle2-InsertFind-Unindexed

### DIFF
--- a/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Unindexed.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Unindexed.yml.template
@@ -80,4 +80,8 @@ tests:
         arguments:
           filter: { encryptedUnindexed: "value123" }
         result:
-          errorContains: "Cannot query"
+          # Expected error message changed in https://github.com/10gen/mongo-enterprise-modules/commit/212b584d4f7a44bed41c826a180a4aff00923d7a#diff-5f12b55e8d5c52c2f62853ec595dc2c1e2e5cb4fdbf7a32739a8e3acb3c6f818
+          # Before the message was "cannot query non-indexed fields with the randomized encryption algorithm"
+          # After: "can only execute encrypted equality queries with an encrypted equality index"
+          # Use a small common substring.
+          errorContains: "encrypt"

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.json
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.json
@@ -241,7 +241,7 @@
             }
           },
           "result": {
-            "errorContains": "Cannot query"
+            "errorContains": "encrypt"
           }
         }
       ]

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.yml
@@ -80,4 +80,8 @@ tests:
         arguments:
           filter: { encryptedUnindexed: "value123" }
         result:
-          errorContains: "Cannot query"
+          # Expected error message changed in https://github.com/10gen/mongo-enterprise-modules/commit/212b584d4f7a44bed41c826a180a4aff00923d7a#diff-5f12b55e8d5c52c2f62853ec595dc2c1e2e5cb4fdbf7a32739a8e3acb3c6f818
+          # Before the message was "cannot query non-indexed fields with the randomized encryption algorithm"
+          # After: "can only execute encrypted equality queries with an encrypted equality index"
+          # Use a small common substring.
+          errorContains: "encrypt"


### PR DESCRIPTION
# Summary
- Update expected error in fle2-InsertFind-Unindexed.

# Background & Motivation

The expected error message changed recently in https://github.com/10gen/mongo-enterprise-modules/commit/212b584d4f7a44bed41c826a180a4aff00923d7a#diff-5f12b55e8d5c52c2f62853ec595dc2c1e2e5cb4fdbf7a32739a8e3acb3c6f818 Driver tests against "latest" will start failing.

Before the message was "cannot query non-indexed fields with the randomized encryption algorithm". Now it is "can only execute encrypted equality queries with an encrypted equality index". 

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date.
- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested in [Go](https://github.com/mongodb/mongo-go-driver/pull/1037)**
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

