### PR TITLE
DRIVERS-2369 Default causal consistency should be false in implicit sessions

### DIFF
--- a/source/causal-consistency/causal-consistency.rst
+++ b/source/causal-consistency/causal-consistency.rst
@@ -158,11 +158,13 @@ causalConsistency
 Applications set ``causalConsistency`` when starting a session to
 indicate whether they want causal consistency.
 
-Note that the ``causalConsistency`` property is optional. The default value of
-this property is ``not supplied``. If no value is supplied for
+Note that the ``causalConsistency`` property is optional. For explicit sessions,
+the default value of this property is ``not supplied``. If no value is supplied for
 ``causalConsistency`` the value will be inherited. Currently it is inherited
 from the global default which is defined to be true. In the future it *might*
-be inherited from client settings.
+be inherited from client settings. For implicit sessions, the value of this
+property MUST be set to ``false`` in order to avoid potential conflicts with
+an operation's read concern level.
 
 Causal consistency is provided at the session level by tracking the ``clusterTime``
 and ``operationTime`` for each session. In some cases an application may wish
@@ -507,6 +509,7 @@ Q&A
 Changelog
 =========
 
+:2022-11-11: Require ``causalConsistency=false`` for implicit sessions.
 :2022-10-05: Remove spec front matter and reformat changelog.
 :2022-01-28: Fix formatting for prose tests
 :2022-01-22: Remove outdated prose test #10

--- a/source/sessions/tests/implicit-sessions-default-causal-consistency.json
+++ b/source/sessions/tests/implicit-sessions-default-causal-consistency.json
@@ -1,0 +1,313 @@
+{
+  "description": "implicit sessions default causal consistency",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.2",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "implicit-sessions-causal-consistency-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collectionDefault",
+        "database": "database0",
+        "collectionName": "coll-default"
+      }
+    },
+    {
+      "collection": {
+        "id": "collectionSnapshot",
+        "database": "database0",
+        "collectionName": "coll-snapshot",
+        "collectionOptions": {
+          "readConcern": {
+            "level": "snapshot"
+          }
+        }
+      }
+    },
+    {
+      "collection": {
+        "id": "collectionlinearizable",
+        "database": "database0",
+        "collectionName": "coll-linearizable",
+        "collectionOptions": {
+          "readConcern": {
+            "level": "linearizable"
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll-default",
+      "databaseName": "implicit-sessions-causal-consistency-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": "default"
+        }
+      ]
+    },
+    {
+      "collectionName": "coll-snapshot",
+      "databaseName": "implicit-sessions-causal-consistency-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": "snapshot"
+        }
+      ]
+    },
+    {
+      "collectionName": "coll-linearizable",
+      "databaseName": "implicit-sessions-causal-consistency-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": "linearizable"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "readConcern is not sent on retried read in implicit session when readConcern level is not specified",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collectionDefault",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": "default"
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-default",
+                  "filter": {},
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                },
+                "databaseName": "implicit-sessions-causal-consistency-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-default",
+                  "filter": {},
+                  "readConcern": {
+                    "$$exists": false
+                  }
+                },
+                "databaseName": "implicit-sessions-causal-consistency-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "afterClusterTime is not sent on retried read in implicit session when readConcern level is snapshot",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collectionSnapshot",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": "snapshot"
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-snapshot",
+                  "filter": {},
+                  "readConcern": {
+                    "level": "snapshot",
+                    "afterClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                },
+                "databaseName": "implicit-sessions-causal-consistency-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-snapshot",
+                  "filter": {},
+                  "readConcern": {
+                    "level": "snapshot",
+                    "afterClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                },
+                "databaseName": "implicit-sessions-causal-consistency-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "afterClusterTime is not sent on retried read in implicit session when readConcern level is linearizable",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "errorCode": 11600
+              }
+            }
+          }
+        },
+        {
+          "name": "find",
+          "object": "collectionlinearizable",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": "linearizable"
+            }
+          ]
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-linearizable",
+                  "filter": {},
+                  "readConcern": {
+                    "level": "linearizable",
+                    "afterClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                },
+                "databaseName": "implicit-sessions-causal-consistency-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll-linearizable",
+                  "filter": {},
+                  "readConcern": {
+                    "level": "linearizable",
+                    "afterClusterTime": {
+                      "$$exists": false
+                    }
+                  }
+                },
+                "databaseName": "implicit-sessions-causal-consistency-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/sessions/tests/implicit-sessions-default-causal-consistency.json
+++ b/source/sessions/tests/implicit-sessions-default-causal-consistency.json
@@ -25,7 +25,7 @@
       "database": {
         "id": "database0",
         "client": "client0",
-        "databaseName": "implicit-sessions-causal-consistency-tests"
+        "databaseName": "implicit-cc-tests"
       }
     },
     {
@@ -63,7 +63,7 @@
   "initialData": [
     {
       "collectionName": "coll-default",
-      "databaseName": "implicit-sessions-causal-consistency-tests",
+      "databaseName": "implicit-cc-tests",
       "documents": [
         {
           "_id": 1,
@@ -73,7 +73,7 @@
     },
     {
       "collectionName": "coll-snapshot",
-      "databaseName": "implicit-sessions-causal-consistency-tests",
+      "databaseName": "implicit-cc-tests",
       "documents": [
         {
           "_id": 1,
@@ -83,7 +83,7 @@
     },
     {
       "collectionName": "coll-linearizable",
-      "databaseName": "implicit-sessions-causal-consistency-tests",
+      "databaseName": "implicit-cc-tests",
       "documents": [
         {
           "_id": 1,
@@ -142,7 +142,7 @@
                     "$$exists": false
                   }
                 },
-                "databaseName": "implicit-sessions-causal-consistency-tests"
+                "databaseName": "implicit-cc-tests"
               }
             },
             {
@@ -154,7 +154,7 @@
                     "$$exists": false
                   }
                 },
-                "databaseName": "implicit-sessions-causal-consistency-tests"
+                "databaseName": "implicit-cc-tests"
               }
             }
           ]
@@ -163,6 +163,11 @@
     },
     {
       "description": "afterClusterTime is not sent on retried read in implicit session when readConcern level is snapshot",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -213,7 +218,7 @@
                     }
                   }
                 },
