### PR TITLE
DRIVERS-2503: Require connectionId and serverConnectionId to be int64.

### DIFF
--- a/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+++ b/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
@@ -417,6 +417,8 @@ The following key-value pairs MUST be included in all command messages:
    * - serverConnectionId
      - Int64
      - The server's ID for the connection used for the command. Optional; only present for server versions 4.2+.
+     - NOTE: Existing drivers may represent this as an Int32 already. For strongly-typed languages, you may have to introduce
+     -       a new Int64 field and deprecate the old Int32 field. The next major version should remove the old Int32 field.
 
    * - serviceId
      - String

--- a/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+++ b/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
@@ -237,10 +237,9 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
     /**
      * Returns the server connection id for the command. The server connection id is distinct from
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
-     * from the server on 4.2+. Drivers MAY use a wider type to represent the server connection ID
-     * value, but the server's behavior is to return an Int32.
+     * from the server on 4.2+. Drivers MUST use an Int64 to represent the server connection ID value.
      */
-    serverConnectionId: Optional<Int32>;
+    serverConnectionId: Optional<Int64>;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.
@@ -291,10 +290,9 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
     /**
      * Returns the server connection id for the command. The server connection id is distinct from
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
-     * from the server on 4.2+. Drivers MAY use a wider type to represent the server connection ID
-     * value, but the server's behavior is to return an Int32.
+     * from the server on 4.2+. Drivers MUST use an Int64 to represent the server connection ID value.
      */
-    serverConnectionId: Optional<Int32>;
+    serverConnectionId: Optional<Int64>;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.
@@ -346,10 +344,9 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
     /**
      * Returns the server connection id for the command. The server connection id is distinct from
      * the connection id and is returned by the hello or legacy hello response as "connectionId"
-     * from the server on 4.2+. Drivers MAY use a wider type to represent the server connection ID
-     * value, but the server's behavior is to return an Int32.
+     * from the server on 4.2+. Drivers MUST use an Int64 to represent the server connection ID value.
      */
-    serverConnectionId: Optional<Int32>;
+    serverConnectionId: Optional<Int64>;
 
     /**
      * Returns the service id for the command when the driver is in load balancer mode.
@@ -401,7 +398,7 @@ The following key-value pairs MUST be included in all command messages:
      - The driver-generated operation ID. Optional; only present if the driver generated operation IDs and this command has one. 
 
    * - driverConnectionId
-     - Int
+     - Int64
      - The driver's ID for the connection used for the command. Note this is NOT the same as ``CommandStartedEvent.connectionId`` defined above,
        but refers to the `connectionId` defined in the  `connection monitoring and pooling specification <../connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst>`_.
        Unlike ``CommandStartedEvent.connectionId`` this field MUST NOT contain the host/port; that information MUST be in the following fields,
@@ -418,7 +415,7 @@ The following key-value pairs MUST be included in all command messages:
        the user does not specify a port and the default (27017) is used, the driver SHOULD include it here. 
 
    * - serverConnectionId
-     - Int
+     - Int64
      - The server's ID for the connection used for the command. Optional; only present for server versions 4.2+.
 
    * - serviceId
@@ -560,3 +557,4 @@ Changelog
 :2022-12-13: Updated log message ``serverPort`` field description to clarify drivers should populate it with the
              default port 27017 when relevant. Updated suggested unstructured forms of log messages to more
              clearly label connection IDs and use more readable server address representations.
+:2023-03-23: Updated ``serverConnectionId`` field to be Int64 as long-running servers can return Int64.

--- a/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+++ b/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
@@ -417,8 +417,8 @@ The following key-value pairs MUST be included in all command messages:
    * - serverConnectionId
      - Int64
      - The server's ID for the connection used for the command. Optional; only present for server versions 4.2+.
-     - NOTE: Existing drivers may represent this as an Int32 already. For strongly-typed languages, you may have to introduce
-     -       a new Int64 field and deprecate the old Int32 field. The next major version should remove the old Int32 field.
+       NOTE: Existing drivers may represent this as an Int32 already. For strongly-typed languages, you may have to introduce
+       a new Int64 field and deprecate the old Int32 field. The next major version should remove the old Int32 field.
 
    * - serviceId
      - String

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
@@ -893,7 +893,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
       /**
        *  The ID of the Connection
        */
-      connectionId: number;
+      connectionId: int64;
     }
 
     /**
@@ -908,7 +908,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
       /**
        *  The ID of the Connection
        */
