### PR TITLE
DRIVERS-2505 clarify type expectations in prose test

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2807,7 +2807,7 @@ Each test listed in the cases below must pass for all supported data types unles
 
 Case 1: can decrypt a payload
 `````````````````````````````
-Use ``clientEncryption.encrypt()`` to encrypt the value 6. Ensure the type matches with the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the double value 6.0.
+Use ``clientEncryption.encrypt()`` to encrypt the value 6. Ensure the encoded BSON type matches the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the BSON double value 6.0.
 
 Store the result in ``insertPayload``.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2807,7 +2807,7 @@ Each test listed in the cases below must pass for all supported data types unles
 
 Case 1: can decrypt a payload
 `````````````````````````````
-Use ``clientEncryption.encrypt()`` to encrypt the value 6. Ensure the encoded BSON type matches the type of the encrypted field. For example, if the encrypted field is ``encryptedDoubleNoPrecision`` encrypt the BSON double value 6.0.
+Use ``clientEncryption.encrypt()`` to encrypt the value 6. Ensure the encoded BSON type matches the type of the encrypted field. For example, if the encrypted field is ``encryptedLong`` encrypt the 64-bit BSON long value 6, not the 32-bit BSON int value 6.
 
 Store the result in ``insertPayload``.
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2823,6 +2823,11 @@ Encrypt with the matching ``RangeOpts`` listed in `Test Setup: RangeOpts`_ and t
 
 Use ``clientEncryption`` to decrypt ``insertPayload``. Assert the returned value equals 6.
 
+.. note::
+
+   The type returned by ``clientEncryption.decrypt()`` may differ from the input type to ``clientEncryption.encrypt()`` depending on how the driver unmarshals BSON numerics to language native types.
+   Example: a driver may unmarshal a BSON long to a numeric type that does not distinguish between int64 and int32.
+
 Case 2: can find encrypted range and return the maximum 
 ```````````````````````````````````````````````````````
 Use ``clientEncryption.encryptExpression()`` to encrypt this query:


### PR DESCRIPTION
# Summary
- Clarify type returned by `clientEncryption.decrypt()` may not match input type to `clientEncryption.encrypt()`

# Background & Motivation

Clarification was requested in [this slack conversation](https://mongodb.slack.com/archives/C0406ECL478/p1681999190775319?thread_ts=1681989382.950349&cid=C0406ECL478).

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ **Not applicable.**
- ~~[ ] Make sure there are generated JSON files from the YAML test files.~~ **Not applicable.**
- ~~[ ] Test changes in at least one language driver.~~**Not applicable.**
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~**Not applicable.**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

