### PR TITLE
DRIVERS-2524 assert collections are not created on unsupported server

### DIFF
--- a/source/client-side-encryption/tests/legacy/fle2v2-CreateCollection-OldServer.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-CreateCollection-OldServer.json
@@ -55,6 +55,38 @@
           "result": {
             "errorContains": "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
           }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.esc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "enxcol_.encryptedCollection.ecoc"
+          }
+        },
+        {
+          "name": "assertCollectionNotExists",
+          "object": "testRunner",
+          "arguments": {
+            "database": "default",
+            "collection": "encryptedCollection"
+          }
         }
       ]
     }

--- a/source/client-side-encryption/tests/legacy/fle2v2-CreateCollection-OldServer.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-CreateCollection-OldServer.yml
@@ -37,3 +37,25 @@ tests:
           collection: "encryptedCollection"
         result:
           errorContains: "Driver support of Queryable Encryption is incompatible with server. Upgrade server to use Queryable Encryption."
+      # Assert no collections were created.
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: &esc_collection_name "enxcol_.encryptedCollection.esc"
+      # ecc collection is no longer created for QEv2
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: &ecc_collection_name "enxcol_.encryptedCollection.ecc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: &ecoc_collection_name "enxcol_.encryptedCollection.ecoc"
+      - name: assertCollectionNotExists
+        object: testRunner
+        arguments:
+          database: *database_name
+          collection: encryptedCollection


### PR DESCRIPTION
# Summary

- Assert collections are not created on unsupported server for QEv2.

# Background & Motivation

CDRIVER-4653 reports a bug in the C driver implementation of DRIVERS-2524:

> the state collections for QEv2 are created before the wire version check for MongoDB 7.0+.

The assertions in this PR are intended to verify no other drivers have this bug.


<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ **N/A. Only test file changes.**
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested in C**
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~ **Tested in C on replica set. C does not test Queryable Encryption on sharded or serverless**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

