### PR TITLE
DRIVERS-2035 Use minimum RTT for CSOT maxTimeMS calculation instead of 90th percentile

### DIFF
--- a/source/client-side-operations-timeout/client-side-operations-timeout.rst
+++ b/source/client-side-operations-timeout/client-side-operations-timeout.rst
@@ -299,7 +299,7 @@ Command Execution
 ~~~~~~~~~~~~~~~~~
 
 If ``timeoutMS`` is set, drivers MUST append a ``maxTimeMS`` field to
-commands executed against a MongoDB server using the minimum RTT of
+commands executed against a MongoDB server using the ``minRoundTripTime`` field of
 the selected server. Note that this value MUST be retrieved during server
 selection using the ``servers`` field of the same `TopologyDescription
 <../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#TopologyDescription>`__
@@ -309,8 +309,8 @@ server is reset to the default description (e.g. due to an error in the
 monitoring thread) after it has been selected but before the RTT is
 retrieved.
 
-If the minimum RTT of the selected server is less than the remaining timeoutMS,
-the value of this field MUST be ``remaining timeoutMS - minimum RTT``.
+If the ``minRoundTripTime`` is less than the remaining timeoutMS,
+the value of this field MUST be ``remaining timeoutMS - minRoundTripTime``.
 If not, drivers MUST return a timeout error without
 attempting to send the message to the server. This is done to ensure that an
 operation is not routed to the server if it will likely fail with a socket
@@ -905,8 +905,9 @@ Drivers use minimum RTT to short circuit operations
 A previous version of this spec used the 90th percentile RTT to short
 circuit operations that might otherwise fail with a socket timeout.
 We decided to change this logic to avoid canceling operations that may
-have a high chance of succeeding and also removes a dependency on t-digest.
-Instead, drivers use the minimum RTT from the last 10 samples.
+have a high chance of succeeding and also remove a dependency on t-digest.
+Instead, drivers use the minimum RTT from the last 10 samples, or 0 until
+at least 2 samples have been recorded.
 
 Future work
 ===========

--- a/source/client-side-operations-timeout/client-side-operations-timeout.rst
+++ b/source/client-side-operations-timeout/client-side-operations-timeout.rst
@@ -299,7 +299,7 @@ Command Execution
 ~~~~~~~~~~~~~~~~~
 
 If ``timeoutMS`` is set, drivers MUST append a ``maxTimeMS`` field to
-commands executed against a MongoDB server using the 90th percentile RTT of
+commands executed against a MongoDB server using the minimum RTT of
 the selected server. Note that this value MUST be retrieved during server
 selection using the ``servers`` field of the same `TopologyDescription
 <../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#TopologyDescription>`__
@@ -309,9 +309,9 @@ server is reset to the default description (e.g. due to an error in the
 monitoring thread) after it has been selected but before the RTT is
 retrieved.
 
-If the 90th percentile RTT of the selected server is less than the remaining
-timeoutMS, the value of this field MUST be ``remaining timeoutMS - 90th
-percentile RTT``. If not, drivers MUST return a timeout error without
+If the minimum RTT of the selected server is less than the remaining timeoutMS,
+the value of this field MUST be ``remaining timeoutMS - minimum RTT``.
+If not, drivers MUST return a timeout error without
 attempting to send the message to the server. This is done to ensure that an
 operation is not routed to the server if it will likely fail with a socket
 timeout as that could cause connection churn. The ``maxTimeMS`` field MUST be
@@ -319,7 +319,7 @@ appended after all blocking work is complete.
 
 After wire message construction, drivers MUST check for timeout before
 writing the message to the server. If the timeout has expired or the amount
-of time remaining is less than the selected server's 90th percentile RTT,
+of time remaining is less than the selected server's minimum RTT,
 drivers MUST return the connection to the pool and raise a timeout exception.
 Otherwise, drivers MUST set the connection’s write timeout to the remaining
 ``timeoutMS`` value before writing a message to the server. After the write
