### PR TITLE
Add missing retryable write case to pseudo code

### DIFF
--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -513,6 +513,11 @@ The above rules are implemented in the following pseudo-code:
       if (timeoutMS != null && isExpired(timeoutMS) {
         throw previousError;
       }
+
+      /* If CSOT is not enabled attempt one retry before giving up. */
+      if (timeoutMS == null) {
+        return executeCommand(server, retryableCommand);
+      }
     }
   }
 


### PR DESCRIPTION
The pseudo code example for executing retryable write commands was missing the case below:

- CSOT is not enabled and one retry was attempted.

This corrects the pseudo code to unify it with the prose description.

Related to: DRIVERS-1807

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

