### PR TITLE
DRIVERS-2507 Permit `tlsDisableOCSPEndpointCheck` in KMS TLS options

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -4,8 +4,8 @@ Client Side Encryption
 
 :Status: Accepted
 :Minimum Server Version: 4.2 (CSFLE), 6.0 (Queryable Encryption)
-:Last Modified: 2022-11-10
-:Version: 1.11.0
+:Last Modified: 2022-11-28
+:Version: 1.11.1
 
 .. _lmc-c-api: https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h.in
 
@@ -718,8 +718,10 @@ This includes options equivalent to the following URI options:
 - `tlsInsecure`
 - `tlsAllowInvalidCertificates`
 - `tlsAllowInvalidHostnames`
-- `tlsDisableOCSPEndpointCheck`
 - `tlsDisableCertificateRevocationCheck`
+
+Drivers MUST NOT raise an error if `tlsDisableOCSPEndpointCheck` is set.
+Setting `tlsDisableOCSPEndpointCheck` may prevent operation errors when OCSP responders are unresponsive.
 
 See the OCSP specification for a description of the default values of
 `tlsDisableOCSPEndpointCheck
@@ -2602,6 +2604,7 @@ explicit session parameter as described in the
 Changelog
 =========
 
+:2022-11-28: Permit `tlsDisableOCSPEndpointCheck` in KMS TLS options.
 :2022-11-10: Defined a ``CreateEncryptedCollection`` helper for creating new
              encryption keys automatically for the queryable encrypted fields in
              a new collection.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1645,6 +1645,29 @@ the same masterKey.
 
 Expect an error indicating TLS handshake failed due to an invalid hostname.
 
+Case 5: `tlsDisableOCSPEndpointCheck` is permitted
+``````````````````````````````````````````````````
+
+This test does not apply if the driver does not support the the option ``tlsDisableOCSPEndpointCheck``.
+
+Create a ``ClientEncryption`` object with the following KMS providers:
+
+   .. code:: javascript
+
+      {
+            "aws": {
+               "accessKeyId": "foo",
+               "secretAccessKey": "bar"
+            }
+      }
+
+   Add TLS options for the ``aws`` with the following options:
+
+   - ``tlsDisableOCSPEndpointCheck`` (or equivalent) set to ``true``.
+
+Expect no error on construction.
+
+
 12. Explicit Encryption
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
# Summary
- Permit `tlsDisableOCSPEndpointCheck` in KMS TLS options.

# Background & Motivation

There is a report of [timeouts to OCSP responders during KMS](https://jira.mongodb.org/browse/HELP-39172?focusedCommentId=4989713&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4989713). That results in operation failures using CSFLE. 

The rationale to prohibit the option is to avoid enabling insecure settings when using CSFLE. Product is OK with allowing `tlsDisableOCSPEndpointCheck` to be opt-in (see [comment](https://jira.mongodb.org/browse/DRIVERS-2507?focusedCommentId=5001801&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-5001801)).

Tested in C: https://github.com/mongodb/mongo-c-driver/pull/1153

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files. **Not applicable**
- [x] Test changes in at least one language driver. **Tested in [C](https://github.com/mongodb/mongo-c-driver/pull/1153)**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). **Not applicable**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

