### PR TITLE
DRIVERS-2612: Require 7.0+ for explain apiVersion bug fix

### DIFF
--- a/source/client-side-encryption/etc/test-templates/explain.yml.template
+++ b/source/client-side-encryption/etc/test-templates/explain.yml.template
@@ -1,5 +1,5 @@
 runOn:
-  - minServerVersion: "4.1.10"
+  - minServerVersion: "7.0.0"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 

--- a/source/client-side-encryption/tests/legacy/explain.json
+++ b/source/client-side-encryption/tests/legacy/explain.json
@@ -1,7 +1,7 @@
 {
   "runOn": [
     {
-      "minServerVersion": "4.1.10"
+      "minServerVersion": "7.0.0"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/explain.yml
+++ b/source/client-side-encryption/tests/legacy/explain.yml
@@ -1,5 +1,5 @@
 runOn:
-  - minServerVersion: "4.1.10"
+  - minServerVersion: "7.0.0"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 


### PR DESCRIPTION
In previous server versions, apiVersion is not properly appended to the root of an explain command document.

When testing with requireApiVersion=1, that can cause test failures if the driver does not have additional logic to always append the field to a crypt_shared/mongocryptd respnse.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

POC: https://github.com/mongodb/mongo-php-library/pull/1111

As noted in [DRIVERS-2612](https://jira.mongodb.org/browse/DRIVERS-2612?focusedCommentId=5502676&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-5502676), this is blocked on the release of 7.0.0-rc4 for [BACKPORT-16190](https://jira.mongodb.org/browse/BACKPORT-16190).

