### PR TITLE
DRIVERS-1954 Fix hello->helloOk typo + regenerate all json tests

### DIFF
--- a/source/crud/tests/unified/distinct-comment.json
+++ b/source/crud/tests/unified/distinct-comment.json
@@ -64,7 +64,11 @@
               "key": "value"
             }
           },
-          "expectResult": [ 11, 22, 33 ]
+          "expectResult": [
+            11,
+            22,
+            33
+          ]
         }
       ],
       "expectEvents": [
@@ -105,7 +109,11 @@
             "filter": {},
             "comment": "comment"
           },
-          "expectResult": [ 11, 22, 33 ]
+          "expectResult": [
+            11,
+            22,
+            33
+          ]
         }
       ],
       "expectEvents": [

--- a/source/server-discovery-and-monitoring/tests/rs/set_version_can_rollback.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/set_version_can_rollback.yml
@@ -70,7 +70,7 @@ phases:
     responses:
       - - a:27017
         - ok: 1
-          hello: true
+          helloOk: true
           isWritablePrimary: true
           hosts:
             - a:27017


### PR DESCRIPTION
Fixes this error:
```
diff --git a/source/server-discovery-and-monitoring/tests/rs/set_version_can_rollback.json b/source/server-discovery-and-monitoring/tests/rs/set_version_can_rollback.json
index 6a7ca02..704a232 100644
--- a/source/server-discovery-and-monitoring/tests/rs/set_version_can_rollback.json
+++ b/source/server-discovery-and-monitoring/tests/rs/set_version_can_rollback.json
@@ -102,7 +102,7 @@
           "a:27017",
           {
             "ok": 1,
-            "helloOk": true,
+            "hello": true,
             "isWritablePrimary": true,
             "hosts": [
               "a:27017",
```

I also regenerated all the JSON files and the only other change was some formatting in `crud/tests/unified/distinct-comment.json`.