### PR TITLE
DRIVERS-2253: Remove spec front matter and reformat changelogs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!-- Thanks for contributing! -->
 
 Please complete the following before merging:
-- [ ] Bump spec version and last modified date.
+
 - [ ] Update changelog.
 - [ ] Make sure there are generated JSON files from the YAML test files.
 - [ ] Test changes in at least one language driver.

--- a/source/atlas-data-lake-testing/tests/README.rst
+++ b/source/atlas-data-lake-testing/tests/README.rst
@@ -2,6 +2,9 @@
 Atlas Data Lake Tests
 =====================
 
+:Status: Accepted
+:Minimum Server Version: N/A
+
 .. contents::
 
 ----
@@ -81,5 +84,6 @@ Atlas Data Lake.
 Changelog
 =========
 
+:2022-10-05: Add spec front matter
 :2020-07-15: Link to CRUD test runner implementation and note that the collection
              under test must not be dropped before each test.

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -5,15 +5,8 @@
 Driver Authentication
 =====================
 
-:Spec: 100
-:Spec Version: 1.21.0
-:Title: Driver Authentication
-:Author: Craig Wilson, David Golden
-:Advisors: Andy Schwerin, Bernie Hacket, Jeff Yemin, David Golden
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 2.6
-:Last Modified: 2022-08-25
 
 .. contents::
 
@@ -1338,103 +1331,56 @@ Q: Why does SCRAM sometimes SASLprep and sometimes not?
 Q: Should drivers support accessing Amazon EC2 instance metadata in Amazon ECS?
 	No. While it's possible to allow access to EC2 instance metadata in ECS, for security reasons, Amazon states it's best practice to avoid this. (See `accessing EC2 metadata in ECS <https://aws.amazon.com/premiumsupport/knowledge-center/ecs-container-ec2-metadata/>`_ and `IAM Roles for Tasks <https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html>`_)
 
-Version History
-===============
+Changelog
+=========
 
-Version 1.12.0 Changes
-    * Add support for AWS AssumeRoleWithWebIdentity.
+:2022-10-05: Remove spec front matter and convert version history to changelog.
+:2022-09-07: Add support for AWS AssumeRoleWithWebIdentity.
+:2022-01-20: Require that timeouts be applied per the client-side operations timeout spec.
+:2022-01-14: Clarify that ``OP_MSG`` must be used for authentication when it is supported.
+:2021-04-23: Updated to use hello and legacy hello.
+:2021-03-04: Note that errors encountered during auth are handled by SDAM.
+:2020-03-06: Add reference to the speculative authentication section of the handshake spec.
+:2020-02-15: Rename MONGODB-IAM to MONGODB-AWS
+:2020-02-04: Support shorter SCRAM conversation starting in version 4.4 of the server.
+:2020-01-31: Clarify that drivers must raise an error when a connection string
+             has an empty value for authSource.
+:2020-01-23: Clarify when authentication will occur.
+:2020-01-22: Clarify that authSource in URI is not treated as a user configuring
+             auth credentials.
+:2019-12-05: Added MONGODB-IAM auth mechanism
+:2019-07-13: Clarify database to use for auth mechanism negotiation.
+:2019-04-26: * Test format changed to improve specificity of behavior assertions.
+             * Clarify that database name in URI is not treated as a user configuring auth credentials.
+:2018-08-08: Unknown users don't cause handshake errors. This was changed before
+             server 4.0 GA in SERVER-34421, so the auth spec no longer refers to
+             such a possibility.
+:2018-04-17: * Clarify authSource defaults
+             * Fix PLAIN authSource rule to allow user provided values
+             * Change SCRAM-SHA-256 rules such that usernames are *NOT*
+               normalized; this follows a change in the server design and should
+               be available in server 4.0-rc0.
+:2018-03-29: Clarify auth handshake and that it only applies to non-monitoring sockets.
+:2018-03-15: Describe CANONICALIZE_HOST_NAME algorithm.
+:2018-03-02: * Added SCRAM-SHA-256 and mechanism negotiation as provided by server 4.0
+             * Updated default mechanism determination
+             * Clarified SCRAM-SHA-1 rules around SASLprep
+             * Require SCRAM-SHA-1 and SCRAM-SHA-256 to enforce a minimum iteration count
+:2017-11-10: * Updated minimum server version to 2.6
+             * Updated the Q & A to recommend support for at most a single credential per MongoClient
+             * Removed lazy authentication section
+             * Changed the list of server types requiring authentication
+             * Made providing username for X509 authentication optional
+:2015-02-04: * Added SCRAM-SHA-1 sasl mechanism
+             * Added connection handshake
+             * Changed connection string to support mechanism properties in generic form
+             * Added example conversations for all mechanisms except GSSAPI
+             * Miscellaneous wording changes for clarification
+             * Added MONGODB-X509
+             * Added PLAIN sasl mechanism
+             * Added support for GSSAPI mechanism property gssapiServiceName
 
-Version 1.11.0 Changes
-    * Require that timeouts be applied per the client-side operations timeout spec.
-
-Version 1.10.5 Changes
-    * Clarify that ``OP_MSG`` must be used for authentication when it is
-      supported.
-
-Version 1.10.4 Changes
-    * Updated to use hello and legacy hello.
-
-Version 1.10.3 Changes
-    * Note that errors encountered during auth are handled by SDAM.
-
-Version 1.10.2 Changes
-    * Add reference to the speculative authentication section of the handshake spec.
-
-Version 1.10.1 Changes
-    * Rename MONGODB-IAM to MONGODB-AWS
-
-Version 1.10.0 Changes
-    * Support shorter SCRAM conversation starting in version 4.4 of the server.
-
-Version 1.9.1 Changes
-    * Clarify when authentication will occur.
-
-Version 1.9.0 Changes
-    * Clarify that drivers must raise an error when a connection string
-      has an empty value for authSource.
-
-Version 1.8.3 Changes
-    * Clarify that authSource in URI is not treated as a user configuring
-      auth credentials.
-
-Version 1.8.2 Changes
-    * Added MONGODB-IAM auth mechanism
-
-Version 1.8.1 Changes
-    * Clarify database to use for auth mechanism negotiation.
-
-Version 1.8.0 Changes
-    * Test format changed to improve specificity of behavior assertions.
-
-Version 1.7.2 Changes
-    * Clarify that database name in URI is not treated as a user configuring
-      auth credentials.
-
-Version 1.7.1 Changes
-    * Unknown users don't cause handshake errors. This was changed before
-      server 4.0 GA in SERVER-34421, so the auth spec no longer refers to
-      such a possibility.
-
-Version 1.7 Changes
-    * Clarify authSource defaults
-    * Fix PLAIN authSource rule to allow user provided values
-
-Version 1.6 Changes
-    * Change SCRAM-SHA-256 rules such that usernames are *NOT* normalized;
-      this follows a change in the server design and should be available in
-      server 4.0-rc0.
-
-Version 1.5 Changes
-    * Clarify auth handshake and that it only applies to non-monitoring
-      sockets.
-
-Version 1.4.1 Changes
-    * Describe CANONICALIZE_HOST_NAME algorithm.
-
-Version 1.4 Changes
-	* Added SCRAM-SHA-256 and mechanism negotiation as provided by server 4.0
-	* Updated default mechanism determination
-	* Clarified SCRAM-SHA-1 rules around SASLprep
-	* Require SCRAM-SHA-1 and SCRAM-SHA-256 to enforce a minimum iteration count
-
-Version 1.3 Changes
-	* Updated minimum server version to 2.6
-	* Updated the Q & A to recommend support for at most a single credential per MongoClient
-	* Removed lazy authentication section
-	* Changed the list of server types requiring authentication
-	* Made providing username for X509 authentication optional
-
-Version 1.2 Changes
-	* Added SCRAM-SHA-1 sasl mechanism
-	* Added connection handshake
-	* Changed connection string to support mechanism properties in generic form
-	* Added example conversations for all mechanisms except GSSAPI
-	* Miscellaneous wording changes for clarification
-
-Version 1.1 Changes
-	* Added MONGODB-X509
-	* Added PLAIN sasl mechanism
-	* Added support for GSSAPI mechanism property gssapiServiceName
+----
 
 .. Section for links.
 

--- a/source/benchmarking/benchmarking.rst
+++ b/source/benchmarking/benchmarking.rst
@@ -2,11 +2,8 @@
 MongoDB Driver Performance Benchmarking
 =======================================
 
-:Title: MongoDB Driver Performance Benchmarking
-:Author: David Golden
+:Status: Accepted
 :Minimum Server Version: N/A
-:Last Modified: April 6, 2021
-:Version: 1.4
 
 .. contents::
 
@@ -1132,41 +1129,27 @@ Question?
 
 Answer.
 
-Change log
-==========
+Changelog
+=========
 
-v1.4 (Apr 6, 2021)
-
--  Update run command test to use 'hello' command
-
-V1.3 (Aug 13, 2016)
-
--  Update corpus files to allow much greater compression of data
--  Updated LDJSON corpus size to reflect revisions to the test data
--  Published data files on GitHub and updated instructions on how to
-   find datasets
--  RunCommand and query benchmark can create collection objects during
-   setup rather than before task.  (No change on actual benchmark.)
-
-v1.2 (Jan 6, 2016)
-
--  Clarify that 'bulk insert' means 'insert\_many'
--  Clarify that "create a collection" means using the 'create' command
--  Add omitted "upload files" step to setup for GridFS multi-file
-   download; also clarify that steps should be using the default bucket
-   in the 'perftest' database
-
-v1.1 (Dec 23, 2015)
-
--  Rename benchmark names away from MMA/weight class names
--  Split BSON encoding and decoding micro-benchmarks
--  Rename BSON micro-benchmarks to better match dataset names
--  Move "Run Command" micro-benchmark out of composite
--  Reduced amount of data held in memory and sent to/from the server to
-   decrease memory pressure and increase number of iterations in a
-   reasonable time (e.g. file sizes and number of documents in certain
-   datasets changed)
--  Create empty collections/indexes during the 'before' phase when
-   appropriate
--  Updated data set sizes to account for changes in the source file
-   structure/size
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2021-04-06: Update run command test to use 'hello' command
+:2016-08-13: * Update corpus files to allow much greater compression of data
+             * Updated LDJSON corpus size to reflect revisions to the test data
+             * Published data files on GitHub and updated instructions on how to find datasets
+             * RunCommand and query benchmark can create collection objects during setup rather than before task. (No change on actual benchmark.)
+:2016-01-06: * Clarify that 'bulk insert' means 'insert\_many'
+             * Clarify that "create a collection" means using the 'create' command
+             * Add omitted "upload files" step to setup for GridFS multi-file
+               download; also clarify that steps should be using the default
+               bucket in the 'perftest' database
+:2015-12-23: * Rename benchmark names away from MMA/weight class names
+             * Split BSON encoding and decoding micro-benchmarks
+             * Rename BSON micro-benchmarks to better match dataset names
+             * Move "Run Command" micro-benchmark out of composite
+             * Reduced amount of data held in memory and sent to/from the server
+               to decrease memory pressure and increase number of iterations in
+               a reasonable time (e.g. file sizes and number of documents in
+               certain datasets changed)
+             * Create empty collections/indexes during the 'before' phase when appropriate
+             * Updated data set sizes to account for changes in the source file structure/size

--- a/source/bson-corpus/bson-corpus.rst
+++ b/source/bson-corpus/bson-corpus.rst
@@ -2,15 +2,8 @@
 BSON Corpus
 ===========
 
-:Title: BSON Corpus
-:Author: Luke Lovett, David Golden
-:Lead: Jeff Yemin
-:Advisors: Craig Wilson
-:Status: Approved
-:Type: Standards
+:Status: Accepted
 :Minimum Server Version: N/A
-:Last Modified: September 9, 2021
-:Version: 2.1.1
 
 .. contents::
 
@@ -495,44 +488,23 @@ but the ``canonical_bson`` field is the same.  This is by design so that each
 case stands alone and can be confirmed to be internally consistent via the
 assertions.  This makes for easier and safer test case development.
 
-Changes
-=======
+Changelog
+=========
 
-Version 2.1.1 - September 9, 2021
-
-* Clarify error expectation rules for ``parseErrors``.
-
-Version 2.1 - September 2, 2021
-
-* Add spec and prose tests for prohibiting null bytes in null-terminated strings
-  within document field names and regular expressions.
-
-* Clarify type-specific rules for ``parseErrors``.
-
-Version 2.0 - May 26, 2017
-
-* Revised to be consistent with Extended JSON spec 2.0: valid case fields
-  have changed, as have the test assertions.
-
-Version 1.3 - January 23, 2017
-
-* Added ``multi-type.json`` to test encoding and decoding all BSON types within
-  the same document.
-
-* Amended all extended JSON strings to adhere to the Extended JSON
-  Specification.
-
-* Modified the "Use of extjson" section of this specification to note that
-  canonical extended JSON is now used.
-
-Version 1.2 - November 14, 2016
-
-* Removed "invalid flags" BSON Regexp case.
-
-Version 1.1 – October 25, 2016
-
-* Added a "non-alphabetized flags" case to the BSON Regexp corpus file;
-  decoders must be able to read non-alphabetized flags, but encoders must
-  emit alphabetized flags.
-
-* Added an "invalid flags" case to the BSON Regexp corpus file.
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2021-09-09: Clarify error expectation rules for ``parseErrors``.
+:2021-09-02: Add spec and prose tests for prohibiting null bytes in
+             null-terminated strings within document field names and regular
+             expressions. Clarify type-specific rules for ``parseErrors``.
+:2017-05-26: Revised to be consistent with Extended JSON spec 2.0: valid case
+             fields have changed, as have the test assertions.
+:2017-01-23: Added ``multi-type.json`` to test encoding and decoding all BSON
+             types within the same document. Amended all extended JSON strings
+             to adhere to the Extended JSON Specification. Modified the "Use of
+             extjson" section of this specification to note that canonical
+             extended JSON is now used.
+:2016-11-14: Removed "invalid flags" BSON Regexp case.
+:2016-10-25: Added a "non-alphabetized flags" case to the BSON Regexp corpus
+             file; decoders must be able to read non-alphabetized flags, but
+             encoders must emit alphabetized flags. Added an "invalid flags"
+             case to the BSON Regexp corpus file.

--- a/source/bson-decimal128/decimal128.rst
+++ b/source/bson-decimal128/decimal128.rst
@@ -2,17 +2,8 @@
 BSON Decimal128 Type Handling in Drivers
 ========================================
 
-:Spec Title: BSON Decimal128 Type Handling In Drivers
-:Spec Version: 1.0
-:Author: Hannes Magnusson
-:Advisory Group: Emily Stolfo and Craig Wilson
-:Kernel Advisory: Geert Bosch
-:Original Work: David Hatch and Raymond Jacobson
-:Status: Approved
-:Type: Standards
+:Status: Accepted
 :Minimum Server Version: 3.4
-:Last Modified: 2016-06-06
-
 
 .. contents::
 
@@ -450,3 +441,8 @@ Q&A
    * No
 * Is there a wire version bump or something for Decimal128?
    * No
+
+Changelog
+=========
+
+:2022-10-05: Remove spec front matter.

--- a/source/causal-consistency/causal-consistency.rst
+++ b/source/causal-consistency/causal-consistency.rst
@@ -2,17 +2,8 @@
 Causal Consistency Specification
 ================================
 
-:Spec Title: Causal Consistency Specification (See the registry of specs)
-:Spec Version: 1.1
-:Author: Robert Stam
-:Spec Lead: A\. Jesse Jiryu Davis
-:Advisory Group: Jeremy Mikola, Jeff Yemin, Misha Tyulene, A. Jesse Jiryu Davis
-:Approver(s): A\. Jesse Jiryu Davis, Jeff Yemin, Bernie Hackett, David Golden, Matt Broadstone, Andy Schwerin, Kal Manassiev, Eliot
-:Informed: drivers@, Bryan Reinero, Christopher Hendel
-:Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
-:Type: Standards
-:Minimum Server Version: 3.6 (The minimum server version this spec applies to)
-:Last Modified: 2022-01-28
+:Status: Accepted
+:Minimum Server Version: 3.6
 
 .. contents::
 
@@ -516,14 +507,16 @@ Q&A
 Changelog
 =========
 
-- 2017-09-13: Renamed "causally consistent reads" to "causal consistency"
-- 2017-09-13: If no value is supplied for ``causallyConsistent`` assume true
-- 2017-09-28: Remove remaining references to collections being associated with sessions
-- 2017-09-28: Update spec to reflect that replica sets use $clusterTime also now
-- 2017-10-04: Added advanceOperationTime
-- 2017-10-05: How to handle default read concern
-- 2017-10-06: advanceOperationTime MUST NOT validate operationTime
-- 2017-11-17: Added link to ReadConcern spec which lists commands that support readConcern
-- 2021-06-26: Default value for causalConsistency is influenced by snapshot reads
-- 2022-01-22: Remove outdated prose test #10
-- 2022-01-28: Fix formatting for prose tests
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-01-28: Fix formatting for prose tests
+:2022-01-22: Remove outdated prose test #10
+:2021-06-26: Default value for causalConsistency is influenced by snapshot reads
+:2017-11-17: Added link to ReadConcern spec which lists commands that support readConcern
+:2017-10-06: advanceOperationTime MUST NOT validate operationTime
+:2017-10-05: How to handle default read concern
+:2017-10-04: Added advanceOperationTime
+:2017-09-28: Remove remaining references to collections being associated with
+             sessions. Update spec to reflect that replica sets use $clusterTime
+             also now.
+:2017-09-13: Renamed "causally consistent reads" to "causal consistency". If no
+             value is supplied for ``causallyConsistent`` assume true.

--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -2,15 +2,8 @@
 Change Streams
 ==============
 
-:Title: Change Streams
-:Author: Matt Broadstone
-:Advisory Group: David Golden, A. Jesse Jiryu Davis
-:Approvers: Jeff Yemin, A. Jesse Jiryu Davis, Bernie Hackett, David Golden, Eliot
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: 2022-08-22
-:Version: 1.18
 
 .. contents::
 
