### PR TITLE
Update SDAM Spec to remove "RSGhosts may report their setNames in the future"

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -631,8 +631,6 @@ However, the client MUST keep the RSGhost member in its TopologyDescription,
 in case the client's only hope for staying connected to the replica set
 is that this member will transition to a more useful state.
 
-RSGhosts may report their setNames in the future
-(see `SERVER-13458 <https://jira.mongodb.org/browse/SERVER-13458>`_).
 For simplicity, this is the rule:
 any server is an RSGhost that reports "isreplicaset: true".
 


### PR DESCRIPTION
> RSGhosts may report their setNames in the future (see SERVER-13458). 

Remove the above reference as SERVER-13458 was closed in 2014 as _Works as Designed_. This shouldn't require a changelog update.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

