### PR TITLE
DRIVERS-2344: add disambiguatedPaths to change streams update document

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -332,6 +332,7 @@ If an aggregate command with a ``$changeStream`` stage completes successfully, t
 The responses to a change stream aggregate or getMore have the following structures:
 
 .. code:: typescript
+
   /**
    * Response to a successful aggregate.
    */

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -10,7 +10,7 @@ Change Streams
 :Type: Standards
 :Minimum Server Version: 3.6
 :Last Modified: 2022-05-19
-:Version: 1.16
+:Version: 1.17
 
 .. contents::
 
@@ -1089,4 +1089,6 @@ Changelog
 | 2022-05-17 | Added ``wallTime`` to ``ChangeStreamDocument``.            |
 +------------+------------------------------------------------------------+
 | 2022-05-19 | Support new change stream events with showExpandedEvents.  |
++------------+------------------------------------------------------------+
+| 2022-08-17 | Support `disambiguatedPaths` in `UpdateDescription`.       |
 +------------+------------------------------------------------------------+

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -9,7 +9,7 @@ Change Streams
 :Status: Accepted
 :Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: 2022-05-19
+:Last Modified: 2022-08-18
 :Version: 1.17
 
 .. contents::

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -332,7 +332,6 @@ If an aggregate command with a ``$changeStream`` stage completes successfully, t
 The responses to a change stream aggregate or getMore have the following structures:
 
 .. code:: typescript
-spo
   /**
    * Response to a successful aggregate.
    */

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -307,12 +307,32 @@ If an aggregate command with a ``$changeStream`` stage completes successfully, t
      * @since 4.7.0
      */
     truncatedArrays: Array<Document>;
+
+    /**
+     * A document containing a map that associates an update path to an array containing the path components used in the update document.  This data
+     * can be used in combination with the other fields in an `UpdateDescription` to determine the actual path in the document that was updated. This is 
+     * necessary in cases where a key contains a dot-separated strings (i.e., `{ "a.b": "c" }`) or a document contains a numeric literal string key
+     * (i.e., `{ "a": { "0": "a" } }`.  Note that in this scenario, the numeric key can't be the top level key, because `{ "0": "a" }` is not ambiguous - 
+     * update paths would simply be `'0'` which is unambiguous because BSON documents cannot have arrays at the top level.).
+     * 
+     * Each entry in the document maps an update path to an array which contains the actual path used when the document was updated.  
+     * For example, given a document with the following shape `{ "a": { "0": 0 } }` and an update of `{ $inc: { "a.0": 1 } }`, `disambiguatedPaths` would
+     * look like the following:
+     *   {
+     *      "a.0": ["a", "0"]
+     *   }
+     * 
+     * In each array, all elements will be returned as strings with the exception of array indices, which will be returned as 32 bit integers.
+     * 
+     * @since 6.1.0
+     */
+    disambiguatedPaths?: Document
   }
 
 The responses to a change stream aggregate or getMore have the following structures:
 
 .. code:: typescript
-
+spo
   /**
    * Response to a successful aggregate.
    */

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -309,10 +309,10 @@ If an aggregate command with a ``$changeStream`` stage completes successfully, t
     truncatedArrays: Array<Document>;
 
     /**
-     * A document containing a map that associates an update path to an array containing the path components used in the update document.  This data
+     * A document containing a map that associates an update path to an array containing the path components used in the update document. This data
      * can be used in combination with the other fields in an `UpdateDescription` to determine the actual path in the document that was updated. This is 
-     * necessary in cases where a key contains a dot-separated strings (i.e., `{ "a.b": "c" }`) or a document contains a numeric literal string key
-     * (i.e., `{ "a": { "0": "a" } }`.  Note that in this scenario, the numeric key can't be the top level key, because `{ "0": "a" }` is not ambiguous - 
+     * necessary in cases where a key contains dot-separated strings (i.e., `{ "a.b": "c" }`) or a document contains a numeric literal string key
+     * (i.e., `{ "a": { "0": "a" } }`. Note that in this scenario, the numeric key can't be the top level key, because `{ "0": "a" }` is not ambiguous - 
      * update paths would simply be `'0'` which is unambiguous because BSON documents cannot have arrays at the top level.).
      * 
      * Each entry in the document maps an update path to an array which contains the actual path used when the document was updated.  
@@ -326,7 +326,7 @@ If an aggregate command with a ``$changeStream`` stage completes successfully, t
      * 
      * @since 6.1.0
      */