@@ -1099,4 +1092,6 @@ Changelog
 | 2022-08-17 | Support `disambiguatedPaths` in `UpdateDescription`.       |
 +------------+------------------------------------------------------------+
 | 2022-08-22 | Added ``clusterTime`` to ``ChangeStreamDocument``.         |
++------------+------------------------------------------------------------+
+| 2022-10-05 | Remove spec front matter.                                  |
 +------------+------------------------------------------------------------+

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -535,8 +535,6 @@ accept arbitrary strings at runtime for forward-compatibility.
 Automatic Credentials
 `````````````````````
 
-.. versionadded:: 1.9.0 2022/06/22
-
 Certain values of KMSProviders_ indicate a request by the user that the
 associated KMS providers should be populated lazily on-demand. The driver MUST
 be able to populate the respective options object on-demand if-and-only-if such
@@ -599,8 +597,6 @@ __ ../auth/auth.html#obtaining-credentials
 Obtaining GCP Credentials
 `````````````````````````
 
-.. versionadded:: 1.11.0 2022/07/20
-
 Set ``HOST`` to ``metadata.google.internal``.
 
 Send an HTTP request to the URL
@@ -622,8 +618,6 @@ Return "access_token" as the credential.
 
 Obtaining an Access Token for Azure Key Vault
 `````````````````````````````````````````````
-
-.. versionadded:: 1.12.0 2022/08/30
 
 Virtual machines running on the Azure platform have one or more *Managed
 Identities* associated with them. From within the VM, an identity can be used by
@@ -2513,7 +2507,7 @@ Changelog
    :align: left
 
    Date, Description
-   22-10-05, Remove spec front matter.
+   22-10-05, Remove spec front matter and ``versionadded`` RST macros (since spec version was removed)
    22-09-26, Add behavior for automatic Azure KeyVault credentials for ``kmsProviders``.
    22-09-09, Prohibit ``rewrapManyDataKey`` with libmongocrypt <= 1.5.1.
    22-07-20, Add behavior for automatic GCP credential loading in ``kmsProviders``.

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -2,16 +2,8 @@
 Client Side Encryption
 ======================
 
-:Title: Client Side Encryption
-:Author: Kevin Albertson
-:Spec Lead: Jeff Yemin
-:Approvers: Bernie Hackett, David Golden, David Storch
-:Advisory Group: A\. Jesse Jiryu Davis, Kenn White, Scott L'Hommedieu, Mark Benvenuto, Bernie Hackett, Samantha Ritter, Matt Broadstone
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 4.2 (CSFLE), 6.0 (Queryable Encryption)
-:Last Modified: 2022-09-26
-:Version: 1.12.0
 
 .. _lmc-c-api: https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h.in
 
@@ -2521,6 +2513,7 @@ Changelog
    :align: left
 
    Date, Description
+   22-10-05, Remove spec front matter.
    22-09-26, Add behavior for automatic Azure KeyVault credentials for ``kmsProviders``.
    22-09-09, Prohibit ``rewrapManyDataKey`` with libmongocrypt <= 1.5.1.
    22-07-20, Add behavior for automatic GCP credential loading in ``kmsProviders``.

--- a/source/client-side-encryption/subtype6.rst
+++ b/source/client-side-encryption/subtype6.rst
@@ -2,16 +2,8 @@
 BSON Binary Subtype 6
 =====================
 
-:Title: BSON Binary Subtype 6
-:Author: Kevin Albertson
-:Spec Lead: A\. Jesse Jiryu Davis
-:Approvers: Bernie Hackett, Dan Pasette, David Storch, Eliot Horowitz, Kenn White, Mark Benvenuto, Scott L'Hommedieu
-:Advisory Group: A\. Jesse Jiryu Davis, Kenn White, Scott L'Hommedieu, Mark Benvenuto, Bernie Hackett
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 4.2
-:Last Modified: June 14, 2019
-:Version: 1.0.0
 
 .. contents::
 
@@ -181,4 +173,7 @@ ciphertext should have been.
 Therefore, the leading byte of the BSON binary subtype distinguishes
 between marking and ciphertext.
 
+Changelog
+=========
 
+:2022-10-05: Remove spec front matter and create changelog.

--- a/source/client-side-operations-timeout/client-side-operations-timeout.rst
+++ b/source/client-side-operations-timeout/client-side-operations-timeout.rst
@@ -2,16 +2,8 @@
 Client Side Operations Timeout
 ==============================
 
-:Title: Client Side Operations Timeout
-:Author: Divjot Arora
-:Spec Lead: Jeff Yemin
-:Approvers: Jeff Yemin, Clyde Bazile
-:Advisory Group: Bernie Hackett, Jason Carey, Will Shulman
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 2.6
-:Last Modified: 2022-01-19
-:Version: 1.0.0
 
 .. contents::
 
@@ -926,4 +918,5 @@ for each database operation. This would mimic using
 Changelog
 =========
 
-:2021-01-19: Initial version.
+:2022-10-05: Remove spec front matter.
+:2022-01-19: Initial version.

--- a/source/collation/collation.rst
+++ b/source/collation/collation.rst
@@ -5,15 +5,8 @@
 Collation
 =========
 
-:Spec: 79
-:Title: Collation
-:Authors: Emily Stolfo
-:Advisory Group: Derick Rethans, Craig Wilson
-:Status: Approved
-:Type: Standards
+:Status: Accepted
 :Minimum Server Version: 1.8
-:Last Modified: May 15, 2017
-:Version: 1.0
 
 .. contents::
 
@@ -295,8 +288,9 @@ A: A collection with a default collation can be created using the create helper
 and by providing a collation option.
 
 
-Version History
-===============
+Changelog
+=========
 
-- 2017-05-15: minor markup fixes in API section.
-- 2016-08-31: version 1.0.
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2017-05-15: Minor markup fixes in API section.
+:2016-08-31: Initial version.

--- a/source/command-monitoring/command-monitoring.rst
+++ b/source/command-monitoring/command-monitoring.rst
@@ -5,8 +5,7 @@
 Command Monitoring
 ==================
 
-:Title: Command Monitoring
-:Status: Approved
+:Status: Accepted
 :Minimum Server Version: 2.4
 
 .. contents::
@@ -388,49 +387,25 @@ See the README in the test directory for requirements and guidance.
 Changelog
 =========
 
-16 SEP 2015:
-  - Removed ``limit`` from find test with options to support 3.2.
-  - Changed find test read preference to ``primaryPreferred``.
-
-1 OCT 2015:
-  - Changed find test with a kill cursors to not run on server versions greater than 3.0
-  - Added a find test with no kill cursors command which only runs on 3.1 and higher.
-  - Added notes on which tests should run based on server versions.
-
-19 OCT 2015:
-  - Changed batchSize in the 3.2 find tests to expect the remaining value.
-
-31 OCT 2015:
-  - Changed find test on 3.1 and higher to ignore being run on sharded clusters.
-
-22 NOV 2015:
-  - Specify how to merge OP_MSG document sequences into command-started events.
-
-29 MAR 2016:
-  - Added note on guarantee of the request ids.
-
-2 NOV 2016:
-  - Added clause for not upconverting commands larger than maxBsonSize.
-
-16 APR 2018:
-  - Made inclusion of BSON serialization/deserialization in command durations
-    to be optional.
-
-12 FEB 2020:
-  - Added legacy hello ``speculativeAuthenticate`` to the list of values that should be redacted.
-
-15 APR 2021:
-  - Added ``serviceId`` field to events.
-
-5 MAY 2021:
-  - Updated to use hello and legacy hello.
-
-30 AUG 2021:
-  - Added ``serverConnectionId`` field to ``CommandStartedEvent``, ``CommandSucceededEvent`` and
-    ``CommandFailedEvent``.
-
-18 MAY 2022:
-  - Converted legacy tests to the unified test format.
-
-2 SEPTEMBER 2022:
-  - Remove material that only applies to MongoDB versions < 3.6.
+:2015-09-16: Removed ``limit`` from find test with options to support 3.2.
+             Changed find test read preference to ``primaryPreferred``.
+:2015-10-01: Changed find test with a kill cursors to not run on server versions
+             greater than 3.0. Added a find test with no kill cursors command
+             which only runs on 3.1 and higher. Added notes on which tests
+             should run based on server versions.
+:2015-10-19: Changed batchSize in the 3.2 find tests to expect the remaining value.
+:2015-10-31: Changed find test on 3.1 and higher to ignore being run on sharded clusters.
+:2015-11-22: Specify how to merge OP_MSG document sequences into command-started events.
+:2016-03-29: Added note on guarantee of the request ids.
+:2016-11-02: Added clause for not upconverting commands larger than maxBsonSize.
+:2018-04-16: Made inclusion of BSON serialization/deserialization in command
+             durations to be optional.
+:2020-02-12: Added legacy hello ``speculativeAuthenticate`` to the list of
+             values that should be redacted.
+:2021-04-15: Added ``serviceId`` field to events.
+:2021-05-05: Updated to use hello and legacy hello.
+:2021-08-30: Added ``serverConnectionId`` field to ``CommandStartedEvent``,
+             ``CommandSucceededEvent`` and ``CommandFailedEvent``.
+:2022-05-18: Converted legacy tests to the unified test format.
+:2022-09-02: Remove material that only applies to MongoDB versions < 3.6.
+:2022-10-05: Remove spec front matter and reformat changelog.

--- a/source/compression/OP_COMPRESSED.rst
+++ b/source/compression/OP_COMPRESSED.rst
@@ -2,21 +2,8 @@
 Wire Compression in Drivers
 ===========================
 
-
-:Title: Wire Compression In Drivers
-:Author: Hannes Magnússon
-:Advisory Group: Jonathan Reams, Christian Kvalheim, Ross Lawley
-:Approvers: David Golden (2017-04-26),
-            Christian Kvalheim (2017-04-27),
-            Jeff Yemin (2017-04-27),
-            Bernie Hackett (2017-05-09),
-            Dana Groff (2017-05-02) 
 :Status: Accepted
-:Type: Standards
-:Last Modified: 2021-04-06
 :Minimum Server Version: 3.4
-:Version: 1.3
-
 
 Abstract
 ========
@@ -506,12 +493,8 @@ Q & A
 Changelog
 =========
 
-+------------+--------------------------------------------------------+
-| 2021-04-06 | v1.3 Use 'hello' command                               |
-+------------+--------------------------------------------------------+
-| 2019-05-13 | v1.2 Add zstd as supported compression algorithm       |
-+------------+--------------------------------------------------------+
-| 2017-06-13 | v1.1 Don't require clients to implement legacy opcodes |
-+------------+--------------------------------------------------------+
-| 2017-05-10 | v1.0 Initial commit                                    |
-+------------+--------------------------------------------------------+
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2021-04-06: Use 'hello' command
+:2019-05-13: Add zstd as supported compression algorithm
+:2017-06-13: Don't require clients to implement legacy opcodes
+:2017-05-10: Initial commit.

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -2,15 +2,8 @@
 Connection Monitoring and Pooling
 =================================
 
-:Title: Connection Monitoring and Pooling
-:Author: Dan Aprahamian
-:Advisory Group: Jeff Yemin, Matt Broadstone
-:Approvers: Bernie Hackett, Dan Pasette, Jeff Yemin, Matt Broadstone, Sam Rossi, Scott L'Hommedieu
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2022-01-19
-:Version: 1.6.0
 
 .. contents::
 
@@ -1195,32 +1188,25 @@ Add support for OP_MSG exhaustAllowed
 Exhaust Cursors may require changes to how we close `Connections <#connection>`_ in the future, specifically to add a way to close and remove from its pool a `Connection <#connection>`_ which has unread exhaust messages.
 
 
-Change log
-==========
+Changelog
+=========
 
-:2021-01-19: Require that timeouts be applied per the client-side operations
-             timeout specification.
-
-:2021-01-12: Clarify "clear" method behavior in load balancer mode.
-
-:2020-12-17: Introduce "paused" and "ready" states. Clear WaitQueue on pool clear.
-
-:2020-09-24: Introduce maxConnecting requirement
-
+:2019-06-06: Add "connectionError" as a valid reason for ConnectionCheckOutFailedEvent
 :2020-09-03: Clarify Connection states and definition. Require the use of a
              background thread and/or async I/O. Add tests to ensure
              ConnectionReadyEvents are fired after ConnectionCreatedEvents.
-
-:2019-06-06: Add "connectionError" as a valid reason for
-             ConnectionCheckOutFailedEvent
-
-:2021-4-12: Adding in behaviour for load balancer mode.
-
+:2020-09-24: Introduce maxConnecting requirement
+:2020-12-17: Introduce "paused" and "ready" states. Clear WaitQueue on pool clear.
+:2021-01-12: Clarify "clear" method behavior in load balancer mode.
+:2021-01-19: Require that timeouts be applied per the client-side operations
+             timeout specification.
+:2021-04-12: Adding in behaviour for load balancer mode.
 :2021-06-02: Formalize the behavior of a `Background Thread <#background-thread>`__.
-
 :2021-11-08: Make maxConnecting configurable.
-
 :2022-04-05: Preemptively cancel in progress operations when SDAM heartbeats timeout.
+:2022-10-05: Remove spec front matter and reformat changelog.
+
+----
 
 .. Section for links.
 

--- a/source/connection-string/connection-string-spec.rst
+++ b/source/connection-string/connection-string-spec.rst
@@ -5,14 +5,8 @@
 Connection String Spec
 ======================
 
-:Spec: 104
-:Title: Connection String Spec
-:Authors: Ross Lawley
-:Advisors: \A. Jesse Jiryu Davis, Jeremy Mikola, Anna Herlihy
-:Status: Approved
-:Type: Standards
-:Last Modified: 2019-04-26
-:Version: 1.5.0
+:Status: Accepted
+:Minimum Server Version: N/A
 
 .. contents::
 
@@ -375,20 +369,22 @@ Q: Why must the auth database be URL decoded by the parser?
 Q: How should the space character be encoded in a connection string?
   Space characters SHOULD be encoded as ``%20`` rather than ``+``, this will be portable across all implementations. Implementations MAY support decoding ``+`` into a space, as many languages treat strings as ``x-www-form-urlencoded`` data by default.
 
--------
-Changes
--------
+Changelog
+=========
 
-- 2016-07-22: In Port section, clarify that zero is not an acceptable port.
-- 2017-01-09: In Userinfo section, clarify that percent signs must be encoded.
-- 2017-06-10: In Userinfo section, require username and password to be fully URI
-  encoded, not just "%", "@", and ":". In Auth Database, list the prohibited
-  characters. In Reference Implementation, split at the first "/", not the last.
-- 2018-01-09: Clarified that space characters should be encoded to ``%20``.
-- 2018-06-04: Revised Userinfo section to provide an explicit list of allowed
-  characters and clarify rules for exceptions.
-- 2019-02-04: In Repeated Keys section, clarified that the URI options spec may
-  override the repeated key behavior described here for certain options.
-- 2019-03-04: Require drivers to document option precedence rules
-- 2019-04-26: Database name in URI alone does not trigger authentication
-- 2020-01-21: Clarified how empty values in a connection string are parsed.
+:2016-07-22: In Port section, clarify that zero is not an acceptable port.
+:2017-01-09: In Userinfo section, clarify that percent signs must be encoded.
+:2017-06-10: In Userinfo section, require username and password to be fully URI
+             encoded, not just "%", "@", and ":". In Auth Database, list the
+             prohibited characters. In Reference Implementation, split at the
+             first "/", not the last.
+:2018-01-09: Clarified that space characters should be encoded to ``%20``.
+:2018-06-04: Revised Userinfo section to provide an explicit list of allowed
+             characters and clarify rules for exceptions.
+:2019-02-04: In Repeated Keys section, clarified that the URI options spec may
+             override the repeated key behavior described here for certain
+             options.
+:2019-03-04: Require drivers to document option precedence rules
+:2019-04-26: Database name in URI alone does not trigger authentication
+:2020-01-21: Clarified how empty values in a connection string are parsed.
+:2022-10-05: Remove spec front matter and reformat changelog.

--- a/source/crud/crud.rst
+++ b/source/crud/crud.rst
@@ -5,14 +5,8 @@
 Driver CRUD API
 ===============
 
-:Spec: 110
-:Title: Driver CRUD API
-:Authors: Craig Wilson
-:Advisors: Jeremy Mikola, Jeff Yemin, Tyler Brock
-:Status: Approved
-:Type: Standards
+:Status: Accepted
 :Minimum Server Version: 2.6
-:Last Modified: 2022-02-10
 
 .. contents::
 
@@ -2366,66 +2360,83 @@ Q: Why are client-side errors raised for some unsupported options?
 Q: Why does reverting to using ``count`` instead of ``aggregate`` with ``$collStats`` for estimatedDocumentCount not require a major version bump in the drivers, even though it might break users of the Stable API?
   SemVer `allows <https://semver.org/#what-if-i-inadvertently-alter-the-public-api-in-a-way-that-is-not-compliant-with-the-version-number-change-ie-the-code-incorrectly-introduces-a-major-breaking-change-in-a-patch-release>`_ for a library to include a breaking change in a minor or patch version if the change is required to fix another accidental breaking change introduced in a prior version and is not expected to further break a large number of users. Given that the original switch to ``$collStats`` was a breaking change due to it not working on views, the number of users using estimatedDocumentCount with ``apiStrict: true`` is small, and the server is back-porting the addition of ``count`` to the Stable API, it was decided that this change was acceptable to make in minor version releases of the drivers per the aforementioned allowance in the SemVer spec.
 
-Changes
-=======
+Changelog
+=========
 