@@ -899,6 +899,15 @@ introduce a new knob and increase the API surface of drivers without providing
 a significant benefit.
 
 
+Drivers use minimum RTT to short circuit operations
+---------------------------------------------------
+
+A previous version of this spec used the 90th percentile RTT to short
+circuit operations that might otherwise fail with a socket timeout.
+We decided to change this logic to avoid canceling operations that may
+have a high chance of succeeding and also removes a dependency on t-digest.
+Instead, drivers use the minimum RTT from the last 10 samples.
+
 Future work
 ===========
 
@@ -922,3 +931,4 @@ Changelog
 
 :2022-10-05: Remove spec front matter.
 :2022-01-19: Initial version.
+:2022-11-17: Use minimum RTT for maxTimeMS calculation instead of 90th percentile RTT.

--- a/source/client-side-operations-timeout/tests/command-execution.json
+++ b/source/client-side-operations-timeout/tests/command-execution.json
@@ -61,7 +61,8 @@
                   "useMultipleMongoses": false,
                   "uriOptions": {
                     "appName": "reduceMaxTimeMSTest",
-                    "w": 1
+                    "w": 1,
+                    "timeoutMS": 500
                   },
                   "observeEvents": [
                     "commandStartedEvent"
@@ -77,31 +78,12 @@
               },
               {
                 "collection": {
-                  "id": "regularCollection",
-                  "database": "database",
-                  "collectionName": "coll"
-                }
-              },
-              {
-                "collection": {
                   "id": "timeoutCollection",
                   "database": "database",
-                  "collectionName": "timeoutColl",
-                  "collectionOptions": {
-                    "timeoutMS": 60
-                  }
+                  "collectionName": "timeoutColl"
                 }
               }
             ]
-          }
-        },
-        {
-          "name": "insertOne",
-          "object": "regularCollection",
-          "arguments": {
-            "document": {
-              "_id": 1
-            }
           }
         },
         {
@@ -123,21 +105,9 @@
                 "commandName": "insert",
                 "databaseName": "test",
                 "command": {
-                  "insert": "coll",
-                  "maxTimeMS": {
-                    "$$exists": false
-                  }
-                }
-              }
-            },
-            {
-              "commandStartedEvent": {
-                "commandName": "insert",
-                "databaseName": "test",
-                "command": {
                   "insert": "timeoutColl",
                   "maxTimeMS": {
-                    "$$lte": 60
+                    "$$lte": 500
                   }
                 }
               }
@@ -180,7 +150,8 @@
                   "useMultipleMongoses": false,
                   "uriOptions": {
                     "appName": "rttTooHighTest",
-                    "w": 1
+                    "w": 1,
+                    "timeoutMS": 10
                   },
                   "observeEvents": [
                     "commandStartedEvent"
@@ -196,19 +167,9 @@
               },
               {
                 "collection": {
-                  "id": "regularCollection",
-                  "database": "database",
-                  "collectionName": "coll"
-                }
-              },
-              {
-                "collection": {
                   "id": "timeoutCollection",
                   "database": "database",
-                  "collectionName": "timeoutColl",
-                  "collectionOptions": {
-                    "timeoutMS": 2
-                  }
+                  "collectionName": "timeoutColl"
                 }
               }
             ]
@@ -216,11 +177,38 @@
         },
         {
           "name": "insertOne",
-          "object": "regularCollection",
+          "object": "timeoutCollection",
           "arguments": {
             "document": {
-              "_id": 1
+              "_id": 2
             }
+          },
+          "expectError": {
+            "isTimeoutError": true
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "timeoutCollection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectError": {
+            "isTimeoutError": true
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "timeoutCollection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          },
+          "expectError": {
+            "isTimeoutError": true
           }
         },
         {
@@ -239,20 +227,7 @@
       "expectEvents": [
         {
           "client": "client",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "commandName": "insert",
-                "databaseName": "test",
-                "command": {
-                  "insert": "coll",
-                  "maxTimeMS": {
-                    "$$exists": false
-                  }
-                }
-              }
-            }
-          ]
+          "events": []
         }
       ]
     }

