### PR TITLE
DRIVERS-2465 Test crypt_shared with older server versions

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -332,11 +332,12 @@ with the ``crypt_shared`` library instead of spawning mongocryptd.
 
 crypt_shared_ is released alongside the server.
 crypt_shared_ is only available in versions 6.0 and above.
-Drivers SHOULD prefer testing a version of crypt_shared_ that matches the server version being tested.
-Driver tests on server versions less than 6.0 SHOULD use mongocryptd.
 
-Drivers MUST continue to run all tests with mongocryptd on at least one
-platform for all tested server versions.
+mongocryptd is released alongside the server.
+mongocryptd is available in versions 4.2 and above.
+
+Drivers MUST run all tests with mongocryptd on at least one platform for all
+tested server versions.
 
 Drivers MUST run all tests with crypt_shared_ on at least one platform for all
 tested server versions. For server versions < 6.0, drivers MUST test with the

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -338,9 +338,10 @@ Driver tests on server versions less than 6.0 SHOULD use mongocryptd.
 Drivers MUST continue to run all tests with mongocryptd on at least one
 platform for all tested server versions.
 
-Drivers MUST run all tests with the latest major release of crypt_shared_
-on at least one platform for all tested server versions. Using the latest
-major release of crypt_shared_ is supported with older server versions.
+Drivers MUST run all tests with crypt_shared_ on at least one platform for all
+tested server versions. For server versions < 6.0, drivers MUST test with the
+latest major release of crypt_shared_. Using the latest major release of
+crypt_shared_ is supported with older server versions.
 
 Note that some tests assert on mongocryptd-related behaviors (e.g. the
 ``mongocryptdBypassSpawn`` test).

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -338,6 +338,10 @@ Driver tests on server versions less than 6.0 SHOULD use mongocryptd.
 Drivers MUST continue to run all tests with mongocryptd on at least one
 platform for all tested server versions.
 
+Drivers MUST run all tests with the latest major release of crypt_shared_
+on at least one platform for all tested server versions. Using the latest
+major release of crypt_shared_ is supported with older server versions.
+
 Note that some tests assert on mongocryptd-related behaviors (e.g. the
 ``mongocryptdBypassSpawn`` test).
 


### PR DESCRIPTION
# Summary

- Require drivers test the latest Major release of `crypt_shared` with older server versions.

# Background & Motivation
Testing `crypt_shared` with older server versions is a product ask. See DRIVERS-2465.

This change depends on https://github.com/mongodb-labs/drivers-evergreen-tools/pull/247.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~[ ] Update changelog.~ **Not applicable. Test README changes only.**
- ~[ ] Make sure there are generated JSON files from the YAML test files.~ **Not applicable. Test README changes only.**
- [x] Test changes in at least one language driver. **Tested in [Go](https://github.com/mongodb/mongo-go-driver/pull/1139)**
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

