### PR TITLE
DRIVERS-2490 Only run tests using getnonce on servers < 6.2; correct maxServerVersion for command/reply redaction tests

### DIFF
--- a/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+++ b/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
@@ -555,3 +555,4 @@ Changelog
 :2022-09-02: Remove material that only applies to MongoDB versions < 3.6.
 :2022-10-05: Remove spec front matter and reformat changelog.
 :2022-10-11: Add command logging information and tests.
+:2022-11-16: Update sensitive command tests to only run on server versions where the commands are supported.

--- a/source/command-logging-and-monitoring/tests/logging/redacted-commands.json
+++ b/source/command-logging-and-monitoring/tests/logging/redacted-commands.json
@@ -398,6 +398,11 @@
     },
     {
       "description": "getnonce command and server reply are redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -443,6 +448,11 @@
     },
     {
       "description": "network error in response to getnonce is not redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -753,6 +763,11 @@
     },
     {
       "description": "copydbgetnonce command and resulting server-generated error are redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.6.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -804,7 +819,7 @@
       "description": "network error in response to copydbgetnonce is not redacted",
       "runOnRequirements": [
         {
-          "maxServerVersion": "4.0.99"
+          "maxServerVersion": "3.6.99"
         }
       ],
       "operations": [
@@ -875,6 +890,11 @@
     },
     {
       "description": "copydbsaslstart command and resulting server-generated error are redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -997,6 +1017,11 @@
     },
     {
       "description": "copydb command and resulting server-generated error are redacted",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/source/command-logging-and-monitoring/tests/logging/redacted-commands.yml
+++ b/source/command-logging-and-monitoring/tests/logging/redacted-commands.yml
@@ -241,6 +241,8 @@ tests:
               failure: { $$exists: true }
 
   - description: "getnonce command and server reply are redacted"
+    runOnRequirements:
+      - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *database
@@ -268,6 +270,8 @@ tests:
                 $$matchAsDocument: {}
 
   - description: "network error in response to getnonce is not redacted"
+    runOnRequirements:
+      - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: failPoint
         object: testRunner
@@ -453,6 +457,8 @@ tests:
               failure: { $$exists: true }
 
   - description: "copydbgetnonce command and resulting server-generated error are redacted"
+    runOnRequirements:
+      - maxServerVersion: 3.6.99 # copydbgetnonce was removed as of 4.0 via SERVER-32276
     operations:
       - name: runCommand
         object: *database
@@ -483,7 +489,7 @@ tests:
 
   - description: "network error in response to copydbgetnonce is not redacted"
     runOnRequirements:
-      - maxServerVersion: "4.0.99" # this commmand was removed in MongoDB 4.2 and the server returns CommandNotFound before hitting the failpoint
+      - maxServerVersion: 3.6.99 # copydbgetnonce was removed as of 4.0 via SERVER-32276
     operations:
       - name: failPoint
         object: testRunner
@@ -523,6 +529,8 @@ tests:
               failure: { $$exists: true }
 
   - description: "copydbsaslstart command and resulting server-generated error are redacted"
+    runOnRequirements:
+    - maxServerVersion: 4.0.99 # copydbsaslstart was removed as of 4.2 via SERVER-36211
     operations:
       - name: runCommand
         object: *database
@@ -553,7 +561,7 @@ tests:
 
   - description: "network error in response to copydbsaslstart is not redacted"
     runOnRequirements:
-    - maxServerVersion: "4.0.99"  # this commmand was removed in MongoDB 4.2 and the server returns CommandNotFound before hitting the failpoint
+    - maxServerVersion: 4.0.99 # copydbsaslstart was removed as of 4.2 via SERVER-36211
     operations:
       - name: failPoint
         object: testRunner
@@ -593,6 +601,8 @@ tests:
               failure: { $$exists: true }
 
   - description: "copydb command and resulting server-generated error are redacted"
+    runOnRequirements:
+    - maxServerVersion: 4.0.99 # copydb was removed as of 4.2 via SERVER-36257
     operations:
       - name: runCommand
         object: *database
@@ -623,7 +633,7 @@ tests:
 
   - description: "network error in response to copydb is not redacted"
     runOnRequirements:
-    - maxServerVersion: "4.0.99"  # this commmand was removed in MongoDB 4.2 and the server returns CommandNotFound before hitting the failpoint
+    - maxServerVersion: 4.0.99 # copydb was removed as of 4.2 via SERVER-36257
     operations:
       - name: failPoint
         object: testRunner

--- a/source/command-logging-and-monitoring/tests/monitoring/redacted-commands.json
+++ b/source/command-logging-and-monitoring/tests/monitoring/redacted-commands.json
@@ -162,6 +162,11 @@
     },
     {
       "description": "getnonce",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -293,6 +298,11 @@
     },
     {
       "description": "copydbgetnonce",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "3.6.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -328,6 +338,11 @@
     },
     {
       "description": "copydbsaslstart",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -363,6 +378,11 @@
     },
     {
       "description": "copydb",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "4.0.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/source/command-logging-and-monitoring/tests/monitoring/redacted-commands.yml
+++ b/source/command-logging-and-monitoring/tests/monitoring/redacted-commands.yml
@@ -93,6 +93,8 @@ tests:
                 payload: { $$exists: false }
 
   - description: "getnonce"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *database
@@ -159,6 +161,8 @@ tests:
                 roles: { $$exists: false }
 
   - description: "copydbgetnonce"
+    runOnRequirements:
+    - maxServerVersion: 3.6.99 # copydbgetnonce was removed as of 4.0 via SERVER-32276
     operations:
       - name: runCommand
         object: *database
@@ -176,6 +180,8 @@ tests:
               command: { copydbgetnonce: { $$exists: false } }
 
   - description: "copydbsaslstart"
+    runOnRequirements:
+    - maxServerVersion: 4.0.99 # copydbsaslstart was removed as of 4.2 via SERVER-36211
     operations:
       - name: runCommand
         object: *database
@@ -193,6 +199,8 @@ tests:
               command: { copydbsaslstart: { $$exists: false } }
 
   - description: "copydb"
+    runOnRequirements:
+    - maxServerVersion: 4.0.99 # copydb was removed as of 4.2 via SERVER-36257
     operations:
       - name: runCommand
         object: *database

--- a/source/unified-test-format/tests/valid-pass/observeSensitiveCommands.json
+++ b/source/unified-test-format/tests/valid-pass/observeSensitiveCommands.json
@@ -61,6 +61,11 @@
   "tests": [
     {
       "description": "getnonce is observed with observeSensitiveCommands=true",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -106,6 +111,11 @@
     },
     {
       "description": "getnonce is not observed with observeSensitiveCommands=false",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -127,6 +137,11 @@
     },
     {
       "description": "getnonce is not observed by default",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "6.1.99"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/source/unified-test-format/tests/valid-pass/observeSensitiveCommands.yml
+++ b/source/unified-test-format/tests/valid-pass/observeSensitiveCommands.yml
@@ -38,6 +38,8 @@ createEntities:
 
 tests:
   - description: "getnonce is observed with observeSensitiveCommands=true"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *databaseObserveSensitiveCommands
@@ -57,6 +59,8 @@ tests:
                 nonce: { $$exists: false }
 
   - description: "getnonce is not observed with observeSensitiveCommands=false"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *databaseDoNotObserveSensitiveCommands
@@ -68,6 +72,8 @@ tests:
         events: []
 
   - description: "getnonce is not observed by default"
+    runOnRequirements:
+    - maxServerVersion: 6.1.99 # getnonce removed as of 6.2 via SERVER-71007
     operations:
       - name: runCommand
         object: *databaseDoNotObserveSensitiveCommandsByDefault

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3898,8 +3898,6 @@ Changelog
 
 ..
   Please note schema version bumps in changelog entries where applicable.
-:2022-11-16: Update tests for ``observeSensitiveCommands`` that use ``getnonce`` to
-             only run on server versions < 6.2.
 :2022-10-17: Add description of a `close` operation for client entities.
 :2022-10-14: **Schema version 1.13.**
             Add support for logging assertions via the ``observeLogMessages`` field

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3898,6 +3898,8 @@ Changelog
 
 ..
   Please note schema version bumps in changelog entries where applicable.
+:2022-11-16: Update tests for ``observeSensitiveCommands`` that use ``getnonce`` to
+             only run on server versions < 6.2.
 :2022-10-17: Add description of a `close` operation for client entities.
 :2022-10-14: **Schema version 1.13.**
             Add support for logging assertions via the ``observeLogMessages`` field


### PR DESCRIPTION
* The `getnonce` command is being removed in 6.2. This updates various driver tests which used getnonce to only run on lower server versions.
* While looking into this, I noticed that a lot of the other redaction tests used commands which have also been removed in recent server versions. These passed on newer server versions because they expected errors, so the server returned an error regardless: on newer versions, it would just be an error about the command not existing. This coverage didn't seem particularly valuable, and it seemed worthwhile to have each test annotated with the correct maxServerVersion so that as those versions get dropped from drivers we know when the tests can be removed. 

Tests pass in Rust, and since all this changes here is skipping tests in more places I wouldn't expect this to cause failures for anyone.

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

