### PR TITLE
DRIVERS-1675 Add the end session log expectations for CMAP

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/logging/connection-logging.json
+++ b/source/connection-monitoring-and-pooling/tests/logging/connection-logging.json
@@ -480,6 +480,10 @@
                     "int",
                     "long"
                   ]
+                },
+                "reason": "An error occurred while trying to establish a new connection",
+                "error": {
+                  "$$exists": true
                 }
               }
             }

--- a/source/connection-monitoring-and-pooling/tests/logging/connection-logging.json
+++ b/source/connection-monitoring-and-pooling/tests/logging/connection-logging.json
@@ -191,6 +191,66 @@
               "level": "debug",
               "component": "connection",
               "data": {
+                "message": "Connection checkout started",
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "connection",
+              "data": {
+                "message": "Connection checked out",
+                "driverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "connection",
+              "data": {
+                "message": "Connection checked in",
+                "driverConnectionId": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                },
+                "serverHost": {
+                  "$$type": "string"
+                },
+                "serverPort": {
+                  "$$type": [
+                    "int",
+                    "long"
+                  ]
+                }
+              }
+            },
+            {
+              "level": "debug",
+              "component": "connection",
+              "data": {
                 "message": "Connection closed",
                 "driverConnectionId": {
                   "$$type": [
@@ -420,10 +480,6 @@
                     "int",
                     "long"
                   ]
-                },
-                "reason": "An error occurred while trying to establish a new connection",
-                "error": {
-                  "$$exists": true
                 }
               }
             }

--- a/source/connection-monitoring-and-pooling/tests/logging/connection-logging.yml
+++ b/source/connection-monitoring-and-pooling/tests/logging/connection-logging.yml
@@ -66,7 +66,31 @@ tests:
               driverConnectionId: { $$type: [int, long] }
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
-          
+
+          - level: debug
+            component: connection
+            data:
+              message: "Connection checked out"
+              driverConnectionId: { $$type: [int, long] }
+              serverHost: { $$type: string }
+              serverPort: { $$type: [int, long] }
+
+          - level: debug
+            component: connection
+            data:
+              message: "Connection checked in"
+              driverConnectionId: { $$type: [int, long] }
+              serverHost: { $$type: string }
+              serverPort: { $$type: [int, long] }
+
+          #  The next three expected logs are for ending a session.
+          - level: debug
+            component: connection
+            data:
+              message: "Connection checkout started"
+              serverHost: { $$type: string }
+              serverPort: { $$type: [int, long] }
+
           - level: debug
             component: connection
             data:
@@ -192,5 +216,3 @@ tests:
               message: "Connection checkout failed"
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
-              reason: "An error occurred while trying to establish a new connection"
-              error: { $$exists: true }

--- a/source/connection-monitoring-and-pooling/tests/logging/connection-logging.yml
+++ b/source/connection-monitoring-and-pooling/tests/logging/connection-logging.yml
@@ -216,3 +216,5 @@ tests:
               message: "Connection checkout failed"
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
+              reason: "An error occurred while trying to establish a new connection"
+              error: { $$exists: true }


### PR DESCRIPTION
<!-- Thanks for contributing! -->
DRIVERS-1675

Drivers need to account for the logs created by closing the client as an operation, including those produced by ending a session.

Please complete the following before merging:

- [ ] Update changelog. NA
- [x] Make sure there are generated JSON files from the YAML test files. 
- [x] Test changes in at least one language driver. Go
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

