### PR TITLE
test(DRIVERS-2657): update faas testing spec

### DIFF
--- a/source/faas-automated-testing/faas-automated-testing.rst
+++ b/source/faas-automated-testing/faas-automated-testing.rst
@@ -267,6 +267,8 @@ variables. An explanation of the required environment is as follows:
 +-------------------------------+-------------------------------------+
 | AWS_SESSION_TOKEN             | Assume role automatically sets this |
 +-------------------------------+-------------------------------------+
+| MONGODB_VERSION               | The major version of the cluster    |
++-------------------------------+-------------------------------------+
 
 
 Supported Evergreen variants that have the AWS SAM CLI installed:
@@ -286,52 +288,84 @@ Supported Evergreen variants that have the AWS SAM CLI installed:
 - rhel82-arm64
 
 
-This is an example function in the Evergreen config that accomplishes this, using
-subprocess.exec to execute a script that calls the drivers-evergreen-tools
-function inside of it:
+This is an example task group in the Evergreen config that accomplishes this, using
+subprocess.exec to execute scripts that call the drivers-evergreen-tools
+functions inside of it for setup, teardown, and execution:
 
 .. code:: yaml
 
-  run deployed aws lambda tests:
-  - command: ec2.assume_role
-    params:
-      role_arn: ${LAMBDA_AWS_ROLE_ARN}
-  - command: subprocess.exec
-    params:
-      working_dir: src
-      binary: bash
-      args:
-        - .evergreen/run-deployed-lambda-aws-tests.sh
-      env:
-        TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
-        DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-        DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-        DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-        DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
-        DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
-        DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-        LAMBDA_STACK_NAME: dbx-node-lambda
-        AWS_REGION: us-east-1
-        AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-        AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-        AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+  tasks:
+    - name: test-aws-lambda-deployed
+      commands:
+        - func: install dependencies
+        - command: ec2.assume_role
+          params:
+            role_arn: ${LAMBDA_AWS_ROLE_ARN}
+            duration_seconds: 3600
+        - command: subprocess.exec
+          params:
+            working_dir: src
+            binary: bash
+            args:
+              - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
+            env:
+              MONGODB_URI: ${MONGODB_URI}
+              TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
+              DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+              DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
+              DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
+              DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+              LAMBDA_STACK_NAME: dbx-node-lambda
+              AWS_REGION: us-east-1
+              AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+              AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+              AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
+  task_groups:
+    - name: test_aws_lambda_task_group
+      setup_group:
+        - func: fetch source
+        - command: subprocess.exec
+          params:
+            working_dir: src
+            binary: bash
+            args:
+              - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/setup-atlas-cluster.sh
+            env:
+              DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+              DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
+              DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
+              DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+              DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
+              DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
+              LAMBDA_STACK_NAME: dbx-node-lambda
+              MONGODB_VERSION: 7.0
+        - command: expansions.update
+          params:
+            file: src/atlas-expansion.yml
+      teardown_group:
+        - command: subprocess.exec
+          params:
+            working_dir: src
+            binary: bash
+            args:
+              - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/teardown-atlas-cluster.sh
+            env:
+              DRIVERS_TOOLS: ${DRIVERS_TOOLS}
+              DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
+              DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
+              DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
+              LAMBDA_STACK_NAME: dbx-node-lambda
+      setup_group_can_fail_task: true
+      setup_group_timeout_secs: 1800
+      tasks:
+        - test-aws-lambda-deployed
 
 Drivers MUST run the function on a single variant in Evergreen, in order to not
 potentially hit the Atlas API rate limit. The variant itself MUST be either a
 RHEL8 or Ubuntu 20 variant in order to have the SAM CLI installed.
 
-The script itself:
-
-.. code:: none
-
-  #!/bin/bash
-  set -o errexit  # Exit the script with error if any of the commands fail
-  . ${DRIVERS_TOOLS}/.evergreen/run-deployed-lambda-aws-tests.sh
-
 Description of the behaviour of run-deployed-lambda-aws-tests.sh:
 
-- Creates a new Atlas cluster in a specific driver project
-- Polls for the cluster SRV record when cluster creation is complete
 - Builds the Lambda function locally
 - Deploys the Lambda function to AWS.
 - Queries for the Lambda function ARN.
@@ -339,10 +373,10 @@ Description of the behaviour of run-deployed-lambda-aws-tests.sh:
 - Initiates a primary failover of the cluster in Atlas.
 - Calls the frozen lambda function again.
 - Deletes the Lambda function.
-- Deletes the Atlas cluster.
 
 
 Changelog
 =========
 
+:2023-06-22: Updated evergreen configuration to use task groups.
 :2023-04-14: Added list of supported variants, added additional template config.

--- a/source/faas-automated-testing/faas-automated-testing.rst
+++ b/source/faas-automated-testing/faas-automated-testing.rst
@@ -320,7 +320,7 @@ functions inside of it for setup, teardown, and execution:
             binary: bash
             add_expansions_to_env: true
             args:
