### PR TITLE
Remove MongoDB < 3.6 information and front matter from command monitoring spec

### DIFF
--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -443,3 +443,6 @@ Changelog
 
 18 MAY 2022:
   - Converted legacy tests to the unified test format.
+
+2 SEPTEMBER 2022:
+  - Remove material that only applies to MongoDB versions < 3.6.

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -131,7 +131,7 @@ fields in the reply beyond the ``ok`` field.
 
 *2. Why are document sequences included as BSON arrays?*
 
-The OP_MSG wire protocol was introduced in MongoDB 3.6, with document sequences as an optimization for bulk writes. We have chosen to represent these OP_MSGs as single command or reply documents for now, until a need for a more accurate (and perhaps better-performing) command monitoring API for document sequences has been demonstrated.
+The OP_MSG wire protocol was introduced in MongoDB 3.6, with document sequences as an optimization for bulk writes. We have chosen to represent these OP_MSGs as single command documents for now, until a need for a more accurate (and perhaps better-performing) command monitoring API for document sequences has been demonstrated.
 
 *3. Why is BSON serialization and deserialization optional to include in durations?*
 

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -5,14 +5,9 @@
 Command Monitoring
 ==================
 
-:Spec: 200
 :Title: Command Monitoring
-:Authors: Durran Jordan
 :Status: Approved
-:Type: Standards
 :Minimum Server Version: 2.4
-:Last Modified: 2022-05-18
-:Version: 1.10.0
 
 .. contents::
 

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -109,18 +109,6 @@ Implementation Notes
 
 When a driver sends an OP_MSG with a document sequence, it MUST include the document sequence as a BSON array in CommandStartedEvent.command. The array's field name MUST be the OP_MSG sequence identifier. For example, if the driver sends an "update" command using OP_MSG, and sends a document sequence as a separate section of payload type 1 with identifier "updates", the driver MUST include the documents as a BSON array in CommandStartedEvent.command with field name "updates".
 
-When a driver receives an OP_MSG with a document sequence, it MUST include the document sequence as a BSON array in CommandSucceededEvent.reply. The array's field name MUST be the OP_MSG sequence identifier. For example, if the driver receives an OP_MSG reply to a "find" command with a section of payload type 1 with identifier "cursor.firstBatch", it MUST include the documents as a BSON array in CommandSucceededEvent.reply like:
-
-.. code:: javascript
-
-  {
-      cursor: {
-          firstBatch: [ { document 1 }, { document 2 }, ... ]
-      }
-  }
-
-A document sequence in an OP_MSG reply to "aggregate" or "getMore" MUST be similarly included in CommandSucceededEvent.reply.
-
 See "Why are document sequences included as BSON arrays?" in the `rationale`_.
 
 ---------

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -127,7 +127,7 @@ See "Why are document sequences included as BSON arrays?" in the `rationale`_.
 Rationale
 ---------
 
-*2. Why are commands with* ``{ ok: 1 }`` *treated as successful and* ``{ ok: 0 }`` *as failed?*
+*1. Why are commands with* ``{ ok: 1 }`` *treated as successful and* ``{ ok: 0 }`` *as failed?*
 
 The specification is consistent with what the server deems as a successful or failed command and
 reports this as so. This also allows for server changes around this behaviour in the future to
@@ -141,11 +141,11 @@ command. Implementators of the API are free to handle these events as they see f
 code that futher interprets replies to specific commands based on the presence or absence of other
 fields in the reply beyond the ``ok`` field.
 
-*3. Why are document sequences included as BSON arrays?*
+*2. Why are document sequences included as BSON arrays?*
 
 The OP_MSG wire protocol was introduced in MongoDB 3.6, with document sequences as an optimization for bulk writes. We have chosen to represent these OP_MSGs as single command or reply documents for now, until a need for a more accurate (and perhaps better-performing) command monitoring API for document sequences has been demonstrated.
 
