### PR TITLE
DRIVERS-2477: use w:'majority' in consecutive resume change stream tests

### DIFF
--- a/source/change-streams/tests/unified/change-streams.json
+++ b/source/change-streams/tests/unified/change-streams.json
@@ -1650,6 +1650,9 @@
           "arguments": {
             "document": {
               "x": 1
+            },
+            "writeConcern": {
+              "w": "majority"
             }
           }
         },
@@ -1659,6 +1662,9 @@
           "arguments": {
             "document": {
               "x": 2
+            },
+            "writeConcern": {
+              "w": "majority"
             }
           }
         },
@@ -1668,6 +1674,9 @@
           "arguments": {
             "document": {
               "x": 3
+            },
+            "writeConcern": {
+              "w": "majority"
             }
           }
         },

--- a/source/change-streams/tests/unified/change-streams.yml
+++ b/source/change-streams/tests/unified/change-streams.yml
@@ -854,14 +854,20 @@ tests:
         object: *globalCollection0
         arguments:
           document: { x: 1 }
+          writeConcern: 
+            w: 'majority'
       - name: insertOne
         object: *globalCollection0
         arguments:
           document: { x: 2 }
+          writeConcern: 
+            w: 'majority'
       - name: insertOne
         object: *globalCollection0
         arguments:
           document: { x: 3 }
+          writeConcern: 
+            w: 'majority'
       - name: iterateUntilDocumentOrError
         object: *changeStream0
         expectResult:

--- a/source/unified-test-format/tests/valid-pass/poc-change-streams.json
+++ b/source/unified-test-format/tests/valid-pass/poc-change-streams.json
@@ -301,6 +301,9 @@
           "arguments": {
             "document": {
               "x": 1
+            },
+            "writeConcern": {
+              "w": "majority"
             }
           }
         },
@@ -310,6 +313,9 @@
           "arguments": {
             "document": {
               "x": 2
+            },
+            "writeConcern": {
+              "w": "majority"
             }
           }
         },
@@ -319,6 +325,9 @@
           "arguments": {
             "document": {
               "x": 3
+            },
+            "writeConcern": {
+              "w": "majority"
             }
           }
         },

--- a/source/unified-test-format/tests/valid-pass/poc-change-streams.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-change-streams.yml
@@ -172,14 +172,20 @@ tests:
         object: *collection1
         arguments:
           document: { x: 1 }
+          writeConcern: 
+            w: 'majority'
       - name: insertOne
         object: *collection1
         arguments:
           document: { x: 2 }
+          writeConcern: 
+            w: 'majority'
       - name: insertOne
         object: *collection1
         arguments:
           document: { x: 3 }
+          writeConcern: 
+            w: 'majority'
       - name: iterateUntilDocumentOrError
         object: *changeStream0
         expectResult:


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2477

POC in Node: https://github.com/mongodb/node-mongodb-native/pull/3451

The change stream consecutive resume test ([here](https://github.com/mongodb/specifications/blob/e780e91d708fe9c004a0b0023387baa850282881/source/change-streams/tests/unified/change-streams.yml#L833)) fails intermittently in Node because the test inserts documents with write the default write concern instead of majority.

Change events are not reported by the server until they are majority committed.  The test inserts multiple documents and attempts to iterate the change stream, expecting change events.  If the documents haven't been committed by the time the test attempts to iterate the stream, no change will be reported and the test will fail.

This only impacts the consecutive resume test and does not impact users because the change event will eventually be reported.  This test specifically sets up fail commands on getMores, so that the getMore fail and the subsequent aggregate call succeeds and returns a change event in the firstBatch.  The race condition is present only because we expect the aggregate to immediately return documents in the firstBatch.

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

