### PR TITLE
DRIVERS-2402: Clarify the behavior of comments on pre-4.4 servers

### DIFF
--- a/source/enumerate-collections.rst
+++ b/source/enumerate-collections.rst
@@ -12,8 +12,8 @@ Enumerating Collections
 :Status: Draft
 :Type: Standards
 :Server Versions: 1.8-2.7.5, 2.8.0-rc3 and later
-:Last Modified: 2022-02-01
-:Version: 0.9.0
+:Last Modified: 2022-08-17
+:Version: 0.10.0
 
 .. contents::
 
@@ -133,7 +133,9 @@ document::
 MongoDB 4.4 introduced a ``comment``  option to the ``listCollections``
 database command. This option enables users to specify a comment as an arbitrary
 BSON type to help trace the operation through the database profiler, currentOp
-and logs. The default is to not send a value.
+and logs. The default is to not send a value.  If a comment is provided on pre-4.4 
+servers, the comment should still be attached and the driver should rely on the server 
+to provide an error to the user.
 
 Example of usage of the comment option::
 
@@ -465,8 +467,11 @@ The shell implements the first algorithm for falling back if the
 Version History
 ===============
 
+Version 0.10.0 Changes
+    - Clarify the behavior of ``comment`` on pre-4.4 servers.
+
 Version 0.9.0 Changes
-    Add ``comment`` option to ``listCollections`` command.
+    - Add ``comment`` option to ``listCollections`` command.
 
 Version 0.8.0 Changes
     - Require that timeouts be applied per the client-side operations timeout spec.

--- a/source/enumerate-databases.rst
+++ b/source/enumerate-databases.rst
@@ -8,8 +8,8 @@ Enumerating Databases
 :Author: Jeremy Mikola
 :Status: Accepted
 :Type: Standards
-:Minimum Server Version: 3.7
-:Last Modified: 2022-02-01
+:Minimum Server Version: 3.8
+:Last Modified: 2022-08-17
 
 .. contents::
 
@@ -103,7 +103,8 @@ Comment
 MongoDB 4.4 introduced a ``comment``  option to the ``listDatabases``
 command. This option enables users to specify a comment as an arbitrary
 BSON type to help trace the operation through the database profiler, currentOp and logs.
-The default is to not send a value.
+The default is to not send a value.  If a comment is provided on pre-4.4 servers, the comment
+should still be attached and the driver should rely on the server to provide an error to the user.
 
 ::
 
@@ -299,6 +300,7 @@ all ``sizeOnDisk`` fields in the array of database information documents.
 Changes
 =======
 
+* 2022-08-17: Clarify the behavior of comment on pre-4.4 servers.
 * 2022-02-01: Support comment option in listDatabases command
 * 2017-10-30: Support filter option in listDatabases command
 * 2019-11-20: Support authorizedDatabases option in listDatabases command

--- a/source/enumerate-indexes.rst
+++ b/source/enumerate-indexes.rst
@@ -12,8 +12,8 @@ Enumerating Indexes
 :Status: Draft
 :Type: Standards
 :Server Versions: 1.8-2.7.5, 2.8.0-rc3 and later
-:Last Modified: 2022-02-01
-:Version: 0.7.0
+:Last Modified: 2022-08-17
+:Version: 0.8.0
 
 .. contents::
 
@@ -144,7 +144,8 @@ document::
 MongoDB 4.4 introduced a ``comment``  option to the ``listIndexes``
 database command. This option enables users to specify a comment as an arbitrary
 BSON type to help trace the operation through the database profiler, currentOp and logs.
-The default is to not send a value.
+The default is to not send a value.  If a comment is provided on pre-4.4 servers, the comment
+should still be attached and the driver should rely on the server to provide an error to the user.
 
 Example of usage of the comment option::
 
@@ -408,6 +409,9 @@ The shell implements the first algorithm for falling back if the
 
 Version History
 ===============
+
+0.8.0 - 2022-08-17
+    Clarify the behavior of ``comment`` on pre-4.4 servers.
 
 0.7.0 - 2022-02-01
     Add ``comment`` option to ``listIndexes`` command.


### PR DESCRIPTION
This PR clarifies the intended behavior for the following commands on pre-4.4 servers when comment is attached.

- listIndexes
- listCollections
- listDatabases

Please complete the following before merging:
- [x] Bump spec version and last modified date.
- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).
