### PR TITLE
DRIVERS-2056: mandate that drivers error on invalid connection string options

### DIFF
--- a/source/connection-string/connection-string-spec.rst
+++ b/source/connection-string/connection-string-spec.rst
@@ -196,8 +196,6 @@ The values in connection options MUST be URL decoded by the parser. The values c
 
       ?readPreferenceTags=dc:ny,rack:1
     
-    If the option supports a 
-
 Any invalid Values for a given key MUST NOT be ignored and MUST return an error. The error SHOULD have a useful error message, indicating why the connection string is invalid.  For example::
 
   Unsupported value for "fsync" : "ifPossible"

--- a/source/connection-string/connection-string-spec.rst
+++ b/source/connection-string/connection-string-spec.rst
@@ -240,7 +240,7 @@ Connection strings are a mechanism to configure a MongoClient outside the user's
 
 Keys MUST follow existing connection option naming conventions as defined above. Values MUST also follow the existing, specific data types.
 
-Any options that are not supported MUST raise a error as described in the keys section.
+Any options that are not supported MUST raise an error as described in the keys section.
 
 -----------------------------
 Connection options precedence
@@ -326,7 +326,7 @@ Q: Why is it recommended that Connection Options take precedence over applicatio
   2. MongoClient hosts and options
   3. Connection String hosts and options
 
-Q: How long should deprecation options be supported?
+Q: How long should deprecated options be supported?
  This is not declared in this specification. It's not deemed responsible to give a single timeline for how long deprecated options should be supported. As such any specifications that deprecate options that do have the context of the decision should provide the timeline.
 
 Q: Why can I not use a standard URI parser?

--- a/source/connection-string/tests/invalid-options.json
+++ b/source/connection-string/tests/invalid-options.json
@@ -5,13 +5,7 @@
       "uri": "mongodb://example.com/?foo=bar",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
@@ -20,13 +14,7 @@
       "uri": "mongodb://example.com/?fsync=ifPossible",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
@@ -35,96 +23,52 @@
       "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
+      "options": null
     },
     {
       "description": "Repeated option keys with different values",
       "uri": "mongodb://example.com/?replicaSet=test1&replicaSet=test2",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
+      "options": null
     },
     {
       "description": "List option with one empty option specified",
       "uri": "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
+      "options": null
     },
     {
       "description": "List option with an invalid option specified",
       "uri": "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=foobarbaz",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
+      "options": null
     },
     {
       "description": "Error on empty integer option values",
       "uri": "mongodb://localhost/?maxIdleTimeMS=",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
     {
-      "description": "Error on empty non-integer value for integer option",
-      "uri": "mongodb://localhost/?maxIdleTimeMS=",
+      "description": "Error on non-empty invalid value for integer option",
+      "uri": "mongodb://localhost/?maxIdleTimeMS=aString",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
@@ -133,13 +77,7 @@
       "uri": "mongodb://localhost/?journal=",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     },
@@ -148,13 +86,7 @@
       "uri": "mongodb://localhost/?journal=stringValue",
       "valid": false,
       "warning": false,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
+      "hosts": null,
       "auth": null,
       "options": null
     }

--- a/source/connection-string/tests/invalid-options.json
+++ b/source/connection-string/tests/invalid-options.json
@@ -1,0 +1,162 @@
+{
+  "tests": [
+    {
+      "description": "Error on unrecognized option keys",
+      "uri": "mongodb://example.com/?foo=bar",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Error on unsupported option values",
+      "uri": "mongodb://example.com/?fsync=ifPossible",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Repeated option keys with the same value",
+      "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
+      "description": "Repeated option keys with different values",
+      "uri": "mongodb://example.com/?replicaSet=test1&replicaSet=test2",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
+      "description": "List option with one empty option specified",
+      "uri": "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
+      "description": "List option with an invalid option specified",
+      "uri": "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=foobarbaz",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
+      "description": "Error on empty integer option values",
+      "uri": "mongodb://localhost/?maxIdleTimeMS=",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Error on empty non-integer value for integer option",
+      "uri": "mongodb://localhost/?maxIdleTimeMS=",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Error on empty boolean option value",
+      "uri": "mongodb://localhost/?journal=",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Error on non-empty invalid value for boolean option",
+      "uri": "mongodb://localhost/?journal=stringValue",
+      "valid": false,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    }
+  ]
+}

