### PR TITLE
Fix RST syntax for inline literal

### DIFF
--- a/source/client-side-encryption/client-side-encryption.rst
+++ b/source/client-side-encryption/client-side-encryption.rst
@@ -918,7 +918,7 @@ command.
    and no longer allows names to deviate from the following:
 
    - ``enxcol_.<collectionName>.esc``
-   - ``enxcol_.<collectionName>.ecoc`
+   - ``enxcol_.<collectionName>.ecoc``
 
    Drivers MUST NOT document the ``escCollection`` and ``ecocCollection``
    options.


### PR DESCRIPTION
This dates back to aa28f787718eb4306ce7ff8e5a87bd46bb0a2c05