### PR TITLE
regenerate JSON test files

### DIFF
--- a/source/auth/tests/legacy/connection-string.json
+++ b/source/auth/tests/legacy/connection-string.json
@@ -481,10 +481,12 @@
         }
       }
     },
-     {
+    {
       "description": "should recognise the mechanism and request callback (MONGODB-OIDC)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC",
-      "callback": ["oidcRequest"],
+      "callback": [
+        "oidcRequest"
+      ],
       "valid": true,
       "credential": {
         "username": null,
@@ -492,14 +494,16 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "REQUEST_TOKEN_CALLBACK": true
+          "REQUEST_TOKEN_CALLBACK": true
         }
       }
     },
     {
       "description": "should recognise the mechanism when auth source is explicitly specified and with request callback (MONGODB-OIDC)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC&authSource=$external",
-      "callback": ["oidcRequest"],
+      "callback": [
+        "oidcRequest"
+      ],
       "valid": true,
       "credential": {
         "username": null,
@@ -507,14 +511,17 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "REQUEST_TOKEN_CALLBACK": true
+          "REQUEST_TOKEN_CALLBACK": true
         }
       }
     },
     {
       "description": "should recognise the mechanism with request and refresh callback (MONGODB-OIDC)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC",
-      "callback": ["oidcRequest", "oidcRefresh"],
+      "callback": [
+        "oidcRequest",
+        "oidcRefresh"
+      ],
       "valid": true,
       "credential": {
         "username": null,
@@ -522,15 +529,17 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "REQUEST_TOKEN_CALLBACK": true,
-            "REFRESH_TOKEN_CALLBACK": true
+          "REQUEST_TOKEN_CALLBACK": true,
+          "REFRESH_TOKEN_CALLBACK": true
         }
       }
     },
     {
       "description": "should recognise the mechanism and username with request callback (MONGODB-OIDC)",
       "uri": "mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC",
-      "callback": ["oidcRequest"],
+      "callback": [
+        "oidcRequest"
+      ],
       "valid": true,
       "credential": {
         "username": "principalName",
@@ -538,7 +547,7 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "REQUEST_TOKEN_CALLBACK": true
+          "REQUEST_TOKEN_CALLBACK": true
         }
       }
     },
@@ -552,7 +561,7 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "PROVIDER_NAME": "aws"
+          "PROVIDER_NAME": "aws"
         }
       }
     },
@@ -566,14 +575,16 @@
         "source": "$external",
         "mechanism": "MONGODB-OIDC",
         "mechanism_properties": {
-            "PROVIDER_NAME": "aws"
+          "PROVIDER_NAME": "aws"
         }
       }
     },
     {
       "description": "should throw an exception if username and password are specified (MONGODB-OIDC)",
       "uri": "mongodb://user:pass@localhost/?authMechanism=MONGODB-OIDC",
-      "callback": ["oidcRequest"],
+      "callback": [
+        "oidcRequest"
+      ],
       "valid": false,
       "credential": null
     },
@@ -598,7 +609,9 @@
     {
       "description": "should throw an exception when only refresh callback is specified (MONGODB-OIDC)",
       "uri": "mongodb://localhost/?authMechanism=MONGODB-OIDC",
-      "callback": ["oidcRefresh"],
+      "callback": [
+        "oidcRefresh"
+      ],
       "valid": false,
       "credential": null
     },

--- a/source/auth/tests/unified/reauthenticate_without_retry.json
+++ b/source/auth/tests/unified/reauthenticate_without_retry.json
@@ -1,6 +1,6 @@
 {
   "description": "reauthenticate_without_retry",
-  "schemaVersion": "1.12",
+  "schemaVersion": "1.13",
   "runOnRequirements": [
     {
       "minServerVersion": "6.3",

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.json
@@ -56,7 +56,7 @@
     },
     {
       "type": "ConnectionCreated"
-    },    
+    },
     {
       "type": "ConnectionPoolCleared",
       "interruptInUseConnections": true


### PR DESCRIPTION
This PR fixes the [Regenerate JSON test files](https://github.com/mongodb/specifications/actions/runs/4575395096/jobs/8078173164) task.
JSON files were regenerated locally using `make --always-make`. The `--always-make` option ignores file last-modification times and unconditionally makes the targets.

---
<!-- Thanks for contributing! -->

Please complete the following before merging:

~~- [ ] Update changelog.~~ **Not applicable**
- [x] Make sure there are generated JSON files from the YAML test files.
~~- [ ] Test changes in at least one language driver.~~ **Not applicable**
~~- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~ **Not applicable**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

