### PR TITLE
minor: remove extra whitespace from CMAP test

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/pool-clear-interrupt-immediately.json
+++ b/source/connection-monitoring-and-pooling/tests/pool-clear-interrupt-immediately.json
@@ -24,7 +24,7 @@
       "name": "waitForEvent",
       "event": "ConnectionPoolCleared",
       "count": 1,
-      "timeout": 1000      
+      "timeout": 1000
     },
     {
       "name": "waitForEvent",


### PR DESCRIPTION
For some reason the GitHub action that checks the JSON tests have been regenerated started complaining about this on #1303.