### PR TITLE
DRIVERS-2366 Use camelCase for ReadPreference mode in unified tests

### DIFF
--- a/source/server-discovery-and-monitoring/tests/unified/rediscover-quickly-after-step-down.json
+++ b/source/server-discovery-and-monitoring/tests/unified/rediscover-quickly-after-step-down.json
@@ -117,7 +117,7 @@
               "replSetFreeze": 0
             },
             "readPreference": {
-              "mode": "Secondary"
+              "mode": "secondary"
             },
             "commandName": "replSetFreeze"
           }

--- a/source/server-discovery-and-monitoring/tests/unified/rediscover-quickly-after-step-down.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/rediscover-quickly-after-step-down.yml
@@ -78,7 +78,7 @@ tests:
           command:
             replSetFreeze: 0
           readPreference:
-            mode: Secondary
+            mode: secondary
           commandName: replSetFreeze
       # Run replSetStepDown on the meta client.
       - name: runCommand

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3772,9 +3772,10 @@ Change Log
              `ClientEncryption Operations`_.
 
 :2022-04-27: **Schema version 1.9.**
-             Added ``createOptions`` field to ``initialData``, introduced a
-             new ``timeoutMS`` field in ``collectionOrDatabaseOptions``, and
-             added an ``isTimeoutError`` field to ``expectedError``.
+             Added ``createOptions`` field to ``initialData``, introduced a new
+             ``timeoutMS`` field in ``collectionOrDatabaseOptions``, and added
+             an ``isTimeoutError`` field to ``expectedError``. Also introduced
+             the ``createEntities`` operation.
 
 :2022-04-27: **Schema version 1.8.**
              Add ``runOnRequirement.csfle``.


### PR DESCRIPTION
This PR fixes the capitalization of a ReadPreference mode in one of the SDAM unified tests. It currently reads `Secondary`, which is consistent with existing server selection and max-staleness tests but inconsistent with existing unified format tests ([this CRUD unified test](https://github.com/mongodb/specifications/blob/master/source/crud/tests/unified/db-aggregate-write-readPreference.yml#L36) uses `secondaryPreferred`, for example).

This PR also updates the unified test format changelog to mention the addition of the `createEntities` operation.

Thanks to @dariakp for noticing these issues.

@ShaneHarvey @jyemin would you prefer if there was a separate DRIVERS ticket for this since you both already implemented the original change? Or do you just want to sync this in real quick as a one-off? Happy to do either, just figured I'd check before making some Jira noise.