### PR TITLE
DRIVERS-2539 Replace `DataKeyOpts` with `masterKey` in `CreateEncryptedCollection`

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -952,9 +952,10 @@ Create Encrypted Collection Helper
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To support automatic generation of encryption data keys, a helper
-`CreateEncryptedCollection(CE, database, collName, collOpts, kmsProvider, dkOpts)`
+`CreateEncryptedCollection(CE, database, collName, collOpts, kmsProvider, masterKey)`
 is defined, where `CE` is a ClientEncryption_ object, `kmsProvider` is a
-KMSProviderName_ and `dkOpts` is a DataKeyOpts_. It has the following behavior:
+KMSProviderName_ and `masterKey` is equivalent to the `masterKey` defined in DataKeyOpts_.
+It has the following behavior:
 
 - If `collOpts` contains an ``"encryptedFields"`` property, then `EF` is the value
   of that property.  Otherwise, report an error that there are no ``encryptedFields``
@@ -969,6 +970,7 @@ KMSProviderName_ and `dkOpts` is a DataKeyOpts_. It has the following behavior:
     - Otherwise, if `F` has a ``"keyId"`` named element `K` and `K` is a
       ``null`` value:
 
+      - Create a DataKeyOpts_ named `dkOpts` with the `masterKey` argument.
       - Let `D` be the result of ``CE.createDataKey(kmsProvider, dkOpts)``.
       - If generating `D` resulted in an error `E`, the entire
         `CreateEncryptedCollection` must now fail with error `E`. Return the
@@ -1036,7 +1038,7 @@ ClientEncryption
       // create a collection with encrypted fields, automatically allocating and assigning new data encryption
       // keys. It returns a handle to the new collection, as well as a document consisting of the generated
       // "encryptedFields" options. Refer to "Create Encrypted Collection Helper"
-      createEncryptedCollection(database: Database, collName: string, collOpts, kmsProvider: KMSProviderName, dkOpts: DataKeyOpts): [Collection, Document];
+      createEncryptedCollection(database: Database, collName: string, collOpts, kmsProvider: KMSProviderName, masterKey: Optional<Document>): [Collection, Document];
 
       // Creates a new key document and inserts into the key vault collection.
       // Returns the _id of the created document as a UUID (BSON binary subtype 0x04).

--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -4,7 +4,7 @@ Client Side Encryption
 
 :Status: Accepted
 :Minimum Server Version: 4.2 (CSFLE), 6.0 (Queryable Encryption)
-:Last Modified: 2023-01-31
+:Last Modified: 2023-02-01
 :Version: 1.12.0
 
 .. _lmc-c-api: https://github.com/mongodb/libmongocrypt/blob/master/src/mongocrypt.h.in
@@ -2714,6 +2714,7 @@ explicit session parameter as described in the
 Changelog
 =========
 
+:2023-02-01: Replace ``DataKeyOpts`` with ``masterKey`` in ``createEncryptedCollection``.
 :2023-01-31: ``createEncryptedCollection`` does not check AutoEncryptionOptions for the encryptedFieldsMap.
 :2023-01-30: Return ``encryptedFields`` on ``CreateCollection`` error.
 :2023-01-26: Use GetEncryptedFields_ in more helpers.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2509,6 +2509,17 @@ options::
       },
    }
 
+Run each test case with each of these KMS providers: ``aws``, ``local``. The KMS provider name is referred to as ``kmsProvider``.
+When testing ``aws``, use the following as the ``masterKey`` option:
+
+.. code:: javascript
+
+   {
+      region: "us-east-1",
+      key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+   }
+
+When testing ``local``, set ``masterKey`` to ``null``.
 
 Case 1: Simple Creation and Validation
 ``````````````````````````````````````
@@ -2535,7 +2546,7 @@ rejects an attempt to insert plaintext in an encrypted fields.
          }
       }
 
