### PR TITLE
DRIVERS-2687 Add BSON Binary Data subtype Sensitive

### DIFF
--- a/source/bson-corpus/tests/binary.json
+++ b/source/bson-corpus/tests/binary.json
@@ -57,7 +57,7 @@
         },
         {
             "description": "subtype 0x08",
-            "canonical_bson": "1D000000057800100000000773FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_bson": "1D000000057800100000000873FFD26444B34C6990E8E7D1DFC035D400",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"08\"}}}"
         },
         {

--- a/source/bson-corpus/tests/binary.json
+++ b/source/bson-corpus/tests/binary.json
@@ -56,6 +56,11 @@
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"07\"}}}"
         },
         {
+            "description": "subtype 0x08",
+            "canonical_bson": "1D000000057800100000000773FFD26444B34C6990E8E7D1DFC035D400",
+            "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"c//SZESzTGmQ6OfR38A11A==\", \"subType\" : \"08\"}}}"
+        },
+        {
             "description": "subtype 0x80",
             "canonical_bson": "0F0000000578000200000080FFFF00",
             "canonical_extjson": "{\"x\" : { \"$binary\" : {\"base64\" : \"//8=\", \"subType\" : \"80\"}}}"


### PR DESCRIPTION
The new test validates only the correct subtype, number encoding/decoding, and binary data encoding/decoding. Any binary data itself is not validated. [DRIVERS-2687](https://jira.mongodb.org/browse/DRIVERS-2687) specifies that data using this subtype is meant to not be logged, so this should satisfy testing requirements.