-* 2022-04-21: Revert to using the ``count`` command for ``estimatedDocumentCount``
-* 2022-02-18: Add let to BulkWriteOptions.
-* 2022-02-10: Specified that ``getMore`` command must explicitly send inherited comment.
-* 2022-02-01: Add comment attribute to all helpers.
-* 2022-01-27: Use optional return types for write commands and findAndModify
-* 2022-01-19: Deprecate the maxTimeMS option and require that timeouts be applied per the client-side operations timeout spec.
-* 2022-01-14: Add let to ReplaceOptions
-* 2021-11-10: Revise rules for applying read preference for aggregations with $out and $merge.
-* 2021-11-10: Add let to FindOptions, UpdateOptions, DeleteOptions, FindOneAndDeleteOptions, FindOneAndReplaceOptions, FindOneAndUpdateOptions
-* 2021-09-28: Support aggregations with $out and $merge on 5.0+ secondaries
-* 2021-08-31: Allow unacknowledged hints on write operations if supported by server (reverts previous change).
-* 2021-06-02: Introduce WriteError.details and clarify WriteError construction
-* 2021-06-01: Add let to AggregateOptions
-* 2021-01-21: Update estimatedDocumentCount to use $collStats stage for servers >= 4.9
-* 2020-04-17: Specify that the driver must raise an error for unacknowledged hints on any write operation, regardless of server version.
-* 2020-03-19: Clarify that unacknowledged update, findAndModify, and delete operations with a hint option should raise an error on older server versions.
-* 2020-03-06: Added hint option for DeleteOne, DeleteMany, and FindOneAndDelete operations.
-* 2020-01-24: Added hint option for findAndModify update/replace operations.
-* 2020-01-17: Add allowDiskUse to FindOptions.
-* 2020-01-14: Deprecate oplogReplay option for find command
-* 2020-01-10: Clarify client-side error reporting for unsupported options
-* 2020-01-10: Error if hint specified for unacknowledged update using OP_UPDATE or OP_MSG for servers < 4.2
-* 2019-10-28: Removed link to old language examples.
-* 2019-09-26: Added hint option for update commands.
-* 2019-06-07: Consistent treatment for aggregate $merge and $out stages
-* 2019-05-01: Specify a document or pipeline for commands with updates in server 4.2+.
-* 2019-02-20: Mark the request field of BulkWriteError as NOT REQUIRED
-* 2018-11-30: Specify maxAwaitTimeMS in AggregateOptions
-* 2018-11-15: Aggregate commands with an $out stage should not specify batchSize
-* 2018-10-25: Note how results are backed for aggregate, distinct, and find operations
-* 2018-07-25: Added upsertedCount to UpdateResult.
-* 2018-06-07: Deprecated the count helper. Added the estimatedDocumentCount and countDocuments helpers.
-* 2018-03-05: Deprecate snapshot option
-* 2018-03-01: Deprecate maxScan query option.
-* 2018-02-06: Note that batchSize in FindOptions and AggregateOptions should also apply to getMore.
-* 2018-01-26: Only send bypassDocumentValidation option if it's true, don't send false.
-* 2017-10-23: Allow BulkWriteException to provide an intermediary write result.
-* 2017-10-17: Document negative limit for FindOptions.
-* 2017-10-09: Bumped minimum server version to 2.6 and removed references to older versions in spec and tests.
-* 2017-10-09: Prohibit empty insertMany() and bulkWrite() operations.
-* 2017-10-09: Split UpdateOptions and ReplaceOptions. Since replaceOne() previously used UpdateOptions, this may have BC implications for drivers using option classes.
-* 2017-10-05: Removed useCursor option from AggregateOptions.
-* 2017-09-26: Added hint option to AggregateOptions.
-* 2017-09-25: Added comment option to AggregateOptions.
-* 2017-08-31: Added arrayFilters to bulk write update models.
-* 2017-06-29: Remove requirement of using OP_KILL_CURSOR to kill cursors.
-* 2017-06-27: Added arrayFilters to UpdateOptions and FindOneAndUpdateOptions.
-* 2017-06-26: Added FAQ entry for omission of save method.
-* 2017-05-12: Removed extra "collation" option added to several bulk write models.
-* 2017-01-09: Removed modifiers from FindOptions and added in all options.
-* 2017-01-09: Changed the value type of FindOptions.skip and FindOptions.limit to Int64 with a note related to calculating batchSize for opcode writes.
-* 2017-01-09: Reworded description of how default values are handled and when to send certain options.
-* 2016-09-23: Included collation option in the bulk write models.
-* 2016-08-05: Added in collation option.
-* 2015-11-05: Typos in comments about bypassDocumentValidation
-* 2015-10-16: Added maxAwaitTimeMS to FindOptions.
-* 2015-10-01: Moved bypassDocumentValidation into BulkWriteOptions and removed it from the individual write models.
-* 2015-09-16: Added bypassDocumentValidation.
-* 2015-09-16: Added readConcern notes.
-* 2015-06-17: Added limit/batchSize calculation logic.
+:2022-10-05: Remove spec front matter and reformat changlog.
+:2022-04-21: Revert to using the ``count`` command for ``estimatedDocumentCount``
+:2022-02-18: Add let to BulkWriteOptions.
+:2022-02-10: Specified that ``getMore`` command must explicitly send inherited comment.
+:2022-02-01: Add comment attribute to all helpers.
+:2022-01-27: Use optional return types for write commands and findAndModify
+:2022-01-19: Deprecate the maxTimeMS option and require that timeouts be applied
+             per the client-side operations timeout spec.
+:2022-01-14: Add let to ReplaceOptions
+:2021-11-10: Revise rules for applying read preference for aggregations with
+             $out and $merge. Add let to FindOptions, UpdateOptions,
+             DeleteOptions, FindOneAndDeleteOptions, FindOneAndReplaceOptions,
+             FindOneAndUpdateOptions
+:2021-09-28: Support aggregations with $out and $merge on 5.0+ secondaries
+:2021-08-31: Allow unacknowledged hints on write operations if supported by
+             server (reverts previous change).
+:2021-06-02: Introduce WriteError.details and clarify WriteError construction
+:2021-06-01: Add let to AggregateOptions
+:2021-01-21: Update estimatedDocumentCount to use $collStats stage for servers >= 4.9
+:2020-04-17: Specify that the driver must raise an error for unacknowledged
+             hints on any write operation, regardless of server version.
+:2020-03-19: Clarify that unacknowledged update, findAndModify, and delete
+             operations with a hint option should raise an error on older server
+             versions.
+:2020-03-06: Added hint option for DeleteOne, DeleteMany, and FindOneAndDelete operations.
+:2020-01-24: Added hint option for findAndModify update/replace operations.
+:2020-01-17: Add allowDiskUse to FindOptions.
+:2020-01-14: Deprecate oplogReplay option for find command
+:2020-01-10: Clarify client-side error reporting for unsupported options
+:2020-01-10: Error if hint specified for unacknowledged update using OP_UPDATE
+             or OP_MSG for servers < 4.2
+:2019-10-28: Removed link to old language examples.
+:2019-09-26: Added hint option for update commands.
+:2019-06-07: Consistent treatment for aggregate $merge and $out stages
+:2019-05-01: Specify a document or pipeline for commands with updates in server 4.2+.
+:2019-02-20: Mark the request field of BulkWriteError as NOT REQUIRED
+:2018-11-30: Specify maxAwaitTimeMS in AggregateOptions
+:2018-11-15: Aggregate commands with an $out stage should not specify batchSize
+:2018-10-25: Note how results are backed for aggregate, distinct, and find operations
+:2018-07-25: Added upsertedCount to UpdateResult.
+:2018-06-07: Deprecated the count helper. Added the estimatedDocumentCount and
+             countDocuments helpers.
+:2018-03-05: Deprecate snapshot option
+:2018-03-01: Deprecate maxScan query option.
+:2018-02-06: Note that batchSize in FindOptions and AggregateOptions should also
+             apply to getMore.
+:2018-01-26: Only send bypassDocumentValidation option if it's true, don't send false.
+:2017-10-23: Allow BulkWriteException to provide an intermediary write result.
+:2017-10-17: Document negative limit for FindOptions.
+:2017-10-09: Bumped minimum server version to 2.6 and removed references to
+             older versions in spec and tests.
+:2017-10-09: Prohibit empty insertMany() and bulkWrite() operations.
+:2017-10-09: Split UpdateOptions and ReplaceOptions. Since replaceOne()
+             previously used UpdateOptions, this may have BC implications for
+             drivers using option classes.
+:2017-10-05: Removed useCursor option from AggregateOptions.
+:2017-09-26: Added hint option to AggregateOptions.
+:2017-09-25: Added comment option to AggregateOptions.
+:2017-08-31: Added arrayFilters to bulk write update models.
+:2017-06-29: Remove requirement of using OP_KILL_CURSOR to kill cursors.
+:2017-06-27: Added arrayFilters to UpdateOptions and FindOneAndUpdateOptions.
+:2017-06-26: Added FAQ entry for omission of save method.
+:2017-05-12: Removed extra "collation" option added to several bulk write models.
+:2017-01-09: Removed modifiers from FindOptions and added in all options.
+:2017-01-09: Changed the value type of FindOptions.skip and FindOptions.limit to
+             Int64 with a note related to calculating batchSize for opcode writes.
+:2017-01-09: Reworded description of how default values are handled and when to
+             send certain options.
+:2016-09-23: Included collation option in the bulk write models.
+:2016-08-05: Added in collation option.
+:2015-11-05: Typos in comments about bypassDocumentValidation
+:2015-10-16: Added maxAwaitTimeMS to FindOptions.
+:2015-10-01: Moved bypassDocumentValidation into BulkWriteOptions and removed it
+             from the individual write models.
+:2015-09-16: Added bypassDocumentValidation.
+:2015-09-16: Added readConcern notes.
+:2015-06-17: Added limit/batchSize calculation logic.

--- a/source/dbref.rst
+++ b/source/dbref.rst
@@ -2,12 +2,8 @@
 Handling of DBRefs
 ==================
 
-:Spec Title: Handling of DBRefs
-:Spec Version: 1.0
-:Author: Jeremy Mikola
-:Status: Draft
-:Type: Standards
-:Last Modified: 2021-05-21
+:Status: Accepted
+:Minimum Server Version: N/A
 
 .. contents::
 
@@ -355,7 +351,7 @@ out of implicit decoding if desired.
 .. _robustness principle: https://en.wikipedia.org/wiki/Robustness_principle
 
 
-Change Log
-==========
+Changelog
+=========
 
-This section is intentionally blank.
+:2022-10-05: Remove spec front matter.

--- a/source/driver-bulk-update.rst
+++ b/source/driver-bulk-update.rst
@@ -2,42 +2,10 @@
 Bulk API Spec
 =============
 
-:Authors: Christian Kvalheim
 :Status: Deprecated
-:Type: Standards
-:Last Modified: May 18, 2021
+:Minimum Server Version: 2.4
 
 .. contents::
-
-Changes from previous versions
-==============================
-
-Deprecated in favor of the *Driver CRUD API*.
-
-v0.8
-----
-* Removed "Test Case 3: Key validation, no $-prefixed keys allowed" for insert.
-
-v0.7
-----
-* Clarify that "writeConcernErrors" field is plural
-
-v0.6
-----
-* First public version of the specification.
-* Merged in Test Cases from QA tickets
-* Specification cleanup and increased precision
-
-v0.5
-----
-* Specification cleanup and increased precision
-* Suggested Error handling for languages using commonly raising exceptions
-* Narrowed writeConcern reporting requirement
-
-v0.4
-----
-* Renamed nUpdated to nMatched as to reflect that it's the number of matched documents not the number of modified documents.
-
 
 Bulk Operation Builder
 ======================
@@ -1740,3 +1708,22 @@ sleep 6 seconds
     client.admin.command({replSetStepDown: 5})
     batch = client.db.collection.initializeOrderedBulkOp()
     batch.insert({_id: 2}).execute() should succeed
+
+Changelog
+=========
+
+:2022-10-05: Remove spec front matter and reformat changelog. Consolidated
+             changelog entries prior to the first published version of this
+             document, since exact dates were unavailable.
+:2021-05-27: Removed "Test Case 3: Key validation, no $-prefixed keys allowed"
+             for insert.
+:2015-10-23: Clarify that "writeConcernErrors" field is plural
+:2015-05-22: * First public version of the specification.
+             * Deprecated this specification in favor of CRUD API.
+             * Merged in Test Cases from QA tickets.
+             * Specification cleanup and increased precision.
+             * Suggested error handling for languages using commonly raising
+               exceptions.
+             * Narrowed writeConcern reporting requirement.
+             * Renamed nUpdated to nMatched as to reflect that it's the number
+               of matched documents not the number of modified documents.

--- a/source/enumerate-collections.rst
+++ b/source/enumerate-collections.rst
@@ -5,15 +5,8 @@
 Enumerating Collections
 =======================
 
-:Spec: 107
-:Spec-ticket: SPEC-54
-:Title: Enumerating Collections
-:Authors: Derick Rethans
-:Status: Draft
-:Type: Standards
-:Server Versions: 1.8-2.7.5, 2.8.0-rc3 and later
-:Last Modified: 2022-08-17
-:Version: 0.10.0
+:Status: Accepted
+:Minimum Server Version: 1.8
 
 .. contents::
 
@@ -464,55 +457,27 @@ The shell implements the first algorithm for falling back if the
 (`<https://github.com/mongodb/mongo/blob/f32ba54f971c045fb589fe4c3a37da77dc486cee/src/mongo/shell/db.js#L550>`_).
 
 
-Version History
-===============
+Changelog
+=========
 
-Version 0.10.0 Changes
-    - Clarify the behavior of ``comment`` on pre-4.4 servers.
-
-Version 0.9.0 Changes
-    - Add ``comment`` option to ``listCollections`` command.
-
-Version 0.8.0 Changes
-    - Require that timeouts be applied per the client-side operations timeout spec.
-
-Version 0.7.0 Changes
-    - Support ``authorizedCollections`` option in ``listCollections`` command.
-
-Version 0.6.1 Changes
-    - Update to use secondaryOk.
-
-Version 0.6.0 Changes
-    - MongoDB 4.4 no longer includes ``ns`` field in ``idIndex`` field for
-      ``listCollections`` responses.
-
-Version 0.5.1 Changes
-    - The method that returns a list of collection names should be named
-      ``listCollectionNames``. The method that returns a list of collection
-      objects may be named ``listMongoCollections``.
-
-Version 0.5 Changes
-    - Clarify that ``nameOnly`` must not be used with filters other than ``name``.
-
-Version 0.4 Changes
-    - SPEC-1066: Support ``nameOnly`` option in ``listCollections`` command.
-
-Version 0.3.1 Changes
-
-    - Fix typos.
-    - Clarify reason for filtering collection names containing '$'.
-
-Version 0.3 Changes
-
-    - SPEC-121: Clarify trimming of database name
-    - Put preferred method name for listing collections with a cursor as return
-      value.
-
-Version 0.2 Changes
-
-    - Update with the server change to return a cursor for
-      ``listCollections``.
-
-Version 0.1 Changes
-
-    - Initial draft
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-09-15: Clarify the behavior of ``comment`` on pre-4.4 servers.
+:2022-02-01: Add ``comment`` option to ``listCollections`` command.
+:2022-01-20: Require that timeouts be applied per the client-side operations
+             timeout spec.
+:2021-12-17: Support ``authorizedCollections`` option in ``listCollections``
+             command.
+:2021-04-22: Update to use secondaryOk.
+:2020-03-18: MongoDB 4.4 no longer includes ``ns`` field in ``idIndex`` field
+             for ``listCollections`` responses.
+:2019-03-21: The method that returns a list of collection names should be named
+             ``listCollectionNames``. The method that returns a list of
+             collection objects may be named ``listMongoCollections``.
+:2018-07-03: Clarify that ``nameOnly`` must not be used with filters other than
+             ``name``.
+:2018-05-18: Support ``nameOnly`` option in ``listCollections`` command.
+:2017-09-27: Clarify reason for filtering collection names containing '$'.
+:2015-01-14: Clarify trimming of database name. Put preferred method name for
+             listing collections with a cursor as return value.
+:2014-12-18: Update with the server change to return a cursor for
+             ``listCollections``.

--- a/source/enumerate-databases.rst
+++ b/source/enumerate-databases.rst
@@ -3,7 +3,7 @@ Enumerating Databases
 =====================
 
 :Status: Accepted
-:Minimum Server Version: 3.8
+:Minimum Server Version: 3.6
 
 .. contents::
 
@@ -294,7 +294,9 @@ all ``sizeOnDisk`` fields in the array of database information documents.
 Changelog
 =========
 
-:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-10-05: Remove spec front matter and reformat changelog. Also reverts the
+             minimum server version to 3.6, which is where ``nameOnly`` and
+             ``filter`` options were first introduced for ``listDatabases``.
 :2022-08-17: Clarify the behavior of comment on pre-4.4 servers.
 :2022-02-01: Support comment option in listDatabases command
 :2022-01-19: Require that timeouts be applied per the client-side operations timeout spec.

--- a/source/enumerate-databases.rst
+++ b/source/enumerate-databases.rst
@@ -2,14 +2,8 @@
 Enumerating Databases
 =====================
 
-:Spec Title: Enumerating Databases
-:Spec Ticket: SPEC-865
-:Spec Version: 1.0
-:Author: Jeremy Mikola
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 3.8
-:Last Modified: 2022-08-17
 
 .. contents::
 
@@ -297,11 +291,12 @@ opposed to an optional output argument (if supported by the language).
 Furthermore, the ``totalSize`` value can be calculated client-side by summing
 all ``sizeOnDisk`` fields in the array of database information documents.
 
-Changes
-=======
+Changelog
+=========
 
-* 2022-08-17: Clarify the behavior of comment on pre-4.4 servers.
-* 2022-02-01: Support comment option in listDatabases command
-* 2017-10-30: Support filter option in listDatabases command
-* 2019-11-20: Support authorizedDatabases option in listDatabases command
-* 2022-01-19: Require that timeouts be applied per the client-side operations timeout spec.
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-08-17: Clarify the behavior of comment on pre-4.4 servers.
+:2022-02-01: Support comment option in listDatabases command
+:2022-01-19: Require that timeouts be applied per the client-side operations timeout spec.
+:2019-11-20: Support authorizedDatabases option in listDatabases command
+:2017-10-30: Support filter option in listDatabases command

