### PR TITLE
DRIVERS-2417: Exclude create events from change stream when testing showExpandedEvents

### DIFF
--- a/source/change-streams/tests/unified/change-streams-showExpandedEvents.json
+++ b/source/change-streams/tests/unified/change-streams-showExpandedEvents.json
@@ -275,7 +275,15 @@
           "name": "createChangeStream",
           "object": "collection0",
           "arguments": {
-            "pipeline": [],
+            "pipeline": [
+              {
+                "$match": {
+                  "operationType": {
+                    "$ne": "create"
+                  }
+                }
+              }
+            ],
             "showExpandedEvents": true
           },
           "saveResultAsEntity": "changeStream0"

--- a/source/change-streams/tests/unified/change-streams-showExpandedEvents.yml
+++ b/source/change-streams/tests/unified/change-streams-showExpandedEvents.yml
@@ -160,7 +160,15 @@ tests:
       - name: createChangeStream
         object: *collection0
         arguments:
-          pipeline: []
+          pipeline:
+            # On sharded clusters, the create command run when loading initial
+            # data sometimes is still reported in the change stream. To avoid
+            # this, we exclude the create command when creating the change
+            # stream, but specifically don't exclude other events to still catch
+            # driver errors.
+            - $match:
+                operationType:
+                  $ne: create
           showExpandedEvents: true
         saveResultAsEntity: &changeStream0 changeStream0
       - name: createIndex


### PR DESCRIPTION
The test in question sometimes fails for the PHP driver, due to the `create` event being emitted in the change stream. Since the test only checks the first event, we have to exclude the `create` event to ensure we only receive the `createIndexes` event we're looking for. This fixes the issue for PHP and shouldn't introduce problems for other drivers.

Note: after discussion with @jmikola we decided to only exclude the problematic `create` event from the change stream. This was done so that any other additional commands sent to the server before the `createIndex` call would cause the test to fail. This may be very unlikely to happen, but we figured it was more sensible than only including `createIndexes` in the change stream.

Please complete the following before merging:
- [ ] Bump spec version and last modified date. (N/A)
- [ ] Update changelog. (N/A)
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