-*4. Why is BSON serialization and deserialization optional to include in durations?*
+*3. Why is BSON serialization and deserialization optional to include in durations?*
 
 Different drivers will serialize and deserialize BSON at different levels of
 the driver architecture.  For example, some parts of a command (e.g. inserted

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -23,8 +23,6 @@ Specification
 
 The performance monitoring specification defines a set of behaviour in the drivers for providing runtime information about commands to any 3rd party APM library as well internal driver use, such as logging.
 
-This specification intends to abstract the wire protocol so listeners receive similar events no matter what version of MongoDB the driver is connected to.
-
 -----------
 Definitions
 -----------
@@ -40,10 +38,6 @@ Terms
 
 Document
   The term ``Document`` refers to the implementation in the driver's language of a BSON document.
-
-GLE
-  The term "GLE" refers to a ``getLastError`` command.
-
 
 --------
 Guidance
@@ -84,12 +78,12 @@ Guarantees
 
 The driver MUST guarantee that every ``CommandStartedEvent`` has either a correlating ``CommandSucceededEvent`` or ``CommandFailedEvent``.
 
-The driver MUST guarantee that the ``requestId`` of the ``CommandStartedEvent`` and the corresponding ``CommandSucceededEvent`` or ``CommandFailedEvent`` is the same. In the case of acknowledged writes on server version 2.4 [where the driver sends an operation followed by a ``getLastError``] the ``requestId`` MUST be either the ``requestId`` from the original message or the ``requestId`` from the ``getLastError``.
+The driver MUST guarantee that the ``requestId`` of the ``CommandStartedEvent`` and the corresponding ``CommandSucceededEvent`` or ``CommandFailedEvent`` is the same.
 
 Unacknowledged/Acknowledged Writes
 ----------------------------------
 
-For server versions that do not support write commands, the driver MUST treat an acknowledged write as a single command event, where the GLE command is ignored as a started event and the response to the GLE is treated as the reply in the ``CommandSucceededEvent``. Unacknowledged writes must provide a ``CommandSucceededEvent`` with a ``{ ok: 1 }`` reply.
+ Unacknowledged writes must provide a ``CommandSucceededEvent`` with a ``{ ok: 1 }`` reply.
 
 A non-default write concern MUST be included in the published command. The default write concern is not required to be included.
 
@@ -108,16 +102,6 @@ Error Handling
 
 If an exception occurs while sending the operation to the server, the driver MUST generate a ``CommandFailedEvent`` with the exception or message and re-raise the exception.
 
-Upconversion
-------------
-
-All legacy operations MUST be converted to their equivalent commands in the 3.2 server in the event's
-``command`` and ``reply`` fields. This includes OP_INSERT, OP_DELETE, OP_UPDATE, OP_QUERY, OP_GET_MORE and
-OP_KILL_CURSORS. Upconversion expectations are provided in the tests.
-
-For cases where the upconverted commands would exceed the server's ``maxBsonObjectSize``, the driver MUST NOT
-split the upconverted commands and leave the original upconversion intact.
-
 Bulk Writes
 -----------
 
@@ -127,41 +111,6 @@ together via the same ``operationId``.
 
 Implementation Notes
 --------------------
-
-Legacy wire protocol messages MUST be up-converted to the corresponding commands in order to ensure
-that the data in the events follows the same format across all server versions. The provided tests
-assert these conversions take place.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 50 50
-
-   * - Legacy Message
-     - Upconverted Command
-
-   * - ``OP_QUERY``
-     - find command
-
-   * - ``OP_QUERY`` with ``$explain``
-     - explain command
-
-   * - ``OP_QUERY`` to ``$cmd`` collection
-     - command
-
-   * - ``OP_GET_MORE``
-     - getMore command
-
-   * - ``OP_KILL_CURSORS``
-     - killCursors command
-
-   * - ``OP_INSERT``
-     - insert command
-
-   * - ``OP_UPDATE``
-     - update command
-
-   * - ``OP_DELETE``
-     - delete command
 
 When a driver sends an OP_MSG with a document sequence, it MUST include the document sequence as a BSON array in CommandStartedEvent.command. The array's field name MUST be the OP_MSG sequence identifier. For example, if the driver sends an "update" command using OP_MSG, and sends a document sequence as a separate section of payload type 1 with identifier "updates", the driver MUST include the documents as a BSON array in CommandStartedEvent.command with field name "updates".
 
@@ -179,24 +128,9 @@ A document sequence in an OP_MSG reply to "aggregate" or "getMore" MUST be simil
 
 See "Why are document sequences included as BSON arrays?" in the `rationale`_.
 
-Read Preference
-^^^^^^^^^^^^^^^
-
-In cases where queries or commands are embedded in a ``$query`` parameter when a read preference
-is provided, they MUST be unwrapped and the value of the ``$query`` attribute becomes the
-``filter`` or the command in the started event. The read preference will subsequently be dropped
-as it is considered metadata and metadata is not currently provided in the command events.
-
 ---------
 Rationale
 ---------
-
-*1. Why does the specification treat all events as commands, even those that are not sent as such?*
-
-As a public facing API, subscribers to the events should need no knowledge of the MongoDB wire
-protocol or variations in messages depending on server versions. The core motivation behind the
-specification was to eliminate changes in our drivers' implementations breaking third party APM
-solutions. Providing a unified view of operations satisfies this requirement.
 
 *2. Why are commands with* ``{ ok: 1 }`` *treated as successful and* ``{ ok: 0 }`` *as failed?*
 
@@ -210,11 +144,11 @@ replies are received. As such, it would be innappropiate at this level for a dri
 custom logic around particular commands to determine what failure or success means for a particular
 command. Implementators of the API are free to handle these events as they see fit, which may include
 code that futher interprets replies to specific commands based on the presence or absence of other
-fields in the reply beyond the ‘ok’ field.
+fields in the reply beyond the ``ok`` field.
 
 *3. Why are document sequences included as BSON arrays?*
 
-The OP_MSG wire protocol was introduced in MongoDB 3.6, with document sequences as an optimization for bulk writes. The same optimization will be introduced for "find" and "aggregate" replies in 3.8. We have chosen to represent these OP_MSGs as single command or reply documents for now, until a need for a more accurate (and perhaps better-performing) command monitoring API for document sequences has been demonstrated.
+The OP_MSG wire protocol was introduced in MongoDB 3.6, with document sequences as an optimization for bulk writes. We have chosen to represent these OP_MSGs as single command or reply documents for now, until a need for a more accurate (and perhaps better-performing) command monitoring API for document sequences has been demonstrated.
 
 *4. Why is BSON serialization and deserialization optional to include in durations?*
 
@@ -471,9 +405,6 @@ See the README in the test directory for requirements and guidance.
 Changelog
 =========
 
-22 NOV 2015:
-  - Specify how to merge OP_MSG document sequences into command-started events.
-
 16 SEP 2015:
   - Removed ``limit`` from find test with options to support 3.2.
   - Changed find test read preference to ``primaryPreferred``.
@@ -488,6 +419,9 @@ Changelog
 
 31 OCT 2015:
   - Changed find test on 3.1 and higher to ignore being run on sharded clusters.
+
+22 NOV 2015:
+  - Specify how to merge OP_MSG document sequences into command-started events.
 
 29 MAR 2016:
   - Added note on guarantee of the request ids.


### PR DESCRIPTION
I'm going to be making somewhat significant additions to this spec around command logging. A lot of the information in here is currently for outdated server versions that most drivers do not support and soon no drivers will support. Rather than trying to preserve it as I incorporate new information, I propose we remove it altogether. 

Rather than bumping the spec version and last modified date, I also took the liberty of removing the spec version and front matter as @jmikola will do in DRIVERS-2253 will do for all specs.

