### PR TITLE
DRIVERS-2505 Add explicit encryption API and tests for range indexes

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1246,6 +1246,7 @@ EncryptOpts
       rangeOpts: Optional<RangeOpts>
    }
 
+   // NOTE: The Range algorithm is experimental only. It is not intended for public use.
    // RangeOpts specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
    // min, max, sparsity, and range must match the values set in the encryptedFields of the destination collection.
    // For double and decimal128, min/max/precision must all be set, or all be unset.
@@ -1284,10 +1285,14 @@ The result of explicit encryption with the "Indexed" or "RangePreview" algorithm
    To insert or query with an "Indexed" or "RangePreview" encrypted payload, use a ``MongoClient`` configured with ``AutoEncryptionOpts``.
    ``AutoEncryptionOpts.bypassQueryAnalysis`` may be true. ``AutoEncryptionOpts.bypassAutoEncryption`` must be false.
 
+NOTE: The Range algorithm is experimental only. It is not intended for public use.
+
 contentionFactor
 ^^^^^^^^^^^^^^^^
 contentionFactor only applies when algorithm is "Indexed" or "RangePreview".
 It is an error to set contentionFactor when algorithm is not "Indexed".
+
+NOTE: The Range algorithm is experimental only. It is not intended for public use.
 
 queryType
 ^^^^^^^^^
@@ -1298,10 +1303,14 @@ One of the strings:
 queryType only applies when algorithm is "Indexed" or "RangePreview".
 It is an error to set queryType when algorithm is not "Indexed" or "RangePreview".
 
+NOTE: The Range algorithm is experimental only. It is not intended for public use.
+
 rangeOpts
 ^^^^^^^^^
 rangeOpts only applies when queryType is "rangePreview".
 It is an error to set rangeOpts when queryType is not "rangePreview".
+
+NOTE: The Range algorithm is experimental only. It is not intended for public use.
 
 User facing API: When Auto Encryption Fails
 ===========================================

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1045,7 +1045,7 @@ ClientEncryption
       getKeyByAltName(keyAltName: String): Optional<Document>;
 
       // Encrypts a BsonValue with a given key and algorithm.
-      // If `opts.queryType` == "range", `value` is expected to be a BSON document
+      // If `opts.queryType` == "rangePreview", `value` is expected to be a BSON document
       // of one of the following forms:
       // 1. A Match Expression of this form:
       //   {$and: [{<field>: {$gt: <value1>}}, {<field>: {$lt: <value2> }}]}
@@ -1246,7 +1246,7 @@ EncryptOpts
       rangeOpts: Optional<RangeOpts>
    }
 
-   // RangeOpts specifies index options for a Queryable Encryption field supporting "range" queries.
+   // RangeOpts specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
    // min, max, sparsity, and range must match the values set in the encryptedFields of the destination collection.
    // For double and decimal128, min/max/precision must all be set, or all be unset.
    class RangeOpts {
@@ -1277,31 +1277,31 @@ One of the strings:
 - "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
 - "Indexed"
 - "Unindexed"
-- "Range"
+- "RangePreview"
 
-The result of explicit encryption with the "Indexed" or "Range" algorithm must be processed by the server to insert or query. Drivers MUST document the following behavior:
+The result of explicit encryption with the "Indexed" or "RangePreview" algorithm must be processed by the server to insert or query. Drivers MUST document the following behavior:
 
-   To insert or query with an "Indexed" or "Range" encrypted payload, use a ``MongoClient`` configured with ``AutoEncryptionOpts``.
+   To insert or query with an "Indexed" or "RangePreview" encrypted payload, use a ``MongoClient`` configured with ``AutoEncryptionOpts``.
    ``AutoEncryptionOpts.bypassQueryAnalysis`` may be true. ``AutoEncryptionOpts.bypassAutoEncryption`` must be false.
 
 contentionFactor
 ^^^^^^^^^^^^^^^^
-contentionFactor only applies when algorithm is "Indexed" or "Range".
+contentionFactor only applies when algorithm is "Indexed" or "RangePreview".
 It is an error to set contentionFactor when algorithm is not "Indexed".
 
 queryType
 ^^^^^^^^^
 One of the strings:
 - "equality"
-- "range"
+- "rangePreview"
 
-queryType only applies when algorithm is "Indexed" or "Range".
-It is an error to set queryType when algorithm is not "Indexed" or "Range".
+queryType only applies when algorithm is "Indexed" or "RangePreview".
+It is an error to set queryType when algorithm is not "Indexed" or "RangePreview".
 
 rangeOpts
 ^^^^^^^^^
-rangeOpts only applies when queryType is "range".
-It is an error to set rangeOpts when queryType is not "range".
+rangeOpts only applies when queryType is "rangePreview".
+It is an error to set rangeOpts when queryType is not "rangePreview".
 
 User facing API: When Auto Encryption Fails
 ===========================================

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -2573,6 +2573,7 @@ libmongocrypt, and not the driver, to use the new values.
 Why is there an encryptExpression helper?
 -----------------------------------------
 
+Querying a range index requires encrypting a lower bound (value for ``$gt`` or ``$gte``) and upper bound (value for ``$lt`` or ``$lte``) payload.
 A rejected alternative API is to encrypt the lower and upper bound payloads separately.
 The lower and upper bound payloads must have a unique matching UUID. The lower and upper bound payloads are unique.
 This API requires handling the UUID and distinguishing the upper and lower bounds. Here are examples showing possible errors:
@@ -2590,7 +2591,7 @@ This API requires handling the UUID and distinguishing the upper and lower bound
    # Both bounds match UUID ... OK
    db.coll.find_one ({"age": {"$gt": lower, "$lt": upper }})
 
-   # Lower bound is used as an upper bound ... ERROR!
+   # Upper bound is used as a lower bound ... ERROR!
    db.coll.find_one ({"age": {"$gt": upper }})
 
    lower2 = clientEncryption.encrypt (value=35, lOpts)

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1058,7 +1058,7 @@ ClientEncryption
       //   {$and: [{$gt: [<fieldpath>, <value1>]}, {$lt: [<fieldpath>, <value2>]}]
       // $gt may also be $gte. $lt may also be $lte.
       // Only supported for queryType "rangePreview"
-      // NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
+      // NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
       encryptExpression(expr: Document, opts: EncryptOpts): Document;
 
       // Decrypts an encrypted value (BSON binary of subtype 6).
@@ -1252,7 +1252,7 @@ EncryptOpts
       rangeOpts: Optional<RangeOpts>
    }
 
-   // NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
+   // NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
    // RangeOpts specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
    // min, max, sparsity, and range must match the values set in the encryptedFields of the destination collection.
    // For double and decimal128, min/max/precision must all be set, or all be unset.
@@ -1291,14 +1291,14 @@ The result of explicit encryption with the "Indexed" or "RangePreview" algorithm
    To insert or query with an "Indexed" or "RangePreview" encrypted payload, use a ``MongoClient`` configured with ``AutoEncryptionOpts``.
    ``AutoEncryptionOpts.bypassQueryAnalysis`` may be true. ``AutoEncryptionOpts.bypassAutoEncryption`` must be false.
 
-NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
+NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 
 contentionFactor
 ^^^^^^^^^^^^^^^^
 contentionFactor only applies when algorithm is "Indexed" or "RangePreview".
 It is an error to set contentionFactor when algorithm is not "Indexed".
 
-NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
+NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 
 queryType
 ^^^^^^^^^
@@ -1309,14 +1309,14 @@ One of the strings:
 queryType only applies when algorithm is "Indexed" or "RangePreview".
 It is an error to set queryType when algorithm is not "Indexed" or "RangePreview".
 
-NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
+NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 
 rangeOpts
 ^^^^^^^^^
 rangeOpts only applies when algorithm is "rangePreview".
 It is an error to set rangeOpts when algorithm is not "rangePreview".
 
-NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
+NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
 
 User facing API: When Auto Encryption Fails
 ===========================================

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1307,8 +1307,8 @@ NOTE: The Range algorithm is experimental only. It is not intended for public us
 
 rangeOpts
 ^^^^^^^^^
-rangeOpts only applies when queryType is "rangePreview".
-It is an error to set rangeOpts when queryType is not "rangePreview".
+rangeOpts only applies when algorithm is "rangePreview".
+It is an error to set rangeOpts when algorithm is not "rangePreview".
 
 NOTE: The Range algorithm is experimental only. It is not intended for public use.
 

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1057,7 +1057,7 @@ ClientEncryption
       // 2. An Aggregate Expression of this form:
       //   {$and: [{$gt: [<fieldpath>, <value1>]}, {$lt: [<fieldpath>, <value2>]}]
       // $gt may also be $gte. $lt may also be $lte.
-      // Only supported for queryType "rangePreview"
+      // Only supported when queryType is "rangePreview" and algorithm is "RangePreview".
       // NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
       encryptExpression(expr: Document, opts: EncryptOpts): Document;
 

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1056,6 +1056,7 @@ ClientEncryption
       //   {$and: [{$gt: [<fieldpath>, <value1>]}, {$lt: [<fieldpath>, <value2>]}]
       // $gt may also be $gte. $lt may also be $lte.
       // Only supported for queryType "rangePreview"
