### PR TITLE
DRIVERS-2209 remove `env.url` reference

### DIFF
--- a/source/mongodb-handshake/handshake.rst
+++ b/source/mongodb-handshake/handshake.rst
@@ -170,8 +170,7 @@ provided as a BSON object. This object has the following structure::
                 name: "<string>",         /* REQUIRED */
                 timeout_sec: 42,          /* OPTIONAL */
                 memory_mb: 1024,          /* OPTIONAL */
-                region: "<string>",       /* OPTIONAL */
-                url: "<string>"           /* OPTIONAL */
+                region: "<string>"        /* OPTIONAL */
             }
         }
     }


### PR DESCRIPTION
# Summary

- Remove `env.url` from `Hello Command` structure

# Background & Motivation

This is a follow up to https://github.com/mongodb/specifications/pull/1398.

`env.url` is no longer expected to be set by drivers.


<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ **Not applicable? This is a minor fix**
- ~~[ ] Make sure there are generated JSON files from the YAML test files.~~ **Not applicable.**
- ~~[ ] Test changes in at least one language driver.~~ **Not applicable**
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~ **Not applicable**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

