### PR TITLE
DRIVERS-2674 Update server versions for `$changeStreamSplitLargeEvent` test

### DIFF
--- a/source/change-streams/change-streams.rst
+++ b/source/change-streams/change-streams.rst
@@ -1000,6 +1000,7 @@ Reference Implementations
 Changelog
 =========
 
+:2023-08-11: Update server versions for ``$changeStreamSplitLargeEvent`` test.
 :2023-05-22: Add spec test for ``$changeStreamSplitLargeEvent``.
 :2022-10-20: Reformat changelog.
 :2022-10-05: Remove spec front matter.

--- a/source/change-streams/tests/README.rst
+++ b/source/change-streams/tests/README.rst
@@ -242,7 +242,7 @@ The following tests have not yet been automated, but MUST still be tested. All t
 
 #. Validate that large ``ChangeStream`` events are split when using ``$changeStreamSplitLargeEvent``:
 
-   #. Run only against servers ``>=7.0``
+   #. Run only against servers ``>=6.0.9 && <6.1`` or ``>=7.0``.
    #. Create a new collection _C_ with ``changeStreamPreAndPostImages`` enabled.
    #. Insert into _C_ a document at least 10mb in size, e.g. ``{ "value": "q"*10*1024*1024 }``
    #. Create a change stream _S_ by calling ``watch`` on _C_ with pipeline ``[{ "$changeStreamSplitLargeEvent": {} }]`` and ``fullDocumentBeforeChange=required``.


### PR DESCRIPTION
- [*] Update changelog.
- [n/a] Make sure there are generated JSON files from the YAML test files.
- [*] Test changes in at least one language driver.
- [*] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

https://github.com/mongodb/mongo-rust-driver/pull/930 implements this for the Rust driver.