+      // NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
       encryptExpression(expr: Document, opts: EncryptOpts): Document;
 
       // Decrypts an encrypted value (BSON binary of subtype 6).
@@ -1249,7 +1250,7 @@ EncryptOpts
       rangeOpts: Optional<RangeOpts>
    }
 
-   // NOTE: The Range algorithm is experimental only. It is not intended for public use.
+   // NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
    // RangeOpts specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
    // min, max, sparsity, and range must match the values set in the encryptedFields of the destination collection.
    // For double and decimal128, min/max/precision must all be set, or all be unset.
@@ -1288,14 +1289,14 @@ The result of explicit encryption with the "Indexed" or "RangePreview" algorithm
    To insert or query with an "Indexed" or "RangePreview" encrypted payload, use a ``MongoClient`` configured with ``AutoEncryptionOpts``.
    ``AutoEncryptionOpts.bypassQueryAnalysis`` may be true. ``AutoEncryptionOpts.bypassAutoEncryption`` must be false.
 
-NOTE: The Range algorithm is experimental only. It is not intended for public use.
+NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
 
 contentionFactor
 ^^^^^^^^^^^^^^^^
 contentionFactor only applies when algorithm is "Indexed" or "RangePreview".
 It is an error to set contentionFactor when algorithm is not "Indexed".
 
-NOTE: The Range algorithm is experimental only. It is not intended for public use.
+NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
 
 queryType
 ^^^^^^^^^
@@ -1306,14 +1307,14 @@ One of the strings:
 queryType only applies when algorithm is "Indexed" or "RangePreview".
 It is an error to set queryType when algorithm is not "Indexed" or "RangePreview".
 
-NOTE: The Range algorithm is experimental only. It is not intended for public use.
+NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
 
 rangeOpts
 ^^^^^^^^^
 rangeOpts only applies when algorithm is "rangePreview".
 It is an error to set rangeOpts when algorithm is not "rangePreview".
 
-NOTE: The Range algorithm is experimental only. It is not intended for public use.
+NOTE: The Range algorithm is experimental only. It is not intended for public use. The API is subject to breaking changes.
 
 User facing API: When Auto Encryption Fails
 ===========================================

--- a/source/client-side-encryption/etc/data/range-encryptedFields-Date.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-Date.json
@@ -1,0 +1,30 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedDate",
+        "bsonType": "date",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          },
+          "min": {
+            "$date": {
+              "$numberLong": "0"
+          }
+          },
+          "max": {
+            "$date": {
+              "$numberLong": "200"
+          }
+          }
+        }
+      }
+    ]
+}

--- a/source/client-side-encryption/etc/data/range-encryptedFields-Date.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-Date.json
@@ -12,7 +12,7 @@
         "queries": {
           "queryType": "rangePreview",
           "sparsity": {
-            "$numberInt": "1"
+            "$numberLong": "1"
           },
           "min": {
             "$date": {

--- a/source/client-side-encryption/etc/data/range-encryptedFields-DoubleNoPrecision.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-DoubleNoPrecision.json
@@ -1,0 +1,21 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedDoubleNoPrecision",
+        "bsonType": "double",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          }
+        }
+      }
+    ]
+  }
+  

--- a/source/client-side-encryption/etc/data/range-encryptedFields-DoubleNoPrecision.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-DoubleNoPrecision.json
@@ -12,7 +12,7 @@
         "queries": {
           "queryType": "rangePreview",
           "sparsity": {
-            "$numberInt": "1"
+            "$numberLong": "1"
           }
         }
       }

--- a/source/client-side-encryption/etc/data/range-encryptedFields-DoublePrecision.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-DoublePrecision.json
@@ -1,0 +1,30 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedDoublePrecision",
+        "bsonType": "double",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          },
+          "min": {
+            "$numberDouble": "0.0"
+          },
+          "max": {
+            "$numberDouble": "199.9"
+          },
+          "precision": {
+            "$numberInt": "2"
+          }
+        }
+      }
+    ]
+  }
+  

--- a/source/client-side-encryption/etc/data/range-encryptedFields-DoublePrecision.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-DoublePrecision.json
@@ -12,7 +12,7 @@
         "queries": {
           "queryType": "rangePreview",
           "sparsity": {
-            "$numberInt": "1"
+            "$numberLong": "1"
           },
           "min": {
             "$numberDouble": "0.0"

--- a/source/client-side-encryption/etc/data/range-encryptedFields-DoublePrecision.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-DoublePrecision.json
@@ -18,7 +18,7 @@
             "$numberDouble": "0.0"
           },
           "max": {
-            "$numberDouble": "199.9"
+            "$numberDouble": "200.0"
           },
           "precision": {
             "$numberInt": "2"

--- a/source/client-side-encryption/etc/data/range-encryptedFields-Int.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-Int.json
@@ -12,7 +12,7 @@
         "queries": {
           "queryType": "rangePreview",
           "sparsity": {
-            "$numberInt": "1"
+            "$numberLong": "1"
           },
           "min": {
             "$numberInt": "0"

--- a/source/client-side-encryption/etc/data/range-encryptedFields-Int.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-Int.json
@@ -1,0 +1,27 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedInt",
+        "bsonType": "int",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          },
+          "min": {
+            "$numberInt": "0"
+          },
+          "max": {
+            "$numberInt": "250"
+          }
+        }
+      }
+    ]
+  }
+  

--- a/source/client-side-encryption/etc/data/range-encryptedFields-Int.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-Int.json
@@ -18,7 +18,7 @@
             "$numberInt": "0"
           },
           "max": {
-            "$numberInt": "250"
+            "$numberInt": "200"
           }
         }
       }

--- a/source/client-side-encryption/etc/data/range-encryptedFields-Long.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-Long.json
@@ -1,0 +1,27 @@
+{
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedLong",
+        "bsonType": "long",
+        "queries": {
+          "queryType": "rangePreview",
+          "sparsity": {
+            "$numberInt": "1"
+          },
+          "min": {
+            "$numberLong": "0"
+          },
+          "max": {
+            "$numberLong": "200"
+          }
+        }
+      }
+    ]
+  }
+  

--- a/source/client-side-encryption/etc/data/range-encryptedFields-Long.json
+++ b/source/client-side-encryption/etc/data/range-encryptedFields-Long.json
@@ -12,7 +12,7 @@
         "queries": {
           "queryType": "rangePreview",
           "sparsity": {
-            "$numberInt": "1"
+            "$numberLong": "1"
           },
           "min": {
             "$numberLong": "0"

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2678,9 +2678,11 @@ Encrypt these values with the matching ``RangeOpts`` listed in `Test Setup: Rang
 
 Store the result in ``insertPayload``.
 
-Use ``encryptedClient`` to insert the different documents with a variable ``i`` to store the ``_id`` value ``{ "encrypted<Type>": <insertPayload>, _id: i }`` into ``db.explicit_encryption``. For example, for ``date`` insert the document ``{ "encryptedDate": <insertPayload>, _id: i }``.
+Create a variable ``i`` to assign ``_id`` values to the documents. 
 
-After inserting the documents, use ``clientEncryption`` to decrypt ``insertPayload``. Assert the returned value equals the value of one of the documents inserted.
+Use ``encryptedClient`` to insert the document ``{ "encrypted<Type>": <insertPayload>, _id: i }`` into ``db.explicit_encryption``. For example, for ``date`` insert the document ``{ "encryptedDate": <insertPayload>, _id: i }``.
+
+After inserting all the documents, use ``clientEncryption`` to decrypt ``insertPayload``. Assert the returned value equals the value of the last document inserted.
 
 Case 2: can find encrypted range and return the maximum 
 ```````````````````````````````````````````````````````
@@ -2710,7 +2712,8 @@ Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryptio
 
 Assert these three documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }, { "encrypted<Type>": 200}`` are returned.
 
-If the encrypted field is ``encryptedDoubleNoPrecision`` two documents (not three) will be returned, since there is not a maximum value to insert.
+If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }`` are returned.
+
 
 Case 3: can find encrypted range and return the minimum 
 ```````````````````````````````````````````````````````
@@ -2741,7 +2744,7 @@ Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryptio
 
 Assert these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
 
-If the encrypted field is ``encryptedDoubleNoPrecision`` one document (not two) will be returned, since there is not a minimum value to insert.
+If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 6 }`` is returned.
 
 Case 4: can find encrypted range with an open range query
 `````````````````````````````````````````````````````````
@@ -2778,7 +2781,7 @@ Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryptio
 
 Assert that only this document ``{ "encrypted<Type>": 200 }`` is returned. 
 
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that the document ``{ "encrypted<Type>": 30 }`` is returned.
+If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 30 }`` is returned.
 
 Case 5: can run an aggregation expression inside $expr 
 `````````````````````````````````````````````````````````````
@@ -2807,7 +2810,7 @@ Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryptio
 
 Assert that these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
 
-If the encrypted field is ``encryptedDoubleNoPrecision`` one document (not two) will be returned, since no minimum is set.
+If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 6 }`` is returned.
 
 Case 6: can aggregate encrypted range and return the maximum  
 `````````````````````````````````````````````````````````````