--- a/source/enumerate-indexes.rst
+++ b/source/enumerate-indexes.rst
@@ -5,15 +5,8 @@
 Enumerating Indexes
 ===================
 
-:Spec: 106
-:Spec-ticket: SPEC-53
-:Title: Enumerating Indexes
-:Authors: Derick Rethans
-:Status: Draft
-:Type: Standards
-:Server Versions: 1.8-2.7.5, 2.8.0-rc3 and later
-:Last Modified: 2022-08-17
-:Version: 0.8.0
+:Status: Accepted
+:Minimum Server Version: 1.8
 
 .. contents::
 
@@ -407,37 +400,21 @@ The shell implements the first algorithm for falling back if the
 (`<https://github.com/mongodb/mongo/blob/f32ba54f971c045fb589fe4c3a37da77dc486cee/src/mongo/shell/collection.js#L942>`_).
 
 
-Version History
-===============
+Changelog
+=========
 
-0.8.0 - 2022-08-17
-    Clarify the behavior of ``comment`` on pre-4.4 servers.
-
-0.7.0 - 2022-02-01
-    Add ``comment`` option to ``listIndexes`` command.
-
-0.6.0 - 2022-01-19
-    Require that timeouts be applied per the client-side operations timeout spec.
-
-0.5.1 - 2021-04-06
-    Changed to secondaryOk.
-
-0.5.0 - 2020-01-14
-    MongoDB 4.4 no longer includes ``ns`` field in ``listIndexes`` responses.
-
-0.4.1 - 2018-04-05
-    Fix typo.
-
-0.4 - 2017-09-20
-    Allow more leniency for handling error code 26 (collection does not
-    exist).
-
-0.3 - 2015-01-14
-    Put preferred method name for listing indexes with a cursor as return
-    value.
-
-0.2
-    Update with the server change to return a cursor for ``listIndexes``.
-
-0.1
-    Initial draft
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-08-17: Clarify the behavior of ``comment`` on pre-4.4 servers.
+:2022-02-01: Add ``comment`` option to ``listIndexes`` command.
+:2022-01-19: Require that timeouts be applied per the client-side operations
+             timeout spec.
+:2021-04-06: Changed to secondaryOk.
+:2020-01-14: MongoDB 4.4 no longer includes ``ns`` field in ``listIndexes``
+             responses.
+:2018-04-05: Fix typo.
+:2017-09-20: Allow more leniency for handling error code 26 (collection does not
+             exist).
+:2015-01-14: Put preferred method name for listing indexes with a cursor as
+             return value.
+:2014-12-18: Update with the server change to return a cursor for
+             ``listIndexes``.

--- a/source/extended-json.rst
+++ b/source/extended-json.rst
@@ -2,16 +2,8 @@
 Extended JSON
 =============
 
-:Spec: 587
-:Spec-ticket: SPEC-587
-:Title: Extended JSON
-:Author: Luke Lovett, David Golden
-:Spec Lead: David Golden, Jeff Yemin
-:Advisory Group: Jeff Yemin, Christian Kvalheim, Hannes Magnusson, Matt Broadstone, Jesse Davis
-:Status: Proposed
-:Type: Standards
-:Last Modified: May 21, 2021
-:Version: 2.2.0
+:Status: Accepted
+:Minimum Server Version: N/A
 
 .. contents::
 
@@ -931,52 +923,34 @@ a MongoDB query filter containing the ``$type`` operator?
 
 **A**. Yes, "extjson" is short for "Extended JSON".
 
-Changes
-=======
+Changelog
+=========
 
