### PR TITLE
DRIVERS-2577: runCommand set min server version correctly

### DIFF
--- a/source/run-command/tests/unified/runCommand.json
+++ b/source/run-command/tests/unified/runCommand.json
@@ -108,7 +108,22 @@
               "commandStartedEvent": {
                 "command": {
                   "ping": 1,
-                  "$db": "db"
+                  "$db": "db",
+                  "lsid": {
+                    "$$exists": true
+                  },
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "apiVersion": {
+                    "$$exists": false
+                  },
+                  "apiStrict": {
+                    "$$exists": false
+                  },
+                  "apiDeprecationErrors": {
+                    "$$exists": false
+                  }
                 },
                 "commandName": "ping"
               }
@@ -276,6 +291,11 @@
     },
     {
       "description": "does not retry retryable errors on given command",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2"
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -419,6 +439,11 @@
     },
     {
       "description": "attaches apiVersion fields to given command when stableApi is configured on the client",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "5.0"
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/source/run-command/tests/unified/runCommand.yml
+++ b/source/run-command/tests/unified/runCommand.yml
@@ -63,6 +63,11 @@ tests:
               command:
                 ping: 1
                 $db: *db
+                lsid: { $$exists: true }
+                $readPreference: { $$exists: false }
+                apiVersion: { $$exists: false }
+                apiStrict: { $$exists: false }
+                apiDeprecationErrors: { $$exists: false }
               commandName: ping
 
   - description: attaches the provided session lsid to given command
@@ -145,6 +150,8 @@ tests:
               commandName: insert
 
   - description: does not retry retryable errors on given command
+    runOnRequirements:
+      - minServerVersion: "4.2"
     operations:
       - name: failPoint
         object: testRunner
@@ -215,6 +222,8 @@ tests:
               databaseName: admin
 
   - description: attaches apiVersion fields to given command when stableApi is configured on the client
+    runOnRequirements:
+      - minServerVersion: "5.0"
     operations:
       - name: runCommand
         object: *dbWithStableApi


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