@@ -2846,7 +2849,7 @@ Assert that these two documents ``{ "encrypted<Type>": 30 }, { "encrypted<Type>"
 
 If the encrypted field is ``encryptedDoublePrecision`` assert that these two documents ``{ "encrypted<Type>": 30 }, { "encrypted<Type>": 199.9}`` are returned.
 
-If the encrypted field is ``encryptedDoubleNoPrecision`` two documents (not three) will be returned, since no minimum is set.
+If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 30 }`` is returned.
 
 Case 7: can aggregate encrypted range and return the minimum 
 `````````````````````````````````````````````````````````````
@@ -2881,7 +2884,7 @@ Use ``encryptedClient`` to run an aggregation command on the ``db.explicit_encry
 
 Assert that these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
 
-If the encrypted field is ``encryptedDoubleNoPrecision`` only the document ``{ "encrypted<Type>": 6 }`` is returned.
+If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 6 }`` is returned.
 
 Case 8: can aggregate encrypted range and return no documents
 `````````````````````````````````````````````````````````````
@@ -2930,6 +2933,8 @@ Use ``clientEncryption`` to try to encrypt the value 201 with the matching ``Ran
       contentionFactor: 0
    }
 
+Ensure 201 matches the type of the encrypted field. The error should be raised because -1 is less than the minimum.
+
 Assert that an error was raised.
 
 Case 10: encrypting a document less than the minimum errors
@@ -2945,6 +2950,8 @@ Use ``clientEncryption`` to try to encrypt the value -1 with the matching ``Rang
       algorithm: "RangePreview",
       contentionFactor: 0
    }
+
+Ensure -1 matches the type of the encrypted field. The error should be raised because -1 is less than the minimum.
 
 Assert that an error was raised.
 
@@ -3008,4 +3015,4 @@ Use ``clientEncryption`` to try to encrypt the value 6 with these ``EncryptOpts`
       precision: 2,
    }
 
-   Assert an error was raised.
+Assert an error was raised.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2628,9 +2628,9 @@ Create a variable ``i`` to assign ``_id`` values to the documents.
 
 Use ``encryptedClient`` to insert the document ``{ "encrypted<Type>": <insertPayload>, _id: i }`` into ``db.explicit_encryption``. For example, for ``date`` insert the document ``{ "encryptedDate": <insertPayload>, _id: i }``.
 
-Assert that these 4 documents ``{ "encrypted<Type>": 6, _id: 0 }``, ``{ "encrypted<Type>": 30, _id: 1 }``, ``{ "encrypted<Type>": 200, _id: 2 }``, ``{ "encrypted<Type>": 0, _id: 4 }`` were successfully inserted in ``db.explicit_encryption``. 
+Assert that these 4 documents ``{ "encrypted<Type>": 6, _id: 0 }``, ``{ "encrypted<Type>": 30, _id: 1 }``, ``{ "encrypted<Type>": 200, _id: 2 }``, ``{ "encrypted<Type>": 0, _id: 3 }`` were successfully inserted in ``db.explicit_encryption``. 
 
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }`` were successfully inserted in ``db.explicit_encryption``.
+If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two documents ``{ "encrypted<Type>": 6, _id: 0 }, { "encrypted<Type>": 30, _id: 1 }`` were successfully inserted in ``db.explicit_encryption``.
 
 
 Test Setup: RangeOpts

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2610,7 +2610,7 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
 
 The remaining tasks require setting ``RangeOpts``. `Test Setup: RangeOpts`_ lists the values to use for ``RangeOpts`` for each of the supported data types. The values in ``RangeOpts`` should also match the values listed in ``encryptedFields`` for each support data type.  
 
-Use ``clientEncryption`` to encrypt these values separately: 6, 30, and the minimum and maximum set in ``RangeOpts`` (if the minimum and maximum are set). Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0. 
+Use ``clientEncryption`` to encrypt these values in separate documents: 6, 30, and the minimum and maximum set in ``RangeOpts`` (if the minimum and maximum are set). Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0. 
 
 Encrypt these values with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
 
@@ -2622,13 +2622,16 @@ Encrypt these values with the matching ``RangeOpts`` listed in `Test Setup: Rang
       contentionFactor: 0
    }
 
-Store the result in ``insertPayload``.
+Store each of the encrypted results in a separate ``insertPayload``. 
 
 Create a variable ``i`` to assign ``_id`` values to the documents.
 
 Use ``encryptedClient`` to insert the document ``{ "encrypted<Type>": <insertPayload>, _id: i }`` into ``db.explicit_encryption``. For example, for ``date`` insert the document ``{ "encryptedDate": <insertPayload>, _id: i }``.
 
-Assert that the documents were successfully inserted.
+Assert that these 4 documents ``{ "encrypted<Type>": 6, _id: 0 }``, ``{ "encrypted<Type>": 30, _id: 1 }``, ``{ "encrypted<Type>": 200, _id: 2 }``, ``{ "encrypted<Type>": 0, _id: 4 }`` were successfully inserted in ``db.explicit_encryption``. 
+
+If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }``were successfully inserted in ``db.explicit_encryption``.
+
 
 Test Setup: RangeOpts
 `````````````````````

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2568,7 +2568,7 @@ when attempting to create a collection with such invalid settings.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Range Explicit Encryption tests require MongoDB server 6.2+. The tests must not run against a standalone.
 
-Each of the following test cases must pass for each of the supported types (``double``, ``double`` with precision, ``date``, ``integer``, and ``long``).
+Each of the following test cases must pass for each of the supported types (``double``, ``double`` with precision, ``date``, ``integer``, and ``long``), unless it is stated the type should be skipped.
 
 Before running each of the following test cases, perform the following Test Setup.
 
@@ -2610,7 +2610,9 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
  
 Test Setup: RangeOpts
 `````````````````````
-Each range explicit encryption test requires each data type to use a different ``RangeOpts``. Use these ``RangeOpts`` for each of the supported types: 
+Each test listed in the cases below must pass for all supported data types unless it is stated the type should be skipped. 
+
+Each data type must use a different ``RangeOpts``. Use these ``RangeOpts`` for each of the supported types: 
 
 #. Double
 
@@ -2837,13 +2839,13 @@ Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``En
       contentionFactor: 0
    }
 
-Store the result in ``findPayload``.
+Store the result in ``aggPayload``.
 
 Use ``encryptedClient`` to run an aggregation command on the ``db.explicit_encryption`` collection with this pipeline: 
 
 .. code:: javascript
 
-   {"pipeline": [{"$match": "<findPayload>"}, {"$sort": { "_id: 1"}}]}
+   {"pipeline": [{"$match": "<aggPayload>"}, {"$sort": { "_id: 1"}}]}
 
 Assert that these two documents ``{ "encrypted<Type>": 30 }, { "encrypted<Type>": 200}`` are returned.
 
@@ -2874,13 +2876,13 @@ Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``En
       contentionFactor: 0
    }
 
-Store the result in ``findPayload``.
+Store the result in ``aggPayload``.
 
 Use ``encryptedClient`` to run an aggregation command on the ``db.explicit_encryption`` collection with this pipeline:
 
 .. code:: javascript
 
-   {"pipeline": [{"$match": "<findPayload>"}, {"$sort": { "_id: 1"}}]}
+   {"pipeline": [{"$match": "<aggPayload>"}, {"$sort": { "_id: 1"}}]}
 
 Assert that these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
 
@@ -2909,13 +2911,13 @@ Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``En
       contentionFactor: 0
    }
 
-Store the result in ``findPayload``.
+Store the result in ``aggPayload``.
 
 Use ``encryptedClient`` to run an aggregation command on the ``db.explicit_encryption`` collection with this pipeline:
 
 .. code:: javascript
 
-   {"pipeline": [{"$match": "<findPayload>"}, {"$sort": { "_id: 1"}}]}
+   {"pipeline": [{"$match": "<aggPayload>"}, {"$sort": { "_id: 1"}}]}
 
 Assert that no documents are returned.
 
@@ -2933,7 +2935,7 @@ Use ``clientEncryption`` to try to encrypt the value 201 with the matching ``Ran
       contentionFactor: 0
    }
 
-Ensure 201 matches the type of the encrypted field. The error should be raised because -1 is less than the minimum.
+Ensure 201 matches the type of the encrypted field. The error should be raised because 201 is greater than the maximum value in ``RangeOpts``.
 
 Assert that an error was raised.
 
@@ -2951,7 +2953,7 @@ Use ``clientEncryption`` to try to encrypt the value -1 with the matching ``Rang
       contentionFactor: 0
    }
 
-Ensure -1 matches the type of the encrypted field. The error should be raised because -1 is less than the minimum.
+Ensure -1 matches the type of the encrypted field. The error should be raised because -1 is less than the minimum value in ``RangeOpts``.
 
 Assert that an error was raised.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2607,8 +2607,6 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
       kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
       bypassQueryAnalysis: true
    }
-
-.. _setup_reference-label:
  
 Test Setup: RangeOpts
 `````````````````````
@@ -2805,7 +2803,7 @@ Assert that this document is returned ``{ "encrypted<Type>": 30 }``.
 
 Case 7: can aggregate encrypted range and return no documents
 `````````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query with the matching ``RangeOpts`` :ref:`setup_reference-label` and these ``EncryptOpts``:
+Use ``clientEncryption`` to encrypt this query with the matching ``RangeOpts`` `Test Setup: RangeOpts` and these ``EncryptOpts``:
 
 .. code:: javascript
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2844,25 +2844,7 @@ Ensure 201 matches the type of the encrypted field. The error should be raised b
 
 Assert that an error was raised.
 
