### PR TITLE
DRIVERS-2577: $readPreference is not sent to standalone server

### DIFF
--- a/source/run-command/run-command.rst
+++ b/source/run-command/run-command.rst
@@ -113,7 +113,7 @@ To facilitate server selection the RunCommand operation MUST accept an optional 
 
 * See Server Selection's section on `Use of read preferences with commands <https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#use-of-read-preferences-with-commands>`_
 
-If the provided ReadPreference is NOT ``{mode: primary}``, the command sent MUST include the ``$readPreference`` global command argument.
+If the provided ReadPreference is NOT ``{mode: primary}`` and the selected server is NOT a standalone, the command sent MUST include the ``$readPreference`` global command argument.
 
 * See OP_MSG's section on `Global Command Arguments <https://github.com/mongodb/specifications/blob/master/source/message/OP_MSG.rst#global-command-arguments>`_
 
@@ -190,4 +190,5 @@ Drivers MUST document the behavior of RunCommand if a ``maxTimeMS`` field  is al
 Changelog
 =========
 
+:2023:05-08: ``$readPreference`` is not sent to standalone servers
 :2023-04-20: Add run command specification.

--- a/source/run-command/tests/unified/runCommand.json
+++ b/source/run-command/tests/unified/runCommand.json
@@ -259,6 +259,46 @@
       ]
     },
     {
+      "description": "does not attach primary $readPreference to given command",
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "readPreference": {
+              "mode": "primary"
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$readPreference": {
+                    "$$exists": false
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "description": "does not inherit readConcern specified at the db level",
       "operations": [
         {

--- a/source/run-command/tests/unified/runCommand.json
+++ b/source/run-command/tests/unified/runCommand.json
@@ -163,6 +163,16 @@
     },
     {
       "description": "attaches the provided $readPreference to given command",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "replicaset",
+            "sharded-replicaset",
+            "load-balanced",
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",
@@ -191,6 +201,53 @@
                   "ping": 1,
                   "$readPreference": {
                     "mode": "nearest"
+                  },
+                  "$db": "db"
+                },
+                "commandName": "ping"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "does not attach $readPreference to given command on standalone",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "single"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "runCommand",
+          "object": "db",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            },
+            "readPreference": {
+              "mode": "nearest"
+            }
+          },
+          "expectResult": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "ping": 1,
+                  "$readPreference": {
+                    "$$exists": false
                   },
                   "$db": "db"
                 },

--- a/source/run-command/tests/unified/runCommand.yml
+++ b/source/run-command/tests/unified/runCommand.yml
@@ -87,6 +87,9 @@ tests:
               commandName: ping
 
   - description: attaches the provided $readPreference to given command
+    runOnRequirements:
+      # Exclude single topology, which is most likely a standalone server
+      - topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
     operations:
       - name: runCommand
         object: *db
@@ -102,6 +105,31 @@ tests:
               command:
                 ping: 1
                 $readPreference: *readPreference
+                $db: *db
+              commandName: ping
+
+  - description: does not attach $readPreference to given command on standalone
+    runOnRequirements:
+      # This test assumes that the single topology contains a standalone server;
+      # however, it is possible for a single topology to contain a direct
+      # connection to another server type.
+      # See: https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.rst#topology-type-single
+      - topologies: [ single ]
+    operations:
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+          readPreference: { mode: 'nearest' }
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                ping: 1
+                $readPreference: { $$exists: false }
                 $db: *db
               commandName: ping
 

--- a/source/run-command/tests/unified/runCommand.yml
+++ b/source/run-command/tests/unified/runCommand.yml
@@ -133,6 +133,25 @@ tests:
                 $db: *db
               commandName: ping
 
+  - description: does not attach primary $readPreference to given command
+    operations:
+      - name: runCommand
+        object: *db
+        arguments:
+          commandName: ping
+          command: { ping: 1 }
+          readPreference: { mode: 'primary' }
+        expectResult: { ok: 1 }
+    expectEvents:
+      - client: *client
+        events:
+          - commandStartedEvent:
+              command:
+                ping: 1
+                $readPreference: { $$exists: false }
+                $db: *db
+              commandName: ping
+
   - description: does not inherit readConcern specified at the db level
     operations:
       - name: runCommand


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2577

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

POC PR in PHPLIB: https://github.com/mongodb/mongo-php-library/pull/1066
