### PR TITLE
DRIVERS-2489 Properly skip createChangeStream tests on serverless

### DIFF
--- a/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
@@ -2,6 +2,7 @@
 
 description: "retryable reads handshake failures"
 
+# 1.4 is required for "serverless: forbid".
 schemaVersion: "1.4"
 
 runOnRequirements:

--- a/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
@@ -53,7 +53,7 @@ tests:
   #   - Triggers failpoint (second time).
   #   - Tests whether operation successfully retries the handshake and succeeds.
 {% for operation in operations %}
-  - description: "{{operation.operation_name}} succeeds after retryable handshake network error"
+  - description: "{{operation.object}}.{{operation.operation_name}} succeeds after retryable handshake network error"
     {%- if operation.operation_name == 'createChangeStream' %}
     runOnRequirements:
       - serverless: forbid
@@ -104,7 +104,7 @@ tests:
           - commandSucceededEvent:
               commandName: {{operation.command_name}}
 
-  - description: "{{operation.operation_name}} succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "{{operation.object}}.{{operation.operation_name}} succeeds after retryable handshake server error (ShutdownInProgress)"
     {%- if operation.operation_name == 'createChangeStream' %}
     runOnRequirements:
       - serverless: forbid

--- a/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
@@ -54,7 +54,8 @@ tests:
   #   - Tests whether operation successfully retries the handshake and succeeds.
 {% for operation in operations %}
   - description: "{{operation.object}}.{{operation.operation_name}} succeeds after retryable handshake network error"
-    {%- if operation.operation_name == 'createChangeStream' %}
+    {%- if ((operation.operation_name == 'createChangeStream') or
+            (operation.operation_name == 'aggregate' and operation.object == 'database')) %}
     runOnRequirements:
       - serverless: forbid
     {%- endif %}
@@ -105,7 +106,8 @@ tests:
               commandName: {{operation.command_name}}
 
   - description: "{{operation.object}}.{{operation.operation_name}} succeeds after retryable handshake server error (ShutdownInProgress)"
-    {%- if operation.operation_name == 'createChangeStream' %}
+    {%- if ((operation.operation_name == 'createChangeStream') or
+            (operation.operation_name == 'aggregate' and operation.object == 'database')) %}
     runOnRequirements:
       - serverless: forbid
     {%- endif %}

--- a/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
@@ -53,6 +53,10 @@ tests:
   #   - Tests whether operation successfully retries the handshake and succeeds.
 {% for operation in operations %}
   - description: "{{operation.operation_name}} succeeds after retryable handshake network error"
+    {%- if operation.operation_name == 'createChangeStream' %}
+    runOnRequirements:
+      - serverless: forbid
+    {%- endif %}
     operations:
       - name: failPoint
         object: testRunner
@@ -100,6 +104,10 @@ tests:
               commandName: {{operation.command_name}}
 
   - description: "{{operation.operation_name}} succeeds after retryable handshake server error (ShutdownInProgress)"
+    {%- if operation.operation_name == 'createChangeStream' %}
+    runOnRequirements:
+      - serverless: forbid
+    {%- endif %}
     operations:
       - name: failPoint
         object: testRunner

--- a/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-reads/tests/etc/templates/handshakeError.yml.template
@@ -2,7 +2,7 @@
 
 description: "retryable reads handshake failures"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "4.2"

