### PR TITLE
DRIVERS-2327: limit prose test to server versions 6.0+

### DIFF
--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -404,7 +404,7 @@ and sharded clusters.
    2. only run against replica sets as mongos does not propagate the
       NoWritesPerformed label to the drivers.
 
-   3. be run against server versions 4.4 and above.
+   3. be run against server versions 6.0 and above.
 
    Additionally, this test requires drivers to set a fail point after an
    ``insertOne`` operation but before the subsequent retry. Drivers that are

--- a/source/retryable-writes/tests/README.rst
+++ b/source/retryable-writes/tests/README.rst
@@ -404,6 +404,8 @@ and sharded clusters.
    2. only run against replica sets as mongos does not propagate the
       NoWritesPerformed label to the drivers.
 
+   3. be run against server versions 4.4 and above.
+
    Additionally, this test requires drivers to set a fail point after an
    ``insertOne`` operation but before the subsequent retry. Drivers that are
    unable to set a failCommand after the CommandSucceededEvent SHOULD use


### PR DESCRIPTION
There is doubt as to whether we should limit this prose test to 4.4+ or 6.1+. This test will work on versions 4.4+, but it doesn't become relevant until 6.1+. For now, I have left it as 4.4+, but I am open to changing it. See the discussion [here](https://jira.mongodb.org/browse/DRIVERS-2327?focusedCommentId=4815873&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4815873).

EDIT: Consensus seems to be that this change will be backported to 6.0, so I will leave this test as 6.0+.