### PR TITLE
DRIVERS-2505: Clarifications for Range Explicit Encryption prose tests 

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2629,7 +2629,7 @@ when attempting to create a collection with such invalid settings.
 Case 4: Insert encrypted value
 ``````````````````````````````
 
-This test is continuation of the case 1 and provides a way to complete inserting 
+This test is continuation of the case 1 and provides a way to complete inserting
 with encrypted value.
 
 1. Create a new create-collection options `Opts` including the following::
@@ -2737,14 +2737,14 @@ Use ``encryptedClient`` to insert the following documents into ``db.explicit_enc
 
 Test Setup: RangeOpts
 `````````````````````
-This section lists the values to use for ``RangeOpts`` for each of the supported data types, since each data type requires a different ``RangeOpts``. 
+This section lists the values to use for ``RangeOpts`` for each of the supported data types, since each data type requires a different ``RangeOpts``.
 
-Each test listed in the cases below must pass for all supported data types unless it is stated the type should be skipped. 
+Each test listed in the cases below must pass for all supported data types unless it is stated the type should be skipped.
 
 #. DecimalNoPrecision
 
    .. code:: typescript
-   
+
       class RangeOpts {
          sparsity: 1,
       }
@@ -2752,7 +2752,7 @@ Each test listed in the cases below must pass for all supported data types unles
 #. DecimalPrecision
 
    .. code:: typescript
-   
+
       class RangeOpts {
          min: { "$numberDecimal": "0" },
          max: { "$numberDecimal": "200" },
@@ -2763,7 +2763,7 @@ Each test listed in the cases below must pass for all supported data types unles
 #. DoubleNoPrecision
 
    .. code:: typescript
-   
+
       class RangeOpts {
          sparsity: 1,
       }
@@ -2771,7 +2771,7 @@ Each test listed in the cases below must pass for all supported data types unles
 #. DoublePrecision
 
    .. code:: typescript
-   
+
       class RangeOpts {
          min: { "$numberDouble": "0" },
          max: { "$numberDouble": "200" },
@@ -2782,7 +2782,7 @@ Each test listed in the cases below must pass for all supported data types unles
 #. Date
 
    .. code:: typescript
-   
+
       class RangeOpts {
          min: {"$date": { "$numberLong": "0" } } ,
          max: {"$date": { "$numberLong": "200" } },
@@ -2792,7 +2792,7 @@ Each test listed in the cases below must pass for all supported data types unles
 #. Int
 
    .. code:: typescript
-   
+
       class RangeOpts {
          min: {"$numberInt": "0" } ,
          max: {"$numberInt": "200" },
@@ -2802,7 +2802,7 @@ Each test listed in the cases below must pass for all supported data types unles
 #. Long
 
    .. code:: typescript
-   
+
       class RangeOpts {
          min: {"$numberLong": "0" } ,
          max: {"$numberLong": "200" },
@@ -2834,7 +2834,7 @@ Use ``clientEncryption`` to decrypt ``insertPayload``. Assert the returned value
    Example: a driver may unmarshal a BSON int64 to a numeric type that does not distinguish between int64 and int32.
 
 
-Case 2: can find encrypted range and return the maximum 
+Case 2: can find encrypted range and return the maximum
 ```````````````````````````````````````````````````````
 Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
@@ -2869,12 +2869,12 @@ Assert the following three documents are returned:
    { "_id": 3, "encrypted<Type>": 200 }
 
 
