### PR TITLE
chore(DRIVERS-2384): update localhost test domain

### DIFF
--- a/source/faas-automated-testing/faas-automated-testing.rst
+++ b/source/faas-automated-testing/faas-automated-testing.rst
@@ -369,3 +369,4 @@ Changelog
 :2023-08-17: Add docker container notes for localhost.
 :2023-06-22: Updated evergreen configuration to use task groups.
 :2023-04-14: Added list of supported variants, added additional template config.
+:2023-04-28: Fixed URI typo, added host note, increase assume role duration.

--- a/source/faas-automated-testing/faas-automated-testing.rst
+++ b/source/faas-automated-testing/faas-automated-testing.rst
@@ -223,7 +223,9 @@ Run the function locally from the same directory where the template.yaml resides
   sam local invoke --parameter-overrides "MongoDbUri=${MONGODB_URI}"
 
 *NOTE* "127.0.0.1" in the MONGODB_URI MUST be replaced with "host.docker.internal" to test
-a local MongoDB deployment.
+a local MongoDB deployment. If "host.docker.internal" does not work (can occur on M1
+machines), drivers MAY choose to use a [bridged docker container](https://docs.docker.com/network/bridge/)
+to test locally.
 
 
 Implementing the Function

--- a/source/faas-automated-testing/faas-automated-testing.rst
+++ b/source/faas-automated-testing/faas-automated-testing.rst
@@ -368,7 +368,6 @@ Description of the behaviour of run-deployed-lambda-aws-tests.sh:
 Changelog
 =========
 
-:2023-08-17: Add docker container notes for localhost.
+:2023-08-17: Fixed URI typo, added host note, increase assume role duration.
 :2023-06-22: Updated evergreen configuration to use task groups.
 :2023-04-14: Added list of supported variants, added additional template config.
-:2023-04-28: Fixed URI typo, added host note, increase assume role duration.

--- a/source/faas-automated-testing/faas-automated-testing.rst
+++ b/source/faas-automated-testing/faas-automated-testing.rst
@@ -222,6 +222,9 @@ Run the function locally from the same directory where the template.yaml resides
   sam build
   sam local invoke --parameter-overrides "MongoDbUri=${MONGODB_URI}"
 
+*NOTE* "127.0.0.1" in the MONGODB_URI MUST be replaced with "host.docker.internal" to test
+a local MongoDB deployment.
+
 
 Implementing the Function
 `````````````````````````
@@ -346,7 +349,6 @@ functions inside of it for setup, teardown, and execution:
       tasks:
         - test-aws-lambda-deployed
 
-
 Drivers MUST run the function on a single variant in Evergreen, in order to not
 potentially hit the Atlas API rate limit. The variant itself MUST have the SAM CLI installed.
 
@@ -364,5 +366,6 @@ Description of the behaviour of run-deployed-lambda-aws-tests.sh:
 Changelog
 =========
 
+:2023-08-17: Add docker container notes for localhost.
 :2023-06-22: Updated evergreen configuration to use task groups.
 :2023-04-14: Added list of supported variants, added additional template config.


### PR DESCRIPTION
Fixes `MONGODB_URI` typo, makes notes on how Docket can access a localhost server, increases assume role duration to 1 hour (from default 15 minutes)

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

