### PR TITLE
DRIVERS-2641: Allow int32 or int64 for getMore cursor ID

### DIFF
--- a/source/client-side-encryption/etc/test-templates/getMore.yml.template
+++ b/source/client-side-encryption/etc/test-templates/getMore.yml.template
@@ -48,7 +48,7 @@ tests:
           command_name: find
       - command_started_event:
           command:
-            getMore: { $$type: "long" }
+            getMore: { $$type: [ int, long ] }
             collection: *collection_name
             batchSize: 2
           command_name: getMore

--- a/source/client-side-encryption/tests/legacy/getMore.json
+++ b/source/client-side-encryption/tests/legacy/getMore.json
@@ -216,7 +216,10 @@
           "command_started_event": {
             "command": {
               "getMore": {
-                "$$type": "long"
+                "$$type": [
+                  "int",
+                  "long"
+                ]
               },
               "collection": "default",
               "batchSize": 2

--- a/source/client-side-encryption/tests/legacy/getMore.yml
+++ b/source/client-side-encryption/tests/legacy/getMore.yml
@@ -48,7 +48,7 @@ tests:
           command_name: find
       - command_started_event:
           command:
-            getMore: { $$type: "long" }
+            getMore: { $$type: [ int, long ] }
             collection: *collection_name
             batchSize: 2
           command_name: getMore

--- a/source/load-balancers/tests/cursors.json
+++ b/source/load-balancers/tests/cursors.json
@@ -222,7 +222,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -239,7 +242,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -333,7 +339,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -475,7 +484,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -492,7 +504,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -605,7 +620,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -750,7 +768,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "firstBatch": {
                       "$$type": "array"
@@ -767,7 +788,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -858,7 +882,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -950,7 +977,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": {
                     "$$type": "string"
@@ -1100,7 +1130,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },

--- a/source/load-balancers/tests/cursors.yml
+++ b/source/load-balancers/tests/cursors.yml
@@ -126,14 +126,14 @@ tests:
             commandSucceededEvent:
               reply:
                 cursor:
-                  id: { $$type: long }
+                  id: { $$type: [ int, long ] }
                   firstBatch: { $$type: array }
                   ns: { $$type: string }
               commandName: find
           - &getMoreStarted
             commandStartedEvent:
               command:
-                getMore: { $$type: long }
+                getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
               commandName: getMore
           - &getMoreSucceeded
@@ -386,7 +386,7 @@ tests:
           # is not equal to *collection0Name as the command is not executed against a collection.
           - commandStartedEvent:
               command:
-                getMore: { $$type: long }
+                getMore: { $$type: [ int, long ] }
                 collection: { $$type: string }
               commandName: getMore
           - *getMoreSucceeded

--- a/source/unified-test-format/tests/valid-pass/entity-cursor-iterateOnce.json
+++ b/source/unified-test-format/tests/valid-pass/entity-cursor-iterateOnce.json
@@ -93,7 +93,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },

--- a/source/unified-test-format/tests/valid-pass/entity-cursor-iterateOnce.yml
+++ b/source/unified-test-format/tests/valid-pass/entity-cursor-iterateOnce.yml
@@ -54,6 +54,6 @@ tests:
               databaseName: *database0Name
           - commandStartedEvent:
               command:
-                getMore: { $$type: long }
+                getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
               commandName: getMore

--- a/source/unified-test-format/tests/valid-pass/entity-find-cursor.json
+++ b/source/unified-test-format/tests/valid-pass/entity-find-cursor.json
@@ -109,7 +109,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "ns": {
                       "$$type": "string"
@@ -126,7 +129,10 @@
               "commandStartedEvent": {
                 "command": {
                   "getMore": {
-                    "$$type": "long"
+                    "$$type": [
+                      "int",
+                      "long"
+                    ]
                   },
                   "collection": "coll0"
                 },
@@ -138,7 +144,10 @@
                 "reply": {
                   "cursor": {
                     "id": {
-                      "$$type": "long"
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
                     },
                     "ns": {
                       "$$type": "string"

--- a/source/unified-test-format/tests/valid-pass/entity-find-cursor.yml
+++ b/source/unified-test-format/tests/valid-pass/entity-find-cursor.yml
@@ -61,19 +61,19 @@ tests:
           - commandSucceededEvent:
               reply:
                 cursor:
-                  id: { $$type: long }
+                  id: { $$type: [ int, long ] }
                   ns: { $$type: string }
                   firstBatch: { $$type: array } 
               commandName: find
           - commandStartedEvent:
               command:
-                getMore: { $$type: long }
+                getMore: { $$type: [ int, long ] }
                 collection: *collection0Name
               commandName: getMore
           - commandSucceededEvent:
               reply:
                 cursor:
-                  id: { $$type: long }
+                  id: { $$type: [ int, long ] }
                   ns: { $$type: string }
                   nextBatch: { $$type: array } 
               commandName: getMore


### PR DESCRIPTION
This accommodate drivers that encode BSON integers according to their range and is consistent with what is done in most other spec tests.

Please complete the following before merging:

- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

