### PR TITLE
DRIVERS-1746 replace typo of `AWS_ROLE_SESSION_NAME` to `AWS_ROLE_ARN`

### DIFF
--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -956,7 +956,7 @@ The order in which Drivers MUST search for credentials is:
 #. The URI
 #. Environment variables
 #. Using ``AssumeRoleWithWebIdentity`` if ``AWS_WEB_IDENTITY_TOKEN_FILE`` and
-   ``AWS_ROLE_SESSION_NAME``  are set.
+   ``AWS_ROLE_ARN``  are set.
 #. The ECS endpoint if ``AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`` is set. Otherwise, the EC2 endpoint.
 
 .. note::

--- a/source/auth/auth.rst
+++ b/source/auth/auth.rst
@@ -991,7 +991,7 @@ case where another part the application has refreshed the credentials.
 
 However, if environment variables are not present during initial authorization,
 credentials may be fetched from another source and cached.  Even if the
-environmnet variables are present in subsequent authorization attempts,
+environment variables are present in subsequent authorization attempts,
 the driver MUST use the cached credentials, or refresh them if applicable.
 This behavior is consistent with how the AWS SDKs behave.
 


### PR DESCRIPTION
# Summary

- replace typo of `AWS_ROLE_SESSION_NAME` to `AWS_ROLE_ARN`
- fix typo of environment

<!-- Thanks for contributing! -->

Please complete the following before merging:

~~- [ ] Update changelog.~~
~~- [ ] Make sure there are generated JSON files from the YAML test files.~~
~~- [ ] Test changes in at least one language driver.~~
~~- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

