### PR TITLE
fix(DRIVERS-2415): change device terminology to service provider

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -1258,7 +1258,7 @@ Server will use principalName (n) if provided in clientStep1 to select an approp
 
 username
     MUST specified if more than one OIDC provider is configured and
-    DEVICE_NAME mechanism property is not specified.
+    SERVICE_NAME mechanism property is not specified.
 
 source
     MUST be "$external". Defaults to ``$external``.
@@ -1270,9 +1270,9 @@ mechanism
     MUST be "MONGODB-OIDC"
 
 mechanism_properties
-    DEVICE_NAME
-        Drivers MUST allow the user to specify a name for the device
-        workflow that is one of "aws", "azure", or "gcp".
+    SERVICE_NAME
+        Drivers MUST allow the user to specify a name for using a service
+        to obtain credentials that is one of "aws", "azure", or "gcp".
     REQUEST_TOKEN_CALLBACK
         Drivers MUST allow the user to specify a callback of the form
         "onOIDCRequestToken" (defined below), if the driver supports
@@ -1282,7 +1282,7 @@ mechanism_properties
         "onOIDCRefreshToken" (defined below), if the driver supports
         providing objects as mechanism property values.
 
-Drivers MUST skip client step 1 for device workflows
+Drivers MUST skip client step 1 when using a service to obtain credentials
 or when the server step 1 response value is cached.  When skipping step 1,
 drivers will use ``saslStart`` and a payload with the ``jwt`` value.
 
@@ -1345,32 +1345,32 @@ well as the cached OIDCRequestTokenResult and return a new OIDCRequestTokenResul
 If the callback does not return an object in the correct form of ``OIDCRequestTokenResult``, the driver MUST raise an error.
 
 If the refresh callback is given and the request callback is not given,
-the driver MUST raise an error.  If DEVICE_NAME is given and one or more
+the driver MUST raise an error.  If SERVICE_NAME is given and one or more
 callbacks are given, the driver MUST raise an error.
 
-If no callbacks are given, the driver MUST enforce that a DEVICE_NAME
+If no callbacks are given, the driver MUST enforce that a SERVICE_NAME
 mechanism_properties is set and one of ("aws",).
 The callback mechanism can be used to support both Authentication
 Code Workflows or Device workflows that are not explicitly implemented
-by drivers.  If there is no callback and no DEVICE_NAME, or the
-DEVICE_NAME is set but credentials cannot be automatically obtained,
+by drivers.  If there is no callback and no SERVICE_NAME, or the
+SERVICE_NAME is set but credentials cannot be automatically obtained,
 the driver MUST raise an error.
 
 
 Supported Device Workflows
 ``````````````````````````
 
-Drivers MUST support device workflows for "aws", given
-by the DEVICE_NAME mechanism property.  In all cases the acquired token
+Drivers MUST support obtaining credentials for a service for "aws", given
+by the SERVICE_NAME mechanism property.  In all cases the acquired token
 will be given as the ``jwt`` argument and the second client step of the
 OIDC SASL exchange MUST be made directly, skipping the clientStep1.
-Drivers MUST raise an error if both a DEVICE_NAME and username are
-given, since the device workflow will not use the username.
+Drivers MUST raise an error if both a SERVICE_NAME and username are
+given, since using a service will not use the username.
 
 AWS
 ___
 
-When the DEVICE_NAME mechanism property is set to "aws", the driver MUST
+When the SERVICE_NAME mechanism property is set to "aws", the driver MUST
 attempt to read the value given by the ``AWS_WEB_IDENTITY_TOKEN_FILE`` and
 interpret it as a file path.  The contents of the file are read as the
 access token.
@@ -1400,7 +1400,7 @@ possible in the driver language.
 Using the socket address and port accounts for the case when two different
 servers use the same username but could be configurated differently.
 There is an edge case where if the same username is used and two aliases
-to the same local host address are given, there will be duplicate user/device
+to the same local host address are given, there will be duplicate user/service
 interactions, unless the driver can resolve the local host address as well.
 Note that because we use the server socket address, there will different cache
 keys for each member of a replica set.

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -1258,7 +1258,7 @@ Server will use principalName (n) if provided in clientStep1 to select an approp
 
 username
     MUST specified if more than one OIDC provider is configured and
-    SERVICE_NAME mechanism property is not specified.
+    PROVIDER_NAME mechanism property is not specified.
 
 source
     MUST be "$external". Defaults to ``$external``.