-Case 7: encrypting a document less than the minimum errors
-``````````````````````````````````````````````````````````
-This test case should be skipped if the encrypted field is ``encryptedDoubleNoPrecision``.
-
-Use ``clientEncryption.encrypt()`` to try to encrypt the value -1 with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
-
-.. code:: typescript
-
-   class EncryptOpts {
-      keyId : <key1ID>
-      algorithm: "RangePreview",
-      contentionFactor: 0
-   }
-
-Ensure -1 matches the type of the encrypted field. The error should be raised because -1 is less than the minimum value in ``RangeOpts``.
-
-Assert that an error was raised.
-
-Case 8: encrypting a document of a different type errors 
+Case 7: encrypting a document of a different type errors 
 ````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoubleNoPrecision``.
 
@@ -2901,7 +2883,7 @@ For all the tests below use these ``EncryptOpts``:
    Assert an error was raised.
 
 
-Case 9: setting precision errors if the type is not a double
+Case 8: setting precision errors if the type is not a double
 ````````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoubleWithPrecision`` or ``encryptedDoubleNoPrecision``.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2800,7 +2800,7 @@ Assert that only this document ``{ "encrypted<Type>": 200 }`` is returned.
 If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 30 }`` is returned.
 
 Case 5: can run an aggregation expression inside $expr 
-`````````````````````````````````````````````````````````````
+``````````````````````````````````````````````````````
 Use ``clientEncryption.encryptExpression()`` to encrypt this query: 
 
 .. code:: javascript

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2612,44 +2612,44 @@ Data Types RangeOpts
 `````````````````````
 In each test below, each data type will require different ``RangeOpts``. Use these ``RangeOpts`` for each of the supported types: 
 
-#. Double no precision
+#. DoubleNoPrecision
 
-.. code:: typescript
+   .. code:: typescript
    
-   class RangeOpts {
-      sparsity: 1
-   }
+      class RangeOpts {
+         sparsity: 1
+      }
 
-#. Double with precision 
+#. DoubleWithPrecision
 
-.. code:: typescript
+   .. code:: typescript
    
-   class RangeOpts {
-      min: 0,
-      max: 199.9,
-      sparsity: 1,
-      precision: 2
-   }
+      class RangeOpts {
+         min: 0,
+         max: 199.9,
+         sparsity: 1,
+         precision: 2
+      }
 
 #. Date 
 
-.. code:: typescript
+   .. code:: typescript
    
-   class RangeOpts {
-      min: 0,
-      max: 200,
-      sparsity: 1
-   }
+      class RangeOpts {
+         min: 0,
+         max: 200,
+         sparsity: 1
+      }
 
 #. Integer and Long
 
-.. code:: typescript
+   .. code:: typescript
    
-   class RangeOpts {
-      min: 0,
-      max: 200,
-      sparsity: 1
-   }
+      class RangeOpts {
+         min: 0,
+         max: 200,
+         sparsity: 1
+      }
 
 Case 1: can insert encrypted range and decrypt 
 ```````````````````````````````````````````````
@@ -2697,7 +2697,7 @@ Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryptio
 
 Assert these three documents are returned ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }, { "encrypted<Type>": 200}``.
 
-If testing ``double`` no precision two documents (not three) will be returned, since no maximum is set.
+If testing ``doubleNoPrecision`` two documents (not three) will be returned, since no maximum is set.
 
 Case 3: can find encrypted range and return the minimum 
 ```````````````````````````````````````````````````````
@@ -2722,7 +2722,7 @@ Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryptio
 
 Assert these two documents are returned ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }``.
 
-If testing ``double`` no precision one document (not two) will be returned, since no minimum is set.
+If testing ``doubleNoPrecision`` one document (not two) will be returned, since no minimum is set.
 
 Case 4: can find encrypted range with an open range query
 `````````````````````````````````````````````````````````
@@ -2776,7 +2776,7 @@ Use ``encryptedClient`` to run an aggregation command on the ``db.explicit_encry
 
 Assert these three documents are returned ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }, { "encrypted<Type>": 30}``.
 
-If testing ``double`` no precision two documents (not three) will be returned, since no minimum is set.
+If testing ``doubleNoPrecision`` two documents (not three) will be returned, since no minimum is set.
 
 Case 6: can aggregate encrypted range and return the minimum 
 `````````````````````````````````````````````````````````````
@@ -2836,27 +2836,87 @@ Case 8: encrypting a document greater than the maximum errors
 `````````````````````````````````````````````````````````````
 This test case should be skipped if the ``encryptedField`` is ``double`` no ``precision``. 
 
-Use ``clientEncryption`` to encrypt the value 6 with these ``EncryptOpts``:
+Use ``clientEncryption`` to encrypt the value 201 with the matching ``RangeOpts`` listed in Data Types RangeOpts and these ``EncryptOpts``:
 
 .. code:: typescript
 
    class EncryptOpts {
       keyId : <key1ID>
-      algorithm: "Indexed",
+      algorithm: "RangePreview",
       contentionFactor: 0
    }
 
+Assert that an error was raised with the message "Value must be greater than or equal to the minimum value and less than or equal to the maximum value"
 
 Case 9: encrypting a document less than the minimum errors
 ```````````````````````````````````````````````````````````
 This test case should be skipped if the ``encryptedField`` is ``double`` no ``precision``. 
 
+Use ``clientEncryption`` to encrypt the value -1 with the matching ``RangeOpts`` listed in Data Types RangeOpts and these ``EncryptOpts``:
+
+.. code:: typescript
+
+   class EncryptOpts {
+      keyId : <key1ID>
+      algorithm: "RangePreview",
+      contentionFactor: 0
+   }
+
+Assert that an error message contains "got min: 0, max: 250, value: -1".
 
 Case 10: encrypting a document of a different type errors 
 `````````````````````````````````````````````````````````
 This test case should be skipped if the ``encryptedField`` is ``double`` no ``precision``. 
 
+For all the tests before use ``clientEncryption`` to try and encrypt the values listed below with these ``EncryptOpts``:
+
+.. code:: typescript
+
+   class EncryptOpts {
+      keyId : <key1ID>
+      algorithm: "RangePreview",
+      contentionFactor: 0
+   }
+
+#. DoubleWithPrecision
+   encrypt 100
+   assert an error is returned with the message "Got range option 'min' of type DOUBLE and value of type INT64"
+#. Date 
+#. Integer 
+#. Long
 
 Case 11: setting precision errors if the type is not a double
 ``````````````````````````````````````````````````````````````
-This test case should be skipped if the ``encryptedField`` is ``double`` with and without ``precision``. 
+This test case should be skipped if the ``encryptedField`` is the type ``doubleWithPrecision`` and ``doubleNoPrecision``.
+
+Use ``clientEncryption`` to encrypt the value 6 with these ``RangeOpts`` and ``EncryptOpts``:
+.. code:: typescript
+
+   class EncryptOpts {
+      keyId : <key1ID>
+      algorithm: "RangePreview",
+      contentionFactor: 0
+
+   }
+
+#. Date 
+
+   .. code:: typescript
+   
+      class RangeOpts {
+         min: 0,
+         max: 200,
+         sparsity: 1
+      }
+
+#. Integer and Long
+
+   .. code:: typescript
+   
+      class RangeOpts {
+         min: 0,
+         max: 200,
+         sparsity: 1
+      }
+
+Assert that an error message contains "expected 'precision' to be set with double or decimal128 index, but got: <TYPE> min"

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2790,7 +2790,7 @@ Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
 
-   {'$and': [ { '$lt': [ '$encrypted<Type>', 25 ] } ] } }
+   {'$and': [ { '$lt': [ '$encrypted<Type>', 30 ] } ] } }
 
 Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts`` to encrypt the query:
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2690,7 +2690,7 @@ Each test listed in the cases below must pass for all supported data types unles
 
 Case 1: can decrypt a payload
 `````````````````````````````
-Use ``clientEncryption`` to encrypt the value 6. Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0.
+Use ``clientEncryption.encrypt()`` to encrypt the value 6. Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0.
 
 Store the result in ``insertPayload``.
 
@@ -2708,7 +2708,7 @@ Use ``clientEncryption`` to decrypt ``insertPayload``. Assert the returned value
 
 Case 2: can find encrypted range and return the maximum 
 ```````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query:
+Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
 
@@ -2737,7 +2737,7 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two d
 
 Case 3: can find encrypted range and return the minimum 
 ```````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query: 
+Use ``clientEncryption.encryptExpression()`` to encrypt this query: 
 
 
 .. code:: javascript
@@ -2766,7 +2766,7 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 4: can find encrypted range with an open range query
 `````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query:
+Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
 
@@ -2801,7 +2801,7 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 5: can run an aggregation expression inside $expr 
 `````````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query: 
+Use ``clientEncryption.encryptExpression()`` to encrypt this query: 
 
 .. code:: javascript
 
@@ -2828,7 +2828,7 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 6: can aggregate encrypted range and return the maximum  
 `````````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query: 
+Use ``clientEncryption.encryptExpression()`` to encrypt this query: 
 
 .. code:: javascript
 
@@ -2861,7 +2861,7 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 7: can aggregate encrypted range and return the minimum 
 `````````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query:
+Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
 
@@ -2894,7 +2894,7 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 8: can aggregate encrypted range and return no documents
 `````````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query:
+Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
 
@@ -2927,7 +2927,7 @@ Case 9: encrypting a document greater than the maximum errors
 `````````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoubleNoPrecision``.
 
-Use ``clientEncryption`` to try to encrypt the value 201 with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
+Use ``clientEncryption.encrypt()`` to try to encrypt the value 201 with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
 
 .. code:: typescript
 
@@ -2945,7 +2945,7 @@ Case 10: encrypting a document less than the minimum errors
 ```````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoubleNoPrecision``.
 
-Use ``clientEncryption`` to try to encrypt the value -1 with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
+Use ``clientEncryption.encrypt()`` to try to encrypt the value -1 with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
 
 .. code:: typescript
 
@@ -2975,25 +2975,25 @@ For all the tests below use these ``EncryptOpts``:
 
 #. Double (with precision)
 
-   Use ``clientEncryption`` and the ``EncryptOpts`` above to encrypt ``{$numberLong : 100 }``.
+   Use ``clientEncryption.encrypt()`` and the ``EncryptOpts`` above to encrypt ``{$numberLong : 100 }``.
    
    Assert an error was raised.
 
 #. Date 
 
-   Use ``clientEncryption`` and the ``EncryptOpts`` above to encrypt an ``{$numberDouble : 4.44 }``.
+   Use ``clientEncryption.encrypt()`` and the ``EncryptOpts`` above to encrypt an ``{$numberDouble : 4.44 }``.
    
    Assert an error was raised.
 
 #. Integer 
 
-   Use ``clientEncryption`` and the ``EncryptOpts`` above to encrypt an ``{$numberDouble : 4.44 }``.
+   Use ``clientEncryption.encrypt()`` and the ``EncryptOpts`` above to encrypt an ``{$numberDouble : 4.44 }``.
    
    Assert an error was raised.
 
 #. Long
 
-   Use ``clientEncryption`` and the ``EncryptOpts`` above to encrypt an ``{$numberInt : 3 }``.
+   Use ``clientEncryption.encrypt()`` and the ``EncryptOpts`` above to encrypt an ``{$numberInt : 3 }``.
    
    Assert an error was raised.
 
@@ -3002,7 +3002,7 @@ Case 12: setting precision errors if the type is not a double
 ``````````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoubleWithPrecision`` or ``encryptedDoubleNoPrecision``.
 
-Use ``clientEncryption`` to try to encrypt the value 6 with these ``EncryptOpts`` and these ``RangeOpts``:
+Use ``clientEncryption.encrypt()`` to try to encrypt the value 6 with these ``EncryptOpts`` and these ``RangeOpts``:
 
 .. code:: typescript
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2689,7 +2689,7 @@ Each test listed in the cases below must pass for all supported data types unles
       }
 
 Case 1: can decrypt a payload
-```````````````````````````````````````````````
+`````````````````````````````
 Use ``clientEncryption`` to encrypt the value 6. Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0.
 
 Store the result in ``insertPayload``.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2630,7 +2630,7 @@ Use ``encryptedClient`` to insert the document ``{ "encrypted<Type>": <insertPay
 
 Assert that these 4 documents ``{ "encrypted<Type>": 6, _id: 0 }``, ``{ "encrypted<Type>": 30, _id: 1 }``, ``{ "encrypted<Type>": 200, _id: 2 }``, ``{ "encrypted<Type>": 0, _id: 4 }`` were successfully inserted in ``db.explicit_encryption``. 
 
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }``were successfully inserted in ``db.explicit_encryption``.
+If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }`` were successfully inserted in ``db.explicit_encryption``.
 
 
 Test Setup: RangeOpts

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2826,104 +2826,7 @@ Assert that these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>":
 
 If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 6 }`` is returned.
 
-Case 6: can aggregate encrypted range and return the maximum  
-`````````````````````````````````````````````````````````````
-Use ``clientEncryption.encryptExpression()`` to encrypt this query: 
-
-.. code:: javascript
-
-   {'$and': ["
-      "{ 'encrypted<Type>': { '$gte': { '$<type>': '30' } } },"
-      "{ 'encrypted<Type>': { '$lte': { '$<type>': '200' } } } ] }
-
-Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts`` to encrypt the query:
-
-.. code:: typescript
-
-   class EncryptOpts {
-      keyId : <key1ID>
-      algorithm: "RangePreview",
-      queryType: "rangePreview",
-      contentionFactor: 0
-   }
-
-Store the result in ``aggPayload``.
-
-Use ``encryptedClient`` to run an aggregation command on the ``db.explicit_encryption`` collection with this pipeline: 
-
-.. code:: javascript
-
-   {"pipeline": [{"$match": "<aggPayload>"}, {"$sort": { "_id: 1"}}]}
-
-Assert that these two documents ``{ "encrypted<Type>": 30 }, { "encrypted<Type>": 200}`` are returned.
-
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 30 }`` is returned.
-
-Case 7: can aggregate encrypted range and return the minimum 
-`````````````````````````````````````````````````````````````
-Use ``clientEncryption.encryptExpression()`` to encrypt this query:
-
-.. code:: javascript
-
-     {'$and': ["
-      "{ 'encrypted<Type>': { '$gte': { '$<type>': '0' } } },"
-      "{ 'encrypted<Type>': { '$lte': { '$<type>': '6' } } } ] }
-
-Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts`` to encrypt the query:
-
-.. code:: typescript
-
-   class EncryptOpts {
-      keyId : <key1ID>
-      algorithm: "RangePreview",
-      queryType: "rangePreview",
-      contentionFactor: 0
-   }
-
-Store the result in ``aggPayload``.
-
-Use ``encryptedClient`` to run an aggregation command on the ``db.explicit_encryption`` collection with this pipeline:
-
-.. code:: javascript
-
-   {"pipeline": [{"$match": "<aggPayload>"}, {"$sort": { "_id: 1"}}]}
-
-Assert that these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
-
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 6 }`` is returned.
-
-Case 8: can aggregate encrypted range and return no documents
-`````````````````````````````````````````````````````````````
-Use ``clientEncryption.encryptExpression()`` to encrypt this query:
-
-.. code:: javascript
-
-        {'$and': ["
-      "{ 'encrypted<Type>': { '$gt': { '$<type>': '0' } } },"
-      "{ 'encrypted<Type>': { '$lt': { '$<type>': '6' } } } ] }
-
-Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts`` to encrypt the query:
-
-.. code:: typescript
-
-   class EncryptOpts {
-      keyId : <key1ID>
-      algorithm: "RangePreview",
-      queryType: "rangePreview",
-      contentionFactor: 0
-   }
-
-Store the result in ``aggPayload``.
-
-Use ``encryptedClient`` to run an aggregation command on the ``db.explicit_encryption`` collection with this pipeline:
-
-.. code:: javascript
-
-   {"pipeline": [{"$match": "<aggPayload>"}, {"$sort": { "_id: 1"}}]}
-
-Assert that no documents are returned.
-
-Case 9: encrypting a document greater than the maximum errors
+Case 6: encrypting a document greater than the maximum errors
 `````````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoubleNoPrecision``.
 
@@ -2941,8 +2844,8 @@ Ensure 201 matches the type of the encrypted field. The error should be raised b
 
 Assert that an error was raised.
 
-Case 10: encrypting a document less than the minimum errors
-```````````````````````````````````````````````````````````
+Case 7: encrypting a document less than the minimum errors
+``````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoubleNoPrecision``.
 
 Use ``clientEncryption.encrypt()`` to try to encrypt the value -1 with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
@@ -2959,8 +2862,8 @@ Ensure -1 matches the type of the encrypted field. The error should be raised be
 
 Assert that an error was raised.
 
-Case 11: encrypting a document of a different type errors 
-`````````````````````````````````````````````````````````
+Case 8: encrypting a document of a different type errors 
+````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoubleNoPrecision``.
 
 For all the tests below use these ``EncryptOpts``:
@@ -2998,8 +2901,8 @@ For all the tests below use these ``EncryptOpts``:
    Assert an error was raised.
 
 
-Case 12: setting precision errors if the type is not a double
-``````````````````````````````````````````````````````````````
+Case 9: setting precision errors if the type is not a double
+````````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoubleWithPrecision`` or ``encryptedDoubleNoPrecision``.
 
 Use ``clientEncryption.encrypt()`` to try to encrypt the value 6 with these ``EncryptOpts`` and these ``RangeOpts``:

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2805,7 +2805,7 @@ Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
 
-   {'$and': [ { '$lt': [ '$encrypted<Type>', 10 ] } ] } }
+   {'$and': [ { '$lt': [ '$encrypted<Type>', 25 ] } ] } }
 
 Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts`` to encrypt the query:
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2820,7 +2820,7 @@ Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``En
 
 Store the result in ``findPayload``.
 
-Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{ "encrypted<Type>": {'$expr' :  { <findPayload> } }`` and sort the results by ``_id``.
+Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{'$expr' :  { <findPayload> }`` and sort the results by ``_id``.
 
 Assert that these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 0 }`` are returned.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2827,7 +2827,7 @@ Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``En
 
 Store the result in ``findPayload``.
 
-Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{'$expr' :  { <findPayload> }`` and sort the results by ``_id``.
+Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{'$expr' :  <findPayload> }`` and sort the results by ``_id``.
 
 Assert that these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2574,7 +2574,7 @@ Before running each of the following test cases, perform the following Test Setu
 
 Test Setup
 ``````````
-Load the file for the specific data type being tested ``encryptedFields-<type>.json``. For example, for ``integer`` load `range-encryptedFields-Int.json <https://github.com/galon1/specifications/blob/DRIVERS-2505/source/client-side-encryption/etc/data/range-encryptedFields-Int.json>`_ as ``encryptedFields``.
+Load the file for the specific data type being tested ``encryptedFields-<type>.json``. For example, for ``integer`` load `range-encryptedFields-Int.json <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/etc/data/range-encryptedFields-Int.json>`_ as ``encryptedFields``.
 
 Load the file `key1-document.json <https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/keys/key1-document.json>`_ as ``key1Document``.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2610,7 +2610,7 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
 
 The remaining tasks require setting ``RangeOpts``. `Test Setup: RangeOpts`_ lists the values to use for ``RangeOpts`` for each of the supported data types. The values in ``RangeOpts`` should also match the values listed in ``encryptedFields`` for each support data type.  
 
-Use ``clientEncryption`` to encrypt these values in separate documents: 6, 30, and the minimum and maximum set in ``RangeOpts`` (if the minimum and maximum are set). Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0. 
+Use ``clientEncryption`` to encrypt these values in separate documents: 0, 6, 30, and 200. Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0. 
 
 Encrypt these values with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
 
@@ -2628,9 +2628,7 @@ Create a variable ``i`` to assign ``_id`` values to the documents.
 
 Use ``encryptedClient`` to insert the document ``{ "encrypted<Type>": <insertPayload>, _id: i }`` into ``db.explicit_encryption``. For example, for ``date`` insert the document ``{ "encryptedDate": <insertPayload>, _id: i }``.
 
-Assert that these 4 documents ``{ "encrypted<Type>": 6, _id: 0 }``, ``{ "encrypted<Type>": 30, _id: 1 }``, ``{ "encrypted<Type>": 200, _id: 2 }``, ``{ "encrypted<Type>": 0, _id: 3 }`` were successfully inserted in ``db.explicit_encryption``. 
-
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two documents ``{ "encrypted<Type>": 6, _id: 0 }, { "encrypted<Type>": 30, _id: 1 }`` were successfully inserted in ``db.explicit_encryption``.
+Assert that these 4 documents ``{ "encrypted<Type>": 0, _id: 0 }``, ``{ "encrypted<Type>": 6, _id: 1 }``, ``{ "encrypted<Type>": 30, _id: 2 }``, ``{ "encrypted<Type>": 200, _id: 3 }`` were successfully inserted in ``db.explicit_encryption``. 
 
 
 Test Setup: RangeOpts
@@ -2732,8 +2730,6 @@ Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryptio
 
 Assert these three documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }, { "encrypted<Type>": 200}`` are returned.
 
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }`` are returned.
-
 
 Case 3: can find encrypted range and return the minimum 
 ```````````````````````````````````````````````````````
@@ -2760,9 +2756,7 @@ Store the result in ``findPayload``.
 
 Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{ "encrypted<Type>": <findPayload> }`` and sort the results by ``_id``.
 
-Assert these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 0 }`` are returned.
-
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 6 }`` is returned.
+Assert these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
 
 Case 4: can find encrypted range with an open range query
 `````````````````````````````````````````````````````````
@@ -2772,13 +2766,6 @@ Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
    //convert 150 to match the type of the encrypted field.
    {"$and": [{"encrypted<Type>": {"$gt": 150}}]}
-
-If the encrypted field is ``encryptedDoubleNoPrecision`` encrypt this query instead:
-
-.. code:: javascript
-
-   //convert 25 to match the type of the encrypted field.
-   {"$and": [{"encrypted<Type>": {"$gt": 25}}]}
 
 Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts`` to encrypt the query:
 
@@ -2796,8 +2783,6 @@ Store the result in ``findPayload``.
 Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{ "encrypted<Type>": <findPayload> }`` and sort the results by ``_id``.
 
 Assert that only this document ``{ "encrypted<Type>": 200 }`` is returned. 
-
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 30 }`` is returned.
 
 Case 5: can run an aggregation expression inside $expr 
 ``````````````````````````````````````````````````````