-2. Invoke `CreateEncryptedCollection(CE, DB, "testing1", Opts, "local", null)`
+2. Invoke `CreateEncryptedCollection(CE, DB, "testing1", Opts, kmsProvider, masterKey)`
    to obtain a new collection `Coll`. Expect success.
 3. Attempt to insert the following document into `Coll`::
 
@@ -2559,7 +2570,7 @@ missing.
 
 1. Create a new empty create-collection options `Opts`. (i.e. it must not
    contain any ``encryptedFields`` options.)
-2. Invoke `CreateEncryptedCollection(CE, DB, "testing1", Opts, "local", null)`.
+2. Invoke `CreateEncryptedCollection(CE, DB, "testing1", Opts, kmsProvider, masterKey)`.
 3. Expect the invocation to fail with an error indicating that
    ``encryptedFields`` is not defined for the collection, and expect that no
    collection was created within the database. It would be *incorrect* for
@@ -2592,7 +2603,7 @@ when attempting to create a collection with such invalid settings.
          }
       }
 
-2. Invoke `CreateEncryptedCollection(CE, DB, "testing1", Opts, "local", null)`.
+2. Invoke `CreateEncryptedCollection(CE, DB, "testing1", Opts, kmsProvider, masterKey)`.
 3. Expect an error from the server indicating a validation error at
    ``create.encryptedFields.fields.keyId``, which must be a UUID and not a
    boolean value.
@@ -2615,7 +2626,7 @@ with encrypted value.
          }
       }
 
-2. Invoke `CreateEncryptedCollection(CE, DB, "testing1", Opts, "local", null)`
+2. Invoke `CreateEncryptedCollection(CE, DB, "testing1", Opts, kmsProvider, masterKey)`
    to obtain a new collection `Coll` and data key `key1`. Expect success.
 3. Use `CE` to explicitly encrypt the string "123-45-6789" using
    algorithm `Unindexed` and data key `key1`. Refer result as `encryptedPayload`.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2506,6 +2506,10 @@ options::
       keyVaultNamespace: "keyvault.datakeys",
       kmsProviders: {
          local: { key: base64Decode(LOCAL_MASTERKEY) },
+         aws: {
+            accessKeyId: <set from environment>,
+            secretAccessKey: <set from environment>
+         },
       },
    }
 


### PR DESCRIPTION
# Summary

- Replace `DataKeyOpts` with `masterKey` in `CreateEncryptedCollection`
- Run test cases for `CreateEncryptedCollection` with `aws` KMS provider.

Updated API is implemented and tested in [the Go driver here](https://github.com/mongodb/mongo-go-driver/pull/1169).

# Background & Motivation

Running test cases with the ``aws`` KMS provider is intended to provide test coverage for handling ``masterKey`` option. The ``local`` KMS provider not requiring a ``masterKey`` option.

The motivation for removing `keyAltNames` from `CreateEncryptedCollection` is noted in DRIVERS-2539:
> The problem is that if keyAltNames is given and createEncryptedCollection creates >1 key, then the method will always fail because of a duplicate key error.
> MONGOCRYPT-432 would allow createEncryptedCollection to create keys with different keyAltNames through encryptedFieldsMap/encryptedFields.


The motivation for removing `keyMaterial` from `CreateEncryptedCollection` is due to having no known use-case.
As previously specified, calling `CreateEncryptedCollection` with a custom keyMaterial creates all data keys with the same custom keyMaterial.
Users can still create data keys with custom keyMaterial through the CreateDataKey API.
The rationale for adding custom keyMaterial to CreateDataKey is [documented in the Key Management API scope](https://docs.google.com/document/d/1NXPZwDY62bI81RmORnGpdXQRthzAb5_GwZrP10nDDRw/edit#heading=h.lfd5yrq9s8bm).

# Caveats

C# has released the CreateEncryptedCollection API. Removing these options is a backwards breaking change. For C#, the best option may be to validate and raise an error if keyMaterial or keyAltName is set in CreateEncryptedCollection.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
~~- [ ] Make sure there are generated JSON files from the YAML test files.~~
- [x] Test changes in at least one language driver. **Tested in Go**
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless). (Pending)

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

