### PR TITLE
DRIVERS-2400 Run legacy Client Side Encryption tests on serverless

### DIFF
--- a/source/client-side-encryption/etc/test-templates/fle2-BypassQueryAnalysis.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-BypassQueryAnalysis.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-Compact.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Compact.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-DecryptExistingData.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-DecryptExistingData.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: [

--- a/source/client-side-encryption/etc/test-templates/fle2-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Delete.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-jsonSchema.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-jsonSchema.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-EncryptedFieldsMap-defaults.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-EncryptedFieldsMap-defaults.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-FindOneAndUpdate.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Indexed.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Indexed.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Unindexed.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Unindexed.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-MissingKey.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-MissingKey.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: [

--- a/source/client-side-encryption/etc/test-templates/fle2-NoEncryption.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-NoEncryption.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Update.yml.template
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2-validatorAndPartialFieldExpression.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-validatorAndPartialFieldExpression.yml.template
@@ -3,7 +3,7 @@ runOn:
     # Require server version 6.0.0 to get behavior added in SERVER-64911.
     - minServerVersion: "6.0.0"
       # FLE 2 Encrypted collections are not supported on standalone.
-      topology: [ "replicaset", "sharded" ]
+      topology: [ "replicaset", "sharded", "load-balanced" ]
 
 database_name: &database_name "default"
 collection_name: &collection_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.json
+++ b/source/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-Compact.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Compact.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-Compact.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Compact.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-CreateCollection.json
+++ b/source/client-side-encryption/tests/legacy/fle2-CreateCollection.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
@@ -2,7 +2,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
     
 database_name: &database_name "default"
 collection_name: &collection_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-DecryptExistingData.json
+++ b/source/client-side-encryption/tests/legacy/fle2-DecryptExistingData.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-DecryptExistingData.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-DecryptExistingData.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: [

--- a/source/client-side-encryption/tests/legacy/fle2-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Delete.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Delete.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.json
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.json
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.json
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.json
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-MissingKey.json
+++ b/source/client-side-encryption/tests/legacy/fle2-MissingKey.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-MissingKey.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-MissingKey.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: [

--- a/source/client-side-encryption/tests/legacy/fle2-NoEncryption.json
+++ b/source/client-side-encryption/tests/legacy/fle2-NoEncryption.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-NoEncryption.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-NoEncryption.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Update.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Update.yml
@@ -1,7 +1,7 @@
 runOn:
   - minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
-    topology: [ "replicaset", "sharded" ]
+    topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.json
+++ b/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.json
@@ -4,7 +4,8 @@
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",
-        "sharded"
+        "sharded",
+        "load-balanced"
       ]
     }
   ],

--- a/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
@@ -3,7 +3,7 @@ runOn:
     # Require server version 6.0.0 to get behavior added in SERVER-64911.
     - minServerVersion: "6.0.0"
       # FLE 2 Encrypted collections are not supported on standalone.
-      topology: [ "replicaset", "sharded" ]
+      topology: [ "replicaset", "sharded", "load-balanced" ]
 
 database_name: &database_name "default"
 collection_name: &collection_name "default"

--- a/source/serverless-testing/README.rst
+++ b/source/serverless-testing/README.rst
@@ -115,6 +115,11 @@ included in a driver's Atlas Serverless testing suite:
     transactions tests may hang if an individual test leaves a transaction open
     when it finishes (`CLOUDP-84298`_).
 - Versioned/Stable API
+- Client Side Encryption
+
+  - Drivers MUST test with a version of the ``crypt_shared`` shared library that
+    matches the MongoDB Server version running in Serverless.
+    See `Using crypt_shared <https://github.com/mongodb/specifications/tree/e761591616849d9b507287811e77f7a359fb9587/source/client-side-encryption/tests#using-crypt-shared>`_.
 
 .. _CLOUDP-84298: https://jira.mongodb.org/browse/CLOUDP-84298
 


### PR DESCRIPTION
# Summary

- Run legacy Client Side Encryption tests on serverless.
- Add "load-balanced" to topology list in FLE2 tests.

# Background & Motivation

Serverless rewrites database names in commands. This resulted in Queryable Encryption requiring changes: [CLOUDP-130802](https://jira.mongodb.org/browse/CLOUDP-130802).

This PR proposes using the same version of mongo_crypt Shared Library as the MongoDB Server on Serverless. That is consistent with the test decision made in [DRIVERS-2355](https://jira.mongodb.org/browse/DRIVERS-2355). This PR does not propose testing Serverless with mongocryptd. IMO that does not add much test coverage.

Serverless runs behind a load balancer. "load-balanced" is added to the topology list in FLE2 tests to run those tests on serverless. This PR does not propose adding legacy CSE tests to [load balancer support tests](https://github.com/mongodb/specifications/blob/e761591616849d9b507287811e77f7a359fb9587/source/load-balancers/tests/README.rst#tests).

Serverless on cloud-dev is expected to use tagged versions of the MongoDB Server (see [slack conversation](https://mongodb.slack.com/archives/G01304NFS3C/p1663001404139139)). Drivers are expected to use mongodl.py to download mongo_crypt Shared Library matching the MongoDB Server version. https://github.com/mongodb-labs/drivers-evergreen-tools/pull/231 adds the MongoDB Server version in the serverless expansions.

These tests were run in the Go driver: https://github.com/mongodb/mongo-go-driver/pull/1069

<!-- Thanks for contributing! -->

Please complete the following before merging:
- [ ] Bump spec version and last modified date. **N/A. Test changes only.**
- [ ] Update changelog. **N/A. Test changes only.**
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested in [Go](https://spruce.mongodb.com/version/6320ba8a1e2d1703d76cfd08/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **N/A. Test changes only apply to serverless**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