--- a/source/client-side-operations-timeout/tests/command-execution.json
+++ b/source/client-side-operations-timeout/tests/command-execution.json
@@ -45,7 +45,7 @@
                 ],
                 "appName": "reduceMaxTimeMSTest",
                 "blockConnection": true,
-                "blockTimeMS": 20
+                "blockTimeMS": 50
               }
             }
           }
@@ -62,7 +62,8 @@
                   "uriOptions": {
                     "appName": "reduceMaxTimeMSTest",
                     "w": 1,
-                    "timeoutMS": 500
+                    "timeoutMS": 500,
+                    "heartbeatFrequencyMS": 500
                   },
                   "observeEvents": [
                     "commandStartedEvent"
@@ -107,7 +108,7 @@
                 "command": {
                   "insert": "timeoutColl",
                   "maxTimeMS": {
-                    "$$lte": 500
+                    "$$lte": 450
                   }
                 }
               }
@@ -134,7 +135,7 @@
                 ],
                 "appName": "rttTooHighTest",
                 "blockConnection": true,
-                "blockTimeMS": 20
+                "blockTimeMS": 50
               }
             }
           }
@@ -151,7 +152,8 @@
                   "uriOptions": {
                     "appName": "rttTooHighTest",
                     "w": 1,
-                    "timeoutMS": 10
+                    "timeoutMS": 10,
+                    "heartbeatFrequencyMS": 500
                   },
                   "observeEvents": [
                     "commandStartedEvent"

--- a/source/client-side-operations-timeout/tests/command-execution.json
+++ b/source/client-side-operations-timeout/tests/command-execution.json
@@ -280,6 +280,115 @@
           ]
         }
       ]