@@ -2822,9 +2807,7 @@ Store the result in ``findPayload``.
 
 Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{'$expr' :  { <findPayload> }`` and sort the results by ``_id``.
 
-Assert that these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 0 }`` are returned.
-
-If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 6 }`` is returned.
+Assert that these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
 
 Case 6: encrypting a document greater than the maximum errors
 `````````````````````````````````````````````````````````````

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2574,7 +2574,7 @@ Before running each of the following test cases, perform the following Test Setu
 
 Test Setup
 ``````````
-Load the file for specific data type being tested ``encryptedFields-<type>.json``. For example, for ``integer`` load `range-encryptedFields-Int.json <https://github.com/galon1/specifications/blob/DRIVERS-2505/source/client-side-encryption/etc/data/range-encryptedFields-Int.json>`_ as ``encryptedFields``.
+Load the file for the specific data type being tested ``encryptedFields-<type>.json``. For example, for ``integer`` load `range-encryptedFields-Int.json <https://github.com/galon1/specifications/blob/DRIVERS-2505/source/client-side-encryption/etc/data/range-encryptedFields-Int.json>`_ as ``encryptedFields``.
 
 Load the file `key1-document.json <https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/keys/key1-document.json>`_ as ``key1Document``.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2710,8 +2710,8 @@ Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
 
-   //convert 5 and 200 to match the type of the encrypted field.
-   {"$and": [{"encrypted<Type>": {"$gt": 5}}, {"encrypted<Type>": {"$lte": 200}}]}
+   //convert 6 and 200 to match the type of the encrypted field.
+   {"$and": [{"encrypted<Type>": {"$gte": 6}}, {"encrypted<Type>": {"$lte": 200}}]}
 
 Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts`` to encrypt the query:
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2692,6 +2692,7 @@ Store the result in ``insertPayload``.
 Encrypt with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
 
 .. code:: typescript
+   
    class EncryptOpts {
       keyId : <key1ID>
       algorithm: "RangePreview",

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2760,7 +2760,7 @@ Store the result in ``findPayload``.
 
 Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{ "encrypted<Type>": <findPayload> }`` and sort the results by ``_id``.
 
-Assert these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
+Assert these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 0 }`` are returned.
 
 If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 6 }`` is returned.
 
@@ -2822,7 +2822,7 @@ Store the result in ``findPayload``.
 
 Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{ "encrypted<Type>": {'$expr' :  { <findPayload> } }`` and sort the results by ``_id``.
 
-Assert that these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
+Assert that these two documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 0 }`` are returned.
 
 If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this document ``{ "encrypted<Type>": 6 }`` is returned.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2608,6 +2608,8 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
       bypassQueryAnalysis: true
    }
 
+The remaining tasks require setting ``RangeOpts``. `Test Setup: RangeOpts`_ lists the values to use for ``RangeOpts`` for each of the supported data types. The values in ``RangeOpts`` should also match the values listed in ``encryptedFields`` for each support data type.  
+
 Use ``clientEncryption`` to encrypt these values separately: 6, 30, and the minimum and maximum set in ``RangeOpts`` (if the minimum and maximum are set). Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0. 
 
 Encrypt these values with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