-Case 3: can find encrypted range and return the minimum 
+Case 3: can find encrypted range and return the minimum
 ```````````````````````````````````````````````````````
-Use ``clientEncryption.encryptExpression()`` to encrypt this query: 
+Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
-   
+
    // Convert 0 and 6 to the encrypted field type
    { "$and": [ { "encrypted<Type>": { "$gte": 0 } }, { "encrypted<Type>": { "$lte": 6 } } ] }
 
@@ -2936,9 +2936,9 @@ Assert the following document is returned:
    { "_id": 3, "encrypted<Type>": 200 }
 
 
-Case 5: can run an aggregation expression inside $expr 
+Case 5: can run an aggregation expression inside $expr
 ``````````````````````````````````````````````````````
-Use ``clientEncryption.encryptExpression()`` to encrypt this query: 
+Use ``clientEncryption.encryptExpression()`` to encrypt this query:
 
 .. code:: javascript
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -1711,20 +1711,20 @@ Create a ClientEncryption object named ``clientEncryption`` with these options:
 
 .. code:: typescript
 
-   ClientEncryptionOpts {
-      keyVaultClient: <keyVaultClient>;
-      keyVaultNamespace: "keyvault.datakeys";
-      kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
+   class ClientEncryptionOpts {
+      keyVaultClient: <keyVaultClient>,
+      keyVaultNamespace: "keyvault.datakeys",
+      kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } },
    }
 
 Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``:
 
 .. code:: typescript
 
-   AutoEncryptionOpts {
-      keyVaultNamespace: "keyvault.datakeys";
-      kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
-      bypassQueryAnalysis: true
+   class AutoEncryptionOpts {
+      keyVaultNamespace: "keyvault.datakeys",
+      kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } },
+      bypassQueryAnalysis: true,
    }
 
 
@@ -1736,9 +1736,9 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
 .. code:: typescript
 
    class EncryptOpts {
-      keyId : <key1ID>
+      keyId : <key1ID>,
       algorithm: "Indexed",
-      contentionFactor: 0
+      contentionFactor: 0,
    }
 
 Store the result in ``insertPayload``.
@@ -1750,10 +1750,10 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
 .. code:: typescript
 
    class EncryptOpts {
-      keyId : <key1ID>
+      keyId : <key1ID>,
       algorithm: "Indexed",
       queryType: "equality",
-      contentionFactor: 0
+      contentionFactor: 0,
    }
 
 Store the result in ``findPayload``.
@@ -1770,9 +1770,9 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
 .. code:: typescript
 
    class EncryptOpts {
-      keyId : <key1ID>
+      keyId : <key1ID>,
       algorithm: "Indexed",
-      contentionFactor: 10
+      contentionFactor: 10,
    }
 
 Store the result in ``insertPayload``.
@@ -1786,10 +1786,10 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
 .. code:: typescript
 
    class EncryptOpts {
-      keyId : <key1ID>
+      keyId : <key1ID>,
       algorithm: "Indexed",
       queryType: "equality",
-      contentionFactor: 0
+      contentionFactor: 0,
    }
 
 Store the result in ``findPayload``.
@@ -1803,10 +1803,10 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
 .. code:: typescript
 
    class EncryptOpts {
-      keyId : <key1ID>
+      keyId : <key1ID>,
       algorithm: "Indexed",
       queryType: "equality",
-      contentionFactor: 10
+      contentionFactor: 10,
    }
 
 Store the result in ``findPayload2``.
@@ -1823,8 +1823,8 @@ Use ``clientEncryption`` to encrypt the value "encrypted unindexed value" with t
 .. code:: typescript
 
    class EncryptOpts {
-      keyId : <key1ID>
-      algorithm: "Unindexed"
+      keyId : <key1ID>,
+      algorithm: "Unindexed",
    }
 
 Store the result in ``insertPayload``.
@@ -1843,9 +1843,9 @@ Use ``clientEncryption`` to encrypt the value "encrypted indexed value" with the
 .. code:: typescript
 
    class EncryptOpts {
-      keyId : <key1ID>
+      keyId : <key1ID>,
       algorithm: "Indexed",
-      contentionFactor: 0
+      contentionFactor: 0,
    }
 
 Store the result in ``payload``.
@@ -1860,7 +1860,7 @@ Use ``clientEncryption`` to encrypt the value "encrypted unindexed value" with t
 .. code:: typescript
 
    class EncryptOpts {
-      keyId : <key1ID>
+      keyId : <key1ID>,
       algorithm: "Unindexed",
    }
 
@@ -1943,10 +1943,10 @@ Create a ClientEncryption object named ``clientEncryption`` with these options:
 
 .. code:: typescript
 
-   ClientEncryptionOpts {
+   class ClientEncryptionOpts {
       keyVaultClient: <setupClient>,
       keyVaultNamespace: "keyvault.datakeys",
-      kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
+      kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } },
    }
 
 Create a data key with the "local" KMS provider. Storing the result in a variable named ``keyID``.
@@ -1955,9 +1955,9 @@ Use ``clientEncryption`` to encrypt the string "hello" with the following ``Encr
 
 .. code:: typescript
 
-   EncryptOpts {
+   class EncryptOpts {
       keyId: <keyID>,
-      algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+      algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
    }
 
 Store the result in a variable named ``ciphertext``.
@@ -1969,9 +1969,9 @@ Create a MongoClient named ``encryptedClient`` with these ``AutoEncryptionOpts``
 
 .. code:: typescript
 
-   AutoEncryptionOpts {
-      keyVaultNamespace: "keyvault.datakeys";
-      kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } }
+   class AutoEncryptionOpts {
+      keyVaultNamespace: "keyvault.datakeys",
+      kmsProviders: { "local": { "key": <base64 decoding of LOCAL_MASTERKEY> } },
    }
 
 Configure ``encryptedClient`` with "retryReads=false".
@@ -2059,7 +2059,7 @@ options:
 
 .. code-block:: typescript
 
-   ClientEncryptionOpts {
+   class ClientEncryptionOpts {
       keyVaultClient: <setupClient>,
       keyVaultNamespace: "keyvault.datakeys",
       kmsProviders: { "aws": {} },
@@ -2144,10 +2144,10 @@ Include pairs where ``srcProvider`` equals ``dstProvider``.
 
    .. code:: typescript
 
-      ClientEncryptionOpts {
-         keyVaultClient: <new MongoClient>;
-         keyVaultNamespace: "keyvault.datakeys";
-         kmsProviders: <all KMS providers>
+      class ClientEncryptionOpts {
+         keyVaultClient: <new MongoClient>,
+         keyVaultNamespace: "keyvault.datakeys",
+         kmsProviders: <all KMS providers>,
       }
 
 3. Call ``clientEncryption1.createDataKey`` with ``srcProvider`` and these options:
@@ -2155,7 +2155,7 @@ Include pairs where ``srcProvider`` equals ``dstProvider``.
    .. code:: typescript
 
       class DataKeyOpts {
-         masterKey: <depends on srcProvider>
+         masterKey: <depends on srcProvider>,
       }
 
    Store the return value in ``keyID``.
@@ -2166,7 +2166,7 @@ Include pairs where ``srcProvider`` equals ``dstProvider``.
 
       class EncryptOpts {
          keyId : keyID,
-         algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+         algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
       }
 
    Store the return value in ``ciphertext``.
@@ -2175,10 +2175,10 @@ Include pairs where ``srcProvider`` equals ``dstProvider``.
 
    .. code:: typescript
 
-      ClientEncryptionOpts {
-         keyVaultClient: <new MongoClient>;
-         keyVaultNamespace: "keyvault.datakeys";
-         kmsProviders: <all KMS providers>
+      class ClientEncryptionOpts {
+         keyVaultClient: <new MongoClient>,
+         keyVaultNamespace: "keyvault.datakeys",
+         kmsProviders: <all KMS providers>,
       }
 
 6. Call ``clientEncryption2.rewrapManyDataKey`` with an empty ``filter`` and these options:
@@ -2186,8 +2186,8 @@ Include pairs where ``srcProvider`` equals ``dstProvider``.
    .. code:: typescript
 
       class RewrapManyDataKeyOpts {
-         provider: dstProvider
-         masterKey: <depends on dstProvider>
+         provider: dstProvider,
+         masterKey: <depends on dstProvider>,
       }
 
    Assert that the returned ``RewrapManyDataKeyResult.bulkWriteResult.modifiedCount`` is 1.
@@ -2207,7 +2207,7 @@ options:
 
 .. code-block:: typescript
 
-   ClientEncryptionOpts {
+   class ClientEncryptionOpts {
       keyVaultClient: <setupClient>,
       keyVaultNamespace: "keyvault.datakeys",
       kmsProviders: { "gcp": {} },
@@ -2230,7 +2230,7 @@ following ``DataKeyOpts``:
          "projectId": "devprod-drivers",
          "location": "global",
          "keyRing": "key-ring-csfle",
-         "keyName": "key-name-csfle"
+         "keyName": "key-name-csfle",
       }
    }
 
@@ -2255,7 +2255,7 @@ following ``DataKeyOpts``:
          "projectId": "devprod-drivers",
          "location": "global",
          "keyRing": "key-ring-csfle",
-         "keyName": "key-name-csfle"
+         "keyName": "key-name-csfle",
       }
    }
 
@@ -2405,7 +2405,7 @@ options:
 
 .. code-block:: typescript
 
-   ClientEncryptionOpts {
+   class ClientEncryptionOpts {
       keyVaultClient: <setupClient>,
       keyVaultNamespace: "keyvault.datakeys",
       kmsProviders: { "azure": {} },
@@ -2425,7 +2425,7 @@ following ``DataKeyOpts``:
    class DataKeyOpts {
       masterKey: {
          "keyVaultEndpoint": "https://keyvault-drivers-2411.vault.azure.net/keys/",
-         "keyName": "KEY-NAME"
+         "keyName": "KEY-NAME",
       }
    }
 
@@ -2448,7 +2448,7 @@ following ``DataKeyOpts``:
    class DataKeyOpts {
       masterKey: {
          "keyVaultEndpoint": "https://keyvault-drivers-2411.vault.azure.net/keys/",
-         "keyName": "KEY-NAME"
+         "keyName": "KEY-NAME",
       }
    }
 

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -3014,7 +3014,7 @@ Ensure that ``RangeOpts`` corresponds to the type of the encrypted field (i.e. e
 Assert that an error was raised.
 
 
-Case 8: setting precision errors if the type is not a floating point
+Case 8: setting precision errors if the type is not double or Decimal128
 ````````````````````````````````````````````````````````````````````
 This test case should be skipped if the encrypted field is ``encryptedDoublePrecision``, ``encryptedDoubleNoPrecision``, ``encryptedDecimalPrecision``, or ``encryptedDecimalNoPrecision``.
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2505

Follow-up to https://github.com/mongodb/specifications/pull/1409.

This adds clarifying text and revises formatting inconsistencies throughout the test file. It does not change test behavior.