### PR TITLE
DRIVERS-2338 fix option typos

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -4,8 +4,8 @@ Client Side Encryption
 
 :Status: Accepted
 :Minimum Server Version: 4.2 (CSFLE), 6.0 (Queryable Encryption)
-:Last Modified: 2022-11-10
-:Version: 1.11.0
+:Last Modified: 2022-11-27
+:Version: 1.11.1
 
 .. _lmc-c-api: https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h.in
 
@@ -811,13 +811,13 @@ load. Refer:
 - `Enabling crypt_shared`_
 
 
-``extraOptions.cryptSharedRequired``
+``extraOptions.cryptSharedLibRequired``
 ````````````````````````````````````
 
 :type: :ts:`boolean`
 :default: |false|
 
-.. |opt-crypt_shared-required| replace:: `extraOptions.cryptSharedRequired`_
+.. |opt-crypt_shared-required| replace:: `extraOptions.cryptSharedLibRequired`_
 
 If |true|, the driver MUST refuse to continue unless crypt_shared_ was loaded
 successfully.
@@ -2602,6 +2602,7 @@ explicit session parameter as described in the
 Changelog
 =========
 
+:2022-11-27: Fix typo for references to ``cryptSharedLibRequired`` option.
 :2022-11-10: Defined a ``CreateEncryptedCollection`` helper for creating new
              encryption keys automatically for the queryable encrypted fields in
              a new collection.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1001,7 +1001,7 @@ The following tests that loading crypt_shared_ bypasses spawning mongocryptd.
         "mongocryptdURI": "mongodb://localhost:27021/db?serverSelectionTimeoutMS=1000",
         "mongocryptdSpawnArgs": [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27021"],
         "cryptSharedLibPath": "<path to shared library>",
-        "cryptSharedRequired": true
+        "cryptSharedLibRequired": true
       }
 
    Drivers MAY pass a different port if they expect their testing infrastructure to be using port 27021. Pass a port that should be free.


### PR DESCRIPTION
# Summary

- Rename references of `cryptSharedRequired` to `cryptSharedLibRequired`

# Background & Motivation

The specification is inconsistent about the option name.

Surveying driver implementations, all use a form of `cryptSharedLibRequired` except for the Ruby driver as part of [RUBY-3184](https://jira.mongodb.org/browse/RUBY-3184) which appears unreleased. See [Do drivers use cryptSharedRequired or cryptSharedLibRequired?](https://docs.google.com/spreadsheets/d/1WD6NllbyfEF6Bynnl88LQkCyqXze9btNk9Nz6OotBTo/edit#gid=0).

Including `Lib` is consistent with the other option `cryptSharedLibPath`.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files. **Not applicable.**
- [ ] Test changes in at least one language driver. **Not applicable**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **Not applicable**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