--- a/source/retryable-reads/tests/unified/handshakeError.json
+++ b/source/retryable-reads/tests/unified/handshakeError.json
@@ -1,6 +1,6 @@
 {
   "description": "retryable reads handshake failures",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2",

--- a/source/retryable-reads/tests/unified/handshakeError.json
+++ b/source/retryable-reads/tests/unified/handshakeError.json
@@ -627,6 +627,11 @@
     },
     {
       "description": "database.aggregate succeeds after retryable handshake network error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -727,6 +732,11 @@
     },
     {
       "description": "database.aggregate succeeds after retryable handshake server error (ShutdownInProgress)",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/retryable-reads/tests/unified/handshakeError.json
+++ b/source/retryable-reads/tests/unified/handshakeError.json
@@ -62,7 +62,7 @@
   ],
   "tests": [
     {
-      "description": "listDatabases succeeds after retryable handshake network error",
+      "description": "client.listDatabases succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -155,7 +155,7 @@
       ]
     },
     {
-      "description": "listDatabases succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "client.listDatabases succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -248,7 +248,7 @@
       ]
     },
     {
-      "description": "listDatabaseNames succeeds after retryable handshake network error",
+      "description": "client.listDatabaseNames succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -338,7 +338,7 @@
       ]
     },
     {
-      "description": "listDatabaseNames succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "client.listDatabaseNames succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -428,7 +428,7 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake network error",
+      "description": "client.createChangeStream succeeds after retryable handshake network error",
       "runOnRequirements": [
         {
           "serverless": "forbid"
@@ -527,7 +527,7 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "client.createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
       "runOnRequirements": [
         {
           "serverless": "forbid"
@@ -626,7 +626,7 @@
       ]
     },
     {
-      "description": "aggregate succeeds after retryable handshake network error",
+      "description": "database.aggregate succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -726,7 +726,7 @@
       ]
     },
     {
-      "description": "aggregate succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "database.aggregate succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -826,7 +826,7 @@
       ]
     },
     {
-      "description": "listCollections succeeds after retryable handshake network error",
+      "description": "database.listCollections succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -919,7 +919,7 @@
       ]
     },
     {
-      "description": "listCollections succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "database.listCollections succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1012,7 +1012,7 @@
       ]
     },
     {
-      "description": "listCollectionNames succeeds after retryable handshake network error",
+      "description": "database.listCollectionNames succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1105,7 +1105,7 @@
       ]
     },
     {
-      "description": "listCollectionNames succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "database.listCollectionNames succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1198,7 +1198,7 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake network error",
+      "description": "database.createChangeStream succeeds after retryable handshake network error",
       "runOnRequirements": [
         {
           "serverless": "forbid"
@@ -1297,7 +1297,7 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "database.createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
       "runOnRequirements": [
         {
           "serverless": "forbid"
@@ -1396,7 +1396,7 @@
       ]
     },
     {
-      "description": "aggregate succeeds after retryable handshake network error",
+      "description": "collection.aggregate succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1489,7 +1489,7 @@
       ]
     },
     {
-      "description": "aggregate succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.aggregate succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1582,7 +1582,7 @@
       ]
     },
     {
-      "description": "countDocuments succeeds after retryable handshake network error",
+      "description": "collection.countDocuments succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1675,7 +1675,7 @@
       ]
     },
     {
-      "description": "countDocuments succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.countDocuments succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1768,7 +1768,7 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount succeeds after retryable handshake network error",
+      "description": "collection.estimatedDocumentCount succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1858,7 +1858,7 @@
       ]
     },
     {
-      "description": "estimatedDocumentCount succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.estimatedDocumentCount succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1948,7 +1948,7 @@
       ]
     },
     {
-      "description": "distinct succeeds after retryable handshake network error",
+      "description": "collection.distinct succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2042,7 +2042,7 @@
       ]
     },
     {
-      "description": "distinct succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.distinct succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2136,7 +2136,7 @@
       ]
     },
     {
-      "description": "find succeeds after retryable handshake network error",
+      "description": "collection.find succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2229,7 +2229,7 @@
       ]
     },
     {
-      "description": "find succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.find succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2322,7 +2322,7 @@
       ]
     },
     {
-      "description": "findOne succeeds after retryable handshake network error",
+      "description": "collection.findOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2415,7 +2415,7 @@
       ]
     },
     {
-      "description": "findOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.findOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2508,7 +2508,7 @@
       ]
     },
     {
-      "description": "listIndexes succeeds after retryable handshake network error",
+      "description": "collection.listIndexes succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2598,7 +2598,7 @@
       ]
     },
     {
-      "description": "listIndexes succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.listIndexes succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2688,7 +2688,7 @@
       ]
     },
     {
-      "description": "listIndexNames succeeds after retryable handshake network error",
+      "description": "collection.listIndexNames succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -2778,7 +2778,7 @@
       ]
     },
     {
-      "description": "listIndexNames succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.listIndexNames succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -2868,7 +2868,7 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake network error",
+      "description": "collection.createChangeStream succeeds after retryable handshake network error",
       "runOnRequirements": [
         {
           "serverless": "forbid"
@@ -2967,7 +2967,7 @@
       ]
     },
     {
-      "description": "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
       "runOnRequirements": [
         {
           "serverless": "forbid"

--- a/source/retryable-reads/tests/unified/handshakeError.json
+++ b/source/retryable-reads/tests/unified/handshakeError.json
@@ -429,6 +429,11 @@
     },
     {
       "description": "createChangeStream succeeds after retryable handshake network error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -523,6 +528,11 @@
     },
     {
       "description": "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -1189,6 +1199,11 @@
     },
     {
       "description": "createChangeStream succeeds after retryable handshake network error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -1283,6 +1298,11 @@
     },
     {
       "description": "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -2849,6 +2869,11 @@
     },
     {
       "description": "createChangeStream succeeds after retryable handshake network error",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -2943,6 +2968,11 @@
     },
     {
       "description": "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/retryable-reads/tests/unified/handshakeError.yml
+++ b/source/retryable-reads/tests/unified/handshakeError.yml
@@ -53,7 +53,7 @@ tests:
   #   - Triggers failpoint (second time).
   #   - Tests whether operation successfully retries the handshake and succeeds.
 
-  - description: "listDatabases succeeds after retryable handshake network error"
+  - description: "client.listDatabases succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -93,7 +93,7 @@ tests:
           - commandSucceededEvent:
               commandName: listDatabases
 
-  - description: "listDatabases succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "client.listDatabases succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -133,7 +133,7 @@ tests:
           - commandSucceededEvent:
               commandName: listDatabases
 
-  - description: "listDatabaseNames succeeds after retryable handshake network error"
+  - description: "client.listDatabaseNames succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -171,7 +171,7 @@ tests:
           - commandSucceededEvent:
               commandName: listDatabases
 
-  - description: "listDatabaseNames succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "client.listDatabaseNames succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -209,7 +209,7 @@ tests:
           - commandSucceededEvent:
               commandName: listDatabases
 
-  - description: "createChangeStream succeeds after retryable handshake network error"
+  - description: "client.createChangeStream succeeds after retryable handshake network error"
     runOnRequirements:
       - serverless: forbid
     operations:
@@ -252,7 +252,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "client.createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)"
     runOnRequirements:
       - serverless: forbid
     operations:
@@ -295,7 +295,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "aggregate succeeds after retryable handshake network error"
+  - description: "database.aggregate succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -335,7 +335,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "aggregate succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "database.aggregate succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -375,7 +375,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "listCollections succeeds after retryable handshake network error"
+  - description: "database.listCollections succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -415,7 +415,7 @@ tests:
           - commandSucceededEvent:
               commandName: listCollections
 
-  - description: "listCollections succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "database.listCollections succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -455,7 +455,7 @@ tests:
           - commandSucceededEvent:
               commandName: listCollections
 
-  - description: "listCollectionNames succeeds after retryable handshake network error"
+  - description: "database.listCollectionNames succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -495,7 +495,7 @@ tests:
           - commandSucceededEvent:
               commandName: listCollections
 
-  - description: "listCollectionNames succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "database.listCollectionNames succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -535,7 +535,7 @@ tests:
           - commandSucceededEvent:
               commandName: listCollections
 
-  - description: "createChangeStream succeeds after retryable handshake network error"
+  - description: "database.createChangeStream succeeds after retryable handshake network error"
     runOnRequirements:
       - serverless: forbid
     operations:
@@ -578,7 +578,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "database.createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)"
     runOnRequirements:
       - serverless: forbid
     operations:
@@ -621,7 +621,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "aggregate succeeds after retryable handshake network error"
+  - description: "collection.aggregate succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -661,7 +661,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "aggregate succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.aggregate succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -701,7 +701,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "countDocuments succeeds after retryable handshake network error"
+  - description: "collection.countDocuments succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -741,7 +741,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "countDocuments succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.countDocuments succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -781,7 +781,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "estimatedDocumentCount succeeds after retryable handshake network error"
+  - description: "collection.estimatedDocumentCount succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -819,7 +819,7 @@ tests:
           - commandSucceededEvent:
               commandName: count
 
-  - description: "estimatedDocumentCount succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.estimatedDocumentCount succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -857,7 +857,7 @@ tests:
           - commandSucceededEvent:
               commandName: count
 
-  - description: "distinct succeeds after retryable handshake network error"
+  - description: "collection.distinct succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -898,7 +898,7 @@ tests:
           - commandSucceededEvent:
               commandName: distinct
 
-  - description: "distinct succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.distinct succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -939,7 +939,7 @@ tests:
           - commandSucceededEvent:
               commandName: distinct
 
-  - description: "find succeeds after retryable handshake network error"
+  - description: "collection.find succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -979,7 +979,7 @@ tests:
           - commandSucceededEvent:
               commandName: find
 
-  - description: "find succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.find succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -1019,7 +1019,7 @@ tests:
           - commandSucceededEvent:
               commandName: find
 
-  - description: "findOne succeeds after retryable handshake network error"
+  - description: "collection.findOne succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -1059,7 +1059,7 @@ tests:
           - commandSucceededEvent:
               commandName: find
 
-  - description: "findOne succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.findOne succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -1099,7 +1099,7 @@ tests:
           - commandSucceededEvent:
               commandName: find
 
-  - description: "listIndexes succeeds after retryable handshake network error"
+  - description: "collection.listIndexes succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -1137,7 +1137,7 @@ tests:
           - commandSucceededEvent:
               commandName: listIndexes
 
-  - description: "listIndexes succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.listIndexes succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -1175,7 +1175,7 @@ tests:
           - commandSucceededEvent:
               commandName: listIndexes
 
-  - description: "listIndexNames succeeds after retryable handshake network error"
+  - description: "collection.listIndexNames succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -1213,7 +1213,7 @@ tests:
           - commandSucceededEvent:
               commandName: listIndexes
 
-  - description: "listIndexNames succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.listIndexNames succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -1251,7 +1251,7 @@ tests:
           - commandSucceededEvent:
               commandName: listIndexes
 
-  - description: "createChangeStream succeeds after retryable handshake network error"
+  - description: "collection.createChangeStream succeeds after retryable handshake network error"
     runOnRequirements:
       - serverless: forbid
     operations:
@@ -1294,7 +1294,7 @@ tests:
           - commandSucceededEvent:
               commandName: aggregate
 
-  - description: "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)"
     runOnRequirements:
       - serverless: forbid
     operations:

--- a/source/retryable-reads/tests/unified/handshakeError.yml
+++ b/source/retryable-reads/tests/unified/handshakeError.yml
@@ -296,6 +296,8 @@ tests:
               commandName: aggregate
 
   - description: "database.aggregate succeeds after retryable handshake network error"
+    runOnRequirements:
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -336,6 +338,8 @@ tests:
               commandName: aggregate
 
   - description: "database.aggregate succeeds after retryable handshake server error (ShutdownInProgress)"
+    runOnRequirements:
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/source/retryable-reads/tests/unified/handshakeError.yml
+++ b/source/retryable-reads/tests/unified/handshakeError.yml
@@ -2,6 +2,7 @@
 
 description: "retryable reads handshake failures"
 
+# 1.4 is required for "serverless: forbid".
 schemaVersion: "1.4"
 
 runOnRequirements:

--- a/source/retryable-reads/tests/unified/handshakeError.yml
+++ b/source/retryable-reads/tests/unified/handshakeError.yml
@@ -2,7 +2,7 @@
 
 description: "retryable reads handshake failures"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "4.2"

--- a/source/retryable-reads/tests/unified/handshakeError.yml
+++ b/source/retryable-reads/tests/unified/handshakeError.yml
@@ -209,6 +209,8 @@ tests:
               commandName: listDatabases
 
   - description: "createChangeStream succeeds after retryable handshake network error"
+    runOnRequirements:
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -250,6 +252,8 @@ tests:
               commandName: aggregate
 
   - description: "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)"
+    runOnRequirements:
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -531,6 +535,8 @@ tests:
               commandName: listCollections
 
   - description: "createChangeStream succeeds after retryable handshake network error"
+    runOnRequirements:
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -572,6 +578,8 @@ tests:
               commandName: aggregate
 
   - description: "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)"
+    runOnRequirements:
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -1243,6 +1251,8 @@ tests:
               commandName: listIndexes
 
   - description: "createChangeStream succeeds after retryable handshake network error"
+    runOnRequirements:
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -1284,6 +1294,8 @@ tests:
               commandName: aggregate
 
   - description: "createChangeStream succeeds after retryable handshake server error (ShutdownInProgress)"
+    runOnRequirements:
+      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
@@ -50,7 +50,7 @@ tests:
   #   - Triggers failpoint (second time).
   #   - Tests whether operation successfully retries the handshake and succeeds.
 {% for operation in operations %}
-  - description: "{{operation.operation_name}} succeeds after retryable handshake network error"
+  - description: "{{operation.object}}.{{operation.operation_name}} succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -94,7 +94,7 @@ tests:
           - commandSucceededEvent:
               commandName: {{operation.command_name}}
 
-  - description: "{{operation.operation_name}} succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "{{operation.object}}.{{operation.operation_name}} succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner

--- a/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
@@ -51,10 +51,6 @@ tests:
   #   - Tests whether operation successfully retries the handshake and succeeds.
 {% for operation in operations %}
   - description: "{{operation.operation_name}} succeeds after retryable handshake network error"
-    {%- if operation.operation_name == 'createChangeStream' %}
-    runOnRequirements:
-      - serverless: forbid
-    {%- endif %}
     operations:
       - name: failPoint
         object: testRunner
@@ -99,10 +95,6 @@ tests:
               commandName: {{operation.command_name}}
 
   - description: "{{operation.operation_name}} succeeds after retryable handshake server error (ShutdownInProgress)"
-    {%- if operation.operation_name == 'createChangeStream' %}
-    runOnRequirements:
-      - serverless: forbid
-    {%- endif %}
     operations:
       - name: failPoint
         object: testRunner

--- a/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
@@ -2,7 +2,7 @@
 
 description: "retryable writes handshake failures"
 
-schemaVersion: "1.4"
+schemaVersion: "1.3"
 
 runOnRequirements:
   - minServerVersion: "4.2"

--- a/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
@@ -2,7 +2,7 @@
 
 description: "retryable writes handshake failures"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "4.2"

--- a/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
@@ -51,6 +51,10 @@ tests:
   #   - Tests whether operation successfully retries the handshake and succeeds.
 {% for operation in operations %}
   - description: "{{operation.operation_name}} succeeds after retryable handshake network error"
+    {%- if operation.operation_name == 'createChangeStream' %}
+    runOnRequirements:
+      - serverless: forbid
+    {%- endif %}
     operations:
       - name: failPoint
         object: testRunner
@@ -95,6 +99,10 @@ tests:
               commandName: {{operation.command_name}}
 
   - description: "{{operation.operation_name}} succeeds after retryable handshake server error (ShutdownInProgress)"
+    {%- if operation.operation_name == 'createChangeStream' %}
+    runOnRequirements:
+      - serverless: forbid
+    {%- endif %}
     operations:
       - name: failPoint
         object: testRunner

--- a/source/retryable-writes/tests/unified/handshakeError.json
+++ b/source/retryable-writes/tests/unified/handshakeError.json
@@ -1,6 +1,6 @@
 {
   "description": "retryable writes handshake failures",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2",

--- a/source/retryable-writes/tests/unified/handshakeError.json
+++ b/source/retryable-writes/tests/unified/handshakeError.json
@@ -54,7 +54,7 @@
   ],
   "tests": [
     {
-      "description": "insertOne succeeds after retryable handshake network error",
+      "description": "collection.insertOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -150,7 +150,7 @@
       ]
     },
     {
-      "description": "insertOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.insertOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -246,7 +246,7 @@
       ]
     },
     {
-      "description": "insertMany succeeds after retryable handshake network error",
+      "description": "collection.insertMany succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -344,7 +344,7 @@
       ]
     },
     {
-      "description": "insertMany succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.insertMany succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -442,7 +442,7 @@
       ]
     },
     {
-      "description": "deleteOne succeeds after retryable handshake network error",
+      "description": "collection.deleteOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -535,7 +535,7 @@
       ]
     },
     {
-      "description": "deleteOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.deleteOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -628,7 +628,7 @@
       ]
     },
     {
-      "description": "replaceOne succeeds after retryable handshake network error",
+      "description": "collection.replaceOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -724,7 +724,7 @@
       ]
     },
     {
-      "description": "replaceOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.replaceOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -820,7 +820,7 @@
       ]
     },
     {
-      "description": "updateOne succeeds after retryable handshake network error",
+      "description": "collection.updateOne succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -918,7 +918,7 @@
       ]
     },
     {
-      "description": "updateOne succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.updateOne succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1016,7 +1016,7 @@
       ]
     },
     {
-      "description": "findOneAndDelete succeeds after retryable handshake network error",
+      "description": "collection.findOneAndDelete succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1109,7 +1109,7 @@
       ]
     },
     {
-      "description": "findOneAndDelete succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.findOneAndDelete succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1202,7 +1202,7 @@
       ]
     },
     {
-      "description": "findOneAndReplace succeeds after retryable handshake network error",
+      "description": "collection.findOneAndReplace succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1298,7 +1298,7 @@
       ]
     },
     {
-      "description": "findOneAndReplace succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.findOneAndReplace succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1394,7 +1394,7 @@
       ]
     },
     {
-      "description": "findOneAndUpdate succeeds after retryable handshake network error",
+      "description": "collection.findOneAndUpdate succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1492,7 +1492,7 @@
       ]
     },
     {
-      "description": "findOneAndUpdate succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.findOneAndUpdate succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",
@@ -1590,7 +1590,7 @@
       ]
     },
     {
-      "description": "bulkWrite succeeds after retryable handshake network error",
+      "description": "collection.bulkWrite succeeds after retryable handshake network error",
       "operations": [
         {
           "name": "failPoint",
@@ -1692,7 +1692,7 @@
       ]
     },
     {
-      "description": "bulkWrite succeeds after retryable handshake server error (ShutdownInProgress)",
+      "description": "collection.bulkWrite succeeds after retryable handshake server error (ShutdownInProgress)",
       "operations": [
         {
           "name": "failPoint",

--- a/source/retryable-writes/tests/unified/handshakeError.json
+++ b/source/retryable-writes/tests/unified/handshakeError.json
@@ -1,6 +1,6 @@
 {
   "description": "retryable writes handshake failures",
-  "schemaVersion": "1.4",
+  "schemaVersion": "1.3",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2",

--- a/source/retryable-writes/tests/unified/handshakeError.yml
+++ b/source/retryable-writes/tests/unified/handshakeError.yml
@@ -50,7 +50,7 @@ tests:
   #   - Triggers failpoint (second time).
   #   - Tests whether operation successfully retries the handshake and succeeds.
 
-  - description: "insertOne succeeds after retryable handshake network error"
+  - description: "collection.insertOne succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -90,7 +90,7 @@ tests:
           - commandSucceededEvent:
               commandName: insert
 
-  - description: "insertOne succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.insertOne succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -130,7 +130,7 @@ tests:
           - commandSucceededEvent:
               commandName: insert
 
-  - description: "insertMany succeeds after retryable handshake network error"
+  - description: "collection.insertMany succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -171,7 +171,7 @@ tests:
           - commandSucceededEvent:
               commandName: insert
 
-  - description: "insertMany succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.insertMany succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -212,7 +212,7 @@ tests:
           - commandSucceededEvent:
               commandName: insert
 
-  - description: "deleteOne succeeds after retryable handshake network error"
+  - description: "collection.deleteOne succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -252,7 +252,7 @@ tests:
           - commandSucceededEvent:
               commandName: delete
 
-  - description: "deleteOne succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.deleteOne succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -292,7 +292,7 @@ tests:
           - commandSucceededEvent:
               commandName: delete
 
-  - description: "replaceOne succeeds after retryable handshake network error"
+  - description: "collection.replaceOne succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -333,7 +333,7 @@ tests:
           - commandSucceededEvent:
               commandName: update
 
-  - description: "replaceOne succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.replaceOne succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -374,7 +374,7 @@ tests:
           - commandSucceededEvent:
               commandName: update
 
-  - description: "updateOne succeeds after retryable handshake network error"
+  - description: "collection.updateOne succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -415,7 +415,7 @@ tests:
           - commandSucceededEvent:
               commandName: update
 
-  - description: "updateOne succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.updateOne succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -456,7 +456,7 @@ tests:
           - commandSucceededEvent:
               commandName: update
 
-  - description: "findOneAndDelete succeeds after retryable handshake network error"
+  - description: "collection.findOneAndDelete succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -496,7 +496,7 @@ tests:
           - commandSucceededEvent:
               commandName: findAndModify
 
-  - description: "findOneAndDelete succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.findOneAndDelete succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -536,7 +536,7 @@ tests:
           - commandSucceededEvent:
               commandName: findAndModify
 
-  - description: "findOneAndReplace succeeds after retryable handshake network error"
+  - description: "collection.findOneAndReplace succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -577,7 +577,7 @@ tests:
           - commandSucceededEvent:
               commandName: findAndModify
 
-  - description: "findOneAndReplace succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.findOneAndReplace succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -618,7 +618,7 @@ tests:
           - commandSucceededEvent:
               commandName: findAndModify
 
-  - description: "findOneAndUpdate succeeds after retryable handshake network error"
+  - description: "collection.findOneAndUpdate succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -659,7 +659,7 @@ tests:
           - commandSucceededEvent:
               commandName: findAndModify
 
-  - description: "findOneAndUpdate succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.findOneAndUpdate succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner
@@ -700,7 +700,7 @@ tests:
           - commandSucceededEvent:
               commandName: findAndModify
 
-  - description: "bulkWrite succeeds after retryable handshake network error"
+  - description: "collection.bulkWrite succeeds after retryable handshake network error"
     operations:
       - name: failPoint
         object: testRunner
@@ -742,7 +742,7 @@ tests:
           - commandSucceededEvent:
               commandName: insert
 
-  - description: "bulkWrite succeeds after retryable handshake server error (ShutdownInProgress)"
+  - description: "collection.bulkWrite succeeds after retryable handshake server error (ShutdownInProgress)"
     operations:
       - name: failPoint
         object: testRunner

--- a/source/retryable-writes/tests/unified/handshakeError.yml
+++ b/source/retryable-writes/tests/unified/handshakeError.yml
@@ -2,7 +2,7 @@
 
 description: "retryable writes handshake failures"
 
-schemaVersion: "1.4"
+schemaVersion: "1.3"
 
 runOnRequirements:
   - minServerVersion: "4.2"

--- a/source/retryable-writes/tests/unified/handshakeError.yml
+++ b/source/retryable-writes/tests/unified/handshakeError.yml
@@ -2,7 +2,7 @@
 
 description: "retryable writes handshake failures"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "4.2"


### PR DESCRIPTION
This PR fixes an issue with the tests added in https://github.com/mongodb/specifications/pull/1336

Change streams don't yet work on serverless so we have to skip createChangeStream tests there.

Please complete the following before merging:

- [X] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).
