### PR TITLE
DRIVERS-2525 Add a command logging test covering unacknowledged write behavior

### DIFF
--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
@@ -1,5 +1,5 @@
 {
-  "description": "command-logging",
+  "description": "unacknowledged-write",
   "schemaVersion": "1.13",
   "createEntities": [
     {

--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
@@ -43,10 +43,10 @@
   ],
   "tests": [
     {
-      "description": "An unacknowledged write that will succeed on the server",
+      "description": "An unacknowledged write generates a succeeded log message with ok: 1 reply",
       "operations": [
         {
-          "name": "insert",
+          "name": "insertOne",
           "object": "collection",
           "arguments": {
             "document": {
@@ -70,94 +70,6 @@
                   "$$matchAsDocument": {
                     "$$matchAsRoot": {
                       "insert": "logging-tests-collection",
-                      "$db": "logging-tests"
-                    }
-                  }
-                },
-                "requestId": {
-                  "$$type": [
-                    "int",
-                    "long"
-                  ]
-                },
-                "serverHost": {
-                  "$$type": "string"
-                },
-                "serverPort": {
-                  "$$type": [
-                    "int",
-                    "long"
-                  ]
-                }
-              }
-            },
-            {
-              "level": "debug",
-              "component": "command",
-              "data": {
-                "message": "Command succeeded",
-                "commandName": "insert",
-                "reply": {
-                  "$$matchAsDocument": {
-                    "ok": 1
-                  }
-                },
-                "requestId": {
-                  "$$type": [
-                    "int",
-                    "long"
-                  ]
-                },
-                "serverHost": {
-                  "$$type": "string"
-                },
-                "serverPort": {
-                  "$$type": [
-                    "int",
-                    "long"
-                  ]
-                },
-                "durationMS": {
-                  "$$type": [
-                    "double",
-                    "int",
-                    "long"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "An unacknowledged write that will fail on the server",
-      "operations": [
-        {
-          "name": "insert",
-          "object": "collection",
-          "arguments": {
-            "document": {
-              "_id": 1
-            }
-          }
-        }
-      ],
-      "expectLogMessages": [
-        {
-          "client": "client",
-          "messages": [
-            {
-              "level": "debug",
-              "component": "command",
-              "data": {
-                "message": "Command started",
-                "databaseName": "logging-tests",
-                "commandName": "insert",
-                "command": {
-                  "$$matchAsDocument": {
-                    "$$matchAsRoot": {
-                      "ping": 1,
                       "$db": "logging-tests"
                     }
                   }

--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
@@ -1,0 +1,222 @@
+{
+  "description": "command-logging",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeLogMessages": {
+          "command": "debug"
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "logging-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "logging-tests-collection",
+        "collectionOptions": {
+          "writeConcern": {
+            "w": 0
+          }
+        }
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "logging-tests-collection",
+      "databaseName": "logging-tests",
+      "documents": [
+        {
+          "_id": 1
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "An unacknowledged write that will succeed on the server",
+      "operations": [
+        {
+          "name": "insert",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 2
+            }
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "insert",
+                "command": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "insert": "logging-tests-collection",
+                      "$db": "logging-tests"
+                    }
+                  }
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "insert",
+                "reply": {
+                  "$$matchAsDocument": {
+                    "ok": 1
+                  }
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "An unacknowledged write that will fail on the server",
+      "operations": [
+        {
+          "name": "insert",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectLogMessages": [
+        {
+          "client": "client",
+          "messages": [
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command started",
+                "databaseName": "logging-tests",
+                "commandName": "insert",
+                "command": {
+                  "$$matchAsDocument": {
+                    "$$matchAsRoot": {
+                      "ping": 1,
+                      "$db": "logging-tests"
+                    }
+                  }
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "command",
+              "data": {
+                "message": "Command succeeded",
+                "commandName": "insert",
+                "reply": {
+                  "$$matchAsDocument": {
+                    "ok": 1
+                  }
+                },
+                "requestId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "durationMS": {
+                  "$$type": [
+                    "double",
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
@@ -1,0 +1,102 @@
+description: "command-logging"
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client client
+      observeLogMessages:
+        command: debug
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName logging-tests
+  - collection:
+      id: &collection collection
+      database: *database
+      collectionName: &collectionName logging-tests-collection
+      collectionOptions:
+        writeConcern: { w: 0 }
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "An unacknowledged write that will succeed on the server"
+    operations:
+      - name: &commandName insert
+        object: *collection
+        arguments:
+          document: { _id: 2 }
+    expectLogMessages:
+      - client: *client
+        messages:
+          - level: debug
+            component: command
+            data:
+              message: "Command started"
+              databaseName: *databaseName
+              commandName: *commandName
+              command:
+                $$matchAsDocument:
+                  $$matchAsRoot:
+                    insert: *collectionName
+                    $db: *databaseName
+              requestId: { $$type: [int, long] }
+              serverHost: { $$type: string }
+              serverPort: { $$type: [int, long] }
+
+          - level: debug
+            component: command
+            data:
+              message: "Command succeeded"
+              commandName: *commandName
+              reply:
+                $$matchAsDocument:
+                  ok: 1
+              requestId: { $$type: [int, long] }
+              serverHost: { $$type: string }
+              serverPort: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
+        
+  - description: "An unacknowledged write that will fail on the server"
+    operations:
+      # this should fail server-side with a duplicate key error
+      - name: &commandName insert
+        object: *collection
+        arguments:
+          document: { _id: 1 }
+    expectLogMessages:
+      - client: *client
+        messages:
+          - level: debug
+            component: command
+            data:
+              message: "Command started"
+              databaseName: *databaseName
+              commandName: *commandName
+              command:
+                $$matchAsDocument:
+                  $$matchAsRoot:
+                    ping: 1
+                    $db: *databaseName
+              requestId: { $$type: [int, long] }
+              serverHost: { $$type: string }
+              serverPort: { $$type: [int, long] }
+
+          - level: debug
+            component: command
+            data:
+              message: "Command succeeded"
+              commandName: *commandName
+              reply:
+                $$matchAsDocument:
+                  ok: 1
+              requestId: { $$type: [int, long] }
+              serverHost: { $$type: string }
+              serverPort: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
+

--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
@@ -25,9 +25,9 @@ initialData:
       - { _id: 1 }
 
 tests:
-  - description: "An unacknowledged write that will succeed on the server"
+  - description: "An unacknowledged write generates a succeeded log message with ok: 1 reply"
     operations:
-      - name: &commandName insert
+      - name: insertOne
         object: *collection
         arguments:
           document: { _id: 2 }
@@ -39,7 +39,7 @@ tests:
             data:
               message: "Command started"
               databaseName: *databaseName
-              commandName: *commandName
+              commandName: insert
               command:
                 $$matchAsDocument:
                   $$matchAsRoot:
@@ -53,7 +53,7 @@ tests:
             component: command
             data:
               message: "Command succeeded"
-              commandName: *commandName
+              commandName: insert
               reply:
                 $$matchAsDocument:
                   ok: 1
@@ -62,41 +62,4 @@ tests:
               serverPort: { $$type: [int, long] }
               durationMS: { $$type: [double, int, long] }
         
-  - description: "An unacknowledged write that will fail on the server"
-    operations:
-      # this should fail server-side with a duplicate key error
-      - name: &commandName insert
-        object: *collection
-        arguments:
-          document: { _id: 1 }
-    expectLogMessages:
-      - client: *client
-        messages:
-          - level: debug
-            component: command
-            data:
-              message: "Command started"
-              databaseName: *databaseName
-              commandName: *commandName
-              command:
-                $$matchAsDocument:
-                  $$matchAsRoot:
-                    ping: 1
-                    $db: *databaseName
-              requestId: { $$type: [int, long] }
-              serverHost: { $$type: string }
-              serverPort: { $$type: [int, long] }
-
-          - level: debug
-            component: command
-            data:
-              message: "Command succeeded"
-              commandName: *commandName
-              reply:
-                $$matchAsDocument:
-                  ok: 1
-              requestId: { $$type: [int, long] }
-              serverHost: { $$type: string }
-              serverPort: { $$type: [int, long] }
-              durationMS: { $$type: [double, int, long] }
 

--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
@@ -1,4 +1,4 @@
-description: "command-logging"
+description: "unacknowledged-write"
 
 schemaVersion: "1.13"
 


### PR DESCRIPTION
Adds a command logging test covering unacknowledged write behavior. Drivers are supposed to emit a "command succeeded" message with a reply of ok: 1 for unacknowledged writes but we were missing test coverage.

Rust doesn't have unacknowledged writes but @jyemin has confirmed this test passes for the Java driver.