### PR TITLE
DRIVERS-2675: Remove use of "sharded-replicaset"

### DIFF
--- a/source/run-command/tests/unified/runCommand.json
+++ b/source/run-command/tests/unified/runCommand.json
@@ -229,7 +229,6 @@
         {
           "topologies": [
             "replicaset",
-            "sharded-replicaset",
             "load-balanced",
             "sharded"
           ]
@@ -493,7 +492,7 @@
         {
           "minServerVersion": "4.2",
           "topologies": [
-            "sharded-replicaset",
+            "sharded",
             "load-balanced"
           ]
         }

--- a/source/run-command/tests/unified/runCommand.yml
+++ b/source/run-command/tests/unified/runCommand.yml
@@ -119,7 +119,7 @@ tests:
   - description: attaches the provided $readPreference to given command
     runOnRequirements:
       # Exclude single topology, which is most likely a standalone server
-      - topologies: [ replicaset, sharded-replicaset, load-balanced, sharded ]
+      - topologies: [ replicaset, load-balanced, sharded ]
     operations:
       - name: runCommand
         object: *db
@@ -250,7 +250,7 @@ tests:
       - minServerVersion: "4.0"
         topologies: [ replicaset ]
       - minServerVersion: "4.2"
-        topologies: [ sharded-replicaset, load-balanced ]
+        topologies: [ sharded, load-balanced ]
     operations:
       - name: withTransaction
         object: *session


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2675

Although one test does not specify a minServerVersion, "sharded-replicaset" is still redundant since $readPreference is always sent to mongos.

- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).
