### PR TITLE
DRIVERS-2435 add maxServerVersion 6.2.99 to fle2v1 tests

### DIFF
--- a/source/client-side-encryption/etc/test-templates/fle2-BypassQueryAnalysis.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-BypassQueryAnalysis.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Compact.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Compact.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-DecryptExistingData.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-DecryptExistingData.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Delete.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-jsonSchema.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-EncryptedFields-vs-jsonSchema.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-EncryptedFieldsMap-defaults.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-EncryptedFieldsMap-defaults.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-FindOneAndUpdate.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Indexed.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Indexed.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Unindexed.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-InsertFind-Unindexed.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-MissingKey.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-MissingKey.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-NoEncryption.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-NoEncryption.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Date-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Date-Aggregate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Date-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Date-Correctness.yml.template
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Date-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Date-Delete.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Date-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Date-FindOneAndUpdate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Date-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Date-InsertFind.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Date-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Date-Update.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-Aggregate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-Correctness.yml.template
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-Delete.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-FindOneAndUpdate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-InsertFind.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Decimal-Update.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-Aggregate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-Correctness.yml.template
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-Delete.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-FindOneAndUpdate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-InsertFind.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DecimalPrecision-Update.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Double-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Double-Aggregate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Double-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Double-Correctness.yml.template
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Double-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Double-Delete.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Double-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Double-FindOneAndUpdate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Double-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Double-InsertFind.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Double-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Double-Update.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-Aggregate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-Correctness.yml.template
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-Delete.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-FindOneAndUpdate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-InsertFind.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-DoublePrecision-Update.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Int-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Int-Aggregate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Int-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Int-Correctness.yml.template
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Int-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Int-Delete.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Int-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Int-FindOneAndUpdate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Int-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Int-InsertFind.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Int-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Int-Update.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Long-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Long-Aggregate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Long-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Long-Correctness.yml.template
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Long-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Long-Delete.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Long-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Long-FindOneAndUpdate.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Long-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Long-InsertFind.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Range-Long-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Range-Long-Update.yml.template
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-Update.yml.template
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/etc/test-templates/fle2-validatorAndPartialFieldExpression.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2-validatorAndPartialFieldExpression.yml.template
@@ -1,7 +1,9 @@
 # This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
     # Require server version 6.0.0 to get behavior added in SERVER-64911.
-    - minServerVersion: "6.0.0"
+    - maxServerVersion: "6.2.99"
+      # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+      minServerVersion: "6.0.0"
       # FLE 2 Encrypted collections are not supported on standalone.
       topology: [ "replicaset", "sharded", "load-balanced" ]
 

--- a/source/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.json
+++ b/source/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-BypassQueryAnalysis.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Compact.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Compact.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Compact.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Compact.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-CreateCollection.json
+++ b/source/client-side-encryption/tests/legacy/fle2-CreateCollection.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-CreateCollection.yml
@@ -1,6 +1,8 @@
 # This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
     

