### PR TITLE
Sync retryable reads with SDAM

### DIFF
--- a/source/retryable-reads/retryable-reads.rst
+++ b/source/retryable-reads/retryable-reads.rst
@@ -678,6 +678,7 @@ degraded performance can simply disable ``retryableReads``.
 Changelog
 =========
 
+:2023-08-21: Update Q&A that contradicts SDAM transient error logic
 :2022-11-09: CLAM must apply both events and log messages.
 :2022-10-18: When CSOT is enabled multiple retry attempts may occur.
 :2022-10-05: Remove spec front matter, move footnote, and reformat changelog.

--- a/source/retryable-reads/retryable-reads.rst
+++ b/source/retryable-reads/retryable-reads.rst
@@ -614,10 +614,9 @@ The spec concerns itself with retrying read operations that encounter a
 retryable error (i.e. no response due to network error or a response indicating
 that the node is no longer a primary). A retryable error may be classified as
 either a transient error (e.g. dropped connection, replica set failover) or
-persistent outage. In the case of a transient error, the driver will mark the
-server as "unknown" per the `SDAM`_
-spec. A subsequent retry attempt will allow the driver to rediscover the primary
-within the designated server selection timeout period (30 seconds by
+persistent outage. If a transient error results in the server being marked as 
+"unknown", a subsequent retry attempt will allow the driver to rediscover the 
+primary within the designated server selection timeout period (30 seconds by
 default). If server selection times out during this retry attempt, we can
 reasonably assume that there is a persistent outage. In the case of a persistent
 outage, multiple retry attempts are fruitless and would waste time. See `How To


### PR DESCRIPTION
<!-- Thanks for contributing! -->
This PR proposes a re-phrasing of the "[Why are read operations only retried once by default?](https://github.com/mongodb/specifications/blob/master/source/retryable-reads/retryable-reads.rst#id40)" section of retryable reads to fix inconsistencies between the retryable reads and SDAM specifications. From the retryable reads [Q&A](https://github.com/mongodb/specifications/blob/master/source/retryable-reads/retryable-reads.rst#why-are-read-operations-only-retried-once-by-default) on why read operations are only retried once:

> In the case of a transient error, the driver will mark the server as “unknown” per the [SDAM](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst) spec.

From the SDAM rationale for “[Other transient errors](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#other-transient-errors)” :
>There are other transient errors a server may return, e.g. retryable errors listed in the retryable writes spec. SDAM does not consider these because they do not imply the connected server should be marked as “Unknown”.

- [x] Update changelog.
~~- [ ] Make sure there are generated JSON files from the YAML test files.~~
~~- [ ] Test changes in at least one language driver.~~
~~- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

