### PR TITLE
relax logging to allow expected to subset actual

### DIFF
--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -1394,9 +1394,8 @@ The structure of each object is as follows:
   messages, which are expected to be observed (in this order) on the corresponding
   client while executing `operations`_. If the array is empty, the test runner
   MUST assert that no messages were observed on the client. The driver MUST assert
-  that the messages produced are an exact match, i.e. that the expected and actual
-  message counts are the same and that there are no extra messages emitted by the
-  client during the test run.
+  that the messages match, i.e. that the expected messages are a subset of the
+  actual messages.
 
 expectedLogMessage
 ~~~~~~~~~~~~~~~~~~
@@ -1644,7 +1643,7 @@ the topology. For languages that rely on built-in language mechanisms such as re
 counting to automatically close/deinitialize clients once they go out of scope, this may
 require implementing an abstraction to allow a client entity's underlying client to be set
 to null. Because drivers do not consistently propagate errors encountered while closing a
-client, test files SHOULD NOT specify `expectResult <operation_expectResult_>`_ or 
+client, test files SHOULD NOT specify `expectResult <operation_expectResult_>`_ or
 `expectError <operation_expectError_>`_ for this operation. Test files SHOULD NOT
 specify any operations for a client entity or any entity descended from it following
 a `close` operation on it, as driver behavior when an operation is attempted on a closed

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3897,6 +3897,8 @@ Changelog
 
 ..
   Please note schema version bumps in changelog entries where applicable.
+:2023-01-26 Relax logging expectations to allow expected logs to be a subset of
+            the actual logs.
 :2022-10-17: Add description of a `close` operation for client entities.
 :2022-10-14: **Schema version 1.13.**
             Add support for logging assertions via the ``observeLogMessages`` field


### PR DESCRIPTION
<!-- Thanks for contributing! -->

When validating the logs, it could be the case that there are more "actual" logs being queued than "expected" logs. For example, the Go Driver closes sessions when the client is disconnected which triggers three extra checkout logs than are expected in the CMAP UST. In this case, the unified test will result in |actual| = |expected| + 3 and fail.

It seems realistic to assume that most drivers will have "noisy"/"extra" logs while running unified spec tests. To be more precise, a valid case could meet the condition such that  |actual| >= |expected| > 0. Perhaps we should relax the conditions on what it means for "expected" to match "actual". Instead of an exact match, we could require that expected messages be an "ordered subset" of the actual messages.

- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files. NA
- [x] Test changes in at least one language driver. Go
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