+    },
+    {
+      "description": "short-circuit is not enabled with only 1 RTT measurement",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": "alwaysOn",
+              "data": {
+                "failCommands": [
+                  "hello",
+                  "isMaster"
+                ],
+                "appName": "reduceMaxTimeMSTest",
+                "blockConnection": true,
+                "blockTimeMS": 100
+              }
+            }
+          }
+        },
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "useMultipleMongoses": false,
+                  "uriOptions": {
+                    "appName": "reduceMaxTimeMSTest",
+                    "w": 1,
+                    "timeoutMS": 90,
+                    "heartbeatFrequencyMS": 100000
+                  },
+                  "observeEvents": [
+                    "commandStartedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "test"
+                }
+              },
+              {
+                "collection": {
+                  "id": "timeoutCollection",
+                  "database": "database",
+                  "collectionName": "timeoutColl"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "timeoutCollection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "timeoutMS": 100000
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "timeoutCollection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "timeoutColl"
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "timeoutColl",
+                  "maxTimeMS": {
+                    "$$lte": 450
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/source/client-side-operations-timeout/tests/command-execution.json
+++ b/source/client-side-operations-timeout/tests/command-execution.json
@@ -3,7 +3,14 @@
   "schemaVersion": "1.9",
   "runOnRequirements": [
     {
-      "minServerVersion": "4.9"
+      "minServerVersion": "4.9",
+      "topologies": [
+        "single",
+        "replicaset",
+        "sharded-replicaset",
+        "sharded"
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [
@@ -92,6 +99,23 @@
           "object": "timeoutCollection",
           "arguments": {
             "document": {
+              "_id": 1
+            },
+            "timeoutMS": 100000
+          }
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 1000
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "timeoutCollection",
+          "arguments": {
+            "document": {
               "_id": 2
             }
           }
@@ -101,6 +125,15 @@
         {
           "client": "client",
           "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "timeoutColl"
+                }
+              }
+            },
             {
               "commandStartedEvent": {
                 "commandName": "insert",
@@ -182,11 +215,16 @@
           "object": "timeoutCollection",
           "arguments": {
             "document": {
-              "_id": 2
-            }
-          },
-          "expectError": {
-            "isTimeoutError": true
+              "_id": 1
+            },
+            "timeoutMS": 100000
+          }
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 1000
           }
         },
         {
@@ -206,7 +244,7 @@
           "object": "timeoutCollection",
           "arguments": {
             "document": {
-              "_id": 2
+              "_id": 3
             }
           },
           "expectError": {
@@ -218,7 +256,7 @@
           "object": "timeoutCollection",
           "arguments": {
             "document": {
-              "_id": 2
+              "_id": 4
             }
           },
           "expectError": {
@@ -229,7 +267,17 @@
       "expectEvents": [
         {
           "client": "client",
-          "events": []
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "insert",
+                "databaseName": "test",
+                "command": {
+                  "insert": "timeoutColl"
+                }
+              }
+            }
+          ]
         }
       ]
     }

--- a/source/client-side-operations-timeout/tests/command-execution.yml
+++ b/source/client-side-operations-timeout/tests/command-execution.yml
@@ -181,3 +181,70 @@ tests:
               databaseName: *databaseName
               command:
                 insert: *timeoutCollectionName
+
+  - description: "short-circuit is not enabled with only 1 RTT measurement"
+    operations:
+      # Artificially increase the server RTT to ~300ms.
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *failPointClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode: "alwaysOn"
+            data:
+              failCommands: ["hello", "isMaster"]
+              appName: &appName reduceMaxTimeMSTest
+              blockConnection: true
+              blockTimeMS: 100
+      # Create a client with the app name specified in the fail point and timeoutMS lower than blockTimeMS.
+      # Also create database and collection entities derived from the new client.
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                useMultipleMongoses: false
+                uriOptions:
+                  appName: *appName
+                  w: 1  # Override server's w:majority default to speed up the test.
+                  timeoutMS: 90
+                  heartbeatFrequencyMS: 100000  # Override heartbeatFrequencyMS to ensure only 1 RTT is recorded.
+                observeEvents:
+                  - commandStartedEvent
+            - database:
+                id: &database database
+                client: *client
+                databaseName: *databaseName
+            - collection:
+                id: &timeoutCollection timeoutCollection
+                database: *database
+                collectionName: *timeoutCollectionName
+      # Do an operation with a large timeout to ensure the servers are discovered.
+      - name: insertOne
+        object: *timeoutCollection
+        arguments:
+          document: { _id: 1 }
+          timeoutMS: 100000
+      # Do an operation with timeoutCollection which will succeed. If this
+      # fails it indicates the driver mistakenly used the min RTT even though
+      # there has only been one sample.
+      - name: insertOne
+        object: *timeoutCollection
+        arguments:
+          document: { _id: 2 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              databaseName: *databaseName
+              command:
+                insert: *timeoutCollectionName
+          - commandStartedEvent:
+              commandName: insert
+              databaseName: *databaseName
+              command:
+                insert: *timeoutCollectionName
+                maxTimeMS: { $$lte: 450 }

--- a/source/client-side-operations-timeout/tests/command-execution.yml
+++ b/source/client-side-operations-timeout/tests/command-execution.yml
@@ -27,7 +27,7 @@ initialData:
 tests:
   - description: "maxTimeMS value in the command is less than timeoutMS"
     operations:
-      # Artificially increase the server RTT to ~20ms.
+      # Artificially increase the server RTT to ~50ms.
       - name: failPoint
         object: testRunner
         arguments:
@@ -39,7 +39,7 @@ tests:
               failCommands: ["hello", "isMaster"]
               appName: &appName reduceMaxTimeMSTest
               blockConnection: true
-              blockTimeMS: 20
+              blockTimeMS: 50
       # Create a client with the app name specified in the fail point and timeoutMS higher than blockTimeMS.
       # Also create database and collection entities derived from the new client.
       - name: createEntities
@@ -52,7 +52,8 @@ tests:
                 uriOptions:
                   appName: *appName
                   w: 1  # Override server's w:majority default to speed up the test.
-                  timeoutMS: &timeoutMS 500
+                  timeoutMS: 500
+                  heartbeatFrequencyMS: 500
                 observeEvents:
                   - commandStartedEvent
             - database:
@@ -76,11 +77,11 @@ tests:
               databaseName: *databaseName
               command:
                 insert: *timeoutCollectionName
-                maxTimeMS: { $$lte: *timeoutMS }
+                maxTimeMS: { $$lte: 450 }
 
   - description: "command is not sent if RTT is greater than timeoutMS"
     operations:
-      # Artificially increase the server RTT to ~20ms.
+      # Artificially increase the server RTT to ~50ms.
       - name: failPoint
         object: testRunner
         arguments:
@@ -92,7 +93,7 @@ tests:
               failCommands: ["hello", "isMaster"]
               appName: &appName rttTooHighTest
               blockConnection: true
-              blockTimeMS: 20
+              blockTimeMS: 50
       # Create a client with the app name specified in the fail point. Also create database and collection entities
       # derived from the new client. There is one collection entity with no timeoutMS and another with a timeoutMS
       # that's lower than the fail point's blockTimeMS value.
@@ -107,6 +108,7 @@ tests:
                   appName: *appName
                   w: 1  # Override server's w:majority default to speed up the test.
                   timeoutMS: 10
+                  heartbeatFrequencyMS: 500
                 observeEvents:
                   - commandStartedEvent
             - database:

--- a/source/client-side-operations-timeout/tests/command-execution.yml
+++ b/source/client-side-operations-timeout/tests/command-execution.yml
@@ -40,9 +40,8 @@ tests:
               appName: &appName reduceMaxTimeMSTest
               blockConnection: true
               blockTimeMS: 20
-      # Create a client with the app name specified in the fail point. Also create database and collection entities
-      # derived from the new client. There are two collection entities: one with no timeoutMS, which is used to run
-      # an initial operation, and one with a timeoutMS higher than the fail point's blockTimeMS value.
+      # Create a client with the app name specified in the fail point and timeoutMS higher than blockTimeMS.
+      # Also create database and collection entities derived from the new client.
       - name: createEntities
         object: testRunner
         arguments:
@@ -53,6 +52,7 @@ tests:
                 uriOptions:
                   appName: *appName
                   w: 1  # Override server's w:majority default to speed up the test.
+                  timeoutMS: &timeoutMS 500
                 observeEvents:
                   - commandStartedEvent
             - database:
@@ -60,20 +60,9 @@ tests:
                 client: *client
                 databaseName: *databaseName
             - collection:
-                id: &regularCollection regularCollection
-                database: *database
-                collectionName: *regularCollectionName
-            - collection:
                 id: &timeoutCollection timeoutCollection
                 database: *database
                 collectionName: *timeoutCollectionName
-                collectionOptions:
-                  timeoutMS: &timeoutMS 60
-      # Do an operation with regularCollection to ensure the servers are discovered.
-      - name: insertOne
-        object: *regularCollection
-        arguments:
-          document: { _id : 1 }
       # Do an operation with timeoutCollection so the event will include a maxTimeMS field.
       - name: insertOne
         object: *timeoutCollection
@@ -82,12 +71,6 @@ tests:
     expectEvents:
       - client: *client
         events:
-          - commandStartedEvent:
-              commandName: insert
-              databaseName: *databaseName
-              command:
-                insert: *regularCollectionName
-                maxTimeMS: { $$exists: false }
           - commandStartedEvent:
               commandName: insert
               databaseName: *databaseName
@@ -123,6 +106,7 @@ tests:
                 uriOptions:
                   appName: *appName
                   w: 1  # Override server's w:majority default to speed up the test.
+                  timeoutMS: 10
                 observeEvents:
                   - commandStartedEvent
             - database:
@@ -130,20 +114,30 @@ tests:
                 client: *client
                 databaseName: *databaseName
             - collection:
-                id: &regularCollection regularCollection
-                database: *database
-                collectionName: *regularCollectionName
-            - collection:
                 id: &timeoutCollection timeoutCollection
                 database: *database
                 collectionName: *timeoutCollectionName
-                collectionOptions:
-                  timeoutMS: 2
-      # Do an operation with regularCollection to ensure the servers are discovered.
+      # Do an operation with timeoutCollection which will error.
       - name: insertOne
-        object: *regularCollection
+        object: *timeoutCollection
         arguments:
-          document: { _id : 1 }
+          document: { _id: 2 }
+        expectError:
+          isTimeoutError: true
+      # Do an operation with timeoutCollection which will error.
+      - name: insertOne
+        object: *timeoutCollection
+        arguments:
+          document: { _id: 2 }
+        expectError:
+          isTimeoutError: true
+      # Do an operation with timeoutCollection which will error.
+      - name: insertOne
+        object: *timeoutCollection
+        arguments:
+          document: { _id: 2 }
+        expectError:
+          isTimeoutError: true
       # Do an operation with timeoutCollection which will error.
       - name: insertOne
         object: *timeoutCollection
@@ -152,13 +146,6 @@ tests:
         expectError:
           isTimeoutError: true
     expectEvents:
-      # There should only be one event, which corresponds to the first insertOne call. For the second insertOne call,
-      # drivers should fail client-side.
+      # There should be no events because the driver should fail client-side.
       - client: *client
-        events:
-          - commandStartedEvent:
-              commandName: insert
-              databaseName: *databaseName
-              command:
-                insert: *regularCollectionName
-                maxTimeMS: { $$exists: false }
+        events: []

--- a/source/client-side-operations-timeout/tests/command-execution.yml
+++ b/source/client-side-operations-timeout/tests/command-execution.yml
@@ -6,6 +6,9 @@ runOnRequirements:
   # The appName filter cannot be used to set a fail point on connection handshakes until server version 4.9 due to
   # SERVER-49220/SERVER-49336.
   - minServerVersion: "4.9"
+    # Skip load-balanced and serverless which do not support RTT measurements.
+    topologies: [ single, replicaset, sharded-replicaset, sharded ]
+    serverless: forbid
 
 createEntities:
   - client:
@@ -64,6 +67,17 @@ tests:
                 id: &timeoutCollection timeoutCollection
                 database: *database
                 collectionName: *timeoutCollectionName
+      # Do an operation with a large timeout to ensure the servers are discovered.
+      - name: insertOne
+        object: *timeoutCollection
+        arguments:
+          document: { _id: 1 }
+          timeoutMS: 100000
+      # Wait until short-circuiting has been enabled (at least 2 RTT measurements).
+      - name: wait
+        object: testRunner
+        arguments:
+          ms: 1000
       # Do an operation with timeoutCollection so the event will include a maxTimeMS field.
       - name: insertOne
         object: *timeoutCollection
@@ -72,6 +86,11 @@ tests:
     expectEvents:
       - client: *client
         events:
+          - commandStartedEvent:
+              commandName: insert
+              databaseName: *databaseName
+              command:
+                insert: *timeoutCollectionName
           - commandStartedEvent:
               commandName: insert
               databaseName: *databaseName
@@ -119,6 +138,17 @@ tests:
                 id: &timeoutCollection timeoutCollection
                 database: *database
                 collectionName: *timeoutCollectionName
+      # Do an operation with a large timeout to ensure the servers are discovered.
+      - name: insertOne
+        object: *timeoutCollection
+        arguments:
+          document: { _id: 1 }
+          timeoutMS: 100000
+      # Wait until short-circuiting has been enabled (at least 2 RTT measurements).
+      - name: wait
+        object: testRunner
+        arguments:
+          ms: 1000
       # Do an operation with timeoutCollection which will error.
       - name: insertOne
         object: *timeoutCollection
@@ -130,24 +160,24 @@ tests:
       - name: insertOne
         object: *timeoutCollection
         arguments:
-          document: { _id: 2 }
+          document: { _id: 3 }
         expectError:
           isTimeoutError: true
       # Do an operation with timeoutCollection which will error.
       - name: insertOne
         object: *timeoutCollection
         arguments:
-          document: { _id: 2 }
-        expectError:
-          isTimeoutError: true
-      # Do an operation with timeoutCollection which will error.
-      - name: insertOne
-        object: *timeoutCollection
-        arguments:
-          document: { _id: 2 }
+          document: { _id: 4 }
         expectError:
           isTimeoutError: true
     expectEvents:
-      # There should be no events because the driver should fail client-side.
+      # There should only be one event, which corresponds to the first
+      # insertOne call. For the subsequent insertOne calls, drivers should
+      # fail client-side.
       - client: *client
-        events: []
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              databaseName: *databaseName
+              command:
+                insert: *timeoutCollectionName

--- a/source/client-side-operations-timeout/tests/legacy-timeouts.yml
+++ b/source/client-side-operations-timeout/tests/legacy-timeouts.yml
@@ -116,8 +116,8 @@ tests:
                   wtimeout: *wTimeoutMS
 
   # If the maxTimeMS option is set for a specific command, it should be used as the maxTimeMS command field without any
-  # modifications. This is different than timeoutMS because in that case, drivers subtract the target server's 90%
-  # percentile RTT from the remaining timeout to derive a maxTimeMS field.
+  # modifications. This is different from timeoutMS because in that case, drivers subtract the target server's min
+  # RTT from the remaining timeout to derive a maxTimeMS field.
   - description: "maxTimeMS option is used directly as the maxTimeMS field on a command"
     operations:
       - name: createEntities

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst
@@ -328,7 +328,7 @@ Fields:
   from the address the client uses.
 * (=) error: information about the last error related to this server. Default null.
 * roundTripTime: the duration of the hello or legacy hello call. Default null.
-* ninetiethPercentileRoundTripTime: the 90th percentile RTT for the server. Default null.
+* minRoundTripTime: the minimum RTT for the server. Default null.
 * lastWriteDate: a 64-bit BSON datetime or null.
   The "lastWriteDate" from the server's most recent hello or legacy hello response.
 * opTime: an opTime or null.
@@ -663,7 +663,7 @@ roundTripTime
 Drivers MUST record the server's `round trip time`_ (RTT) after each
 successful call to hello or legacy hello. The Server Selection Spec
 describes how RTT is averaged and how it is used in server selection.
-Drivers MUST also record the server's 90th percentile RTT per
+Drivers MUST also record the server's minimum RTT per
 `Server Monitoring (Measuring RTT)`_.
 
 If a hello or legacy hello call fails, the RTT is not updated.
@@ -2542,6 +2542,7 @@ Changelog
 :2022-07-11: Convert integration tests to the unified format.
 :2022-09-30: Update ``updateRSFromPrimary`` to include logic before and after 6.0 servers
 :2022-10-05: Remove spec front matter, move footnote, and reformat changelog.
+:2022-11-17: Add minimum RTT tracking and remove 90th percentile RTT.
 
 ----
 

--- a/source/server-discovery-and-monitoring/server-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-monitoring.rst
@@ -810,11 +810,12 @@ on a dedicated connection, for example:
         helloOk = stableApi != Null
         lock = Mutex()
         movingAverage = MovingAverage()
-        rttMin = MinWindow() # for min RTT calculation
+        rttMin = MinWindow(max_window_size=10) # for min RTT calculation
 
     def reset():
         with lock:
             movingAverage.reset()
+            rttMin.reset()
 
     def addSample(rtt):
         with lock:


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2035

Please complete the following before merging:

- [X] Update changelog.
- [X] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver: https://spruce.mongodb.com/version/63e568b07742ae5e72e81ce0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