--- a/source/client-side-encryption/tests/legacy/fle2-DecryptExistingData.json
+++ b/source/client-side-encryption/tests/legacy/fle2-DecryptExistingData.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-DecryptExistingData.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-DecryptExistingData.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Delete.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Delete.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-EncryptedFieldsMap.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.json
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFields-vs-jsonSchema.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.json
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-EncryptedFieldsMap-defaults.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-FindOneAndUpdate.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.json
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Indexed.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.json
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-InsertFind-Unindexed.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-MissingKey.json
+++ b/source/client-side-encryption/tests/legacy/fle2-MissingKey.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-MissingKey.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-MissingKey.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-NoEncryption.json
+++ b/source/client-side-encryption/tests/legacy/fle2-NoEncryption.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-NoEncryption.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-NoEncryption.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-Aggregate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-Aggregate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-Correctness.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-Correctness.yml
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-Delete.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-Delete.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-FindOneAndUpdate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-FindOneAndUpdate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-InsertFind.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-InsertFind.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-Update.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Date-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Date-Update.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Aggregate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Aggregate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Correctness.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Correctness.yml
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Delete.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Delete.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-FindOneAndUpdate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-FindOneAndUpdate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-InsertFind.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-InsertFind.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Update.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Decimal-Update.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Aggregate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Aggregate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Correctness.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Correctness.yml
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Delete.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Delete.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-FindOneAndUpdate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-InsertFind.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-InsertFind.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Update.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DecimalPrecision-Update.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-Aggregate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-Aggregate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-Correctness.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-Correctness.yml
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-Delete.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-Delete.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-FindOneAndUpdate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-FindOneAndUpdate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-InsertFind.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-InsertFind.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-Update.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Double-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Double-Update.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Aggregate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Aggregate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Correctness.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Correctness.yml
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Delete.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Delete.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-FindOneAndUpdate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-InsertFind.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-InsertFind.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Update.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-DoublePrecision-Update.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-Aggregate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-Aggregate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-Correctness.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-Correctness.yml
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-Delete.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-Delete.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-FindOneAndUpdate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-FindOneAndUpdate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-InsertFind.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-InsertFind.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-Update.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Int-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Int-Update.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-Aggregate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-Aggregate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-Correctness.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-Correctness.yml
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-Delete.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-Delete.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-FindOneAndUpdate.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-FindOneAndUpdate.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-InsertFind.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-InsertFind.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-Update.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-Long-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-Long-Update.yml
@@ -1,6 +1,8 @@
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Range-WrongType.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-WrongType.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.2.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Range-WrongType.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Range-WrongType.yml
@@ -2,7 +2,9 @@
 # Does not include command monitoring expectations or outcome assertions to make tests more readable.
 # Requires libmongocrypt 1.7.0.
 runOn:
-  - minServerVersion: "6.2.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.2.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2-Update.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-Update.yml
@@ -1,5 +1,7 @@
 runOn:
-  - minServerVersion: "6.0.0"
+  - maxServerVersion: "6.2.99"
+    # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+    minServerVersion: "6.0.0"
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
 database_name: &database_name "default"

--- a/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.json
+++ b/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.json
@@ -1,6 +1,7 @@
 {
   "runOn": [
     {
+      "maxServerVersion": "6.2.99",
       "minServerVersion": "6.0.0",
       "topology": [
         "replicaset",

--- a/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
+++ b/source/client-side-encryption/tests/legacy/fle2-validatorAndPartialFieldExpression.yml
@@ -1,7 +1,9 @@
 # This test requires libmongocrypt 1.5.0-alpha2.
 runOn:
     # Require server version 6.0.0 to get behavior added in SERVER-64911.
-    - minServerVersion: "6.0.0"
+    - maxServerVersion: "6.2.99"
+      # Do not test on server version >= 6.3.0. Server version >= 6.3.0 includes backwards breaking changes to FLE2 protocol. Refer: DRIVERS-2435
+      minServerVersion: "6.0.0"
       # FLE 2 Encrypted collections are not supported on standalone.
       topology: [ "replicaset", "sharded", "load-balanced" ]
 


### PR DESCRIPTION
# Summary
- Add maxServerVersion `6.2.99` to FLE2 tests.

# Background & Motivation
Backwards breaking changes were made to the FLE2 protocol as part of [PM-2972](https://jira.mongodb.org/browse/PM-2972). The backwards breaking changes are enabled with a feature flag, `featureFlagFLE2ProtocolVersion2`. `featureFlagFLE2ProtocolVersion2` was added in [SERVER-69562](https://jira.mongodb.org/browse/SERVER-69562) with `fixVersion=6.3.0-rc0`. `featureFlagFLE2ProtocolVersion2` is disabled by default, but will be enabled by default in [SERVER-69563](https://jira.mongodb.org/browse/SERVER-69563).

This PR proposes skipping FLE2 tests on server version 6.3.0 and higher to prevent driver tests from failing against latest server builds after SERVER-69563 is merged. 

New tests for the new protocol will be added in a future PR.

Tests were run in the Go driver here: https://spruce.mongodb.com/version/64219435c9ec4433a5d0477b

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ N/A, only test files are updated.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested in Go.**
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

