### PR TITLE
DRIVERS-2505: Fix typo in RangeOpts doc block

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -1281,7 +1281,7 @@ EncryptOpts
 
    // NOTE: The Range algorithm is experimental only. It is not intended for public use. It is subject to breaking changes.
    // RangeOpts specifies index options for a Queryable Encryption field supporting "rangePreview" queries.
-   // min, max, sparsity, and range must match the values set in the encryptedFields of the destination collection.
+   // min, max, sparsity, and precision must match the values set in the encryptedFields of the destination collection.
    // For double and decimal128, min/max/precision must all be set, or all be unset.
    class RangeOpts {
       // min is required if precision is set.


### PR DESCRIPTION
I'm pretty sure this was a typo, but I'd like to defer to one of the spec owners to confirm.

This dates back to https://github.com/mongodb/specifications/commit/4de4e3c1897ca07efa09d456943badbe002cd756 for #1355.

