### PR TITLE
DRIVERS-2619 Remove null values from `command_started_event` in fle2v2-CreateCollection.yml

### DIFF
--- a/source/client-side-encryption/tests/legacy/fle2v2-CreateCollection.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-CreateCollection.json
@@ -158,9 +158,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -343,9 +340,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -851,9 +845,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1048,9 +1039,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1367,9 +1355,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",
@@ -1635,9 +1620,6 @@
             "command": {
               "create": "encryptedCollection",
               "encryptedFields": {
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                   {
                     "path": "firstName",

--- a/source/client-side-encryption/tests/legacy/fle2v2-CreateCollection.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-CreateCollection.yml
@@ -101,10 +101,6 @@ tests:
             command:
               create: *encrypted_collection_name
               encryptedFields: &encrypted_fields_expectation {
-                # Expect state collections are not included in the encryptedFields sent to the server.
-                "escCollection": null,
-                "ecocCollection": null,
-                "eccCollection": null,
                 "fields": [
                     {
                         "path": "firstName",

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -322,7 +322,7 @@ Then for each element in ``tests``:
 #. Call ``session0.endSession()`` and ``session1.endSession``.
 #. If the test includes a list of command-started events in ``expectations``,
    compare them to the actual command-started events using the
-   same logic as the Command Monitoring Spec Tests runner, plus the rules in
+   same logic as the `legacy Command Monitoring Spec Tests runner <https://github.com/mongodb/specifications/blob/09ee1ebc481f1502e3246971a9419e484d736207/source/command-monitoring/tests/README.rst#expectations>`_, plus the rules in
    the Command-Started Events instructions below.
 #. If ``failPoint`` is specified, disable the fail point to avoid spurious
    failures in subsequent tests. The fail point may be disabled like so::

--- a/source/transactions/tests/README.rst
+++ b/source/transactions/tests/README.rst
@@ -507,10 +507,10 @@ value "session0" or "session1". Tests MUST assert that the command's actual
 Null Values
 ~~~~~~~~~~~
 
-Some command-started events in ``expectations`` include ``null`` values for
-fields such as ``txnNumber``, ``autocommit``, and ``writeConcern``.
-Tests MUST assert that the actual command **omits** any field that has a
-``null`` value in the expected command.
+Some command-started events in ``expectations`` include ``null`` values for top
+level ```command``` fields such as ``txnNumber``, ``autocommit``, and
+``writeConcern``. Tests MUST assert that the actual command **omits** any field
+that has a ``null`` value in the expected command.
 
 Cursor Id
 ~~~~~~~~~


### PR DESCRIPTION
# Summary

- Remove null values from `command_started_event` in fle2v2-CreateCollection.yml.
- Link to legacy command monitoring spec tests runner in transactions test README.rst.
- Note `null` is only expected in top level fields of `command`.

The C driver incorrectly allows extra fields in subdocuments of the `command`. With this behavior fixed, the updated `fle2v2-CreateCollection.yml` test was [run in this patch](https://spruce.mongodb.com/version/6478a0cd7742ae7b3d6e48e3)


# Background & Motivation

DRIVERS-2524 added a legacy Client Side Encryption (CSE) test with embedded null fields in a `command_started_event` in [fle2v2-CreateCollection.yml](https://github.com/mongodb/specifications/blob/aa28f78/source/client-side-encryption/tests/legacy/fle2v2-CreateCollection.yml#L99-L107):
```yml
        - command_started_event:
            command:
              create: *encrypted_collection_name
              encryptedFields: &encrypted_fields_expectation {
                # Expect state collections are not included in the encryptedFields sent to the server.
                "escCollection": null,
                "ecocCollection": null,
                "eccCollection": null,
```

The null fields are intended to assert that `escCollection`, `ecocCollection` and `eccCollection` are not present in the `encryptedFields` document.

The legacy CSE format is based on the legacy Transactions test format. The legacy Transaction test README [references the Command Monitoring Spec Tests runner](https://github.com/mongodb/specifications/blob/2a51e9827a10e61617b1c34c53377edeed0f6a7b/source/transactions/tests/README.rst?plain=1#L323-L326):
> If the test includes a list of command-started events in ``expectations``,
   compare them to the actual command-started events using the
   same logic as the Command Monitoring Spec Tests runner, plus the rules in
   the Command-Started Events instructions below.

The legacy Command Monitoring Spec test format README was removed in https://github.com/mongodb/specifications/commit/c51e7373aab211ed673061bd6fdb542f655e413d#diff-5c0a965655147652fef540421431fb48533cd30c9120331276a7776ecc5171e2L62 and included:

> The driver MUST assert the expected data is present and also MUST allow for additional data to be present as well at the top level of the command document or reply document.

> However, if there are fields in command subdocuments that are not mentioned in the YAML, then the command does *not* pass the test

This suggests test runners are expected not to allow extra fields in subdocuments of the `command`. Test runners are not expected to handle `null` values specially for subdocuments of the `command`.

This resulted in [necessary workarounds](https://github.com/mongodb/mongo-python-driver/commit/deb0566c3e8ede09fa7f88fd173ef25b0e40c3a9#diff-eedc2f983a77d7ec19322ccab2cfb65dc3a5f8f6c1dd776c426334c48ed88cc2R432-R437) in the pymongo test runner.

---
Please complete the following before merging:

- ~~[ ] Update changelog.~~ **N/A. Only test README and test files changed**
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested in [C](https://spruce.mongodb.com/version/6478a0cd7742ae7b3d6e48e3/changes?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)**
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~ **C does not test legacy CSFLE tests on sharded clusters or serverless**.

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