-    disambiguatedPaths?: Document
+    disambiguatedPaths: Optional<Document>
   }
 
 The responses to a change stream aggregate or getMore have the following structures:

--- a/source/change-streams/tests/unified/change-streams-disambiguatedPaths.json
+++ b/source/change-streams/tests/unified/change-streams-disambiguatedPaths.json
@@ -1,0 +1,250 @@
+{
+  "description": "disambiguatedPaths",
+  "schemaVersion": "1.9",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "runOnRequirements": [
+    {
+      "minServerVersion": "6.1.0",
+      "topologies": [
+        "replicaset",
+        "sharded-replicaset",
+        "load-balanced"
+      ]
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "collection0",
+      "databaseName": "database0",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "disambiguatedPaths is not present when showExpandedEvents is false/unset",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "1": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "$$exists": false
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "disambiguatedPaths is present on updateDescription when an ambiguous path is present",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "1": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "a.1": [
+                  "a",
+                  "1"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "disambiguatedPaths returns array indices as integers",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": [
+                {
+                  "1": 1
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [],
+            "showExpandedEvents": true
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.0.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "a.0.1": [
+                  "a",
+                  {
+                    "$$type": "int"
+                  },
+                  "1"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/change-streams/tests/unified/change-streams-disambiguatedPaths.json
+++ b/source/change-streams/tests/unified/change-streams-disambiguatedPaths.json
@@ -1,6 +1,6 @@
 {
   "description": "disambiguatedPaths",
-  "schemaVersion": "1.9",
+  "schemaVersion": "1.3",
   "createEntities": [
     {
       "client": {
@@ -29,7 +29,8 @@
       "topologies": [
         "replicaset",
         "sharded-replicaset",
-        "load-balanced"
+        "load-balanced",
+        "sharded"
       ]
     }
   ],

--- a/source/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
+++ b/source/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
@@ -1,5 +1,5 @@
 description: "disambiguatedPaths"
-schemaVersion: "1.9"
+schemaVersion: "1.3"
 createEntities:
   - client:
       id: &client0 client0
@@ -15,7 +15,7 @@ createEntities:
 
 runOnRequirements:
   - minServerVersion: "6.1.0"
-    topologies: [ replicaset, sharded-replicaset, load-balanced ]
+    topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
 
 initialData:
   - collectionName: *collection0

--- a/source/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
+++ b/source/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
@@ -1,0 +1,102 @@
+description: "disambiguatedPaths"
+schemaVersion: "1.9"
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: *database0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: *collection0
+
+runOnRequirements:
+  - minServerVersion: "6.1.0"
+    topologies: [ replicaset, sharded-replicaset, load-balanced ]
+
+initialData:
+  - collectionName: *collection0
+    databaseName: *database0
+    documents: []
+
+tests:
+  - description: "disambiguatedPaths is not present when showExpandedEvents is false/unset"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': { '1': 1 } }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { $$exists: false }
+
+  - description: "disambiguatedPaths is present on updateDescription when an ambiguous path is present"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': { '1': 1 } }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [], showExpandedEvents: true }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { 'a.1': ['a', '1'] }
+
+  - description: "disambiguatedPaths returns array indices as integers"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': [{'1': 1 }] }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [], showExpandedEvents: true }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.0.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { 'a.0.1': ['a', { $$type: 'int' },  '1'] }


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2344

POC PR in Node: https://github.com/mongodb/node-mongodb-native/pull/3365

A new field, `disambiguatedPaths` has been added to change stream update documents for servers >=6.1 where `showExpandedEvents` is enabled.

This feature is only supported in server 6.1 and above, so testing these changes will require running against the latest server build.

---

- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).