### PR TITLE
DRIVERS-2286 allow skipping some fle2-Range on mac

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -163,6 +163,8 @@ Do the following before running spec tests:
 
 Load each YAML (or JSON) file using a Canonical Extended JSON parser.
 
+If the test file name matches the form ``fle2-Range-<type>-Correctness``, drivers MAY skip the test on macOS. The ``fle2-Range`` tests are very slow on macOS and do not provide significant additional test coverage.
+
 Then for each element in ``tests``:
 
 #. If the ``skipReason`` field is present, skip this test completely.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -163,7 +163,7 @@ Do the following before running spec tests:
 
 Load each YAML (or JSON) file using a Canonical Extended JSON parser.
 
-If the test file name matches the form ``fle2-Range-<type>-Correctness``, drivers MAY skip the test on macOS. The ``fle2-Range`` tests are very slow on macOS and do not provide significant additional test coverage.
+If the test file name matches the regular expression ``fle2\-Range\-.*\-Correctness``, drivers MAY skip the test on macOS. The ``fle2-Range`` tests are very slow on macOS and do not provide significant additional test coverage.
 
 Then for each element in ``tests``:
 


### PR DESCRIPTION
# Summary

- Skip `fle2-Range-<type>-Correctness` tests on macOS

Change applied in the Go driver [here](https://github.com/mongodb/mongo-go-driver/pull/1164).

# Background & Motivation

The `fle-Range-*` tests are especially slow on macOS. Running the `fle-Range-*` tests on a 3-node replica on macOS with the Go driver takes 11 minutes. The same tests on Ubuntu 18.04 take 2 minutes. After skipping `fle2-Range-<type>-Correctness` tests, the `fle-Range-*` tests on macOS take 2 minutes.

It may be sufficient test coverage to test `fle2-Range-<type>-Correctness` on Linux and Windows.
The `fle2-Range-<type>-<operation>` tests will still run on macOS and provide some test coverage for Range Index on macOS.

# Rejected alternatives

Removing the `fle2-Range-<type>-Correctness` tests entirely was considered and rejected. The `fle2-Range-<type>-Correctness` tests different query types and client error conditions. [Tests in the server](https://github.com/10gen/mongo-enterprise-modules/tree/master/jstests/fle2/query/range) test different query types. libmongocrypt tests [client error conditions](https://github.com/mongodb/libmongocrypt/blob/9cb5bd8beab29ad8e56fbfae7f8df8df95d145e2/test/test-mc-range-encoding.c#L93-L110). Arguably the server and client components are sufficiently tested without driver integration tests. This idea was rejected to prefer erring towards extra test coverage.

Adding a `skip_macos` field to the test format was considered and rejected. The FLE tests may eventually be ported to the unified format DRIVERS-2295. Adding a field specific to these tests may add difficulty to porting.

<!-- Thanks for contributing! -->

Please complete the following before merging:

~~- [ ] Update changelog.~~ N/A
~~- [ ] Make sure there are generated JSON files from the YAML test files.~~ N/A
~~- [] Test changes in at least one language driver.~~ N/A
~~- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~ N/A

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