--- a/source/connection-string/tests/invalid-options.yml
+++ b/source/connection-string/tests/invalid-options.yml
@@ -1,0 +1,126 @@
+tests:
+    -
+        description: "Error on unrecognized option keys"
+        uri: "mongodb://example.com/?foo=bar"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Error on unsupported option values"
+        uri: "mongodb://example.com/?fsync=ifPossible"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Repeated option keys with the same value"
+        uri: "mongodb://example.com/?replicaSet=test&replicaSet=test"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+            replicaset: "test"
+
+    -
+        description: "Repeated option keys with different values"
+        uri: "mongodb://example.com/?replicaSet=test1&replicaSet=test2"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+            replicaset: "test"
+    -
+        description: "List option with one empty option specified"
+        uri: "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags="
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+            replicaset: "test"
+    -
+        description: "List option with an invalid option specified"
+        uri: "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=foobarbaz"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+            replicaset: "test"
+    -
+        description: "Error on empty integer option values"
+        uri: "mongodb://localhost/?maxIdleTimeMS="
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Error on empty non-integer value for integer option"
+        uri: "mongodb://localhost/?maxIdleTimeMS="
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Error on empty boolean option value"
+        uri: "mongodb://localhost/?journal="
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~
+    -
+        description: "Error on non-empty invalid value for boolean option"
+        uri: "mongodb://localhost/?journal=stringValue"
+        valid: false
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~

--- a/source/connection-string/tests/invalid-options.yml
+++ b/source/connection-string/tests/invalid-options.yml
@@ -61,8 +61,7 @@ tests:
                 host: "example.com"
                 port: ~
         auth: ~
-        options:
-            replicaset: "test"
+        options: ~
     -
         description: "List option with an invalid option specified"
         uri: "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=foobarbaz"
@@ -74,8 +73,7 @@ tests:
                 host: "example.com"
                 port: ~
         auth: ~
-        options:
-            replicaset: "test"
+        options: ~
     -
         description: "Error on empty integer option values"
         uri: "mongodb://localhost/?maxIdleTimeMS="

--- a/source/connection-string/tests/invalid-options.yml
+++ b/source/connection-string/tests/invalid-options.yml
@@ -4,11 +4,7 @@ tests:
         uri: "mongodb://example.com/?foo=bar"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -16,11 +12,7 @@ tests:
         uri: "mongodb://example.com/?fsync=ifPossible"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -28,38 +20,23 @@ tests:
         uri: "mongodb://example.com/?replicaSet=test&replicaSet=test"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
-        options:
-            replicaset: "test"
-
+        options: ~
     -
         description: "Repeated option keys with different values"
         uri: "mongodb://example.com/?replicaSet=test1&replicaSet=test2"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
-        options:
-            replicaset: "test"
+        options: ~
     -
         description: "List option with one empty option specified"
         uri: "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags="
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -67,11 +44,7 @@ tests:
         uri: "mongodb://example.com/?readPreferenceTags=dc:ny,rack:1&readPreferenceTags=dc:ny&readPreferenceTags=foobarbaz"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -79,23 +52,15 @@ tests:
         uri: "mongodb://localhost/?maxIdleTimeMS="
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
-        description: "Error on empty non-integer value for integer option"
-        uri: "mongodb://localhost/?maxIdleTimeMS="
+        description: "Error on non-empty invalid value for integer option"
+        uri: "mongodb://localhost/?maxIdleTimeMS=aString"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -103,11 +68,7 @@ tests:
         uri: "mongodb://localhost/?journal="
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~
     -
@@ -115,10 +76,6 @@ tests:
         uri: "mongodb://localhost/?journal=stringValue"
         valid: false
         warning: false
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
+        hosts: ~
         auth: ~
         options: ~

