### PR TITLE
test(DRIVERS-2523): allow optional bulk write result inserted ids

### DIFF
--- a/source/client-side-encryption/tests/unified/rewrapManyDataKey.json
+++ b/source/client-side-encryption/tests/unified/rewrapManyDataKey.json
@@ -321,7 +321,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -503,7 +506,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -687,7 +693,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -873,7 +882,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -1055,7 +1067,10 @@
               "modifiedCount": 4,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         }
@@ -1218,7 +1233,10 @@
               "modifiedCount": 5,
               "deletedCount": 0,
               "upsertedCount": 0,
-              "upsertedIds": {}
+              "upsertedIds": {},
+              "insertedIds": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         },

--- a/source/client-side-encryption/tests/unified/rewrapManyDataKey.yml
+++ b/source/client-side-encryption/tests/unified/rewrapManyDataKey.yml
@@ -130,6 +130,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -182,6 +183,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -236,6 +238,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -285,6 +288,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -334,6 +338,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -381,6 +386,7 @@ tests:
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
       - name: find
         object: *collection0
         arguments:


### PR DESCRIPTION
The `BulkWriteResult` can contain an optional `insertedIds` property so we check for it not being present or empty.

<!-- Thanks for contributing! -->

Tests running in the Node driver suite from PR: https://github.com/mongodb/node-mongodb-native/pull/3516

Please complete the following before merging:

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

