### PR TITLE
DRIVERS-2313 note prose test server requirement

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2493,6 +2493,8 @@ The following tests that a mongocryptd client is not created when shared library
 21. Automatic Data Encryption Keys
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The Automatic Data Encryption Keys tests require MongoDB server 6.0+. The tests must not run against a standalone.
+
 For each of the following test cases, assume `DB` is a valid open database
 handle, and assume a ClientEncryption_ object `CE` created using the following
 options::


### PR DESCRIPTION
`encryptedFields` requires MongoDB 6.0+ and is not supported on standalone. The message is consistent with `12. Explicit Encryption`

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ **Not applicable.**
- ~~[ ] Make sure there are generated JSON files from the YAML test files.~~ **Not applicable**
- ~~[ ] Test changes in at least one language driver.~~ **Not applicable**
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~ **Not applicable**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