-              - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/setup-atlas-cluster.sh
+              - ${DRIVERS_TOOLS}/.evergreen/atlas/setup-atlas-cluster.sh
         - command: expansions.update
           params:
             file: src/atlas-expansion.yml
@@ -331,7 +331,7 @@ functions inside of it for setup, teardown, and execution:
             binary: bash
             add_expansions_to_env: true
             args:
-              - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/teardown-atlas-cluster.sh
+              - ${DRIVERS_TOOLS}/.evergreen/atlas/teardown-atlas-cluster.sh
       setup_group_can_fail_task: true
       setup_group_timeout_secs: 1800
       tasks:

--- a/source/faas-automated-testing/faas-automated-testing.rst
+++ b/source/faas-automated-testing/faas-automated-testing.rst
@@ -238,7 +238,7 @@ Running in CI requires Evergreen to be setup to assume the appropriate role in A
 and then execute the script in drivers-evergreen-tools with the required environment
 variables. An explanation of the required environment is as follows:
 
-+-------------------------------+----------+--------------------------+
++-------------------------------+-------------------------------------+
 | Name                          | Description                         |
 +===============================+=====================================+
 | LAMBDA_AWS_ROLE_ARN           | The role ARN to assume              |

--- a/source/faas-automated-testing/faas-automated-testing.rst
+++ b/source/faas-automated-testing/faas-automated-testing.rst
@@ -267,8 +267,6 @@ variables. An explanation of the required environment is as follows:
 +-------------------------------+-------------------------------------+
 | AWS_SESSION_TOKEN             | Assume role automatically sets this |
 +-------------------------------+-------------------------------------+
-| MONGODB_VERSION               | The major version of the cluster    |
-+-------------------------------+-------------------------------------+
 
 
 Supported Evergreen variants that have the AWS SAM CLI installed:
@@ -295,9 +293,9 @@ functions inside of it for setup, teardown, and execution:
 .. code:: yaml
 
   tasks:
-    - name: test-aws-lambda-deployed
+    - name: "test-aws-lambda-deployed"
       commands:
-        - func: install dependencies
+        - func: "install dependencies"
         - command: ec2.assume_role
           params:
             role_arn: ${LAMBDA_AWS_ROLE_ARN}
@@ -306,20 +304,12 @@ functions inside of it for setup, teardown, and execution:
           params:
             working_dir: src
             binary: bash
+            add_expansions_to_env: true
             args:
               - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/run-deployed-lambda-aws-tests.sh
             env:
-              MONGODB_URI: ${MONGODB_URI}
               TEST_LAMBDA_DIRECTORY: ${PROJECT_DIRECTORY}/test/lambda
-              DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-              DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-              DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-              DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-              LAMBDA_STACK_NAME: dbx-node-lambda
               AWS_REGION: us-east-1
-              AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-              AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-              AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN}
   task_groups:
     - name: test_aws_lambda_task_group
       setup_group:
@@ -328,17 +318,9 @@ functions inside of it for setup, teardown, and execution:
           params:
             working_dir: src
             binary: bash
+            add_expansions_to_env: true
             args:
               - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/setup-atlas-cluster.sh
-            env:
-              DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-              DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-              DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-              DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-              DRIVERS_ATLAS_LAMBDA_USER: ${DRIVERS_ATLAS_LAMBDA_USER}
-              DRIVERS_ATLAS_LAMBDA_PASSWORD: ${DRIVERS_ATLAS_LAMBDA_PASSWORD}
-              LAMBDA_STACK_NAME: dbx-node-lambda
-              MONGODB_VERSION: 7.0
         - command: expansions.update
           params:
             file: src/atlas-expansion.yml
@@ -347,18 +329,14 @@ functions inside of it for setup, teardown, and execution:
           params:
             working_dir: src
             binary: bash
+            add_expansions_to_env: true
             args:
               - ${DRIVERS_TOOLS}/.evergreen/aws_lambda/teardown-atlas-cluster.sh
-            env:
-              DRIVERS_TOOLS: ${DRIVERS_TOOLS}
-              DRIVERS_ATLAS_PUBLIC_API_KEY: ${DRIVERS_ATLAS_PUBLIC_API_KEY}
-              DRIVERS_ATLAS_PRIVATE_API_KEY: ${DRIVERS_ATLAS_PRIVATE_API_KEY}
-              DRIVERS_ATLAS_GROUP_ID: ${DRIVERS_ATLAS_GROUP_ID}
-              LAMBDA_STACK_NAME: dbx-node-lambda
       setup_group_can_fail_task: true
       setup_group_timeout_secs: 1800
       tasks:
         - test-aws-lambda-deployed
+
 
 Drivers MUST run the function on a single variant in Evergreen, in order to not
 potentially hit the Atlas API rate limit. The variant itself MUST be either a


### PR DESCRIPTION
Updates the FaaS testing spec to recommend using task groups as provided in https://github.com/mongodb-labs/drivers-evergreen-tools/pull/325

Node impl: https://github.com/mongodb/node-mongodb-native/pull/3740

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