--- a/source/connection-string/tests/valid-warnings.json
+++ b/source/connection-string/tests/valid-warnings.json
@@ -1,53 +1,6 @@
 {
   "tests": [
     {
-      "description": "Unrecognized option keys are ignored",
-      "uri": "mongodb://example.com/?foo=bar",
-      "valid": true,
-      "warning": true,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
-      "auth": null,
-      "options": null
-    },
-    {
-      "description": "Unsupported option values are ignored",
-      "uri": "mongodb://example.com/?fsync=ifPossible",
-      "valid": true,
-      "warning": true,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
-      "auth": null,
-      "options": null
-    },
-    {
-      "description": "Repeated option keys",
-      "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test",
-      "valid": true,
-      "warning": true,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "example.com",
-          "port": null
-        }
-      ],
-      "auth": null,
-      "options": {
-        "replicaset": "test"
-      }
-    },
-    {
       "description": "Deprecated (or unknown) options are ignored if replacement exists",
       "uri": "mongodb://example.com/?wtimeout=5&wtimeoutMS=10",
       "valid": true,
@@ -63,36 +16,6 @@
       "options": {
         "wtimeoutms": 10
       }
-    },
-    {
-      "description": "Empty integer option values are ignored",
-      "uri": "mongodb://localhost/?maxIdleTimeMS=",
-      "valid": true,
-      "warning": true,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
-      "auth": null,
-      "options": null
-    },
-    {
-      "description": "Empty boolean option value are ignored",
-      "uri": "mongodb://localhost/?journal=",
-      "valid": true,
-      "warning": true,
-      "hosts": [
-        {
-          "type": "hostname",
-          "host": "localhost",
-          "port": null
-        }
-      ],
-      "auth": null,
-      "options": null
     }
   ]
 }

--- a/source/connection-string/tests/valid-warnings.yml
+++ b/source/connection-string/tests/valid-warnings.yml
@@ -1,42 +1,5 @@
 tests:
     -
-        description: "Unrecognized option keys are ignored"
-        uri: "mongodb://example.com/?foo=bar"
-        valid: true
-        warning: true
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
-        auth: ~
-        options: ~
-    -
-        description: "Unsupported option values are ignored"
-        uri: "mongodb://example.com/?fsync=ifPossible"
-        valid: true
-        warning: true
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
-        auth: ~
-        options: ~
-    -
-        description: "Repeated option keys"
-        uri: "mongodb://example.com/?replicaSet=test&replicaSet=test"
-        valid: true
-        warning: true
-        hosts:
-            -
-                type: "hostname"
-                host: "example.com"
-                port: ~
-        auth: ~
-        options:
-            replicaset: "test"
-    -
         description: "Deprecated (or unknown) options are ignored if replacement exists"
         uri: "mongodb://example.com/?wtimeout=5&wtimeoutMS=10"
         valid: true
@@ -49,27 +12,3 @@ tests:
         auth: ~
         options:
             wtimeoutms: 10
-    -
-        description: "Empty integer option values are ignored"
-        uri: "mongodb://localhost/?maxIdleTimeMS="
-        valid: true
-        warning: true
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
-        auth: ~
-        options: ~
-    -
-        description: "Empty boolean option value are ignored"
-        uri: "mongodb://localhost/?journal="
-        valid: true
-        warning: true
-        hosts:
-            -
-                type: "hostname"
-                host: "localhost"
-                port: ~
-        auth: ~
-        options: ~

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -30,9 +30,7 @@ document are to be interpreted as described in
 Conflicting TLS options
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Per the `Connection String spec <https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.rst#repeated-keys>`__,
-the behavior of duplicates of most URI options is undefined. However, due
-to the security implications of certain options, drivers MUST raise an
+Due to the security implications of certain options, drivers MUST raise an
 error to the user during parsing if any of the following circumstances
 occur:
 

--- a/source/uri-options/uri-options.rst
+++ b/source/uri-options/uri-options.rst
@@ -50,7 +50,7 @@ occur:
    ``tlsDisableCertificateRevocationCheck`` appear in the URI options.
 7. Both ``tlsDisableOCSPEndpointCheck`` and
    ``tlsDisableCertificateRevocationCheck`` appear in the URI options.
-8. All instances of ``tls`` and ``ssl`` in the URI options do not have the
+8. Both ``tls`` and ``ssl`` appear in the URI options and they do not have the
    same value. If all instances of ``tls`` and ``ssl`` have the same
    value, an error MUST NOT be raised.
 
@@ -525,6 +525,7 @@ this specification MUST be updated to reflect those changes.
 Changelog
 ---------
 
+:2023-03-28: Mandate that drivers error on invalid connection string keys and values.
 :2022-10-05: Remove spec front matter and reformat changelog.
 :2022-01-19: Add the timeoutMS option and deprecate some existing timeout options
 :2021-12-14: Add SOCKS5 options


### PR DESCRIPTION
Node POC: https://github.com/mongodb/node-mongodb-native/pull/3611

With the changes in this PR, drivers must error when parsing the connection string if:

- an invalid option key is encountered
- an invalid option value is encountered

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

