### PR TITLE
DRIVERS-2617 Add prose test for change stream splitting

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -1000,6 +1000,7 @@ Reference Implementations
 Changelog
 =========
 
+:2023-05-22: Add spec test for ``$changeStreamSplitLargeEvent``.
 :2022-10-20: Reformat changelog.
 :2022-10-05: Remove spec front matter.
 :2022-08-22: Add ``clusterTime`` to ``ChangeStreamDocument``.


### PR DESCRIPTION
- [✓] Update changelog.
- [n/a] Make sure there are generated JSON files from the YAML test files.
- [✓] Test changes in at least one language driver.
- [✓] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

DRIVERS-2617

This adds a simple test that validates that drivers handle the large event splitting properly.  PoC implementation for Rust can be seen [here](https://github.com/mongodb/mongo-rust-driver/pull/878).