### PR TITLE
DRIVERS-2333 add steps to credential caching tests

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -991,7 +991,7 @@ case where another part the application has refreshed the credentials.
 
 However, if environment variables are not present during initial authorization,
 credentials may be fetched from another source and cached.  Even if the
-environmnet variables are present in subsequent authorization attempts,
+environment variables are present in subsequent authorization attempts,
 the driver MUST use the cached credentials, or refresh them if applicable.
 This behavior is consistent with how the AWS SDKs behave.
 

--- a/source/auth/tests/mongodb-aws.rst
+++ b/source/auth/tests/mongodb-aws.rst
@@ -157,9 +157,11 @@ with the auth provider directly instead of using a client.
 #. Set the AWS environment variables to invalid values.
 #. Create a new client.
 #. Ensure that a ``find`` operation results in an error.
+#. Clear the AWS environment variables.
 
 #. Create a new client.
 #. Ensure that a ``find`` operation adds credentials to the cache.
 #. Set the AWS environment variables to invalid values.
 #. Create a new client.
 #. Ensure that a ``find`` operation succeeds.
+#. Clear the AWS environment variables.

--- a/source/auth/tests/mongodb-aws.rst
+++ b/source/auth/tests/mongodb-aws.rst
@@ -147,6 +147,7 @@ add the following tests. Note that if integration tests are run in
 parallel for the driver, then these tests must be run as unit tests interacting
 with the auth provider directly instead of using a client.
 
+#. Clear the cache.
 #. Create a new client.
 #. Ensure that a ``find`` operation adds credentials to the cache.
 #. Set the AWS environment variables based on the cached credentials.
@@ -159,6 +160,7 @@ with the auth provider directly instead of using a client.
 #. Ensure that a ``find`` operation results in an error.
 #. Clear the AWS environment variables.
 
+#. Clear the cache.
 #. Create a new client.
 #. Ensure that a ``find`` operation adds credentials to the cache.
 #. Set the AWS environment variables to invalid values.

--- a/source/auth/tests/mongodb-aws.rst
+++ b/source/auth/tests/mongodb-aws.rst
@@ -151,12 +151,15 @@ with the auth provider directly instead of using a client.
 #. Ensure that a ``find`` operation adds credentials to the cache.
 #. Set the AWS environment variables based on the cached credentials.
 #. Clear the cache.
+#. Create a new client.
 #. Ensure that a ``find`` operation succeeds and does not add credentials to
    the cache.
 #. Set the AWS environment variables to invalid values.
+#. Create a new client.
 #. Ensure that a ``find`` operation results in an error.
 
 #. Create a new client.
 #. Ensure that a ``find`` operation adds credentials to the cache.
 #. Set the AWS environment variables to invalid values.
+#. Create a new client.
 #. Ensure that a ``find`` operation succeeds.


### PR DESCRIPTION
# Summary
- Create a new client before a `find` operation. 
- Clear the AWS environment variables after the test.
- Clear the cache before steps expecting to cache credentials.

# Background & Motivation
Create a new client before a `find` operation to ensure authentication is attempted.
Clear the AWS environment variables after the test to prevent the environment variable interacting with  other tests.

<!-- Thanks for contributing! -->

Please complete the following before merging:

~~- [ ] Update changelog.~~
~~- [ ] Make sure there are generated JSON files from the YAML test files.~~
- [x] Test changes in at least one language driver. **Updated steps are tested in [C](https://github.com/mongodb/mongo-c-driver/pull/1207/files#diff-6b8b6c50d722af8c2029c7c665ebb7f8db62b13816f8b9bd65c8e077d367303aR278)**
~~- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

