### PR TITLE
DRIVERS-2377 remove GCE_METADATA_HOST check

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -578,8 +578,7 @@ Obtaining GCP Credentials
 
 .. versionadded:: 1.11.0 2022/07/20
 
-Set ``HOST`` to ``metadata.google.internal``. If the environment variable
-``GCE_METADATA_HOST`` is set, use the value of ``GCE_METADATA_HOST`` as ``HOST``.
+Set ``HOST`` to ``metadata.google.internal``.
 
 Send an HTTP request to the URL
 `http://<HOST>/computeMetadata/v1/instance/service-accounts/default/token` with


### PR DESCRIPTION
# Scope
- Remove requirement to check `GCE_METADATA_HOST`.

# Background & Motivation

The check for `GCE_METADATA_HOST` was added in https://github.com/mongodb/specifications/commit/847d9ba741201f9c9d1305831a9c60e8ab2a1544 with the motivation:

> I found it useful for development to test with a mock server. It may be useful for diagnosing bugs in the future.

It defies the YAGNI principal. There are no specification tests for the `GCE_METADATA_HOST` environment variable check.

---
<!-- Thanks for contributing! -->

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files. **N/A**
- [ ] Test changes in at least one language driver. **N/A**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **N/A**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

