### PR TITLE
Fix filename example in range index prose test

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2675,7 +2675,7 @@ Before running each of the following test cases, perform the following Test Setu
 
 Test Setup
 ``````````
-Load the file for the specific data type being tested ``encryptedFields-<type>.json``. For example, for ``Int`` load `range-encryptedFields-Int.json <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/etc/data/range-encryptedFields-Int.json>`_ as ``encryptedFields``.
+Load the file for the specific data type being tested ``range-encryptedFields-<type>.json``. For example, for ``Int`` load `range-encryptedFields-Int.json <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/etc/data/range-encryptedFields-Int.json>`_ as ``encryptedFields``.
 
 Load the file `key1-document.json <https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/keys/key1-document.json>`_ as ``key1Document``.
 


### PR DESCRIPTION
The encryptedFields-Range-type.json files are used by test templates to generate spec tests (https://github.com/mongodb/specifications/commit/3634d568587a776f18885502cde4f26f1c0ac051). Prose tests rely on the range-encryptedFields-type.json files (https://github.com/mongodb/specifications/commit/4de4e3c1897ca07efa09d456943badbe002cd756).