@@ -2630,9 +2632,9 @@ Assert that the documents were successfully inserted.
 
 Test Setup: RangeOpts
 `````````````````````
-Each test listed in the cases below must pass for all supported data types unless it is stated the type should be skipped. 
+This section lists the values to use for ``RangeOpts`` for each of the supported data types, since each data type requires a different ``RangeOpts``. 
 
-Each data type must use a different ``RangeOpts``. Use these ``RangeOpts`` for each of the supported types: 
+Each test listed in the cases below must pass for all supported data types unless it is stated the type should be skipped. 
 
 #. Double
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2591,13 +2591,13 @@ when attempting to create a collection with such invalid settings.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The Range Explicit Encryption tests require MongoDB server 6.2+. The tests must not run against a standalone.
 
-Each of the following test cases must pass for each of the supported types (``double``, ``double`` with precision, ``date``, ``integer``, and ``long``), unless it is stated the type should be skipped.
+Each of the following test cases must pass for each of the supported types (``DoublePrecision``, ``DoubleNoPrecision``, ``Date``, ``Int``, and ``Long``), unless it is stated the type should be skipped.
 
 Before running each of the following test cases, perform the following Test Setup.
 
 Test Setup
 ``````````
-Load the file for the specific data type being tested ``encryptedFields-<type>.json``. For example, for ``integer`` load `range-encryptedFields-Int.json <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/etc/data/range-encryptedFields-Int.json>`_ as ``encryptedFields``.
+Load the file for the specific data type being tested ``encryptedFields-<type>.json``. For example, for ``Int`` load `range-encryptedFields-Int.json <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/etc/data/range-encryptedFields-Int.json>`_ as ``encryptedFields``.
 
 Load the file `key1-document.json <https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/keys/key1-document.json>`_ as ``key1Document``.
 
@@ -2659,7 +2659,7 @@ This section lists the values to use for ``RangeOpts`` for each of the supported
 
 Each test listed in the cases below must pass for all supported data types unless it is stated the type should be skipped. 
 
-#. Double (without precision)
+#. DoubleNoPrecision
 
    .. code:: typescript
    
@@ -2667,7 +2667,7 @@ Each test listed in the cases below must pass for all supported data types unles
          sparsity: 1
       }
 
-#. Double (with precision)
+#. DoublePrecision
 
    .. code:: typescript
    
@@ -2688,7 +2688,7 @@ Each test listed in the cases below must pass for all supported data types unles
          sparsity: 1
       }
 
-#. Integer
+#. Int
 
    .. code:: typescript
    
@@ -2870,7 +2870,7 @@ Assert an error was raised.
 
 Case 8: setting precision errors if the type is not a double
 ````````````````````````````````````````````````````````````
-This test case should be skipped if the encrypted field is ``encryptedDoubleWithPrecision`` or ``encryptedDoubleNoPrecision``.
+This test case should be skipped if the encrypted field is ``encryptedDoublePrecision`` or ``encryptedDoubleNoPrecision``.
 
 Use ``clientEncryption.encrypt()`` to try to encrypt the value 6 with these ``EncryptOpts`` and these ``RangeOpts``:
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2764,8 +2764,8 @@ Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
 
-   //convert 150 to match the type of the encrypted field.
-   {"$and": [{"encrypted<Type>": {"$gt": 150}}]}
+   //convert 30 to match the type of the encrypted field.
+   {"$and": [{"encrypted<Type>": {"$gt": 30}}]}
 
 Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts`` to encrypt the query:
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2748,7 +2748,7 @@ Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``En
 
 Store the result in ``findPayload``.
 
-Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{ "encrypted<Type>": <findPayload> }`` and sort the results by ``_id``.
+Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``findPayload`` and sort the results by ``_id``.
 
 Assert these three documents ``{ "encrypted<Type>": 6 }, { "encrypted<Type>": 30 }, { "encrypted<Type>": 200}`` are returned.
 
@@ -2776,7 +2776,7 @@ Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``En
 
 Store the result in ``findPayload``.
 
-Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{ "encrypted<Type>": <findPayload> }`` and sort the results by ``_id``.
+Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``findPayload`` and sort the results by ``_id``.
 
 Assert these two documents ``{ "encrypted<Type>": 0 }, { "encrypted<Type>": 6 }`` are returned.
 
@@ -2802,7 +2802,7 @@ Use the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``En
 
 Store the result in ``findPayload``.
 
-Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``{ "encrypted<Type>": <findPayload> }`` and sort the results by ``_id``.
+Use ``encryptedClient`` to run a "find" operation on the ``db.explicit_encryption`` collection with the filter ``findPayload`` and sort the results by ``_id``.
 
 Assert that only this document ``{ "encrypted<Type>": 200 }`` is returned. 
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2608,9 +2608,9 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
       bypassQueryAnalysis: true
    }
 
-The remaining tasks require setting ``RangeOpts``. `Test Setup: RangeOpts`_ lists the values to use for ``RangeOpts`` for each of the supported data types. The values in ``RangeOpts`` should also match the values listed in ``encryptedFields`` for each support data type.  
+The remaining tasks require setting ``RangeOpts``. `Test Setup: RangeOpts`_ lists the values to use for ``RangeOpts`` for each of the supported data types.
 
-Use ``clientEncryption`` to encrypt these values in separate documents: 0, 6, 30, and 200. Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0. 
+Use ``clientEncryption`` to encrypt these values: 0, 6, 30, and 200. Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0.
 
 Encrypt these values with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
 
@@ -2622,13 +2622,12 @@ Encrypt these values with the matching ``RangeOpts`` listed in `Test Setup: Rang
       contentionFactor: 0
    }
 
-Store each of the encrypted results in a separate ``insertPayload``. 
+Use ``encryptedClient`` to insert these documents into ``db.explicit_encryption``:
 
-Create a variable ``i`` to assign ``_id`` values to the documents.
-
-Use ``encryptedClient`` to insert the document ``{ "encrypted<Type>": <insertPayload>, _id: i }`` into ``db.explicit_encryption``. For example, for ``date`` insert the document ``{ "encryptedDate": <insertPayload>, _id: i }``.
-
-Assert that these 4 documents ``{ "encrypted<Type>": 0, _id: 0 }``, ``{ "encrypted<Type>": 6, _id: 1 }``, ``{ "encrypted<Type>": 30, _id: 2 }``, ``{ "encrypted<Type>": 200, _id: 3 }`` were successfully inserted in ``db.explicit_encryption``. 
+- ``{ "encrypted<Type>": <encrypted 0>, _id: 0 }``
+- ``{ "encrypted<Type>": <encrypted 6>, _id: 1 }``
+- ``{ "encrypted<Type>": <encrypted 30>, _id: 2 }``
+- ``{ "encrypted<Type>": <encrypted 200>, _id: 3 }``
 
 
 Test Setup: RangeOpts

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2659,7 +2659,7 @@ This section lists the values to use for ``RangeOpts`` for each of the supported
 
 Each test listed in the cases below must pass for all supported data types unless it is stated the type should be skipped. 
 
-#. Double
+#. Double (without precision)
 
    .. code:: typescript
    

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2692,7 +2692,7 @@ Store the result in ``insertPayload``.
 Encrypt with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and these ``EncryptOpts``:
 
 .. code:: typescript
