### PR TITLE
DRIVERS-2209 Simplify metadata truncation rules

### DIFF
--- a/source/mongodb-handshake/handshake.rst
+++ b/source/mongodb-handshake/handshake.rst
@@ -474,8 +474,8 @@ the following order until the document is under the size limit:
 
 1. Omit fields from ``env`` except ``env.name``.
 2. Omit fields from ``os`` except ``os.type``.
-2. Omit the ``env`` document entirely.
-3. Truncate ``platform``.
+3. Omit the ``env`` document entirely.
+4. Truncate ``platform``.
 
 Additionally, implementors are encouraged to place high priority information about the
 platform earlier in the string, in order to avoid possible truncating of those details.

--- a/source/mongodb-handshake/handshake.rst
+++ b/source/mongodb-handshake/handshake.rst
@@ -469,16 +469,12 @@ The entire metadata BSON document MUST NOT exceed 512 bytes. This includes all
 BSON overhead.  The ``client.application.name`` cannot exceed 128 bytes.  MongoDB
 will return an error if these limits are not adhered to, which will result in
 handshake failure. Drivers MUST validate these values and truncate or omit driver
-provided values if necessary.  Implementors SHOULD prioritize fields to preserve in
-this order:
+provided values if necessary.  Implementors SHOULD cumulatively update fields in
+the following order until the document is under the size limit:
 
-1. ``application.name``
-2. ``driver.*``
-3. ``os.type``
-4. ``env.name``
-5. ``os.*`` (except ``type``)
-6. ``env.*`` (except ``name``)
-7. ``platform``
+1. Truncate ``platform``.
+2. Omit fields from ``env`` except ``env.name``.
+3. Omit the ``env`` document entirely.
 
 Additionally, implementors are encouraged to place high priority information about the
 platform earlier in the string, in order to avoid possible truncating of those details.

--- a/source/mongodb-handshake/handshake.rst
+++ b/source/mongodb-handshake/handshake.rst
@@ -635,3 +635,4 @@ Changelog
 :2022-02-24: Rename Versioned API to Stable API
 :2022-10-05: Remove spec front matter and reformat changelog.
 :2023-03-13: Add ``env`` to ``client`` document
+:2023-04-03: Simplify truncation for metadata

--- a/source/mongodb-handshake/handshake.rst
+++ b/source/mongodb-handshake/handshake.rst
@@ -465,16 +465,17 @@ acceptable deviations are as follows:
 Limitations
 ===========
 
-The entire metadata BSON document MUST NOT exceed 512 bytes. This includes all
-BSON overhead.  The ``client.application.name`` cannot exceed 128 bytes.  MongoDB
+The entire ``client`` metadata BSON document MUST NOT exceed 512 bytes. This includes
+all BSON overhead.  The ``client.application.name`` cannot exceed 128 bytes.  MongoDB
 will return an error if these limits are not adhered to, which will result in
 handshake failure. Drivers MUST validate these values and truncate or omit driver
 provided values if necessary.  Implementors SHOULD cumulatively update fields in
 the following order until the document is under the size limit:
 
-1. Truncate ``platform``.
-2. Omit fields from ``env`` except ``env.name``.
-3. Omit the ``env`` document entirely.
+1. Omit fields from ``env`` except ``env.name``.
+2. Omit fields from ``os`` except ``os.type``.
+2. Omit the ``env`` document entirely.
+3. Truncate ``platform``.
 
 Additionally, implementors are encouraged to place high priority information about the
 platform earlier in the string, in order to avoid possible truncating of those details.


### PR DESCRIPTION
DRIVERS-2209

The preservation order introduced in #1386 turned out to be both confusing and mildly broken - the server has constraints about the `driver` and `application` documents it wasn't respecting.  This PR simplifies the spec to only resolve the ambiguity that would otherwise have been introduced between `platform` and `env`; a larger scope set of rules, if needed, should be its own spec update.