### PR TITLE
DRIVERS-2452 Add databaseName field to CommandFailedEvent

### DIFF
--- a/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+++ b/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
@@ -318,6 +318,11 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
     commandName: String;
 
     /**
+     * Returns the database name.
+     */
+    databaseName: String;
+
+    /**
      * Returns the failure. Based on the language, this SHOULD be a message string, exception
      * object, or error document.
      */

--- a/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+++ b/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
@@ -565,3 +565,4 @@ Changelog
              default port 27017 when relevant. Updated suggested unstructured forms of log messages to more
              clearly label connection IDs and use more readable server address representations.
 :2023-03-23: Updated ``serverConnectionId`` field to be Int64 as long-running servers can return Int64.
+:2023-06-13: Added ``databaseName`` field to ``CommandFailedEvent``.

--- a/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
+++ b/source/command-logging-and-monitoring/command-logging-and-monitoring.rst
@@ -270,6 +270,11 @@ See the `Load Balancer Specification <../load-balancers/load-balancers.rst#event
     commandName: String;
 
     /**
+     * Returns the database name.
+     */
+    databaseName: String;
+
+    /**
      * Returns the driver generated request id.
      */
     requestId: Int64;
@@ -565,4 +570,4 @@ Changelog
              default port 27017 when relevant. Updated suggested unstructured forms of log messages to more
              clearly label connection IDs and use more readable server address representations.
 :2023-03-23: Updated ``serverConnectionId`` field to be Int64 as long-running servers can return Int64.
-:2023-06-13: Added ``databaseName`` field to ``CommandFailedEvent``.
+:2023-06-13: Added ``databaseName`` field to ``CommandFailedEvent`` and ``CommandSucceededEvent``.

--- a/source/command-logging-and-monitoring/tests/monitoring/find.json
+++ b/source/command-logging-and-monitoring/tests/monitoring/find.json
@@ -1,6 +1,6 @@
 {
   "description": "find",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.15",
   "createEntities": [
     {
       "client": {
@@ -103,7 +103,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -198,7 +199,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -262,7 +264,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -338,7 +341,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             },
             {
@@ -376,7 +380,8 @@
                     ]
                   }
                 },
-                "commandName": "getMore"
+                "commandName": "getMore",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -464,7 +469,8 @@
                     ]
                   }
                 },
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             },
             {
@@ -498,7 +504,8 @@
                     ]
                   }
                 },
-                "commandName": "getMore"
+                "commandName": "getMore",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]
@@ -539,7 +546,8 @@
             },
             {
               "commandFailedEvent": {
-                "commandName": "find"
+                "commandName": "find",
+                "databaseName": "command-monitoring-tests"
               }
             }
           ]

--- a/source/command-logging-and-monitoring/tests/monitoring/find.yml
+++ b/source/command-logging-and-monitoring/tests/monitoring/find.yml
@@ -1,6 +1,6 @@
 description: "find"
 
-schemaVersion: "1.1"
+schemaVersion: "1.15"
 
 createEntities:
   - client:
@@ -56,6 +56,7 @@ tests:
                   firstBatch:
                     -  { _id: 1, x: 11 }
               commandName: find
+              databaseName: *databaseName
 
   - description: "A successful find with options"
     operations:
@@ -98,6 +99,7 @@ tests:
                     - { x: 33 }
                     - { x: 22 }
               commandName: find
+              databaseName: *databaseName
 
   - description: "A successful find with showRecordId and returnKey"
     operations:
@@ -131,6 +133,7 @@ tests:
                     - { _id: 4 }
                     - { _id: 5 }
               commandName: find
+              databaseName: *databaseName
 
   - description: "A successful find with a getMore"
     operations:
@@ -162,6 +165,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
               commandName: find
+              databaseName: *databaseName
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
@@ -179,6 +183,7 @@ tests:
                     - { _id: 4, x: 44 }
                     - { _id: 5, x: 55 }
               commandName: getMore
+              databaseName: *databaseName
 
   - description: "A successful find event with a getmore and the server kills the cursor (<= 4.4)"
     runOnRequirements:
@@ -216,6 +221,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }
               commandName: find
+              databaseName: *databaseName
           - commandStartedEvent:
               command:
                 getMore: { $$type: [ int, long ] }
@@ -232,6 +238,7 @@ tests:
                   nextBatch:
                     - { _id: 4, x: 44 }
               commandName: getMore
+              databaseName: *databaseName
 
   - description: "A failed find event"
     operations:
@@ -252,3 +259,4 @@ tests:
               databaseName: *databaseName
           - commandFailedEvent:
               commandName: find
+              databaseName: *databaseName

--- a/source/unified-test-format/schema-1.15.json
+++ b/source/unified-test-format/schema-1.15.json
@@ -1,0 +1,686 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+  
+    "title": "Unified Test Format",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["description", "schemaVersion", "tests"],
+    "properties": {
+      "description": { "type": "string" },
+      "schemaVersion": { "$ref": "#/definitions/version" },
+      "runOnRequirements": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/definitions/runOnRequirement" }
+      },
+      "createEntities": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/definitions/entity" }
+      },
+      "initialData": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/definitions/collectionData" }
+      },
+      "tests": {
+        "type": "array",
+        "minItems": 1,
+        "items": { "$ref": "#/definitions/test" }
+      },
+      "_yamlAnchors": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+  
+    "definitions": {
+      "version": {
+        "type": "string",
+        "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+      },
+  
+      "runOnRequirement": {
+        "type": "object",
+        "additionalProperties": false,
+        "minProperties": 1,
+        "properties": {
+          "maxServerVersion": { "$ref": "#/definitions/version" },
+          "minServerVersion": { "$ref": "#/definitions/version" },
+          "topologies": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": ["single", "replicaset", "sharded", "sharded-replicaset", "load-balanced"]
+            }
+          },
+          "serverless": {
+            "type": "string",
+            "enum": ["require", "forbid", "allow"]
+          },
+          "serverParameters": {
+            "type": "object",
+            "minProperties": 1
+          },
+          "auth": { "type": "boolean" },
+          "csfle": { "type": "boolean" }
+        }
+      },
+  
+      "entity": {
+        "type": "object",
+        "additionalProperties": false,
+        "maxProperties": 1,
+        "minProperties": 1,
+        "properties": {
+          "client": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id"],
+            "properties": {
+              "id": { "type": "string" },
+              "uriOptions": { "type": "object" },
+              "useMultipleMongoses": { "type": "boolean" },
+              "observeEvents": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "commandStartedEvent",
+                    "commandSucceededEvent",
+                    "commandFailedEvent",
+                    "poolCreatedEvent",
+                    "poolReadyEvent",
+                    "poolClearedEvent",
+                    "poolClosedEvent",
+                    "connectionCreatedEvent",
+                    "connectionReadyEvent",
+                    "connectionClosedEvent",
+                    "connectionCheckOutStartedEvent",
+                    "connectionCheckOutFailedEvent",
+                    "connectionCheckedOutEvent",
+                    "connectionCheckedInEvent",
+                    "serverDescriptionChangedEvent",
+                    "topologyDescriptionChangedEvent"
+                  ]
+                }
+              },
+              "ignoreCommandMonitoringEvents": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string" }
+              },
+              "storeEventsAsEntities": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "$ref": "#/definitions/storeEventsAsEntity" }
+              },
+              "observeLogMessages": {
+                "type": "object",
+                "minProperties": 1,
+                "additionalProperties": false,
+                "properties": {
+                    "command": { "$ref": "#/definitions/logSeverityLevel" },
+                    "topology": { "$ref": "#/definitions/logSeverityLevel" },
+                    "serverSelection": { "$ref": "#/definitions/logSeverityLevel" },
+                    "connection": { "$ref": "#/definitions/logSeverityLevel" }
+                }
+              },
+              "serverApi": { "$ref":  "#/definitions/serverApi" },
+              "observeSensitiveCommands": { "type": "boolean" }
+            }
+          },
+          "clientEncryption": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "clientEncryptionOpts"],
+            "properties": {
+              "id": { "type": "string" },
+              "clientEncryptionOpts": { "$ref": "#/definitions/clientEncryptionOpts" }
+            }
+          },
+          "database": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "client", "databaseName"],
+            "properties": {
+              "id": { "type": "string" },
+              "client": { "type": "string" },
+              "databaseName": { "type": "string" },
+              "databaseOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+            }
+          },
+          "collection": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "database", "collectionName"],
+            "properties": {
+              "id": { "type": "string" },
+              "database": { "type": "string" },
+              "collectionName": { "type": "string" },
+              "collectionOptions": { "$ref": "#/definitions/collectionOrDatabaseOptions" }
+            }
+          },
+          "session": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "client"],
+            "properties": {
+              "id": { "type": "string" },
+              "client": { "type": "string" },
+              "sessionOptions": { "type": "object" }
+            }
+          },
+          "bucket": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "database"],
+            "properties": {
+              "id": { "type": "string" },
+              "database": { "type": "string" },
+              "bucketOptions": { "type": "object" }
+            }
+          },
+          "thread": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id"],
+            "properties": {
+              "id": { "type": "string" }
+            }
+          }
+        }
+      },
+  
+      "logComponent": {
+        "type": "string",
+        "enum": ["command", "topology", "serverSelection", "connection"]
+      },
+
+      "logSeverityLevel": {
+        "type": "string",
+        "enum": ["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug", "trace"]
+      },
+
+      "clientEncryptionOpts": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["keyVaultClient", "keyVaultNamespace", "kmsProviders"],
+        "properties": {
+          "keyVaultClient": { "type": "string" },
+          "keyVaultNamespace": { "type": "string" },
+          "kmsProviders": { "$ref": "#/definitions/kmsProviders" }
+        }
+      },
+  
+      "kmsProviders": {
+        "$defs": {
+          "stringOrPlaceholder": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["$$placeholder"],
+                "properties": {
+                  "$$placeholder": {}
+                }
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "aws": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "accessKeyId": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" },
+              "secretAccessKey": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" },
+              "sessionToken": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" }
+            }
+          },
+          "azure": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "tenantId": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" },
+              "clientId": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" },
+              "clientSecret": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" },
+              "identityPlatformEndpoint": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" }
+            }
+          },
+          "gcp": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "email": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" },
+              "privateKey": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" },
+              "endpoint": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" }
+            }
+          },
+          "kmip": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "endpoint": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" }
+            }
+          },
+          "local": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "key": { "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder" }
+            }
+          }
+        }
+      },
+  
+      "storeEventsAsEntity": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "events"],
+        "properties": {
+          "id": { "type": "string" },
+          "events": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "PoolCreatedEvent",
+                "PoolReadyEvent",
+                "PoolClearedEvent",
+                "PoolClosedEvent",
+                "ConnectionCreatedEvent",
+                "ConnectionReadyEvent",
+                "ConnectionClosedEvent",
+                "ConnectionCheckOutStartedEvent",
+                "ConnectionCheckOutFailedEvent",
+                "ConnectionCheckedOutEvent",
+                "ConnectionCheckedInEvent",
+                "CommandStartedEvent",
+                "CommandSucceededEvent",
+                "CommandFailedEvent",
+                "ServerDescriptionChangedEvent",
+                "TopologyDescriptionChangedEvent"
+              ]
+            }
+          }
+        }
+      },
+  
+      "collectionData": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["collectionName", "databaseName", "documents"],
+        "properties": {
+          "collectionName": { "type": "string" },
+          "databaseName": { "type": "string" },
+          "createOptions": {
+            "type": "object",
+            "properties": {
+              "writeConcern": false
+            }
+          },
+          "documents": {
+            "type": "array",
+            "items": { "type": "object" }
+          }
+        }
+      },
+  
+      "expectedEventsForClient": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["client", "events"],
+        "properties": {
+          "client": { "type": "string" },
+          "eventType": {
+            "type": "string",
+            "enum": ["command", "cmap", "sdam"]
+          },
+          "events": { "type": "array" },
+          "ignoreExtraEvents": { "type": "boolean" }
+        },
+        "oneOf": [
+          {
+            "required": ["eventType"],
+            "properties": {
+              "eventType": { "const": "command" },
+              "events": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/expectedCommandEvent" }
+              }
+            }
+          },
+          {
+            "required": ["eventType"],
+            "properties": {
+              "eventType": { "const": "cmap" },
+              "events": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/expectedCmapEvent" }
+              }
+            }
+          },
+          {
+            "required": ["eventType"],
+            "properties": {
+              "eventType": { "const": "sdam" },
+              "events": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/expectedSdamEvent" }
+              }
+            }
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "client": { "type": "string" },
+              "events": {
+                "type": "array",
+                "items": { "$ref": "#/definitions/expectedCommandEvent" }
+              },
+              "ignoreExtraEvents": { "type": "boolean" }
+            }
+          }
+        ]
+      },
+  
+      "expectedCommandEvent": {
+        "type": "object",
+        "additionalProperties": false,
+        "maxProperties": 1,
+        "minProperties": 1,
+        "properties": {
+          "commandStartedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "command": { "type": "object" },
+              "commandName": { "type": "string" },
+              "databaseName": { "type": "string" },
+              "hasServiceId": { "type": "boolean" },
+              "hasServerConnectionId": { "type": "boolean" }
+            }
+          },
+          "commandSucceededEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "reply": { "type": "object" },
+              "commandName": { "type": "string" },
+              "databaseName": { "type": "string" },
+              "hasServiceId": { "type": "boolean" },
+              "hasServerConnectionId": { "type": "boolean" }
+            }
+          },
+          "commandFailedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "commandName": { "type": "string" },
+              "databaseName": { "type": "string" },
+              "hasServiceId": { "type": "boolean" },
+              "hasServerConnectionId": { "type": "boolean" }
+            }
+          }
+        }
+      },
+  
+      "expectedCmapEvent": {
+        "type": "object",
+        "additionalProperties": false,
+        "maxProperties": 1,
+        "minProperties": 1,
+        "properties": {
+          "poolCreatedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          },
+          "poolReadyEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          },
+          "poolClearedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "hasServiceId": { "type": "boolean" },
+              "interruptInUseConnections": { "type": "boolean" }
+            }
+          },
+          "poolClosedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          },
+          "connectionCreatedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          },
+          "connectionReadyEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          },
+          "connectionClosedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "reason": { "type": "string" }
+            }
+          },
+          "connectionCheckOutStartedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          },
+          "connectionCheckOutFailedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "reason": { "type": "string" }
+            }
+          },
+          "connectionCheckedOutEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          },
+          "connectionCheckedInEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        }
+      },
+  
+      "expectedSdamEvent": {
+        "type": "object",
+        "additionalProperties": false,
+        "maxProperties": 1,
+        "minProperties": 1,
+        "properties": {
+          "serverDescriptionChangedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "previousDescription": { "$ref": "#/definitions/serverDescription" },
+              "newDescription": { "$ref": "#/definitions/serverDescription" }
+            }
+          },
+          "topologyDescriptionChangedEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
+          }
+        }
+      },
+  
+      "serverDescription": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "type": { 
+            "type": "string",
+            "enum": [
+              "Standalone",
+              "Mongos",
+              "PossiblePrimary",
+              "RSPrimary",
+              "RSSecondary",
+              "RSOther",
+              "RSArbiter",
+              "RSGhost",
+              "LoadBalancer",
+              "Unknown"
+            ]
+          }
+        }
+      },
+
+      "expectedLogMessagesForClient": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["client", "messages"],
+        "properties": {
+          "client": { "type": "string" },
+          "messages": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/expectedLogMessage" } 
+            }
+        }
+      },
+
+      "expectedLogMessage": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["level", "component", "data"],
+        "properties": {
+            "level": { "$ref": "#/definitions/logSeverityLevel" },
+            "component": { "$ref": "#/definitions/logComponent" },
+            "data": { "type": "object" },
+            "failureIsRedacted": { "type": "boolean" }
+        }
+      },
+
+      "collectionOrDatabaseOptions": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "readConcern": { "type": "object" },
+          "readPreference": { "type": "object" },
+          "writeConcern": { "type": "object" },
+          "timeoutMS": { "type": "integer" }
+        }
+      },
+  
+      "serverApi": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["version"],
+        "properties": {
+          "version": { "type": "string" },
+          "strict": { "type":  "boolean" },
+          "deprecationErrors": { "type":  "boolean" }
+        }
+      },
+  
+      "operation": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "object"],
+        "properties": {
+          "name": { "type": "string" },
+          "object": { "type": "string" },
+          "arguments": { "type": "object" },
+          "ignoreResultAndError": { "type": "boolean" },
+          "expectError":  { "$ref": "#/definitions/expectedError" },
+          "expectResult": {},
+          "saveResultAsEntity": { "type": "string" }
+        },
+        "allOf": [
+          { "not": { "required": ["expectError", "expectResult"] } },
+          { "not": { "required": ["expectError", "saveResultAsEntity"] } },
+          { "not": { "required": ["ignoreResultAndError", "expectResult"] } },
+          { "not": { "required": ["ignoreResultAndError", "expectError"] } },
+          { "not": { "required": ["ignoreResultAndError", "saveResultAsEntity"] } }
+        ]
+      },
+  
+      "expectedError": {
+        "type": "object",
+        "additionalProperties": false,
+        "minProperties": 1,
+        "properties": {
+          "isError": {
+            "type": "boolean",
+            "const": true
+          },
+          "isClientError": { "type": "boolean" },
+          "isTimeoutError": { "type": "boolean" },
+          "errorContains": { "type": "string" },
+          "errorCode": { "type": "integer" },
+          "errorCodeName": { "type": "string" },
+          "errorLabelsContain": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string" }
+          },
+          "errorLabelsOmit": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "type": "string" }
+          },
+          "errorResponse": {
+            "type": "object"
+          },
+          "expectResult": {}
+        }
+      },
+  
+      "test": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["description", "operations"],
+        "properties": {
+          "description": { "type": "string" },
+          "runOnRequirements": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/runOnRequirement" }
+          },
+          "skipReason": { "type": "string" },
+          "operations": {
+            "type": "array",
+            "items": { "$ref": "#/definitions/operation" }
+          },
+          "expectEvents": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/expectedEventsForClient" }
+          },
+          "expectLogMessages": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/expectedLogMessagesForClient" }
+          },
+          "outcome": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#/definitions/collectionData" }
+          }
+        }
+      }
+    }
+  }

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -1,4 +1,4 @@
-SCHEMA=../schema-1.13.json
+SCHEMA=../schema-1.15.json
 
 .PHONY: all invalid valid-fail valid-pass versioned-api load-balancers gridfs transactions crud collection-management sessions command-logging-and-monitoring client-side-operations-timeout HAS_AJV
 

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.json
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedCommandEvent-commandFailedEvent-databaseName-type",
+  "schemaVersion": "1.15",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandFailedEvent": {
+                "databaseName": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandFailedEvent-databaseName-type.yml
@@ -1,0 +1,16 @@
+description: "expectedCommandEvent-commandFailedEvent-databaseName-type"
+
+schemaVersion: "1.15"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandFailedEvent:
+              databaseName: 0

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.json
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.json
@@ -1,0 +1,29 @@
+{
+  "description": "expectedCommandEvent-commandSucceededEvent-databaseName-type",
+  "schemaVersion": "1.15",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "foo",
+      "operations": [],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandSucceededEvent": {
+                "databaseName": 0
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.yml
+++ b/source/unified-test-format/tests/invalid/expectedCommandEvent-commandSucceededEvent-databaseName-type.yml
@@ -1,0 +1,16 @@
+description: "expectedCommandEvent-commandSucceededEvent-databaseName-type"
+
+schemaVersion: "1.15"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "foo"
+    operations: []
+    expectEvents:
+      - client: *client0
+        events:
+          - commandSucceededEvent:
+              databaseName: 0

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -4003,6 +4003,8 @@ Changelog
 
 ..
   Please note schema version bumps in changelog entries where applicable.
+:2023-06-13: **Schema version 1.15.**
+             Add ``databaseName`` field to ``CommandFailedEvent`` and ``CommandSucceededEvent``.
 :2023-05-26: **Schema version 1.14.** 
              Add ``topologyDescriptionChangedEvent``.
 :2023-05-17: Add ``runCursorCommand`` and ``createCommandCursor`` operations.

--- a/source/unified-test-format/unified-test-format.rst
+++ b/source/unified-test-format/unified-test-format.rst
@@ -1253,6 +1253,10 @@ The structure of this object is as follows:
   - ``commandName``: Optional string. Test runners MUST assert that the command
     name matches this value.
 
+  - ``databaseName``: Optional string. Test runners MUST assert that the
+    database name matches this value. The YAML file SHOULD use an `alias node`_
+    for this value (e.g. ``databaseName: *database0Name``).
+
   - ``hasServiceId``: Defined in `hasServiceId`_.
 
   - ``hasServerConnectionId``: Defined in `hasServerConnectionId`_.
@@ -1267,6 +1271,10 @@ The structure of this object is as follows:
 
   - ``commandName``: Optional string. Test runners MUST assert that the command
     name matches this value.
+
+  - ``databaseName``: Optional string. Test runners MUST assert that the
+    database name matches this value. The YAML file SHOULD use an `alias node`_
+    for this value (e.g. ``databaseName: *database0Name``).
 
   - ``hasServiceId``: Defined in `hasServiceId`_.
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
[DRIVERS-2452](https://jira.mongodb.org/browse/DRIVERS-2452)
Add `databaseName` field to `CommandFailedEvent` and `CommandSucceededEvent`.