-   
+
    class EncryptOpts {
       keyId : <key1ID>
       algorithm: "RangePreview",
@@ -2703,8 +2703,6 @@ Use ``clientEncryption`` to decrypt ``insertPayload``. Assert the returned value
 
 Case 2: can find encrypted range and return the maximum 
 ```````````````````````````````````````````````````````
-This test assumes that Case 1 has passed and the documents are in ``db.explicit_encryption``. 
-
 Use ``clientEncryption`` to encrypt this query:
 
 .. code:: javascript
@@ -2734,8 +2732,6 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that these two d
 
 Case 3: can find encrypted range and return the minimum 
 ```````````````````````````````````````````````````````
-This test assumes that Case 1 has passed and the documents are in ``db.explicit_encryption``. 
-
 Use ``clientEncryption`` to encrypt this query: 
 
 
@@ -2765,8 +2761,6 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 4: can find encrypted range with an open range query
 `````````````````````````````````````````````````````````
-This test assumes that Case 1 has passed and the documents are in ``db.explicit_encryption``. 
-
 Use ``clientEncryption`` to encrypt this query:
 
 .. code:: javascript
@@ -2802,8 +2796,6 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 5: can run an aggregation expression inside $expr 
 `````````````````````````````````````````````````````````````
-This test assumes that Case 1 has passed and the documents are in ``db.explicit_encryption``. 
-
 Use ``clientEncryption`` to encrypt this query: 
 
 .. code:: javascript
@@ -2831,8 +2823,6 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 6: can aggregate encrypted range and return the maximum  
 `````````````````````````````````````````````````````````````
-This test assumes that Case 1 has passed and the documents are in ``db.explicit_encryption``. 
-
 Use ``clientEncryption`` to encrypt this query: 
 
 .. code:: javascript
@@ -2866,8 +2856,6 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 7: can aggregate encrypted range and return the minimum 
 `````````````````````````````````````````````````````````````
-This test assumes that Case 1 has passed and the documents are in ``db.explicit_encryption``. 
-
 Use ``clientEncryption`` to encrypt this query:
 
 .. code:: javascript
@@ -2901,8 +2889,6 @@ If the encrypted field is ``encryptedDoubleNoPrecision`` assert that only this d
 
 Case 8: can aggregate encrypted range and return no documents
 `````````````````````````````````````````````````````````````
-This test assumes that Case 1 has passed and the documents are in ``db.explicit_encryption``. 
-
 Use ``clientEncryption`` to encrypt this query:
 
 .. code:: javascript

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2608,7 +2608,7 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
       bypassQueryAnalysis: true
    }
 
-Data Types RangeOpts 
+Test Setup: RangeOpts 
 `````````````````````
 In each test below, each data type will require different ``RangeOpts``. Use these ``RangeOpts`` for each of the supported types: 
 
@@ -2655,7 +2655,7 @@ Case 1: can insert encrypted range and decrypt
 ```````````````````````````````````````````````
 Use ``clientEncryption`` to encrypt these values separately: 6, 30, and minimum and maximum if the minimum and maximum are set. Ensure the type matches with the type of ``encryptedFields``.
 
-Encrypt these values with these ``EncryptOpts`` and the matching ``RangeOpts`` listed in Data Types RangeOpts:
+Encrypt these values with these ``EncryptOpts`` and the matching ``RangeOpts`` listed in `Test Setup: RangeOpts <#Test Setup: RangeOpts>` :
 
 .. code:: typescript
 
@@ -2676,7 +2676,7 @@ After inserting 2 or 4 the documents, use ``clientEncryption`` to decrypt ``inse
 
 Case 2: can find encrypted range and return the maximum 
 ```````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in Data Types RangeOpts:
+Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in `Test Setup: RangeOpts <#Test Setup: RangeOpts>`:
 
 .. code:: javascript
 
@@ -2701,7 +2701,7 @@ If testing ``doubleNoPrecision`` two documents (not three) will be returned, sin
 
 Case 3: can find encrypted range and return the minimum 
 ```````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in Data Types RangeOpts:
+Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in `Test Setup: RangeOpts <#Test Setup: RangeOpts>`:
 
 .. code:: javascript
 
@@ -2726,7 +2726,7 @@ If testing ``doubleNoPrecision`` one document (not two) will be returned, since 
 
 Case 4: can find encrypted range with an open range query
 `````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in Data Types RangeOpts:
+Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in `Test Setup: RangeOpts <#Test Setup: RangeOpts>`:
 
 .. code:: javascript
 
@@ -2751,7 +2751,7 @@ If testing ``double`` <CHECKKKKK>
 
 Case 5: can aggregate encrypted range and return the maximum  
 `````````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in Data Types RangeOpts:
+Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in `Test Setup: RangeOpts <#Test Setup: RangeOpts>`:
 
 .. code:: javascript
 
@@ -2780,7 +2780,7 @@ If testing ``doubleNoPrecision`` two documents (not three) will be returned, sin
 
 Case 6: can aggregate encrypted range and return the minimum 
 `````````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in Data Types RangeOpts:
+Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in `Test Setup: RangeOpts <#Test Setup: RangeOpts>`:
 
 .. code:: javascript
 
@@ -2807,7 +2807,7 @@ Assert that this one document is returned ``{ "encrypted<Type>": 30 }``.
 
 Case 7: can aggregate encrypted range and return no documents
 `````````````````````````````````````````````````````````````
-Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in Data Types RangeOpts:
+Use ``clientEncryption`` to encrypt this query with the following ``EncryptOpts`` and the matching ``RangeOpts`` listed in `Test Setup: RangeOpts <#Test Setup: RangeOpts>`:
 
 .. code:: javascript
 
@@ -2866,9 +2866,9 @@ Assert that an error message contains "got min: 0, max: 250, value: -1".
 
 Case 10: encrypting a document of a different type errors 
 `````````````````````````````````````````````````````````
-This test case should be skipped if the ``encryptedField`` is ``double`` no ``precision``. 
+This test case should be skipped if the ``encryptedField`` is ``doubleNoPrecision``. 
 
-For all the tests before use ``clientEncryption`` to try and encrypt the values listed below with these ``EncryptOpts``:
+For all the tests below use these ``EncryptOpts``:
 
 .. code:: typescript
 
@@ -2879,17 +2879,35 @@ For all the tests before use ``clientEncryption`` to try and encrypt the values 
    }
 
 #. DoubleWithPrecision
-   encrypt 100
-   assert an error is returned with the message "Got range option 'min' of type DOUBLE and value of type INT64"
+
+   Use ``clientEncryption`` and the ``EncryptOpts`` above to encrypt a ``long`` (use 100).
+   
+   Assert an error is returned with the message "Got range option 'min' of type DOUBLE and value of type INT64".
+
 #. Date 
+
+   Use ``clientEncryption`` and the ``EncryptOpts`` above to encrypt an ``double`` (use 4.44).
+   
+   Assert an error is returned with the message "Got range option 'min' of type DATE_TIME and value of type DOUBLE".
+
 #. Integer 
+
+   Use ``clientEncryption`` and the ``EncryptOpts`` above to encrypt an ``double`` (use 4.44).
+   
+   Assert an error is returned with the message "Got range option 'min' of type INT32 and value of type DOUBLE".
+
 #. Long
+
+   Use ``clientEncryption`` and the ``EncryptOpts`` above to encrypt an ``integer`` (use 3).
+   
+   Assert an error is returned with the message "Got range option 'min' of type INT64 and value of type INT32".
+
 
 Case 11: setting precision errors if the type is not a double
 ``````````````````````````````````````````````````````````````
 This test case should be skipped if the ``encryptedField`` is the type ``doubleWithPrecision`` and ``doubleNoPrecision``.
 
-Use ``clientEncryption`` to encrypt the value 6 with these ``RangeOpts`` and ``EncryptOpts``:
+For all the tests below use these ``EncryptOpts``:
 .. code:: typescript
 
    class EncryptOpts {
@@ -2901,22 +2919,30 @@ Use ``clientEncryption`` to encrypt the value 6 with these ``RangeOpts`` and ``E
 
 #. Date 
 
+Use ``clientEncryption`` to encrypt the value 6 with the ``EncryptOpts`` above and these ``RangeOpts`` 
+   
    .. code:: typescript
    
       class RangeOpts {
          min: 0,
          max: 200,
-         sparsity: 1
+         sparsity: 1,
+         precision: 2,
       }
+
+Assert that an error message contains "expected 'precision' to be set with double or decimal128 index, but got: <TYPE> min"
 
 #. Integer and Long
 
+Use ``clientEncryption`` to encrypt the value 6 with the ``EncryptOpts`` above and these ``RangeOpts`` 
+
    .. code:: typescript
    
       class RangeOpts {
          min: 0,
          max: 200,
-         sparsity: 1
+         sparsity: 1,
+         precision: 2
       }
 
 Assert that an error message contains "expected 'precision' to be set with double or decimal128 index, but got: <TYPE> min"

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2649,8 +2649,8 @@ Each test listed in the cases below must pass for all supported data types unles
    .. code:: typescript
    
       class RangeOpts {
-         min: 0,
-         max: 200.0,
+         min: { "$numberDouble": "0" },
+         max: { "$numberDouble": "200" },
          sparsity: 1,
          precision: 2
       }
@@ -2660,8 +2660,8 @@ Each test listed in the cases below must pass for all supported data types unles
    .. code:: typescript
    
       class RangeOpts {
-         min: {'$date': 0 } ,
-         max: {'$date': 200 },
+         min: {"$date": { "$numberLong": "0" } } ,
+         max: {"$date": { "$numberLong": "200" } },
          sparsity: 1
       }
 
@@ -2670,8 +2670,8 @@ Each test listed in the cases below must pass for all supported data types unles
    .. code:: typescript
    
       class RangeOpts {
-         min: {'$numberInt': 0 } ,
-         max: {'$numberInt': 200 },
+         min: {"$numberInt": "0" } ,
+         max: {"$numberInt": "200" },
          sparsity: 1
       }
 
@@ -2680,14 +2680,14 @@ Each test listed in the cases below must pass for all supported data types unles
    .. code:: typescript
    
       class RangeOpts {
-         min: {'$numberLong': 0 } ,
-         max: {'$numberLong': 200 },
+         min: {"$numberLong": "0" } ,
+         max: {"$numberLong": "200" },
          sparsity: 1
       }
 
 Case 1: can decrypt a payload
 `````````````````````````````
-Use ``clientEncryption.encrypt()`` to encrypt the value 6. Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the value 6.0.
+Use ``clientEncryption.encrypt()`` to encrypt the value 6. Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the double value 6.0.
 
 Store the result in ``insertPayload``.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2858,29 +2858,9 @@ For all the tests below use these ``EncryptOpts``:
       contentionFactor: 0
    }
 
-#. Double (with precision)
-
-   Use ``clientEncryption.encrypt()`` and the ``EncryptOpts`` above to encrypt ``{$numberLong : 100 }``.
-   
-   Assert an error was raised.
-
-#. Date 
-
-   Use ``clientEncryption.encrypt()`` and the ``EncryptOpts`` above to encrypt an ``{$numberDouble : 4.44 }``.
-   
-   Assert an error was raised.
-
-#. Integer 
-
-   Use ``clientEncryption.encrypt()`` and the ``EncryptOpts`` above to encrypt an ``{$numberDouble : 4.44 }``.
-   
-   Assert an error was raised.
-
-#. Long
-
-   Use ``clientEncryption.encrypt()`` and the ``EncryptOpts`` above to encrypt an ``{$numberInt : 3 }``.
-   
-   Assert an error was raised.
+If the encrypted field is ``encryptedInt`` insert ``{ "encryptedInt": { "$numberDouble": "6" } }``.
+Otherwise, insert ``{ "encrypted<Type>": { "$numberInt": "6" }``.
+Assert an error was raised.
 
 
 Case 8: setting precision errors if the type is not a double


### PR DESCRIPTION
# Summary

- Add `"rangePreview"` to `queryType`
- Add `"RangePreview"` to `EncrypOpts.algorithm`
- Add `rangeOpts` struct in `EncryptOpts`
- Add `ClientEncryption.encryptExpression()`
- Add prose tests for explicit encryption with range index.

## Notes

Tests require [libmongocrypt 1.7.0-alpha1](https://github.com/mongodb/libmongocrypt/releases/tag/1.7.0-alpha1) release. Binaries for the release are available on this [upload-all task](https://spruce.mongodb.com/task/libmongocrypt_publish_snapshot_upload_all_2cd2f77ae806a3a4c12750b39b0be92b0ca3b2c1_22_12_08_13_33_51/files?execution=0).

Tests have been run with the Go driver here: https://github.com/mongodb/mongo-go-driver/pull/1145

After Decimal128 support is released in [MONGOCRYPT-483](https://jira.mongodb.org/browse/MONGOCRYPT-483), test cases will be added for Decimal128.

Please complete the following before merging:

- [x] Update changelog.
~~- [ ] Make sure there are generated JSON files from the YAML test files.~~ **Not applicable. Prose tests only**.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).