### PR TITLE
Fix typo in description of `$$matchAsRoot` operator

### DIFF
--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3898,6 +3898,7 @@ Changelog
 
 ..
   Please note schema version bumps in changelog entries where applicable.
+:2023-02-24: Fix typo in the description of the ``$$matchAsRoot`` matching operator.
 :2022-10-17: Add description of a `close` operation for client entities.
 :2022-10-14: **Schema version 1.13.**
             Add support for logging assertions via the ``observeLogMessages`` field

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3306,7 +3306,7 @@ $$matchAsRoot
 This operator may be used anywhere a matched value is expected (including
 `expectResult <operation_expectResult_>`_) and the expected and actual values
 are documents. The test runner MUST treat the expected value as a root-level
-document as described in `Evaluating Matches`_ and match it against the expected
+document as described in `Evaluating Matches`_ and match it against the actual
 value.
 
 Test Runner Implementation

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -3305,8 +3305,8 @@ $$matchAsRoot
 `````````````
 This operator may be used anywhere a matched value is expected (including
 `expectResult <operation_expectResult_>`_) and the expected and actual values
-are documents. The test runner MUST treat the expected value as a root-level
-document as described in `Evaluating Matches`_ and match it against the actual
+are documents. The test runner MUST treat the actual value as a root-level
+document as described in `Evaluating Matches`_ and match it against the expected
 value.
 
 Test Runner Implementation


### PR DESCRIPTION
This PR fixes a small typo in the description of the `$$matchAsRoot` operator which may have caused some confusion when interpreting what the desired behaviour should be.