-                "databaseName": "implicit-sessions-causal-consistency-tests"
+                "databaseName": "implicit-cc-tests"
               }
             },
             {
@@ -228,7 +233,7 @@
                     }
                   }
                 },
-                "databaseName": "implicit-sessions-causal-consistency-tests"
+                "databaseName": "implicit-cc-tests"
               }
             }
           ]
@@ -287,7 +292,7 @@
                     }
                   }
                 },
-                "databaseName": "implicit-sessions-causal-consistency-tests"
+                "databaseName": "implicit-cc-tests"
               }
             },
             {
@@ -302,7 +307,7 @@
                     }
                   }
                 },
-                "databaseName": "implicit-sessions-causal-consistency-tests"
+                "databaseName": "implicit-cc-tests"
               }
             }
           ]

--- a/source/sessions/tests/implicit-sessions-default-causal-consistency.yml
+++ b/source/sessions/tests/implicit-sessions-default-causal-consistency.yml
@@ -1,0 +1,117 @@
+description: "implicit sessions default causal consistency"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "4.2"
+    topologies: [replicaset, sharded, load-balanced]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [commandStartedEvent]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName implicit-sessions-causal-consistency-tests
+  - collection:
+      id: &collectionDefault collectionDefault
+      database: *database0
+      collectionName: &collectionNameDefault coll-default
+  - collection:
+      id: &collectionSnapshot collectionSnapshot
+      database: *database0
+      collectionName: &collectionNameSnapshot coll-snapshot
+      collectionOptions:
+        readConcern: { level: snapshot }
+  - collection:
+      id: &collectionlinearizable collectionlinearizable
+      database: *database0
+      collectionName: &collectionNamelinearizable coll-linearizable
+      collectionOptions:
+        readConcern: { level: linearizable }
+
+initialData:
+  - collectionName: *collectionNameDefault
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: default }
+  - collectionName: *collectionNameSnapshot
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: snapshot }
+  - collectionName: *collectionNamelinearizable
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: linearizable }
+
+tests:
+  - description: "readConcern is not sent on retried read in implicit session when readConcern level is not specified"
+    operations:
+      - &failPointCommand
+        name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 1 }
+            data:
+              failCommands: [find]
+              errorCode: 11600 #InterruptedAtShutdown
+      - name: find
+        object: *collectionDefault
+        arguments:
+          filter: {}
+        expectResult: [{ _id: 1, x: default }]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &commandStartedEventDefault
+              command:
+                find: *collectionNameDefault
+                filter: {}
+                readConcern: { $$exists: false }
+              databaseName: *databaseName
+          - commandStartedEvent: *commandStartedEventDefault
+
+  - description: "afterClusterTime is not sent on retried read in implicit session when readConcern level is snapshot"
+    operations:
+      - *failPointCommand
+      - name: find
+        object: *collectionSnapshot
+        arguments:
+          filter: {}
+        expectResult: [{ _id: 1, x: snapshot }]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &commandStartedEventSnapshot
+              command:
+                find: *collectionNameSnapshot
+                filter: {}
+                readConcern:
+                  { level: snapshot, afterClusterTime: { $$exists: false } }
+              databaseName: *databaseName
+          - commandStartedEvent: *commandStartedEventSnapshot
+
+  - description: "afterClusterTime is not sent on retried read in implicit session when readConcern level is linearizable"
+    operations:
+      - *failPointCommand
+      - name: find
+        object: *collectionlinearizable
+        arguments:
+          filter: {}
+        expectResult: [{ _id: 1, x: linearizable }]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &commandStartedEventLinearizable
+              command:
+                find: *collectionNamelinearizable
+                filter: {}
+                readConcern:
+                  { level: linearizable, afterClusterTime: { $$exists: false } }
+              databaseName: *databaseName
+          - commandStartedEvent: *commandStartedEventLinearizable

--- a/source/sessions/tests/implicit-sessions-default-causal-consistency.yml
+++ b/source/sessions/tests/implicit-sessions-default-causal-consistency.yml
@@ -14,7 +14,7 @@ createEntities:
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: &databaseName implicit-sessions-causal-consistency-tests
+      databaseName: &databaseName implicit-cc-tests
   - collection:
       id: &collectionDefault collectionDefault
       database: *database0
@@ -77,6 +77,8 @@ tests:
           - commandStartedEvent: *commandStartedEventDefault
 
   - description: "afterClusterTime is not sent on retried read in implicit session when readConcern level is snapshot"
+    runOnRequirements:
+      - minServerVersion: "5.0"
     operations:
       - *failPointCommand
       - name: find


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