-v2.2.0
-------
-
-* Remove any mention of extra dollar-prefixed keys being prohibited in a DBRef.
-  MongoDB 5.0 and compatible drivers no longer enforce such restrictions.
-
-* Objects that resemble a DBRef without fully complying to its structure should
-  be left as-is during parsing.
-
-v2.1.1
-------
-
-* Note that ``$``-prefixed keys not matching a known type MUST be left as-is
-  when parsing. This is patch-level change as this behavior was already required
-  in the BSON corpus tests ("Document with keys that start with $").
-
-v2.1.0
-------
-
-* Added support for parsing ``$uuid`` fields as BSON Binary subtype 4.
-
-* Changed the example to using the MongoDB Python Driver. It previously
-  used the MongoDB Java Driver. The new example excludes the following
-  BSON types that are unsupported in Python - ``Symbol``, ``SpecialFloat``,
-  ``DBPointer`` and ``Undefined``. Transformations for these types are
-  now only documented in the `Conversion table`_.
-
-v2.0.0
-------
-
-* Added "Relaxed" format.
-
-* Changed BSON timestamp type wrapper back to ``{"t": *int*, "i": *int*}`` for
-  backwards compatibility.  (The change in v1 to unsigned 64-bit string was
-  premature optimization.)
-
-* Changed BSON regular expression type wrapper to
-  ``{"$regularExpression": {pattern: *string*, "options": *string*"}}``.
-
-* Changed BSON binary type wrapper to
-  ``{"$binary": {"base64": <base64-encoded payload as a *string*>,
-  "subType": <BSON binary type as a one- or two-character *hex string*>}}``
-
-* Added "Restrictions and limitations" section.
-
-* Clarified parser and generator rules.
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2021-05-26: * Remove any mention of extra dollar-prefixed keys being prohibited
+               in a DBRef. MongoDB 5.0 and compatible drivers no longer enforce
+               such restrictions.
+             * Objects that resemble a DBRef without fully complying to its
+               structure should be left as-is during parsing.
+:2020-09-01: Note that ``$``-prefixed keys not matching a known type MUST be
+             left as-is when parsing. This is patch-level change as this
+             behavior was already required in the BSON corpus tests ("Document
+             with keys that start with $").
+:2020-09-08: * Added support for parsing ``$uuid`` fields as BSON Binary subtype 4.
+             * Changed the example to using the MongoDB Python Driver. It
+               previously used the MongoDB Java Driver. The new example excludes
+               the following BSON types that are unsupported in Python -
+               ``Symbol``, ``SpecialFloat``, ``DBPointer`` and ``Undefined``.
+               Transformations for these types are now only documented in the
+               `Conversion table`_.
+:2017-07-20: * Bumped specification to version 2.0.
+             * Added "Relaxed" format.
+             * Changed BSON timestamp type wrapper back to
+               ``{"t": *int*, "i": *int*}`` for backwards compatibility. (The
+               change in v1 to unsigned 64-bit string was premature optimization)
+             * Changed BSON regular expression type wrapper to
+               ``{"$regularExpression": {pattern: *string*, "options": *string*"}}``.
+             * Changed BSON binary type wrapper to ``{"$binary": {"base64": <base64-encoded payload as a *string*>, "subType": <BSON binary type as a one- or two-character *hex string*>}}``
+             * Added "Restrictions and limitations" section.
+             * Clarified parser and generator rules.
+:2017-02-01: Initial specification version 1.0.

--- a/source/find_getmore_killcursors_commands.rst
+++ b/source/find_getmore_killcursors_commands.rst
@@ -5,16 +5,8 @@
 Find, getMore and killCursors commands.
 =======================================
 
-:Spec: 137
-:Version: 1.4
-:Title: Find, getMore and killCursors commands
-:Author: Christian Kvalheim
-:Lead: Christian Kvalheim
-:Advisors: \Anna Herlihy, Robert Stam
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 3.2
-:Last Modified: February 01, 2022
 
 .. contents::
 
@@ -468,18 +460,23 @@ More in depth information about passing read preferences to Mongos can be found 
 
 .. _Server Selection Specification: https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#passing-read-preference-to-mongos
 
-Changes
-=======
-2022-02-01 Replace examples/tables for find, getMore, and killCursors with server manual links.
+Changelog
+=========
 
-2021-12-14 Exhaust cursors may fallback to non-exhaust cursors on 5.1+ servers. Relax requirement of OP_MSG for exhaust cursors.
-
-2021-08-27 Exhaust cursors must use OP_MSG on 3.6+ servers.
-
-2021-04-06 Updated to use hello and secondaryOk.
-
-2015-09-30 Legacy secondaryOk flag must be set to true on **getMore** and **killCursors** commands to make drivers have same behavior as for OP_GET_MORE and OP_KILL_CURSORS.
-
-2015-10-13 added guidance on batchSize values as related to the **getMore** command. Legacy secondaryOk flag SHOULD not be set on getMore and killCursors commands. Introduced maxAwaitTimeMS option for setting maxTimeMS on getMore commands when the cursor is a tailable cursor with awaitData set.
-
-2015-10-21 If no **maxAwaitTimeMS** is specified, the driver SHOULD not set **maxTimeMS** on the **getMore** command.
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-02-01: Replace examples/tables for find, getMore, and killCursors with
+             server manual links.
+:2021-12-14: Exhaust cursors may fallback to non-exhaust cursors on 5.1+
+             servers. Relax requirement of OP_MSG for exhaust cursors.
+:2021-08-27: Exhaust cursors must use OP_MSG on 3.6+ servers.
+:2021-04-06: Updated to use hello and secondaryOk.
+:2015-10-21: If no **maxAwaitTimeMS** is specified, the driver SHOULD not set
+             **maxTimeMS** on the **getMore** command.
+:2015-10-13: Added guidance on batchSize values as related to the **getMore**
+             command. Legacy secondaryOk flag SHOULD not be set on getMore and
+             killCursors commands. Introduced maxAwaitTimeMS option for setting
+             maxTimeMS on getMore commands when the cursor is a tailable cursor
+             with awaitData set.
+:2015-09-30: Legacy secondaryOk flag must be set to true on **getMore** and
+             **killCursors** commands to make drivers have same behavior as for
+             OP_GET_MORE and OP_KILL_CURSORS.

--- a/source/gridfs/gridfs-spec.rst
+++ b/source/gridfs/gridfs-spec.rst
@@ -2,15 +2,8 @@
 GridFS Spec
 ===========
 
-:Spec: 105
-:Title: GridFS Spec
-:Authors: Samantha Ritter and Robert Stam
-:Advisors: David Golden and Jeff Yemin
-:Status: Approved
-:Type: Standards
+:Status: Accepted
 :Minimum Server Version: 2.2
-:Last Modified: 2022-01-19
-:Version: 1.5
 
 .. contents::
 
@@ -1208,14 +1201,15 @@ functionality is not in-scope for this spec (see ‘Why can’t I alter
 documents once they are in the system?’) it is a potential area of
 growth for the future.
 
-Changes
-=======
+Changelog
+=========
 
-- 2016-05-10 Support custom file ids
-- 2016-10-07 Drivers SHOULD handle any numeric type of length and chunkSize
-- 2016-10-07 Added ReadConcern to the GridFS spec
-- 2016-10-07 Modified a JSON test that was testing optional behavior
-- 2018-01-31 Deprecated MD5, and specified an option to disable MD5 until removed
-- 2018-07-05 Must not use 'filemd5'
-- 2020-01-17 Added allowDiskUse to GridFSFindOptions
-- 2022-01-19 Require that timeouts be applied per the client-side operations timeout spec
+:2016-05-10: Support custom file ids
+:2016-10-07: Drivers SHOULD handle any numeric type of length and chunkSize
+:2016-10-07: Added ReadConcern to the GridFS spec
+:2016-10-07: Modified a JSON test that was testing optional behavior
+:2018-01-31: Deprecated MD5, and specified an option to disable MD5 until removed
+:2018-07-05: Must not use 'filemd5'
+:2020-01-17: Added allowDiskUse to GridFSFindOptions
+:2022-01-19: Require that timeouts be applied per the client-side operations timeout spec
+:2022-10-05: Remove spec front matter and reformat changelog.

--- a/source/index-management.rst
+++ b/source/index-management.rst
@@ -5,14 +5,8 @@
 Index Management
 ================
 
-:Spec: 79
-:Title: Index Management
-:Authors: Durran Jordan
-:Status: Approved
-:Type: Standards
+:Status: Accepted
 :Minimum Server Version: 2.4
-:Last Modified: 2022-02-10
-:Version: 1.10
 
 .. contents::
 
@@ -881,32 +875,25 @@ Q: Why does the driver manually throw errors if the ``commitQuorum`` option is s
 Changelog
 ---------
 
-17 SEP 2015:
-  - Added ``partialFilterExpression`` attribute to ``IndexOptions`` in order to support partial indexes.
-  - Fixed "provides" typo.
-19 MAY 2016:
-  - Added ``collation`` attribute to ``IndexOptions`` in order to support setting a collation on an index.
-8 AUG 2016:
-  - Fixed ``collation`` language to not mention a collection default.
-11 OCT 2016:
-  - Added note on 3.4 servers validation options passed to ``createIndexes``.
-11 OCT 2016:
-  - Add note on server generated name for the _id index.
-31 MAY 2017:
-  - Add Q & A addressing write concern and maxTimeMS option.
-7 JUN 2017:
-  - Include listIndexes() in Q&A about maxTimeMS.
-24 April 2019:
-  - Added ``wildcardProjection`` attribute to ``IndexOptions`` in order to support setting a wildcard projection on a wildcard index.
-30 MAR 2020:
-  - Added options types to various helpers
-  - Introduced ``commitQuorum`` option
-  - Added deprecation message for ``background`` option.
-19 JAN 2022:
-  - Require that timeouts be applied per the client-side operations timeout spec.
-01 FEB 2022:
-  - Added comment field to helper methods.
-10 FEB 2022:
-  - Specified that ``getMore`` command must explicitly send inherited comment.
-18 APR 2022:
-  - Added the ``clustered`` attribute to ``IndexOptions`` in order to support clustered collections.
+:2015-09-17: Added ``partialFilterExpression`` attribute to ``IndexOptions`` in
+             order to support partial indexes. Fixed "provides" typo.
+:2016-05-19: Added ``collation`` attribute to ``IndexOptions`` in order to
+             support setting a collation on an index.
+:2016-08-08: Fixed ``collation`` language to not mention a collection default.
+:2016-10-11: Added note on 3.4 servers validation options passed to
+             ``createIndexes``. Add note on server generated name for the _id
+             index.
+:2017-05-31: Add Q & A addressing write concern and maxTimeMS option.
+:2017-06-07: Include listIndexes() in Q&A about maxTimeMS.
+:2019-04-24: Added ``wildcardProjection`` attribute to ``IndexOptions`` in order
+             to support setting a wildcard projection on a wildcard index.
+:2020-03-30: Added options types to various helpers. Introduced ``commitQuorum``
+             option. Added deprecation message for ``background`` option.
+:2022-01-19: Require that timeouts be applied per the client-side operations
+             timeout spec.
+:2022-02-01: Added comment field to helper methods.
+:2022-02-10: Specified that ``getMore`` command must explicitly send inherited
+             comment.
+:2022-04-18: Added the ``clustered`` attribute to ``IndexOptions`` in order to
+             support clustered collections.
+:2022-10-05: Remove spec front matter and reformat changelog.

--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -334,7 +334,7 @@ SRV records.
 ChangeLog
 =========
 
-:2022-10-05: Revise spec front matter and reformat change log.
+:2022-10-05: Revise spec front matter and reformat changelog.
 :2021-10-14: Add ``srvMaxHosts`` MongoClient option and restructure Seedlist
              Discovery section. Improve documentation for the ``srvServiceName``
              MongoClient option and add a new URI Validation section.

--- a/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
+++ b/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst
@@ -5,17 +5,8 @@
 Initial DNS Seedlist Discovery
 ==============================
 
-:Spec-ticket: SPEC-878, SPEC-937
-:Title: Initial DNS Seedlist Discovery
-:Authors: Derick Rethans
-:Status: Draft
-:Type: Standards
-:Last Modified: 2021-10-14
-:Version: 1.6.0
-:Spec Lead: Matt Broadstone
-:Advisory Group: \A. Jesse Jiryu Davis
-:Approver(s): Bernie Hackett, David Golden, Jeff Yemin, Matt Broadstone, A. Jesse Jiryu Davis
-
+:Status: Accepted
+:Minimum Server Version: N/A
 
 .. contents::
 
@@ -343,68 +334,37 @@ SRV records.
 ChangeLog
 =========
 
-2021-10-14 - 1.6.0
-    Add ``srvMaxHosts`` MongoClient option and restructure Seedlist Discovery
-    section. Improve documentation for the ``srvServiceName`` MongoClient
-    option and add a new URI Validation section.
-
-2021-09-15 - 1.5.0
-    Clarify that service name only defaults to ``mongodb``, and should be
-    defined by the ``srvServiceName`` URI option.
-
-2021-04-15 - 1.4.0
-    Adding in behaviour for load balancer mode.
-
-2019-03-07 - 1.3.2
-    Clarify that CNAME is not supported
-
-2018-02-08 — 1.3.1
-    Clarify that ``{options}}`` in the Specification_ section includes all the
-    optional elements from the Connection String specification.
-
-2017-11-21 — 1.3.0
-    Add clause that using ``mongodb+srv://`` implies enabling TLS. Add
-    restriction that only ``authSource`` and ``replicaSet`` are allows in TXT
-    records. Add restriction that only one TXT record is supported share
-    the same parent domain name as the given host name.
-
-2017-11-17 — 1.2.0
-    Add new rule that indicates that host names in returned SRV records MUST
-    share the same parent domain name as the given host name.
-
-2017-11-17 — 1.1.6
-    Remove language and tests for non-ASCII characters.
-
-2017-11-07 — 1.1.5
-    Clarified that all parts of listable options such as readPreferenceTags
-    are ignored if they are also present in options to the MongoClient
-    constructor.
-
-    Clarified which host names to use for SRV and TXT DNS queries.
-
-2017-11-01 — 1.1.4
-    Clarified that individual TXT records can have multiple strings.
-
-2017-10-31 — 1.1.3
-    Added a clause that specifying two host names with a ``mongodb+srv://`` URI
-    is not allowed. Added a few more test cases.
-
-2017-10-18 — 1.1.2
-    Removed prohibition of raising DNS related errors when parsing the URI.
-
-2017-10-04 — 1.1.1
-    Removed from `Future Work`_ the line about multiple MongoS discovery. The
-    current specification already allows for it, as multiple host names which
-    are all MongoS servers is already allowed under SDAM. And this
-    specification does not modify SDAM.
-
-2017-10-04 — 1.1
-    Added support for connection string options through TXT records.
-
-2017-09-19
-    Clarify that host names in ``mongodb+srv://`` URLs work like normal host
-    specifications.
-
-2017-09-01
-    Updated test plan with YAML tests, and moved prose tests for URI parsing
-    into invalid-uris.yml in the Connection String Spec tests.
+:2022-10-05: Revise spec front matter and reformat change log.
+:2021-10-14: Add ``srvMaxHosts`` MongoClient option and restructure Seedlist
+             Discovery section. Improve documentation for the ``srvServiceName``
+             MongoClient option and add a new URI Validation section.
+:2021-09-15: Clarify that service name only defaults to ``mongodb``, and should
+             be defined by the ``srvServiceName`` URI option.
+:2021-04-15: Adding in behaviour for load balancer mode.
+:2019-03-07: Clarify that CNAME is not supported
+:2018-02-08: Clarify that ``{options}}`` in the Specification_ section includes
+             all the optional elements from the Connection String specification.
+:2017-11-21: Add clause that using ``mongodb+srv://`` implies enabling TLS. Add
+             restriction that only ``authSource`` and ``replicaSet`` are allows
+             in TXT records. Add restriction that only one TXT record is
+             supported share the same parent domain name as the given host name.
+:2017-11-17: Add new rule that indicates that host names in returned SRV records
+             MUST share the same parent domain name as the given host name.
+             Remove language and tests for non-ASCII characters.
+:2017-11-07: Clarified that all parts of listable options such as
+             readPreferenceTags are ignored if they are also present in options
+             to the MongoClient constructor. Clarified which host names to use
+             for SRV and TXT DNS queries.
+:2017-11-01: Clarified that individual TXT records can have multiple strings.
+:2017-10-31: Added a clause that specifying two host names with a
+             ``mongodb+srv://`` URI is not allowed. Added a few more test cases.
+:2017-10-18: Removed prohibition of raising DNS related errors when parsing the URI.
+:2017-10-04: Removed from `Future Work`_ the line about multiple MongoS
+             discovery. The current specification already allows for it, as
+             multiple host names which are all MongoS servers is already allowed
+             under SDAM. And this specification does not modify SDAM. Added
+             support for connection string options through TXT records.
+:2017-09-19: Clarify that host names in ``mongodb+srv://`` URLs work like normal
+             host specifications.
+:2017-09-01: Updated test plan with YAML tests, and moved prose tests for URI
+             parsing into invalid-uris.yml in the Connection String Spec tests.

--- a/source/load-balancers/load-balancers.rst
+++ b/source/load-balancers/load-balancers.rst
@@ -2,14 +2,8 @@
 Load Balancer Support
 =====================
 
-:Spec Title: Load Balancer Support
-:Spec Version: 1.0.1
-:Author: Durran Jordan
-:Advisors: Jeff Yemin, Divjot Arora, Andy Schwerin, Cory Mintz
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 5.0
-:Last Modified: 2022-01-18
 
 .. contents::
 
@@ -425,8 +419,10 @@ in the reference section below, and only load balancers that support the PROXY p
 be supported.
 
 
-Change Log
-==========
-- 2022-01-18: Clarify that ``OP_MSG`` must be used in load balanced mode.
-- 2021-12-22: Clarify that pinned connections in transactions are exclusive.
-- 2021-10-14: Note that ``loadBalanced=true`` conflicts with ``srvMaxHosts``.
+Changelog
+=========
+
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-01-18: Clarify that ``OP_MSG`` must be used in load balanced mode.
+:2021-12-22: Clarify that pinned connections in transactions are exclusive.
+:2021-10-14: Note that ``loadBalanced=true`` conflicts with ``srvMaxHosts``.

--- a/source/max-staleness/max-staleness.rst
+++ b/source/max-staleness/max-staleness.rst
@@ -589,7 +589,7 @@ maxStalenessSeconds when there is no client-side setting.
 Changelog
 =========
 
-:2022-10-05: Remove spec front matter and revise change log.
+:2022-10-05: Remove spec front matter and revise changelog.
 :2021-09-08: Updated tests to support driver removal of support for server versions older than 3.6.
 :2021-09-03: Clarify that wire version check only applies to available servers.
 :2021-04-06: Updated to use hello command.

--- a/source/max-staleness/max-staleness.rst
+++ b/source/max-staleness/max-staleness.rst
@@ -2,15 +2,8 @@
 Max Staleness
 =============
 
-:Spec: 142
-:Title: Max Staleness
-:Author: \A. Jesse Jiryu Davis
-:Lead: Bernie Hackett, Andy Schwerin
-:Advisors: Christian Kvalheim, Jeff Yemin, Eric Milkie
 :Status: Accepted
-:Type: Standards
-:Last Modified: April 6, 2021
-:Version: 1.4.1
+:Minimum Server Version: 3.4
 
 .. contents::
 
@@ -593,16 +586,17 @@ hello response like::
 ... then a future client can use the value from the server as its default
 maxStalenessSeconds when there is no client-side setting.
 
-Changes
-=======
+Changelog
+=========
 
-2021-09-08: Updated tests to support driver removal of support for server versions older than 3.6.
-2021-09-03: Clarify that wire version check only applies to available servers.
-2021-04-06: Updated to use hello command.
-2016-09-29: Specify "no max staleness" in the URI with "maxStalenessMS=-1"
-instead of "maxStalenessMS=0".
-2016-10-24: Rename option from "maxStalenessMS" to "maxStalenessSeconds".
-2016-10-25: Change minimum maxStalenessSeconds value from 2 * heartbeatFrequencyMS
-to heartbeatFrequencyMS + idleWritePeriodMS (with proper conversions of course).
-2016-11-21: Revert changes that would allow idleWritePeriodMS to change in the
-future, require maxStalenessSeconds to be at least 90.
+:2022-10-05: Remove spec front matter and revise change log.
+:2021-09-08: Updated tests to support driver removal of support for server versions older than 3.6.
+:2021-09-03: Clarify that wire version check only applies to available servers.
+:2021-04-06: Updated to use hello command.
+:2016-09-29: Specify "no max staleness" in the URI with "maxStalenessMS=-1" instead of "maxStalenessMS=0".
+:2016-10-24: Rename option from "maxStalenessMS" to "maxStalenessSeconds".
+:2016-10-25: Change minimum maxStalenessSeconds value from 2 *
+             heartbeatFrequencyMS to heartbeatFrequencyMS + idleWritePeriodMS
+             (with proper conversions of course).
+:2016-11-21: Revert changes that would allow idleWritePeriodMS to change in the
+             future, require maxStalenessSeconds to be at least 90.

--- a/source/message/OP_MSG.rst
+++ b/source/message/OP_MSG.rst
@@ -2,19 +2,8 @@
 OP_MSG
 ======
 
-
-:Title: One opcode to rule them all
-:Author: Hannes Magnússon
-:Advisory Group: \A. Jesse Jiryu Davis, Jeremy Mikola, Mathias Stearn, Robert Stam
-:Approvers: Bernie Hackett, David Golden, Jeff Yemin, Matt broadstone
-:Informed: Bryan Reinero, Chris Hendel, drivers@
-:Status: Approved
-:Type: Standards
-:Last Modified: 2021-12-16
+:Status: Accepted
 :Minimum Server Version: 3.6
-:Version: 1.3.1
-
-
 
 .. contents::
 
@@ -621,10 +610,12 @@ Q & A
 
 Changelog
 =========
-- 2022-01-13 Clarify that ``OP_MSG`` must be used when using stable API
-- 2021-12-16 Clarify that old drivers should default to OP_QUERY handshakes
-- 2021-04-20 Suggest using OP_MSG for initial handshake when using stable API
-- 2021-04-06 Updated to use hello and not writable primary
-- 2017-11-12 Specify read preferences for OP_MSG with direct connection
-- 2017-08-17 Added the ``User originating command`` section
-- 2017-07-18 Published 1.0.0
+
+:2022-10-05: Remove spec front matter.
+:2022-01-13: Clarify that ``OP_MSG`` must be used when using stable API
+:2021-12-16: Clarify that old drivers should default to OP_QUERY handshakes
+:2021-04-20: Suggest using OP_MSG for initial handshake when using stable API
+:2021-04-06: Updated to use hello and not writable primary
+:2017-11-12: Specify read preferences for OP_MSG with direct connection
+:2017-08-17: Added the ``User originating command`` section
+:2017-07-18: Published initial version

--- a/source/mongodb-handshake/handshake.rst
+++ b/source/mongodb-handshake/handshake.rst
@@ -2,16 +2,8 @@
 MongoDB Handshake
 =================
 
-:Spec Title: MongoDB Handshake
-:Spec Version: 1.3.1
-:Author: Hannes Magnusson
-:Kernel Advisory: Mark Benvenuto
-:Driver Advisory: Anna Herlihy, Justin Lee
-:Status: Approved
-:Type: Standards
+:Status: Accepted
 :Minimum Server Version: 3.4
-:Last Modified: 2022-02-24
-
 
 .. contents::
 
@@ -509,12 +501,13 @@ Q&A
 * My language doesn't have ``uname``, but does instead provide its own variation of these values, is that OK?
    * Absolutely. As long as the value is identifiable it is fine. The exact method and values are undefined by this specification
 
-Changes
-=======
+Changelog
+=========
 
-* 2019-11-13: Added section about supporting wrapping libraries
-* 2020-02-12: Added section about speculative authentication
-* 2021-04-27: Updated to define ``hello`` and legacy hello
-* 2022-01-13: Updated to disallow ``hello`` using ``OP_QUERY``
-* 2022-01-19: Require that timeouts be applied per the client-side operations timeout spec.
-* 2022-02-24: Rename Versioned API to Stable API
+:2019-11-13: Added section about supporting wrapping libraries
+:2020-02-12: Added section about speculative authentication
+:2021-04-27: Updated to define ``hello`` and legacy hello
+:2022-01-13: Updated to disallow ``hello`` using ``OP_QUERY``
+:2022-01-19: Require that timeouts be applied per the client-side operations timeout spec.
+:2022-02-24: Rename Versioned API to Stable API
+:2022-10-05: Remove spec front matter and reformat changelog.

--- a/source/objectid.rst
+++ b/source/objectid.rst
@@ -5,17 +5,8 @@
 ObjectID format
 ===============
 
-:Spec-ticket: WRITING-2823
-:Title: ObjectID
-:Authors: Derick Rethans
-:Status: Draft
-:Type: Standards
-:Last Modified: 2019-01-14
-:Version: 0.4
-:Spec Lead: n/a
-:Advisory Group: n/a
-:Approver(s): Andy Schwerin, Bernie Hackett, Eliot Horowitz, Jeff Yemin, Jeremy Mikola, Matt Broadstone
-
+:Status: Accepted
+:Minimum Server Version: N/A
 
 .. contents::
 
@@ -180,16 +171,12 @@ Currently there is no full reference implementation yet.
 Changelog
 =========
 
-2019-01-14 — Version 0.4
-	Clarify that the random numbers don't need to be cryptographically secure.
-	Add a test to test that the unique value is different in forked processes.
-
-2018-10-11 — Version 0.3
-	Clarify that the *Timestamp* and *Counter* fields are big endian, and add
-	the reason why.
-
-2018-07-02 — Version 0.2
-	Replaced Machine ID and Process ID fields with a single 5-byte unique value
-
-2018-05-22 — Version 0.1
-	Initial Release
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2019-01-14: Clarify that the random numbers don't need to be cryptographically
+             secure. Add a test to test that the unique value is different in
+             forked processes.
+:2018-10-11: Clarify that the *Timestamp* and *Counter* fields are big endian,
+             and add the reason why.
+:2018-07-02: Replaced Machine ID and Process ID fields with a single 5-byte
+             unique value
+:2018-05-22: Initial Release

--- a/source/ocsp-support/ocsp-support.rst
+++ b/source/ocsp-support/ocsp-support.rst
@@ -2,15 +2,8 @@
 OCSP Support
 ============
 
-:Spec Title: OCSP Support
-:Spec Version: 2.1.0
-:Author: Vincent Kam
-:Lead: Jeremy Mikola
-:Advisory Group: Divjot Arora *(POC author)*, Clyde Bazile *(POC author)*, Esha Bhargava *(Program Manager)*, Matt Broadstone, Bernie Hackett *(POC author)*, Shreyas Kaylan *(Server Project Lead)*, Jeremy Mikola *(Spec Lead)*
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 4.4
-:Last Modified: 2022-01-19
 
 .. contents::
 
@@ -788,37 +781,27 @@ of checking this are:
    certificate.
 
 Changelog
-==========
+=========
 
-**2022-01-19**: 2.1.0: Require that timeouts be applied per the client-side
-operations timeout spec.
-
-**2021-04-07**: 2.0.1: Updated terminology to use allowList.
-
-**2020-07-01**: 2.0.0: Default tlsDisableOCSPEndpointCheck or
-tlsDisableCertificateRevocationCheck to true in the case that a driver's
-TLS library exhibits hard-fail behavior and add provision for
-platform-specific defaults.
-
-**2020-03-20**: 1.3.1: Clarify OCSP documentation requirements for
-drivers unable to enable OCSP by default on a per MongoClient basis.
-
-**2020-03-03**: 1.3.0: Add tlsDisableCertificateRevocationCheck URI
-option. Add Go as a reference implementation. Add hard-fail backwards
-compatibility documentation requirements.
-
-**2020-02-26**: 1.2.0: Add tlsDisableOCSPEndpointCheck URI option.
-
-**2020-02-19**: 1.1.1 Clarify behavior for reaching out to OCSP responders.
-
-**2020-02-10**: 1.1.0: Add cache requirement.
-
-**2020-01-31**: 1.0.2: Add SNI requirement and clarify design rationale
-regarding minimizing round trips.
-
-**2020-01-28**: 1.0.1: Clarify behavior regarding nonces and tolerance periods.
-
-**2020-01-16**: 1.0.0: Initial commit.
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-01-19: Require that timeouts be applied per the client-side operations timeout spec.
+:2021-04-07: Updated terminology to use allowList.
+:2020-07-01: Default tlsDisableOCSPEndpointCheck or
+             tlsDisableCertificateRevocationCheck to true in the case that a
+             driver's TLS library exhibits hard-fail behavior and add provision
+             for platform-specific defaults.
+:2020-03-20: Clarify OCSP documentation requirements for drivers unable to
+             enable OCSP by default on a per MongoClient basis.
+:2020-03-03: Add tlsDisableCertificateRevocationCheck URI option. Add Go as a
+             reference implementation. Add hard-fail backwards compatibility
+             documentation requirements.
+:2020-02-26: Add tlsDisableOCSPEndpointCheck URI option.
+:2020-02-19: Clarify behavior for reaching out to OCSP responders.
+:2020-02-10: Add cache requirement.
+:2020-01-31: Add SNI requirement and clarify design rationale regarding
+             minimizing round trips.
+:2020-01-28: Clarify behavior regarding nonces and tolerance periods.
+:2020-01-16: Initial commit.
 
 Endnotes
 ========

--- a/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
+++ b/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
@@ -5,13 +5,8 @@
 Polling SRV Records for mongos Discovery
 ========================================
 
-:Title: Polling SRV Records for mongos Discovery
-:Author: Derick Rethans
 :Status: Accepted
-:Type: Standards
-:Last Modified: 2020-10-14
-:Version: 1.2.0
-:Spec Lead: David Golden
+:Minimum Server Version: N/A
 
 .. contents::
 
@@ -237,9 +232,7 @@ No future work is expected.
 Changelog
 =========
 
-2021-10-14 - 1.2.0
-    Specify behavior for ``srvMaxHosts`` MongoClient option.
-
-2021-09-15 - 1.1.0
-    Clarify that service name only defaults to ``mongodb``, and should be
-    defined by the ``srvServiceName`` URI option.
+:2022-10-05: Revise spec front matter and reformat change log.
+:2021-10-14: Specify behavior for ``srvMaxHosts`` MongoClient option.
+:2021-09-15: Clarify that service name only defaults to ``mongodb``, and should
+             be defined by the ``srvServiceName`` URI option.

--- a/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
+++ b/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst
@@ -232,7 +232,7 @@ No future work is expected.
 Changelog
 =========
 
-:2022-10-05: Revise spec front matter and reformat change log.
+:2022-10-05: Revise spec front matter and reformat changelog.
 :2021-10-14: Specify behavior for ``srvMaxHosts`` MongoClient option.
 :2021-09-15: Clarify that service name only defaults to ``mongodb``, and should
              be defined by the ``srvServiceName`` URI option.

--- a/source/read-write-concern/read-write-concern.rst
+++ b/source/read-write-concern/read-write-concern.rst
@@ -5,15 +5,8 @@
 Read and Write Concern
 ======================
 
-:Spec: 135
-:Title: Read and Write Concern
-:Authors: Craig Wilson
-:Advisors: Jesse Davis, Hannes Magnusson, Anna Herlihy
-:Status: Approved
-:Type: Standards
-:Server Versions: 2.4+
-:Last Modified: 2022-01-19
-:Version: 1.7
+:Status: Accepted
+:Minimum Server Version: 2.4
 
 .. contents::
 
@@ -697,32 +690,36 @@ Q: Why does a driver send :javascript:`{ readConcern: { level: “local” } }` 
   user does specify a ``ReadConcern``, we do send one. If the user specifies
   level=”local”, for instance, we send it.
 
-Version History
-===============
+Changelog
+=========
 
-  - 2015-10-16: ReadConcern of local is no longer allowed to be used when talking with MaxWireVersion < 4.
-  - 2016-05-20: Added note about helpers for commands that write accepting a writeConcern parameter.
-  - 2016-06-17: Added "linearizable" to ReadConcern levels.
-  - 2016-07-15: Command-specific helper methods for commands that write SHOULD check the server's MaxWireVersion
-    and decide whether to send writeConcern.
-    Advise drivers to parse server replies for writeConcernError
-    and raise an exception if found,
-    only in command-specific helper methods that take a writeConcern parameter,
-    not in generic command methods.
-    Don't mention obscure commands with no helpers.
-  - 2016-08-06: Further clarify that command-specific helper methods for commands that write
-    take write concern options in their parameter lists, and relax from SHOULD to MAY.
-  - 2017-03-13: reIndex silently ignores writeConcern in MongoDB 3.4 and returns
-    an error if writeConcern is included with MongoDB 3.5+. See
-    `SERVER-27891 <https://jira.mongodb.org/browse/SERVER-27891>`_.
-  - 2017-11-17 : Added list of commands that support readConcern
-  - 2017-12-18 : Added "available" to Readconcern level.
-  - 2017-05-29 : Added user management commands to list of commands that write
-  - 2019-01-29 : Added section listing all known examples of writeConcernError.
-  - 2019-06-07: Clarify language for aggregate and mapReduce commands that write.
-  - 2019-10-31: Explicitly define write concern option mappings.
-  - 2020-02-13: Inconsistent write concern must be considered an error.
-  - 2021-04-07: Updated to use hello command.
-  - 2021-06-15: Added "snapshot" to Readconcern level
-  - 2021-07-12: Add missing commas after ReadConcernLevel enum values
-  - 2022-01-19: Deprecate wTimeoutMS in favor of timeoutMS.
+:2015-10-16: ReadConcern of local is no longer allowed to be used when talking
+             with MaxWireVersion < 4.
+:2016-05-20: Added note about helpers for commands that write accepting a
+             writeConcern parameter.
+:2016-06-17: Added "linearizable" to ReadConcern levels.
+:2016-07-15: Command-specific helper methods for commands that write SHOULD
+             check the server's MaxWireVersion and decide whether to send
+             writeConcern. Advise drivers to parse server replies for
+             writeConcernError and raise an exception if found, only in
+             command-specific helper methods that take a writeConcern parameter,
+             not in generic command methods. Don't mention obscure commands with
+             no helpers.
+:2016-08-06: Further clarify that command-specific helper methods for commands
+             that write take write concern options in their parameter lists, and
+             relax from SHOULD to MAY.
+:2017-03-13: reIndex silently ignores writeConcern in MongoDB 3.4 and returns an
+             error if writeConcern is included with MongoDB 3.5+. See
+             `SERVER-27891 <https://jira.mongodb.org/browse/SERVER-27891>`_.
+:2017-11-17: Added list of commands that support readConcern
+:2017-12-18: Added "available" to Readconcern level.
+:2017-05-29: Added user management commands to list of commands that write
+:2019-01-29: Added section listing all known examples of writeConcernError.
+:2019-06-07: Clarify language for aggregate and mapReduce commands that write.
+:2019-10-31: Explicitly define write concern option mappings.
+:2020-02-13: Inconsistent write concern must be considered an error.
+:2021-04-07: Updated to use hello command.
+:2021-06-15: Added "snapshot" to Readconcern level
+:2021-07-12: Add missing commas after ReadConcernLevel enum values
+:2022-01-19: Deprecate wTimeoutMS in favor of timeoutMS.
+:2022-10-05: Remove spec front matter and reformat changelog.

--- a/source/retryable-reads/retryable-reads.rst
+++ b/source/retryable-reads/retryable-reads.rst
@@ -2,16 +2,8 @@
 Retryable Reads
 ===============
 
-:Spec Title: Retryable Reads
-:Spec Version: 1.3.1
-:Author: Vincent Kam
-:Lead: Bernie Hackett
-:Advisory Group: Shane Harvey, Scott L’Hommedieu, Jeremy Mikola
-:Approvers: Jason Carey, Bernie Hackett, Shane Harvey, Eliot Horowitz, Scott L’Hommedieu, Jeremy Mikola, Dan Pasette, Jeff Yemin
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: 2022-01-25
 
 .. contents::
 
@@ -313,6 +305,9 @@ The above requirement can be fulfilled in one of two ways:
    choose to not retry and simply raise the original retryable error because
    there is no guarantee that the lower versioned server can support the
    original command.
+
+.. [1] The first and second commands will be identical unless variations in
+       parameters exist between wire/server versions.
 
 3c. If the retry attempt fails
 ''''''''''''''''''''''''''''''
@@ -685,17 +680,10 @@ degraded performance can simply disable ``retryableReads``.
 Changelog
 =========
 
-2022-01-25: Note that drivers should retry handshake network failures.
-
-2021-04-26: Replaced deprecated terminology; removed requirement to parse error message text as MongoDB 3.6+ servers will always return an error code
-
-2021-03-23: Require that PoolClearedErrors are retried
-
-2019-06-07: Mention $merge stage for aggregate alongside $out
-
-2019-05-29: Renamed InterruptedDueToStepDown to InterruptedDueToReplStateChange
-
-Endnotes
-========
-.. [1] The first and second commands will be identical unless variations in
-       parameters exist between wire/server versions.
+:2022-10-05: Remove spec front matter, move footnote, and reformat changelog.
+:2022-01-25: Note that drivers should retry handshake network failures.
+:2021-04-26: Replaced deprecated terminology; removed requirement to parse error
+             message text as MongoDB 3.6+ servers will always return an error code
+:2021-03-23: Require that PoolClearedErrors are retried
+:2019-06-07: Mention $merge stage for aggregate alongside $out
+:2019-05-29: Renamed InterruptedDueToStepDown to InterruptedDueToReplStateChange

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -2,15 +2,8 @@
 Retryable Writes
 ================
 
-:Spec Title: Retryable Writes
-:Spec Version: 1.8.1
-:Author: Jeremy Mikola
-:Lead: \A. Jesse Jiryu Davis
-:Advisors: Robert Stam, Esha Maharishi, Samantha Ritter, and Kaloian Manassiev
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 3.6
-:Last Modified: 2022-08-30
 
 .. contents::
 
@@ -803,75 +796,55 @@ command, which only happens when the retryWrites option is true on the client.
 For the driver to add the label even if retryWrites is not true would be
 inconsistent with the server and potentially confusing to developers.
 
-Changes
-=======
+Changelog
+=========
 
-2022-01-25: Note that drivers should retry handshake network failures.
-
-2021-11-02: Clarify that error labels are only specified in a top-level field of
-an error.
-
-2021-04-26: Replaced deprecated terminology
-
-2021-03-24: Require that PoolClearedErrors be retried
-
-2020-09-01: State the the driver should only add the RetryableWriteError label
-to network errors when connected to a 4.4+ server.
-
-2020-02-25: State that the driver should only add the RetryableWriteError label
-when retryWrites is on, and make it clear that mongos will sometimes perform
-internal retries and not return the RetryableWriteError label.
-
-2020-02-10: Remove redundant content in Tests section.
-
-2020-01-14: Add ExceededTimeLimit to the list of error codes that should
-receive a RetryableWriteError label.
-
-2019-10-21: Change the definition of "retryable write" to be based on the
-RetryableWriteError label. Stop requiring drivers to parse errmsg to
-categorize retryable errors for pre-4.4 servers.
-
-2019-07-30: Drivers must rewrite error messages for error code 20 when
-txnNumber is not supported by the storage engine.
-
-2019-06-07: Mention $merge stage for aggregate alongside $out
-
-2019-05-29: Renamed InterruptedDueToStepDown to InterruptedDueToReplStateChange
-
-2019-03-06: retryWrites now defaults to true.
-
-2019-03-05: Prohibit resending wire protocol messages if doing so would violate
-rules for gossipping the cluster time.
-
-2018-06-07: WriteConcernFailed is not a retryable error code.
-
-2018-04-25: Evaluate retryable eligibility of bulkWrite() commands individually.
-
-2018-03-14: Clarify that retryable writes may fail with a FCV 3.4 shard.
-
-2017-11-02: Drivers should not raise errors if selected server does not support
-retryable writes and instead fall back to non-retryable behavior. In addition to
-wire protocol version, drivers may check for ``logicalSessionTimeoutMinutes`` to
-determine if a server supports sessions and retryable writes.
-
-2017-10-26: Errors when retrying may be raised instead of the original error
-provided they allow the user to infer that an attempt was made.
-
-2017-10-23: Drivers must document operations that support retryability.
-
-2017-10-23: Raise the original retryable error if server selection or wire
-protocol checks fail during the retry attempt. Encourage drivers to provide
-intermediary write results after an unrecoverable failure during a bulk write.
-
-2017-10-18: Standalone servers do not support retryable writes.
-
-2017-10-18: Also retry writes after a "not writable primary" error.
-
-2017-10-08: Renamed ``txnNum`` to ``txnNumber`` and noted that it must be a
-64-bit integer (BSON type 0x12).
-
-2017-08-25: Drivers will maintain an allow list so that only supported write
-operations may be retried. Transaction IDs will not be included in unsupported
-write commands, irrespective of the ``retryWrites`` option.
-
-2017-08-18: ``retryWrites`` is now a MongoClient option.
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-01-25: Note that drivers should retry handshake network failures.
+:2021-11-02: Clarify that error labels are only specified in a top-level field
+             of an error.
+:2021-04-26: Replaced deprecated terminology
+:2021-03-24: Require that PoolClearedErrors be retried
+:2020-09-01: State the the driver should only add the RetryableWriteError label
+             to network errors when connected to a 4.4+ server.
+:2020-02-25: State that the driver should only add the RetryableWriteError label
+             when retryWrites is on, and make it clear that mongos will
+             sometimes perform internal retries and not return the
+             RetryableWriteError label.
+:2020-02-10: Remove redundant content in Tests section.
+:2020-01-14: Add ExceededTimeLimit to the list of error codes that should
+             receive a RetryableWriteError label.
+:2019-10-21: Change the definition of "retryable write" to be based on the
+             RetryableWriteError label. Stop requiring drivers to parse errmsg
+             to categorize retryable errors for pre-4.4 servers.
+:2019-07-30: Drivers must rewrite error messages for error code 20 when
+             txnNumber is not supported by the storage engine.
+:2019-06-07: Mention $merge stage for aggregate alongside $out
+:2019-05-29: Renamed InterruptedDueToStepDown to InterruptedDueToReplStateChange
+:2019-03-06: retryWrites now defaults to true.
+:2019-03-05: Prohibit resending wire protocol messages if doing so would violate
+             rules for gossipping the cluster time.
+:2018-06-07: WriteConcernFailed is not a retryable error code.
+:2018-04-25: Evaluate retryable eligibility of bulkWrite() commands individually.
+:2018-03-14: Clarify that retryable writes may fail with a FCV 3.4 shard.
+:2017-11-02: Drivers should not raise errors if selected server does not support
+             retryable writes and instead fall back to non-retryable behavior.
+             In addition to wire protocol version, drivers may check for
+             ``logicalSessionTimeoutMinutes`` to determine if a server supports
+             sessions and retryable writes.
+:2017-10-26: Errors when retrying may be raised instead of the original error
+             provided they allow the user to infer that an attempt was made.
+:2017-10-23: Drivers must document operations that support retryability.
+:2017-10-23: Raise the original retryable error if server selection or wire
+             protocol checks fail during the retry attempt. Encourage drivers to
+             provide intermediary write results after an unrecoverable failure
+             during a bulk write.
+:2017-10-18: Standalone servers do not support retryable writes.
+:2017-10-18: Also retry writes after a "not writable primary" error.
+:2017-10-08: Renamed ``txnNum`` to ``txnNumber`` and noted that it must be a
+             64-bit integer (BSON type 0x12).
+:2017-08-25: Drivers will maintain an allow list so that only supported write
+             operations may be retried. Transaction IDs will not be included in
+             unsupported write commands, irrespective of the ``retryWrites``
+             option.
+:2017-08-18: ``retryWrites`` is now a MongoClient option.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst
@@ -5,16 +5,8 @@
 SDAM Monitoring Specification
 =============================
 
-:Spec: 222
-:Title: SDAM Monitoring Specification
-:Spec Version: Same as the `Server Discovery And Monitoring`_ spec
-:Author: Durran Jordan
-:Spec Lead: Durran Jordan
-:Advisory Group: Jeff Yemin, Craig Wilson, Jesse Davis
-:Status: Approved
-:Type: Standards
+:Status: Accepted
 :Minimum Server Version: 2.4
-:Last Modified: 06-May-2021
 
 .. contents::
 
@@ -427,11 +419,14 @@ See the `README <https://github.com/mongodb/specifications/server-discovery-and-
 Changelog
 =========
 
-- 06 MAY 2021: Updated to use modern terminology.
-- 20 APR 2020: Add rules for streaming heartbeat protocol and add "awaited" field to heartbeat events.
-- 12 DEC 2018: Clarified table of rules for readable/writable servers
-- 31 AUG 2016: Added table of rules for determining if topology has readable/writable servers.
-- 11 OCT 2016: TopologyDescription objects MAY have additional methods and properties.
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2021-05-06: Updated to use modern terminology.
+:2020-04-20: Add rules for streaming heartbeat protocol and add "awaited" field to heartbeat events.
+:2018:12-12: Clarified table of rules for readable/writable servers
+:2016-08-31: Added table of rules for determining if topology has readable/writable servers.
+:2016-10-11: TopologyDescription objects MAY have additional methods and properties.
+
+----
 
 .. Section for links.
 

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-summary.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-summary.rst
@@ -2,13 +2,8 @@
 Server Discovery And Monitoring -- Summary
 ==========================================
 
-:Spec: 101
-:Title: Server Discovery And Monitoring
-:Author: A\. Jesse Jiryu Davis
-:Advisors: David Golden, Craig Wilson
-:Status: Draft
-:Type: Standards
-:Last Modified: June 21, 2021
+:Status: Accepted
+:Minimum Server Version: 2.4
 
 .. contents::
 
@@ -221,3 +216,8 @@ and single-threaded clients MUST request a scan before the next operation.
 The client MUST clear its connection pool for the server if the
 server is 4.0 or earlier, and MUST NOT clear its connection pool for the
 server if the server is 4.2 or later.
+
+Changelog
+---------
+
+:2022-10-05: Revise spec front matter and add changelog.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.rst
@@ -2,13 +2,8 @@
 Server Discovery And Monitoring -- Test Plan
 ============================================
 
-:Spec: 101
-:Title: Server Discovery And Monitoring
-:Author: A\. Jesse Jiryu Davis
-:Advisors: David Golden, Craig Wilson
-:Status: Draft
-:Type: Standards
-:Last Modified: June 21, 2021
+:Status: Accepted
+:Minimum Server Version: 2.4
 
 See also the YAML test files and their accompanying README in the "tests"
 directory.

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -2,14 +2,8 @@
 Server Discovery And Monitoring
 ===============================
 
-:Spec: 101
-:Title: Server Discovery And Monitoring
-:Author: A\. Jesse Jiryu Davis
-:Advisors: David Golden, Craig Wilson
 :Status: Accepted
-:Type: Standards
-:Version: 2.35
-:Last Modified: 2022-09-30
+:Minimum Server Version: 2.4
 
 .. contents::
 
@@ -153,6 +147,9 @@ Also known as RTT.
 The client's measurement of the duration of one hello or legacy hello call.
 The round trip time is used to support the "localThresholdMS" [1]_
 option in the Server Selection Spec.
+
+.. [1] "localThresholdMS" was called "secondaryAcceptableLatencyMS" in the Read
+   Preferences Spec, before it was superseded by the Server Selection Spec.
 
 hello or legacy hello outcome
 `````````````````````````````
@@ -2483,92 +2480,61 @@ Mathias Stearn's beautiful design for replica set monitoring in mongos 2.6
 contributed as well.
 Bernie Hackett gently oversaw the specification process.
 
-Changes
--------
+Changelog
+---------
 
+:2015-12-17: Require clients to compare (setVersion, electionId) tuples.
+:2015-10-09: Specify electionID comparison method.
+:2015-06-16: Added cooldownMS.
+:2016-05-04: Added link to SDAM monitoring.
+:2016-07-18: Replace mentions of the "Read Preferences Spec" with "Server
+             Selection Spec", and "secondaryAcceptableLatencyMS" with
+             "localThresholdMS".
+:2016-07-21: Updated for Max Staleness support.
+:2016-08-04: Explain better why clients use the hostnames in RS config, not URI.
+:2016-08-31: Multi-threaded clients SHOULD use hello or legacy hello replies to
+             update the topology when they handshake application connections.
+:2016-10-06: In updateRSWithoutPrimary the hello or legacy hello response's
+             "primary" field should be used to update the topology description,
+             even if address != me.
+:2016-10-29: Allow for idleWritePeriodMS to change someday.
+:2016-11-01: "Unknown" is no longer the default TopologyType, the default is now
+             explicitly unspecified. Update instructions for setting the initial
+             TopologyType when running the spec tests.
+:2016-11-21: Revert changes that would allow idleWritePeriodMS to change in the
+             future.
+:2017-02-28: Update "network error when reading or writing": timeout while
+             connecting does mark a server Unknown, unlike a timeout while
+             reading or writing. Justify the different behaviors, and also
+             remove obsolete reference to auto-retry.
+:2017-06-13: Move socketCheckIntervalMS to Server Selection Spec.
+:2017-08-01: Parse logicalSessionTimeoutMinutes from hello or legacy hello reply.
+:2017-08-11: Clearer specification of "incompatible" logic.
+:2017-09-01: Improved incompatibility error messages.
+:2018-03-28: Specify that monitoring must not do mechanism negotiation or authentication.
+:2019-05-29: Renamed InterruptedDueToStepDown to InterruptedDueToReplStateChange
+:2020-02-13: Drivers must run SDAM flow even when server description is equal to
+             the last one.
+:2020-03-31: Add topologyVersion to ServerDescription. Add rules for ignoring
+             stale application errors.
+:2020-05-07: Include error field in ServerDescription equality comparison.
+:2020-06-08: Clarify reasoning behind how SDAM determines if a topologyVersion is stale.
+:2020-12-17: Mark the pool for a server as "ready" after performing a successful
+             check. Synchronize pool clearing with SDAM updates.
+:2021-01-17: Require clients to compare (electionId, setVersion) tuples.
+:2021-02-11: Errors encountered during auth are handled by SDAM. Auth errors
+             mark the server Unknown and clear the pool.
+:2021-04-12: Adding in behaviour for load balancer mode.
+:2021-05-03: Require parsing "isWritablePrimary" field in responses.
+:2021-06-09: Connection pools must be created and eventually marked ready for
+             any server if a direct connection is used.
+:2021-06-29: Updated to use modern terminology.
+:2022-01-19: Add iscryptd and 90th percentile RTT fields to ServerDescription.
+:2022-07-11: Convert integration tests to the unified format.
+:2022-09-30: Update ``updateRSFromPrimary`` to include logic before and after 6.0 servers
+:2022-10-05: Remove spec front matter, move footnote, and reformat changelog.
 
-2015-12-17: Require clients to compare (setVersion, electionId) tuples.
-
-2015-10-09: Specify electionID comparison method.
-
-2015-06-16: Added cooldownMS.
-
-2016-05-04: Added link to SDAM monitoring.
-
-2016-07-18: Replace mentions of the "Read Preferences Spec" with "Server Selection Spec",
-  and "secondaryAcceptableLatencyMS" with "localThresholdMS".
-
-.. [1] "localThresholdMS" was called "secondaryAcceptableLatencyMS" in the Read Preferences Spec,
-  before it was superseded by the Server Selection Spec.
-
-2016-07-21: Updated for Max Staleness support.
-
-2016-08-04: Explain better why clients use the hostnames in RS config, not URI.
-
-2016-08-31: Multi-threaded clients SHOULD use hello or legacy hello replies to update the topology
-  when they handshake application connections.
-
-2016-10-06: in updateRSWithoutPrimary the hello or legacy hello response's "primary" field
-  should be used to update the topology description, even if address != me.
-
-2016-10-29: Allow for idleWritePeriodMS to change someday.
-
-2016-11-01: "Unknown" is no longer the default TopologyType, the default is now
-  explicitly unspecified. Update instructions for setting the initial
-  TopologyType when running the spec tests.
-
-2016-11-21: Revert changes that would allow idleWritePeriodMS to change in the
-future.
-
-2017-02-28: Update "network error when reading or writing": timeout while
-connecting does mark a server Unknown, unlike a timeout while reading or
-writing. Justify the different behaviors, and also remove obsolete reference
-to auto-retry.
-
-2017-06-13: Move socketCheckIntervalMS to Server Selection Spec.
-
-2017-08-01: Parse logicalSessionTimeoutMinutes from hello or legacy hello reply.
-
-2017-08-11: Clearer specification of "incompatible" logic.
-
-2017-09-01: Improved incompatibility error messages.
-
-2018-03-28: Specify that monitoring must not do mechanism negotiation or
-authentication.
-
-2019-05-29: Renamed InterruptedDueToStepDown to InterruptedDueToReplStateChange
-
-2020-02-13: Drivers must run SDAM flow even when server description is equal
-to the last one.
-
-2020-03-31: Add topologyVersion to ServerDescription. Add rules for ignoring
-stale application errors.
-
-2020-05-07: Include error field in ServerDescription equality comparison.
-
-2020-06-08: Clarify reasoning behind how SDAM determines if a topologyVersion is stale.
-
-2020-12-17: Mark the pool for a server as "ready" after performing a successful
-check. Synchronize pool clearing with SDAM updates.
-
-2021-01-17: Require clients to compare (electionId, setVersion) tuples.
-
-2021-2-11: Errors encountered during auth are handled by SDAM. Auth errors
-mark the server Unknown and clear the pool.
-
-2021-4-12: Adding in behaviour for load balancer mode.
-
-2021-05-03: Require parsing "isWritablePrimary" field in responses.
-
-2021-06-09: Connection pools must be created and eventually marked ready for any server if a direct connection is used.
-
-2021-06-29: Updated to use modern terminology.
-
-2022-01-19: Add iscryptd and 90th percentile RTT fields to ServerDescription.
-
-2022-07-11: Convert integration tests to the unified format.
-
-2022-30-09: Update ``updateRSFromPrimary`` to include logic before and after 6.0 servers
+----
 
 .. Section for links.
 

--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -2,12 +2,8 @@
 Server Monitoring
 =================
 
-:Spec: 1580
-:Title: Server Monitoring
 :Status: Accepted
-:Type: Standards
-:Version: Same as the `Server Discovery And Monitoring`_ spec
-:Last Modified: 2022-06-24
+:Minimum Server Version: 2.4
 
 .. contents::
 
@@ -1143,29 +1139,22 @@ awaitable hello or legacy hello heartbeat in the new protocol.
 Changelog
 ---------
 
-- 2021-06-24: Remove optimization mention that no longer applies
+:2020-02-20: Extracted server monitoring from SDAM into this new spec.
+:2020-03-09: A monitor check that creates a new connection MUST use the
+             connection's handshake to update the topology.
+:2020-04-20: Add streaming heartbeat protocol.
+:2020-05-20: Include rationale for why we don't use `awaitedTimeMS`
+:2020-06-11: Support connectTimeoutMS=0 in streaming heartbeat protocol.
+:2020-12-17: Mark the pool for a server as "ready" after performing a successful
+             check. Synchronize pool clearing with SDAM updates.
+:2021-06-21: Added support for hello/helloOk to handshake and monitoring.
+:2021-06-24: Remove optimization mention that no longer applies
+:2022-01-19: Add 90th percentile RTT tracking.
+:2022-02-24: Rename Versioned API to Stable API
+:2022-04-05: Preemptively cancel in progress operations when SDAM heartbeats timeout.
+:2022-10-05: Remove spec front matter reformat changelog.
 
-- 2021-06-21: Added support for hello/helloOk to handshake and monitoring.
-
-- 2020-12-17: Mark the pool for a server as "ready" after performing a successful
-  check. Synchronize pool clearing with SDAM updates.
-
-- 2020-06-11 Support connectTimeoutMS=0 in streaming heartbeat protocol.
-
-- 2020-05-20 Include rationale for why we don't use `awaitedTimeMS`
-
-- 2020-04-20 Add streaming heartbeat protocol.
-
-- 2020-03-09 A monitor check that creates a new connection MUST use the
-  connection's handshake to update the topology.
-
-- 2020-02-20 Extracted server monitoring from SDAM into this new spec.
-
-- 2022-01-19 Add 90th percentile RTT tracking.
-
-- 2022-02-24: Rename Versioned API to Stable API
-
-- 2022-04-05: Preemptively cancel in progress operations when SDAM heartbeats timeout.
+----
 
 .. Section for links.
 

--- a/source/server-selection/server-selection-tests.rst
+++ b/source/server-selection/server-selection-tests.rst
@@ -2,13 +2,8 @@
 Server Selection -- Test Plan
 =============================
 
-:Spec: 103
-:Title: Server Selection
-:Author: Samantha Ritter
-:Advisors: David Golden
 :Status: Accepted
-:Type: Standards
-:Last Modified: 2022-01-19
+:Minimum Server Version: 2.4
 
 See also the YAML test files and their accompanying README in the "tests"
 directory.

--- a/source/server-selection/server-selection.rst
+++ b/source/server-selection/server-selection.rst
@@ -2,15 +2,8 @@
 Server Selection
 ================
 
-:Spec: 103
-:Title: Server Selection
-:Author: David Golden
-:Lead: Bernie Hackett
-:Advisors: \A. Jesse Jiryu Davis, Samantha Ritter, Robert Stam, Jeff Yemin
 :Status: Accepted
-:Type: Standards
-:Last Modified: 2022-01-19
-:Version: 1.14.0
+:Minimum Server Version: 2.4
 
 .. contents::
 
@@ -490,6 +483,9 @@ eligibility MUST be determined from ``maxStalenessSeconds`` as follows:
 
 See the Max Staleness Spec for overall description and justification of this
 feature.
+
+.. [#] mongos 3.4 refuses to connect to mongods with maxWireVersion < 5,
+   so it does no additional wire version checks related to maxStalenessSeconds.
 
 .. _algorithm for filtering by tag_sets:
 
@@ -1822,76 +1818,53 @@ References
 .. _Connection Monitoring and Pooling: /source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
 .. _Global Command Argument: /source/message/OP_MSG.rst#global-command-arguments
 
-Changes
-=======
+Changelog
+=========
 
-2021-08-05: Updated $readPreference logic to describe OP_MSG behavior.
-
-2015-06-26: Updated single-threaded selection logic with "stale" and serverSelectionTryOnce.
-
-2015-08-10: Updated single-threaded selection logic to ensure a scan always
-happens at least once under serverSelectionTryOnce if selection fails.
-Removed the general selection algorithm and put full algorithms for each of
-the single- and multi-threaded sections. Added a requirement that
-single-threaded drivers document selection time expectations.
-
-2016-07-21: Updated for Max Staleness support.
-
-2016-08-03: Clarify selection algorithm, in particular that maxStalenessMS
-comes before tag_sets.
-
-2016-10-24: Rename option from "maxStalenessMS" to "maxStalenessSeconds".
-
-2016-10-25: Change minimum maxStalenessSeconds value from 2 * heartbeatFrequencyMS
-to heartbeatFrequencyMS + idleWritePeriodMS (with proper conversions of course).
-
-2016-11-01: Update formula for secondary staleness estimate with the
-equivalent, and clearer, expression of this formula from the Max Staleness Spec
-
-2016-11-21: Revert changes that would allow idleWritePeriodMS to change in the
-future, require maxStalenessSeconds to be at least 90.
-
-2017-06-07: Clarify socketCheckIntervalMS behavior, single-threaded drivers
-must retry selection after checking an idle socket and discovering it is broken.
-
-2017-11-10: Added application-configurated server selector.
-
-2017-11-12: Specify read preferences for OP_MSG with direct connection, and
-delete obsolete comment direct connections to secondaries getting "not writable
-primary" errors by design.
-
-2018-01-22: Clarify that $query wrapping is only for OP_QUERY
-
-2018-01-22: Clarify that $out on aggregate follows the "$out Aggregation
-Pipeline Operator" spec and warns if read preference is not primary.
-
-2018-01-29: Remove reference to '$out Aggregation spec'. Clarify runCommand
-selection rules.
-
-2018-12-13: Update tag_set example to use only String values
-
-2019-05-20: Added rule to not send read preferene to standalone servers
-
-2019-06-07: Clarify language for aggregate and mapReduce commands that write
-
-2020-03-17: Specify read preferences with support for server hedged reads
-
-2020-10-10: Consider server load when selecting servers within the latency
-window.
-
-2021-04-07: Adding in behaviour for load balancer mode.
-
-2021-05-12: Removed deprecated URI option in favour of readPreference=secondaryPreferred.
-
-2021-05-13: Updated to use modern terminology.
-
-2021-09-03: Clarify that wire version check only applies to available servers.
-
-2021-09-28: Note that 5.0+ secondaries support aggregate with write stages (e.g.
-``$out`` and ``$merge``). Clarify setting ``SecondaryOk` wire protocol flag or
-``$readPreference`` global command argument for replica set topology.
-
-2022-01-19: Require that timeouts be applied per the client-side operations timeout spec
-
-.. [#] mongos 3.4 refuses to connect to mongods with maxWireVersion < 5,
-   so it does no additional wire version checks related to maxStalenessSeconds.
+:2015-06-26: Updated single-threaded selection logic with "stale" and serverSelectionTryOnce.
+:2015-08-10: Updated single-threaded selection logic to ensure a scan always
+             happens at least once under serverSelectionTryOnce if selection
+             fails. Removed the general selection algorithm and put full
+             algorithms for each of the single- and multi-threaded sections.
+             Added a requirement that single-threaded drivers document selection
+             time expectations.
+:2016-07-21: Updated for Max Staleness support.
+:2016-08-03: Clarify selection algorithm, in particular that maxStalenessMS
+             comes before tag_sets.
+:2016-10-24: Rename option from "maxStalenessMS" to "maxStalenessSeconds".
+:2016-10-25: Change minimum maxStalenessSeconds value from 2 *
+             heartbeatFrequencyMS to heartbeatFrequencyMS + idleWritePeriodMS
+             (with proper conversions of course).
+:2016-11-01: Update formula for secondary staleness estimate with the
+             equivalent, and clearer, expression of this formula from the Max
+             Staleness Spec
+:2016-11-21: Revert changes that would allow idleWritePeriodMS to change in the
+             future, require maxStalenessSeconds to be at least 90.
+:2017-06-07: Clarify socketCheckIntervalMS behavior, single-threaded drivers
+             must retry selection after checking an idle socket and discovering
+             it is broken.
+:2017-11-10: Added application-configurated server selector.
+:2017-11-12: Specify read preferences for OP_MSG with direct connection, and
+             delete obsolete comment direct connections to secondaries getting
+             "not writable primary" errors by design.
+:2018-01-22: Clarify that $query wrapping is only for OP_QUERY
+:2018-01-22: Clarify that $out on aggregate follows the "$out Aggregation
+             Pipeline Operator" spec and warns if read preference is not primary.
+:2018-01-29: Remove reference to '$out Aggregation spec'. Clarify runCommand
+             selection rules.
+:2018-12-13: Update tag_set example to use only String values
+:2019-05-20: Added rule to not send read preferene to standalone servers
+:2019-06-07: Clarify language for aggregate and mapReduce commands that write
+:2020-03-17: Specify read preferences with support for server hedged reads
+:2020-10-10: Consider server load when selecting servers within the latency window.
+:2021-04-07: Adding in behaviour for load balancer mode.
+:2021-05-12: Removed deprecated URI option in favour of readPreference=secondaryPreferred.
+:2021-05-13: Updated to use modern terminology.
+:2021-08-05: Updated $readPreference logic to describe OP_MSG behavior.
+:2021-09-03: Clarify that wire version check only applies to available servers.
+:2021-09-28: Note that 5.0+ secondaries support aggregate with write stages
+             (e.g. ``$out`` and ``$merge``). Clarify setting ``SecondaryOk` wire
+             protocol flag or ``$readPreference`` global command argument for
+             replica set topology.
+:2022-01-19: Require that timeouts be applied per the client-side operations timeout spec
+:2022-10-05: Remove spec front matter, move footnote, and reformat changelog.

--- a/source/server_write_commands.rst
+++ b/source/server_write_commands.rst
@@ -2,9 +2,8 @@
 Write Commands Specification
 ============================
 
-:last modified: July 25, 2022
-:version: 0.9.2
-:status: Approved
+:Status: Accepted
+:Minimum Server Version: 2.6
 
 .. contents::
 
@@ -495,21 +494,10 @@ Yes but as of 2.6 the existing getLastError behavior is supported for backward c
 Changelog
 ---------
 
-v0.8
-~~~~
-* First public version
-
-v0.9
-~~~~
-* Removed text related to bulk operations; see the Bulk API spec for bulk details
-* Clarified some paragraphs; re-ordered the response field sections
-
-v0.9.1
-~~~~~~
-* Updated to use hello command
-
-v0.9.2
-~~~~~~
-* Remove outdated value for ``maxWriteBatchSize``
-
-..  LocalWords:  boolean ie
+:2014-05-14: First public version
+:2014-05-15: Removed text related to bulk operations; see the Bulk API spec for
+             bulk details. Clarified some paragraphs; re-ordered the response
+             field sections.
+:2021-04-22: Updated to use hello command
+:2022-07-25: Remove outdated value for ``maxWriteBatchSize``
+:2022-10-05: Revise spec front matter and reformat changelog.

--- a/source/serverless-testing/README.rst
+++ b/source/serverless-testing/README.rst
@@ -2,6 +2,9 @@
 Atlas Serverless Tests
 ======================
 
+:Status: Accepted
+:Minimum Server Version: N/A
+
 .. contents::
 
 ----
@@ -146,6 +149,6 @@ proxy, so their spec and prose tests MUST be skipped.
 Changelog
 =========
 
+:2022-10-05: Add spec front matter
 :2022-04-22: Testing uses a load balancer fronting a single proxy.
 :2021-08-25: Update tests for load balanced serverless instances.
-

--- a/source/sessions/driver-sessions.rst
+++ b/source/sessions/driver-sessions.rst
@@ -2,17 +2,8 @@
 Driver Sessions Specification
 =============================
 
-:Spec Title: Driver Sessions Specification (See the registry of specs)
-:Spec Version: 1.9.2
-:Author: Robert Stam
-:Spec Lead: A\. Jesse Jiryu Davis
-:Advisory Group: Jeremy Mikola, Jeff Yemin, Samantha Ritter
-:Approver(s): A\. Jesse Jiryu Davis, Jeff Yemin, Bernie Hackett, David Golden, Eliot
-:Informed: drivers@, Bryan Reinero, Christopher Hendel
-:Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
-:Type: Standards
-:Minimum Server Version: 3.6 (The minimum server version this spec applies to)
-:Last Modified: 2022-06-13
+:Status: Accepted
+:Minimum Server Version: 3.6
 
 .. contents::
 
@@ -1163,8 +1154,8 @@ There are a variety of cases, such as retryable operations or cursor creating op
 where a ``serverSession`` must remain acquired by the ``ClientSession`` after an operation is attempted.
 Attempting to account for all these scenarios has risks that do not justify the potential guaranteed ``ServerSession`` allocation limiting.
 
-Change log
-==========
+Changelog
+=========
 
 :2017-09-13: If causalConsistency option is omitted assume true
 :2017-09-16: Omit session ID when opening and authenticating a connection
@@ -1195,3 +1186,4 @@ Change log
 :2022-01-28: Implicit sessions MUST obtain server session after connection checkout succeeds
 :2022-03-24: ServerSession Pooling is required and clarifies session acquisition bounding
 :2022-06-13: Move prose tests to test README and apply new ordering
+:2022-10-05: Remove spec front matter

--- a/source/sessions/snapshot-sessions.rst
+++ b/source/sessions/snapshot-sessions.rst
@@ -2,14 +2,8 @@
 Snapshot Reads Specification
 ============================
 
-:Spec Title: Snapshot Reads Specification
-:Spec Version: 1.2.2
-:Author: Boris Dogadov
-:Advisors: Jeff Yemin, A. Jesse Jiryu Davis, Judah Schvimer
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 5.0
-:Last Modified: 09-Aug-2021
 
 .. contents::
 
@@ -290,3 +284,4 @@ Changelog
 :2021-06-29: Send readConcern with all snapshot session commands.
 :2021-07-16: Grammar revisions. Change SHOULD to MUST for startTransaction error to comply with existing tests.
 :2021-08-09: Updated client-side error spec tests to use correct syntax for ``test.expectEvents``
+:2022-10-05: Remove spec front matter

--- a/source/socks5-support/socks5.rst
+++ b/source/socks5-support/socks5.rst
@@ -2,14 +2,8 @@
 SOCKS5 Support
 ==============
 
-:Spec Title: SOCKS5 Support
-:Spec Version: 1.0.0
-:Author: Anna Henningsen
-:Advisors: Neal Beeken
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2021-12-14
 
 .. contents::
 
@@ -188,5 +182,7 @@ Design Rationales
 Alternative Designs
 -------------------
 
-Change Log
-==========
+Changelog
+=========
+
+:2022-10-05: Remove spec front matter

--- a/source/transactions-convenient-api/transactions-convenient-api.rst
+++ b/source/transactions-convenient-api/transactions-convenient-api.rst
@@ -2,15 +2,8 @@
 Convenient API for Transactions
 ===============================
 
-:Spec Title: Convenient API for Transactions
-:Spec Version: 1.3
-:Author: Jeremy Mikola
-:Lead: Jeff Yemin
-:Advisors: A\. Jesse Jiryu Davis, Kris Brandow, Oleg Pudeyev, Sam Ritter, Tess Avitabile
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: 4.0
-:Last Modified: 2022-01-19
 
 .. contents::
 
@@ -501,10 +494,8 @@ client-side operation timeout, withTransaction can continue to use the
 Changes
 =======
 
-2022-01-19: withTransaction applies timeouts per the client-side
-            operations timeout specification.
-
-2019-04-24: withTransaction does not retry when commit fails with
-            MaxTimeMSExpired.
-
-2018-02-13: withTransaction should retry commits after a wtimeout
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-01-19: withTransaction applies timeouts per the client-side operations
+             timeout specification.
+:2019-04-24: withTransaction does not retry when commit fails with MaxTimeMSExpired.
+:2018-02-13: withTransaction should retry commits after a wtimeout

--- a/source/transactions/transactions.rst
+++ b/source/transactions/transactions.rst
@@ -2,17 +2,8 @@
 Driver Transactions Specification
 =================================
 
-:Spec Title: Driver Transactions Specification
-:Spec Version: 1.8.0
-:Author: Shane Harvey
-:Spec Lead: A\. Jesse Jiryu Davis
-:Advisory Group: A\. Jesse Jiryu Davis, Matt Broadstone, Robert Stam, Jeff Yemin, Spencer Brody
-:Approver(s): A\. Jesse Jiryu Davis, Andrew Morrow, Bernie Hackett, Dan Pasette, Jeff Yemin, Robert Stam, Spencer Brody, Tess Avitabile
-:Informed: drivers@
-:Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
-:Type: Standards
-:Minimum Server Version: 4.0 (The minimum server version this spec applies to)
-:Last Modified: 2022-01-25
+:Status: Accepted
+:Minimum Server Version: 4.0
 
 .. contents::
 
@@ -1416,8 +1407,10 @@ durable, which achieves the primary objective of avoiding duplicate commits.
 **Changelog**
 -------------
 
+:2022-10-05: Remove spec front matter and reformat changelog
 :2022-01-25: Mention the additional case of a retryable handshake error
 :2022-01-19: Deprecate maxCommitTimeMS in favor of timeoutMS.
+:2021-04-12: Adding in behaviour for load balancer mode.
 :2020-04-07: Clarify that all abortTransaction attempts should unpin the session,
              even if the command is not executed.
 :2020-04-07: Specify that sessions should be unpinned once a transaction is aborted.
@@ -1436,4 +1429,3 @@ durable, which achieves the primary objective of avoiding duplicate commits.
 :2018-06-07: The count command is not supported within transactions.
 :2018-06-14: Any retryable writes error raised by commitTransaction must be
              labelled "UnknownTransactionCommitResult".
-:2021-04-12: Adding in behaviour for load balancer mode.

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -2,14 +2,9 @@
 Unified Test Format
 ===================
 
-:Spec Title: Unified Test Format
-:Spec Version: 1.11.0
-:Author: Jeremy Mikola
-:Advisors: Prashant Mital, Isabel Atkinson, Thomas Reggi
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2022-09-02
+:Current Schema Version: 1.11.0
 
 .. contents::
 
@@ -107,7 +102,7 @@ example: if an additive change is made to version 1.0 of the spec, the
 ``schema-1.0.json`` file will be copied to ``schema-1.1.json`` and modified
 accordingly. A new or existing test file using `schemaVersion`_ "1.0" would then
 be expected to validate against both schema files. Schema version bumps MUST be
-noted in the `Change Log`_.
+noted in the `Changelog`_.
 
 A particular minor version MUST be capable of validating any and all test files
 in that major version series up to and including the minor version. For example,
@@ -3670,7 +3665,7 @@ Breaking Changes
 
 This section is reserved for future use. Any breaking changes to the test format
 SHOULD be described here in detail for historical reference, in addition to any
-shorter description that may be added to the `Change Log`_.
+shorter description that may be added to the `Changelog`_.
 
 
 Future Work
@@ -3748,12 +3743,17 @@ better processes can be established for versioning other specs *and* collating
 spec changes developed in parallel or during the same release cycle.
 
 
-Change Log
-==========
+Changelog
+=========
 
+..
+  Please note schema version bumps in changelog entries where applicable.
+
+:2022-10-05: Remove spec front matter, add "Current Schema Version" field, and
+             reformat changelog. Add comment to remind editors to note schema
+             version bumps in changelog updates (where applicable).
 :2022-09-02: **Schema version 1.11.**
              Add ``interruptInUseConnections`` field to ``poolClearedEvent``
-
 :2022-07-28: **Schema version 1.10.**
              Add support for ``thread`` entities (``runOnThread``,
              ``waitForThread``), TopologyDescription entities
@@ -3761,70 +3761,50 @@ Change Log
              ``assertTopologyType``), testRunner event assertion operations
              (``waitForEvent``, ``assertEventCount``), expected SDAM events, and
              the ``wait`` operation.
-
 :2022-07-27: Retroactively note schema version bumps in the change log and
              require doing so for future changes.
-
 :2022-07-11: Update `Future Work`_ to reflect that support for ignoring extra
              observed events was added in schema version 1.7.
-
 :2022-06-16: Require server 4.2+ for ``csfle: true``.
-
 :2022-05-10: Add reference to Client Side Encryption spec under
              `ClientEncryption Operations`_.
-
 :2022-04-27: **Schema version 1.9.**
              Added ``createOptions`` field to ``initialData``, introduced a new
              ``timeoutMS`` field in ``collectionOrDatabaseOptions``, and added
              an ``isTimeoutError`` field to ``expectedError``. Also introduced
              the ``createEntities`` operation.
-
 :2022-04-27: **Schema version 1.8.**
              Add ``runOnRequirement.csfle``.
-
 :2022-04-26: Add ``clientEncryption`` entity and ``$$placeholder`` syntax.
-
 :2022-04-22: Revise ``useMultipleMongoses`` and "Initializing the Test Runner"
              for Atlas Serverless URIs using a load balancer fronting a single
              proxy.
-
 :2022-03-01: **Schema version 1.7.**
              Add ``ignoreExtraEvents`` field to ``expectedEventsForClient``.
-
 :2022-02-24: Rename Versioned API to Stable API
-
 :2021-08-30: **Schema version 1.6.**
              Add ``hasServerConnectionId`` field to ``commandStartedEvent``,
              ``commandSuccededEvent`` and ``commandFailedEvent``.
-
 :2021-08-30: Test runners may create an internal MongoClient for each mongos.
              Better clarify how internal MongoClients may be used.
              Clarify that drivers creating an internal MongoClient for each
              mongos should use those clients for ``targetedFailPoint``
              operations.
-
 :2021-08-23: Allow ``runOnRequirement`` conditions to be evaluated in any order.
-
 :2021-08-09: Updated all existing schema files to require at least one element
              in ``test.expectEvents`` if specified.
-
 :2021-07-29: Note that events for sensitive commands will have redacted
              commands and replies when using ``observeSensitiveCommands``, and
              how that affects conditionally sensitive commands such as ``hello``
              and legacy hello.
-
 :2021-07-01: Note that ``expectError.expectResult`` should use
              ``$$unsetOrMatches`` when the result is optional.
-
 :2021-06-09: **Schema version 1.5.**
              Added an ``observeSensitiveCommands`` property to the ``client``
              entity type.
-
 :2021-05-17: Ensure old JSON schema files remain in place
-
 :2021-04-19: **Schema version 1.4.**
              Introduce ``serverless`` `runOnRequirement`_.
-
 :2021-04-12: **Schema version 1.3.**
              Added a ``FindCursor`` entity type. Defined a set of cursor
              operations. Added an ``auth`` property to ``runOnRequirements``
@@ -3832,30 +3812,22 @@ Change Log
              ``load-balanced``. Added CMAP events to the possible event types
              for ``expectedEvent``. Add ``assertNumberConnectionsCheckedOut``
              operation. Add ``ignoreResultAndError`` operation option.
-
 :2021-04-08: List additional error codes that may be ignored when calling
              ``killAllSessions`` and note that the command should not be called
              when connected to Atlas.
-
 :2021-03-22: Split ``serverApi`` into its own section. Note types for ``loop``
              operation arguments. Clarify how ``loop`` iterations are counted
              for ``storeIterationsAsEntity``.
-
 :2021-03-10: Clarify that ``observedAt`` field measures time in seconds for
              ``storeEventsAsEntities``.
-
 :2021-03-09: Clarify which components of a version string are relevant for
              comparisons.
-
 :2021-03-04: Change ``storeEventsAsEntities`` from a map to an array of
              ``storeEventsAsEntity`` objects.
-
 :2021-03-01: **Schema version 1.2.**
              Added ``storeEventsAsEntities`` option for client entities and
              ``loop`` operation, which is needed for Atlas Driver Testing.
-
 :2020-12-23: Clarify how JSON schema is renamed for new minor versions.
-
 :2020-11-06: **Schema version 1.1.**
              Added ``serverApi`` option for client entities, ``_yamlAnchors``
              property to define values for later use in YAML tests, and

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3761,7 +3761,7 @@ Changelog
              ``assertTopologyType``), testRunner event assertion operations
              (``waitForEvent``, ``assertEventCount``), expected SDAM events, and
              the ``wait`` operation.
-:2022-07-27: Retroactively note schema version bumps in the change log and
+:2022-07-27: Retroactively note schema version bumps in the changelog and
              require doing so for future changes.
 :2022-07-11: Update `Future Work`_ to reflect that support for ignoring extra
              observed events was added in schema version 1.7.

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -2,17 +2,8 @@
 URI Options Specification
 =========================
 
-:Spec Title: URI Options Specification
-:Spec Version: 1.10
-:Author: Sam Rossi
-:Spec Lead: Bernie Hackett
-:Advisory Group: Scott L'Hommedieu
-:Approver(s): Cailin Nelson, Jeff Yemin, Matt Broadstone, Dan Pasette, Prashant Mital, Spencer Jackson
-:Informed: drivers@
-:Status: Accepted (Could be Draft, Accepted, Rejected, Final, or Replaced)
-:Type: Standards
-:Last Modified: 2022-01-19
-
+:Status: Accepted
+:Minimum Server Version: N/A
 
 **Abstract**
 ------------
@@ -531,24 +522,27 @@ written. Whenever another specification is written or modified in a way that
 changes the name or the semantics of a URI option or adds a new URI option,
 this specification MUST be updated to reflect those changes.
 
-Changes
--------
+Changelog
+---------
 
-- 2022-01-19 Add the timeoutMS option and deprecate some existing timeout options
-- 2021-12-14 Add SOCKS5 options
-- 2021-11-08 Add maxConnecting option.
-- 2021-10-14 Add srvMaxHosts option. Merge headings discussing URI validation
-  for directConnection option.
-- 2021-09-15 Add srvServiceName option
-- 2021-09-13 Fix link to load balancer spec
-- 2021-04-15 Adding in behaviour for load balancer mode.
-- 2021-04-08 Updated to refer to hello and legacy hello
-- 2020-03-03 Add tlsDisableCertificateRevocationCheck option
-- 2020-02-26 Add tlsDisableOCSPEndpointCheck option
-- 2019-01-25 Updated to reflect new Connection Monitoring and Pooling Spec
-- 2019-02-04 Specified errors for conflicting TLS-related URI options
-- 2019-04-26 authSource and authMechanism have no default value
-- 2019-09-08 Add retryReads option
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-01-19: Add the timeoutMS option and deprecate some existing timeout options
+:2021-12-14: Add SOCKS5 options
+:2021-11-08: Add maxConnecting option.
+:2021-10-14: Add srvMaxHosts option. Merge headings discussing URI validation
+             for directConnection option.
+:2021-09-15: Add srvServiceName option
+:2021-09-13: Fix link to load balancer spec
+:2021-04-15: Adding in behaviour for load balancer mode.
+:2021-04-08: Updated to refer to hello and legacy hello
+:2020-03-03: Add tlsDisableCertificateRevocationCheck option
+:2020-02-26: Add tlsDisableOCSPEndpointCheck option
+:2019-09-08: Add retryReads option
+:2019-04-26: authSource and authMechanism have no default value
+:2019-02-04: Specified errors for conflicting TLS-related URI options
+:2019-01-25: Updated to reflect new Connection Monitoring and Pooling Spec
+
+----
 
 .. _Connection Pooling spec: https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst#connection-pool-options-1
 .. _SOCKS5 support spec: https://github.com/mongodb/specifications/blob/master/source/socks5-support/socks5.rst#mongoclient-configuration

--- a/source/uuid.rst
+++ b/source/uuid.rst
@@ -2,15 +2,8 @@
 Handling of Native UUID Types
 =============================
 
-:Spec Title: Handling of Native UUID Types
-:Spec Version: 1.0
-:Author: Jeff Yemin
-:Lead: Bernie Hackett
-:Advisory Group: Shane Harvey, Oleg Pudeyev, Robert Stam
-:Informed: drivers@
 :Status: Accepted
-:Type: Standards
-:Last Modified: 2019-11-19
+:Minimum Server Version: N/A
 
 .. contents::
 
@@ -325,3 +318,8 @@ In short, the C# driver has existing behavior that make it infeasible to work th
 The C# driver has a global serialization registry. Since it's global and not per-MongoClient, it's not feasible to override the UUID representation on a per-MongoClient basis, since doing so would require a per-MongoClient registry.  Instead, the specification allows for a global override so that the C# driver can implement the specification.
 
 Additionally, the C# driver has an existing configuration parameter that controls the behavior of BSON readers and writers at a level below the serializers. This configuration affects the semantics of the existing BsonBinary class in a way that doesn't allow for the constructor(UUID) mentioned in the specification.  For this reason, that constructor is specified as optional.
+
+Changelog
+=========
+
+:2022-10-05: Remove spec front matter.

--- a/source/versioned-api/versioned-api.rst
+++ b/source/versioned-api/versioned-api.rst
@@ -2,14 +2,8 @@
 Stable API For Drivers
 ======================
 
-:Spec Title: Stable API For Drivers (previously: Versioned API)
-:Spec Version: 1.2.2
-:Author: Andreas Braun
-:Advisors: Jeff Yemin, A. Jesse Jiryu Davis, Patrick Freed, Oleg Pudeyev
 :Status: Accepted
-:Type: Standards
 :Minimum Server Version: N/A
-:Last Modified: 2022-02-24
 
 .. contents::
 
@@ -292,13 +286,14 @@ and ``MongoCollection`` classes to only include features that are part of the
 stable API. This is not covered in this specification.
 
 
-Change Log
-==========
+Changelog
+=========
 
-* 2022-02-24: Rename Versioned API to Stable API
-* 2022-01-14: Require ``OP_MSG`` for all messages including the initial step
-  of the handshake when using stable API.
-* 2021-05-05: Require sending stable API parameters with ``getMore`` and
-  transaction-continuing commands.
-* 2021-04-20: Require using ``hello`` when using the stable API.
-* 2021-04-10: Replaced usages of ``acceptAPIVersion2`` with ``acceptApiVersion2``.
+:2022-10-05: Remove spec front matter and reformat changelog.
+:2022-02-24: Rename Versioned API to Stable API
+:2022-01-14: Require ``OP_MSG`` for all messages including the initial step of
+             the handshake when using stable API.
+:2021-05-05: Require sending stable API parameters with ``getMore`` and
+             transaction-continuing commands.
+:2021-04-20: Require using ``hello`` when using the stable API.
+:2021-04-10: Replaced usages of ``acceptAPIVersion2`` with ``acceptApiVersion2``.


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2253

This limits front matter fields to "Status" and "Minimum Server Version".

Spec versions were removed across the board, excluding the Unified Test Format, which retained a field for "Current Schema Version". The only other spec where versioning was somewhat relevant was Extended JSON, and the transition from 1.0 to 2.0 is clearly noted in the changelog (minor versions since 2.0 were not relevant).

Apart from the deprecated Bulk API spec, all specs have an "Accepted" status. Some were incorrectly listed as "Draft".

This also revises changelogs across all specs to use "Field List" formatting (like spec front matter). The CSFLE and Change Stream specs were left as-is, since they used CSV and grid tables, respectively. Some existing changelog entries were incorrectly ordered and fixed. Lastly, specs were inconsistent in whether changelogs entries used ascending or descending date order, so existing order was left in place when possible. For some very old specs without dated changelog entries, dates were inferred from git history.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelogs

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