@@ -1270,7 +1270,7 @@ mechanism
     MUST be "MONGODB-OIDC"
 
 mechanism_properties
-    SERVICE_NAME
+    PROVIDER_NAME
         Drivers MUST allow the user to specify a name for using a service
         to obtain credentials that is one of "aws", "azure", or "gcp".
     REQUEST_TOKEN_CALLBACK
@@ -1345,32 +1345,32 @@ well as the cached OIDCRequestTokenResult and return a new OIDCRequestTokenResul
 If the callback does not return an object in the correct form of ``OIDCRequestTokenResult``, the driver MUST raise an error.
 
 If the refresh callback is given and the request callback is not given,
-the driver MUST raise an error.  If SERVICE_NAME is given and one or more
+the driver MUST raise an error.  If PROVIDER_NAME is given and one or more
 callbacks are given, the driver MUST raise an error.
 
-If no callbacks are given, the driver MUST enforce that a SERVICE_NAME
+If no callbacks are given, the driver MUST enforce that a PROVIDER_NAME
 mechanism_properties is set and one of ("aws",).
 The callback mechanism can be used to support both Authentication
 Code Workflows or Device workflows that are not explicitly implemented
-by drivers.  If there is no callback and no SERVICE_NAME, or the
-SERVICE_NAME is set but credentials cannot be automatically obtained,
+by drivers.  If there is no callback and no PROVIDER_NAME, or the
+PROVIDER_NAME is set but credentials cannot be automatically obtained,
 the driver MUST raise an error.
 
 
