### PR TITLE
DRIVERS-2720: Update spec test's minServerVersion

### DIFF
--- a/source/collection-management/tests/timeseries-collection.json
+++ b/source/collection-management/tests/timeseries-collection.json
@@ -255,7 +255,7 @@
       "description": "createCollection with bucketing options",
       "runOnRequirements": [
         {
-          "minServerVersion": "7.0"
+          "minServerVersion": "6.3"
         }
       ],
       "operations": [

--- a/source/collection-management/tests/timeseries-collection.yml
+++ b/source/collection-management/tests/timeseries-collection.yml
@@ -130,7 +130,7 @@ tests:
 
   - description: "createCollection with bucketing options"
     runOnRequirements:
-      - minServerVersion: "7.0"
+      - minServerVersion: "6.3"
     operations:
       - name: dropCollection
         object: *database0


### PR DESCRIPTION
Update spec test's minServerVersion due to the availability of bucketing options starting from version 6.3

Related server ticket: [SERVER-67598](https://jira.mongodb.org/browse/SERVER-67598)
Related documentation: [timeseries-procedures](https://www.mongodb.com/docs/v7.0/core/timeseries/timeseries-procedures/)

Please complete the following before merging:

- [ ] Update changelog. (no changelog) 
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

