### PR TITLE
DRIVERS-2441 add prose test Rewrap Case 2

### DIFF
--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2216,7 +2216,7 @@ Drivers MAY chose not to implement this prose test if their implementation of ``
    .. code:: typescript
 
       class RewrapManyDataKeyOpts {
-         masterKey: { "foo": "bar" }
+         masterKey: {}
       }
 
    Assert that `clientEncryption.rewrapManyDataKey` raises a client error indicating that the required ``RewrapManyDataKeyOpts.provider`` field is missing.

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2196,6 +2196,31 @@ Include pairs where ``srcProvider`` equals ``dstProvider``.
 
 8. Call ``clientEncryption2.decrypt`` with the ``ciphertext``. Assert the return value is "test".
 
+Case 2: Rewrap returns error if masterKey is set, but provider is not set
+`````````````````````````````````````````````````````````````````````````
+
+This test may not apply depending on how the driver models the ``RewrapManyDataKeyOpts`` type.
+Drivers with API that does not permit calling ``ClientEncryption::rewrapManyDataKey`` with the ``masterKey`` set and ``provider`` unset may skip this test.
+
+1. Create a ``ClientEncryption`` object named ``clientEncryption`` with these options:
+
+   .. code:: typescript
+
+      class ClientEncryptionOpts {
+         keyVaultClient: <new MongoClient>,
+         keyVaultNamespace: "keyvault.datakeys",
+         kmsProviders: <all KMS providers>,
+      }
+
+2. Call ``clientEncryption.rewrapManyDataKey`` with an empty ``filter`` and these options:
+
+   .. code:: typescript
+
+      class RewrapManyDataKeyOpts {
+         masterKey: { "foo": "bar" }
+      }
+
+   Assert an error is returned from the driver suggesting that the ``provider`` option is required.
 
 17.  On-demand GCP Credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/client-side-encryption/tests/README.rst
+++ b/source/client-side-encryption/tests/README.rst
@@ -2196,11 +2196,10 @@ Include pairs where ``srcProvider`` equals ``dstProvider``.
 
 8. Call ``clientEncryption2.decrypt`` with the ``ciphertext``. Assert the return value is "test".
 
-Case 2: Rewrap returns error if masterKey is set, but provider is not set
+Case 2: RewrapManyDataKeyOpts.provider is not optional
 `````````````````````````````````````````````````````````````````````````
 
-This test may not apply depending on how the driver models the ``RewrapManyDataKeyOpts`` type.
-Drivers with API that does not permit calling ``ClientEncryption::rewrapManyDataKey`` with the ``masterKey`` set and ``provider`` unset may skip this test.
+Drivers MAY chose not to implement this prose test if their implementation of ``RewrapManyDataKeyOpts`` makes it impossible by design to omit ``RewrapManyDataKeyOpts.provider`` when ``RewrapManyDataKeyOpts.masterKey`` is set.
 
 1. Create a ``ClientEncryption`` object named ``clientEncryption`` with these options:
 
@@ -2220,7 +2219,7 @@ Drivers with API that does not permit calling ``ClientEncryption::rewrapManyData
          masterKey: { "foo": "bar" }
       }
 
-   Assert an error is returned from the driver suggesting that the ``provider`` option is required.
+   Assert that `clientEncryption.rewrapManyDataKey` raises a client error indicating that the required ``RewrapManyDataKeyOpts.provider`` field is missing.
 
 17.  On-demand GCP Credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Summary
- Add prose test to ensure error is returned when calling `rewrapManyDataKey` with a set `masterKey` without a `provider`.

# Background & Motivation

The specified API for `rewrapManyDataKey` does not permit calling with a set `masterKey` without a `provider`.

```typescript
class ClientEncryption {
    rewrapManyDataKey(filter: Document, opts: RewrapManyDataKeyOpts | null): RewrapManyDataKeyResult;
}
class RewrapManyDataKeyOpts {
    provider: String
    masterKey: Optional<Document>
}
```

Some driver implementations do not represent `RewrapManyDataKeyOpts` as a separate type. Instead, the `provider` and `masterKey` are both optional arguments to `RewrapManyDataKey`.

The C driver API permits setting `masterKey` without `provider`:
```c
MONGOC_EXPORT (bool)
mongoc_client_encryption_rewrap_many_datakey (
   mongoc_client_encryption_t *client_encryption,
   const bson_t *filter,
   const char *provider,
   const bson_t *master_key,
   mongoc_client_encryption_rewrap_many_datakey_result_t *result,
   bson_error_t *error);
```

The current behavior of `mongoc_client_encryption_rewrap_many_datakey` silently ignores the `master_key` option if `provider` is NULL.

This may result in unexpected behavior. A user may be attempting to rewrap keys with a new `master_key` and mistakenly passed a NULL `provider`. A NULL `provider` results in rewrapping with the same `master_key`.

The Java driver had similar behavior, which was fixed in [JAVA-4717](https://jira.mongodb.org/browse/JAVA-4717).

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- ~~[ ] Make sure there are generated JSON files from the YAML test files.~~
- [x] Test changes in at least one language driver. **Tested in C [here](https://github.com/mongodb/mongo-c-driver/pull/1259)**
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~ **C does not currently run CSFLE tests against sharded clusters**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