-      connectionId: number;
+      connectionId: int64;
     }
 
     /**
@@ -923,7 +923,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
       /**
        *  The ID of the Connection
        */
-      connectionId: number;
+      connectionId: int64;
     
       /**
        * A reason explaining why this Connection was closed.
@@ -980,7 +980,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
       /**
        *  The ID of the Connection
        */
-      connectionId: number;
+      connectionId: int64;
     }
 
     /**
@@ -995,7 +995,7 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
       /**
        *  The ID of the Connection
        */
-      connectionId: number;
+      connectionId: int64;
     }
 
 Connection Pool Logging
@@ -1168,7 +1168,7 @@ In addition to the common fields defined above, this message MUST contain the fo
      - "Connection created"
 
    * - driverConnectionId
-     - Int
+     - Int64
      - The driver-generated ID for the connection as defined in `Connection <#connection>`_.
 
 The unstructured form SHOULD be as follows, using the values defined in the structured format above to fill in placeholders as appropriate:
@@ -1192,7 +1192,7 @@ In addition to the common fields defined above, this message MUST contain the fo
      - "Connection ready"
 
    * - driverConnectionId
-     - Int
+     - Int64
      - The driver-generated ID for the connection as defined in `Connection <#connection>`_.
 
 The unstructured form SHOULD be as follows, using the values defined in the structured format above to fill in placeholders as appropriate:
@@ -1216,7 +1216,7 @@ In addition to the common fields defined above, this message MUST contain the fo
      - "Connection closed"
 
    * - driverConnectionId
-     - Int
+     - Int64
      - The driver-generated ID for the connection as defined in `Connection <#connection>`_.
 
    * - reason
@@ -1309,7 +1309,7 @@ In addition to the common fields defined above, this message MUST contain the fo
      - "Connection checked out"
 
    * - driverConnectionId
-     - Int
+     - Int64
      - The driver-generated ID for the connection as defined in `Connection <#connection>`_.
 
 The unstructured form SHOULD be as follows, using the values defined in the structured format above to fill in placeholders as appropriate:
@@ -1333,7 +1333,7 @@ In addition to the common fields defined above, this message MUST contain the fo
      - "Connection checked in"
 
    * - driverConnectionId
-     - Int
+     - Int64
      - The driver-generated ID for the connection as defined in `Connection <#connection>`_.
 
 The unstructured form SHOULD be as follows, using the values defined in the structured format above to fill in placeholders as appropriate:

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -28,6 +28,10 @@ The following tests have not yet been automated, but MUST still be tested:
 #. A user MUST be able to subscribe to Connection Monitoring Events in a manner idiomatic to their language and driver
 #. When a check out attempt fails because connection set up throws an error,
    assert that a ConnectionCheckOutFailedEvent with reason="connectionError" is emitted.
+#. Drivers MUST update ``ConnectionId.serverConnectionId`` to match the ``connectionId`` field returned in the ``hello`` or
+   legacy hello response by 4.2+ servers. Servers can return ``connectionId`` as an ``int32``, ``double`` (whole numbers only),
+   or ``int64``. Drivers MUST verify that the update succeeds for each data type. 5.0+ servers will no longer return
+   ``connectionId`` as a ``double``, but 4.2 and 4.4 servers can.
 
 Logging Tests
 =============

--- a/source/connection-monitoring-and-pooling/tests/README.rst
+++ b/source/connection-monitoring-and-pooling/tests/README.rst
@@ -28,10 +28,6 @@ The following tests have not yet been automated, but MUST still be tested:
 #. A user MUST be able to subscribe to Connection Monitoring Events in a manner idiomatic to their language and driver
 #. When a check out attempt fails because connection set up throws an error,
    assert that a ConnectionCheckOutFailedEvent with reason="connectionError" is emitted.
-#. Drivers MUST update ``ConnectionId.serverConnectionId`` to match the ``connectionId`` field returned in the ``hello`` or
-   legacy hello response by 4.2+ servers. Servers can return ``connectionId`` as an ``int32``, ``double`` (whole numbers only),
-   or ``int64``. Drivers MUST verify that the update succeeds for each data type. 5.0+ servers will no longer return
-   ``connectionId`` as a ``double``, but 4.2 and 4.4 servers can.
 
 Logging Tests
 =============


### PR DESCRIPTION
Please complete the following before merging:

- [X] Update changelog.
- [X] Make sure there are generated JSON files from the YAML test files.
- [X] Test changes in at least one language driver.
    - See CSHARP-4483.
- [X] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).
    - Added prose tests.
