### PR TITLE
DRIVERS-2232: remove usages of `currentOp` and `collStats` from tests

### DIFF
--- a/source/client-side-encryption/etc/test-templates/bypassedCommand.yml.template
+++ b/source/client-side-encryption/etc/test-templates/bypassedCommand.yml.template
@@ -26,7 +26,7 @@ tests:
           command:
             ping: 1
           command_name: ping
-  - description: "current op is not bypassed"
+  - description: "kill op is not bypassed"
     clientOptions:
       autoEncryptOpts:
         kmsProviders:
@@ -34,9 +34,10 @@ tests:
     operations:
       - name: runCommand
         object: database
-        command_name: currentOp
+        command_name: killOp
         arguments:
           command:
-            currentOp: 1
+            killOp: 1
+            op: 1234 
         result:
-          errorContains: "command not supported for auto encryption: currentOp"
+          errorContains: "command not supported for auto encryption: killOp"

--- a/source/client-side-encryption/tests/legacy/bypassedCommand.json
+++ b/source/client-side-encryption/tests/legacy/bypassedCommand.json
@@ -78,7 +78,7 @@
       ]
     },
     {
-      "description": "current op is not bypassed",
+      "description": "kill op is not bypassed",
       "clientOptions": {
         "autoEncryptOpts": {
           "kmsProviders": {
@@ -90,14 +90,15 @@
         {
           "name": "runCommand",
           "object": "database",
-          "command_name": "currentOp",
+          "command_name": "killOp",
           "arguments": {
             "command": {
-              "currentOp": 1
+              "killOp": 1,
+              "op": 1234
             }
           },
           "result": {
-            "errorContains": "command not supported for auto encryption: currentOp"
+            "errorContains": "command not supported for auto encryption: killOp"
           }
         }
       ]

--- a/source/client-side-encryption/tests/legacy/bypassedCommand.yml
+++ b/source/client-side-encryption/tests/legacy/bypassedCommand.yml
@@ -26,7 +26,7 @@ tests:
           command:
             ping: 1
           command_name: ping
-  - description: "current op is not bypassed"
+  - description: "kill op is not bypassed"
     clientOptions:
       autoEncryptOpts:
         kmsProviders:
@@ -34,9 +34,10 @@ tests:
     operations:
       - name: runCommand
         object: database
-        command_name: currentOp
+        command_name: killOp
         arguments:
           command:
-            currentOp: 1
+            killOp: 1
+            op: 1234 
         result:
-          errorContains: "command not supported for auto encryption: currentOp"
+          errorContains: "command not supported for auto encryption: killOp"

--- a/source/unified-test-format/tests/valid-pass/collectionData-createOptions.json
+++ b/source/unified-test-format/tests/valid-pass/collectionData-createOptions.json
@@ -49,19 +49,29 @@
       "description": "collection is created with the correct options",
       "operations": [
         {
-          "name": "runCommand",
-          "object": "database0",
+          "object": "collection0",
+          "name": "aggregate",
           "arguments": {
-            "commandName": "collStats",
-            "command": {
-              "collStats": "coll0",
-              "scale": 1
-            }
+            "pipeline": [
+              {
+                "$collStats": {
+                  "storageStats": {}
+                }
+              },
+              {
+                "$project": {
+                  "capped": "$storageStats.capped",
+                  "maxSize": "$storageStats.maxSize"
+                }
+              }
+            ]
           },
-          "expectResult": {
-            "capped": true,
-            "maxSize": 4096
-          }
+          "expectResult": [
+            {
+              "capped": true,
+              "maxSize": 4096
+            }
+          ]
         }
       ]
     }

--- a/source/unified-test-format/tests/valid-pass/collectionData-createOptions.yml
+++ b/source/unified-test-format/tests/valid-pass/collectionData-createOptions.yml
@@ -1,12 +1,9 @@
 description: collectionData-createOptions
-
 schemaVersion: "1.9"
-
 runOnRequirements:
   - minServerVersion: "3.6"
     # Capped collections cannot be created on serverless instances.
     serverless: forbid
-
 createEntities:
   - client:
       id: &client0 client0
@@ -18,7 +15,6 @@ createEntities:
       id: &collection0 collection0
       database: *database0
       collectionName: &collection0Name coll0
-
 initialData:
   - collectionName: *collection0Name
     databaseName: *database0Name
@@ -28,18 +24,14 @@ initialData:
       size: &cappedSize 4096
     documents:
       - { _id: 1, x: 11 }
-
 tests:
   - description: collection is created with the correct options
     operations:
-      # Execute a collStats command to ensure the collection was created with the correct options.
-      - name: runCommand
-        object: *database0
+      - object: *collection0
+        name: aggregate
         arguments:
-          commandName: collStats
-          command:
-            collStats: *collection0Name
-            scale: 1
+          pipeline:
+            - $collStats: { storageStats: {} }
+            - $project: { capped: '$storageStats.capped', maxSize: '$storageStats.maxSize'}
         expectResult:
-          capped: true
-          maxSize: *cappedSize
+          - { capped: true, maxSize: *cappedSize }


### PR DESCRIPTION
Node POC: https://github.com/mongodb/node-mongodb-native/pull/3638

This PR removes usage of the `collStats` command and `currentOp` from tests.  

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

