### PR TITLE
DRIVERS-2679: make delimiting slash between hosts and connection options optional

### DIFF
--- a/source/connection-string/connection-string-spec.rst
+++ b/source/connection-string/connection-string-spec.rst
@@ -389,3 +389,5 @@ Changelog
 :2022-10-05: Remove spec front matter and reformat changelog.
 :2022-12-27: Note that host information ends with a "/" character in connection
              options description.
+:2023-08-02: Make delimiting slash between host information and connection options
+             optional and update tests

--- a/source/connection-string/connection-string-spec.rst
+++ b/source/connection-string/connection-string-spec.rst
@@ -86,7 +86,7 @@ Above and beyond that restriction, drivers SHOULD require connection string user
 ----------------
 Host Information
 ----------------
-Unlike a standard URI, the connection string allows for identifying multiple hosts. The host information section of the connection string is delimited by the trailing slash ("/") or end of string.
+Unlike a standard URI, the connection string allows for identifying multiple hosts. The host information section of the connection string MAY be delimited by the trailing slash ("/") or end of string.
 
 The host information must contain at least one host identifier but may contain more (see the alternative hosts / ports in the general syntax diagram above). Multiple host identifiers are delimited by a comma (",").
 

--- a/source/connection-string/tests/invalid-uris.json
+++ b/source/connection-string/tests/invalid-uris.json
@@ -163,15 +163,6 @@
       "options": null
     },
     {
-      "description": "Missing delimiting slash between hosts and options",
-      "uri": "mongodb://example.com?w=1",
-      "valid": false,
-      "warning": null,
-      "hosts": null,
-      "auth": null,
-      "options": null
-    },
-    {
       "description": "Incomplete key value pair for option",
       "uri": "mongodb://example.com/?w",
       "valid": false,

--- a/source/connection-string/tests/invalid-uris.yml
+++ b/source/connection-string/tests/invalid-uris.yml
@@ -144,14 +144,6 @@ tests:
         auth: ~
         options: ~
     -
-        description: "Missing delimiting slash between hosts and options"
-        uri: "mongodb://example.com?w=1"
-        valid: false
-        warning: ~
-        hosts: ~
-        auth: ~
-        options: ~
-    -
         description: "Incomplete key value pair for option"
         uri: "mongodb://example.com/?w"
         valid: false

--- a/source/connection-string/tests/valid-options.json
+++ b/source/connection-string/tests/valid-options.json
@@ -26,7 +26,13 @@
       "uri": "mongodb://example.com?tls=true",
       "valid": true,
       "warning": false,
-      "hosts": null,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
       "auth": null,
       "options": {
         "tls": true

--- a/source/connection-string/tests/valid-options.json
+++ b/source/connection-string/tests/valid-options.json
@@ -20,6 +20,15 @@
       "options": {
         "authmechanism": "MONGODB-CR"
       }
+    },
+    {
+      "description": "Missing delimiting slash between hosts and options",
+      "uri": "mongodb://example.com?w=1",
+      "valid": true,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
     }
   ]
 }

--- a/source/connection-string/tests/valid-options.json
+++ b/source/connection-string/tests/valid-options.json
@@ -23,12 +23,16 @@
     },
     {
       "description": "Missing delimiting slash between hosts and options",
-      "uri": "mongodb://example.com?w=1",
+      "uri": "mongodb://example.com?tls=true",
       "valid": true,
-      "warning": null,
+      "warning": false,
       "hosts": null,
       "auth": null,
-      "options": null
+      "options": [
+        {
+          "tls": true
+        }
+      ]
     }
   ]
 }

--- a/source/connection-string/tests/valid-options.json
+++ b/source/connection-string/tests/valid-options.json
@@ -28,11 +28,9 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": [
-        {
-          "tls": true
-        }
-      ]
+      "options": {
+        "tls": true
+      }
     }
   ]
 }

--- a/source/connection-string/tests/valid-options.yml
+++ b/source/connection-string/tests/valid-options.yml
@@ -20,7 +20,11 @@ tests:
         uri: "mongodb://example.com?tls=true"
         valid: true
         warning: false
-        hosts: ~
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
         auth: ~
         options:
               tls: true

--- a/source/connection-string/tests/valid-options.yml
+++ b/source/connection-string/tests/valid-options.yml
@@ -15,3 +15,11 @@ tests:
             db: "admin"
         options:
             authmechanism: "MONGODB-CR"
+    -
+        description: "Missing delimiting slash between hosts and options"
+        uri: "mongodb://example.com?w=1"
+        valid: true
+        warning: ~
+        hosts: ~
+        auth: ~
+        options: ~

--- a/source/connection-string/tests/valid-options.yml
+++ b/source/connection-string/tests/valid-options.yml
@@ -17,9 +17,11 @@ tests:
             authmechanism: "MONGODB-CR"
     -
         description: "Missing delimiting slash between hosts and options"
-        uri: "mongodb://example.com?w=1"
+        uri: "mongodb://example.com?tls=true"
         valid: true
-        warning: ~
+        warning: false
         hosts: ~
         auth: ~
-        options: ~
+        options:
+          -
+              tls: true

--- a/source/connection-string/tests/valid-options.yml
+++ b/source/connection-string/tests/valid-options.yml
@@ -23,5 +23,4 @@ tests:
         hosts: ~
         auth: ~
         options:
-          -
               tls: true


### PR DESCRIPTION
- Change spec language to make delimiting slash between hosts and connection options optional.
- Updated connection-string spec tests to allow optional delimiting slash


<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