-Supported Device Workflows
-``````````````````````````
+Supported Service Providers
+```````````````````````````
 
 Drivers MUST support obtaining credentials for a service for "aws", given
-by the SERVICE_NAME mechanism property.  In all cases the acquired token
+by the PROVIDER_NAME mechanism property.  In all cases the acquired token
 will be given as the ``jwt`` argument and the second client step of the
 OIDC SASL exchange MUST be made directly, skipping the clientStep1.
-Drivers MUST raise an error if both a SERVICE_NAME and username are
+Drivers MUST raise an error if both a PROVIDER_NAME and username are
 given, since using a service will not use the username.
 
 AWS
 ___
 
-When the SERVICE_NAME mechanism property is set to "aws", the driver MUST
+When the PROVIDER_NAME mechanism property is set to "aws", the driver MUST
 attempt to read the value given by the ``AWS_WEB_IDENTITY_TOKEN_FILE`` and
 interpret it as a file path.  The contents of the file are read as the
 access token.

--- a/source/auth/tests/legacy/connection-string.json
+++ b/source/auth/tests/legacy/connection-string.json
@@ -544,7 +544,7 @@
     },
     {
       "description": "should recognise the mechanism with aws device (MONGODB-OIDC)",
-      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=DEVICE_NAME:aws",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws",
       "valid": true,
       "credential": {
         "username": null,
@@ -552,13 +552,13 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "DEVICE_NAME": "aws"
+            "SERVICE_NAME": "aws"
         }
       }
     },
     {
       "description": "should recognise the mechanism when auth source is explicitly specified and with aws device (MONGODB-OIDC)",
-      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=$external&authMechanismProperties=DEVICE_NAME:aws",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=$external&authMechanismProperties=SERVICE_NAME:aws",
       "valid": true,
       "credential": {
         "username": null,
@@ -566,7 +566,7 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "DEVICE_NAME": "aws"
+            "SERVICE_NAME": "aws"
         }
       }
     },
@@ -579,13 +579,13 @@
     },
     {
       "description": "should throw an exception if username and deviceName are specified (MONGODB-OIDC)",
-      "uri": "mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&DEVICE_NAME:gcp",
+      "uri": "mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&SERVICE_NAME:gcp",
       "valid": false,
       "credential": null
     },
     {
       "description": "should throw an exception if specified deviceName is not supported (MONGODB-OIDC)",
-      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=DEVICE_NAME:unexisted",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:unexisted",
       "valid": false,
       "credential": null
     },

--- a/source/auth/tests/legacy/connection-string.json
+++ b/source/auth/tests/legacy/connection-string.json
@@ -544,7 +544,7 @@
     },
     {
       "description": "should recognise the mechanism with aws device (MONGODB-OIDC)",
-      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=PROVIDER_NAME:aws",
       "valid": true,
       "credential": {
         "username": null,
@@ -552,13 +552,13 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "SERVICE_NAME": "aws"
+            "PROVIDER_NAME": "aws"
         }
       }
     },
     {
       "description": "should recognise the mechanism when auth source is explicitly specified and with aws device (MONGODB-OIDC)",
-      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=$external&authMechanismProperties=SERVICE_NAME:aws",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=$external&authMechanismProperties=PROVIDER_NAME:aws",
       "valid": true,
       "credential": {
         "username": null,
@@ -566,7 +566,7 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "SERVICE_NAME": "aws"
+            "PROVIDER_NAME": "aws"
         }
       }
     },
@@ -579,13 +579,13 @@
     },
     {
       "description": "should throw an exception if username and deviceName are specified (MONGODB-OIDC)",
-      "uri": "mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&SERVICE_NAME:gcp",
+      "uri": "mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&PROVIDER_NAME:gcp",
       "valid": false,
       "credential": null
     },
     {
       "description": "should throw an exception if specified deviceName is not supported (MONGODB-OIDC)",
-      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:unexisted",
+      "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=PROVIDER_NAME:unexisted",
       "valid": false,
       "credential": null
     },

--- a/source/auth/tests/legacy/connection-string.yml
+++ b/source/auth/tests/legacy/connection-string.yml
@@ -402,7 +402,7 @@ tests:
     mechanism_properties:
       REQUEST_TOKEN_CALLBACK: true
 - description: should recognise the mechanism with aws device (MONGODB-OIDC)
-  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws
+  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=PROVIDER_NAME:aws
   valid: true
   credential:
     username:
@@ -410,10 +410,10 @@ tests:
     source: "$external"
     mechanism: MONGODB-OIDC
     mechanism_properties:
-      SERVICE_NAME: aws
+      PROVIDER_NAME: aws
 - description: should recognise the mechanism when auth source is explicitly specified
     and with aws device (MONGODB-OIDC)
-  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=$external&authMechanismProperties=SERVICE_NAME:aws
+  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=$external&authMechanismProperties=PROVIDER_NAME:aws
   valid: true
   credential:
     username:
@@ -421,7 +421,7 @@ tests:
     source: "$external"
     mechanism: MONGODB-OIDC
     mechanism_properties:
-      SERVICE_NAME: aws
+      PROVIDER_NAME: aws
 - description: should throw an exception if username and password are specified (MONGODB-OIDC)
   uri: mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC
   callback:
@@ -430,12 +430,12 @@ tests:
   credential:
 - description: should throw an exception if username and deviceName are specified
     (MONGODB-OIDC)
-  uri: mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&SERVICE_NAME:gcp
+  uri: mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&PROVIDER_NAME:gcp
   valid: false
   credential:
 - description: should throw an exception if specified deviceName is not supported
     (MONGODB-OIDC)
-  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:unexisted
+  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=PROVIDER_NAME:unexisted
   valid: false
   credential:
 - description: should throw an exception if neither deviceName nor callbacks specified

--- a/source/auth/tests/legacy/connection-string.yml
+++ b/source/auth/tests/legacy/connection-string.yml
@@ -402,7 +402,7 @@ tests:
     mechanism_properties:
       REQUEST_TOKEN_CALLBACK: true
 - description: should recognise the mechanism with aws device (MONGODB-OIDC)
-  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=DEVICE_NAME:aws
+  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws
   valid: true
   credential:
     username:
@@ -410,10 +410,10 @@ tests:
     source: "$external"
     mechanism: MONGODB-OIDC
     mechanism_properties:
-      DEVICE_NAME: aws
+      SERVICE_NAME: aws
 - description: should recognise the mechanism when auth source is explicitly specified
     and with aws device (MONGODB-OIDC)
-  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=$external&authMechanismProperties=DEVICE_NAME:aws
+  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=$external&authMechanismProperties=SERVICE_NAME:aws
   valid: true
   credential:
     username:
@@ -421,7 +421,7 @@ tests:
     source: "$external"
     mechanism: MONGODB-OIDC
     mechanism_properties:
-      DEVICE_NAME: aws
+      SERVICE_NAME: aws
 - description: should throw an exception if username and password are specified (MONGODB-OIDC)
   uri: mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC
   callback:
@@ -430,12 +430,12 @@ tests:
   credential:
 - description: should throw an exception if username and deviceName are specified
     (MONGODB-OIDC)
-  uri: mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&DEVICE_NAME:gcp
+  uri: mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&SERVICE_NAME:gcp
   valid: false
   credential:
 - description: should throw an exception if specified deviceName is not supported
     (MONGODB-OIDC)
-  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=DEVICE_NAME:unexisted
+  uri: mongodb://localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:unexisted
   valid: false
   credential:
 - description: should throw an exception if neither deviceName nor callbacks specified

--- a/source/auth/tests/mongodb-oidc.rst
+++ b/source/auth/tests/mongodb-oidc.rst
@@ -43,7 +43,7 @@ Drivers Evergreen Tools.
 
 #. Set the ``AWS_WEB_IDENTITY_TOKEN_FILE`` environment variable to the location
 of the ``test_user1`` generated token file.
-#. Create a client with the url parameters ``?authMechanism=MONGODB-OIDC&authMechanismProperties=DEVICE_NAME:aws``.
+#. Create a client with the url parameters ``?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws``.
 #. Perform a find operation on the client.
 
 
@@ -68,12 +68,12 @@ file.
 
 #. Set the ``AWS_WEB_IDENTITY_TOKEN_FILE`` environment variable to the location
 of the ``test_user1`` generated token file.
-#. Create a client with a url of the form ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&authMechanismProperties=DEVICE_NAME:aws&directConnection=true&readPreference=secondaryPreferred``.
+#. Create a client with a url of the form ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws&directConnection=true&readPreference=secondaryPreferred``.
 #. Perform a ``find`` operation.
 
 #. Set the ``AWS_WEB_IDENTITY_TOKEN_FILE`` environment variable to the location
 of the ``test_user2`` generated token file.
-#. Create a client with a url of the form ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&authMechanismProperties=DEVICE_NAME:aws&directConnection=true&readPreference=secondaryPreferred``.
+#. Create a client with a url of the form ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws&directConnection=true&readPreference=secondaryPreferred``.
 #. Perform a ``find`` operation.
 
 #. Create a client with a url of the form  ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&directConnection=true&readPreference=secondaryPreferred`` and the OIDC request callback.

--- a/source/auth/tests/mongodb-oidc.rst
+++ b/source/auth/tests/mongodb-oidc.rst
@@ -43,7 +43,7 @@ Drivers Evergreen Tools.
 
 #. Set the ``AWS_WEB_IDENTITY_TOKEN_FILE`` environment variable to the location
 of the ``test_user1`` generated token file.
-#. Create a client with the url parameters ``?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws``.
+#. Create a client with the url parameters ``?authMechanism=MONGODB-OIDC&authMechanismProperties=PROVIDER_NAME:aws``.
 #. Perform a find operation on the client.
 
 
@@ -68,12 +68,12 @@ file.
 
 #. Set the ``AWS_WEB_IDENTITY_TOKEN_FILE`` environment variable to the location
 of the ``test_user1`` generated token file.
-#. Create a client with a url of the form ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws&directConnection=true&readPreference=secondaryPreferred``.
+#. Create a client with a url of the form ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&authMechanismProperties=PROVIDER_NAME:aws&directConnection=true&readPreference=secondaryPreferred``.
 #. Perform a ``find`` operation.
 
 #. Set the ``AWS_WEB_IDENTITY_TOKEN_FILE`` environment variable to the location
 of the ``test_user2`` generated token file.
-#. Create a client with a url of the form ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&authMechanismProperties=SERVICE_NAME:aws&directConnection=true&readPreference=secondaryPreferred``.
+#. Create a client with a url of the form ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&authMechanismProperties=PROVIDER_NAME:aws&directConnection=true&readPreference=secondaryPreferred``.
 #. Perform a ``find`` operation.
 
 #. Create a client with a url of the form  ``mongodb://localhost:27018/?authMechanism=MONGODB-OIDC&directConnection=true&readPreference=secondaryPreferred`` and the OIDC request callback.


### PR DESCRIPTION
<!-- Thanks for contributing! -->

The device workflow terminology was a bit confusing since OIDC device flow generally refers to a user interaction on a device (such as a phone or computer) to perform an action to get a token. This changes to use `PROVIDER_NAME` instead of `DEVICE_NAME` as a mechanism property and changes language of device workflow to "as service to obtain credentials".

Please complete the following before merging:

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

