### PR TITLE
DRIVERS-2668 Add SRV test with uppercase hostname

### DIFF
--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-uppercase-hostname.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-uppercase-hostname.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://TEST1.TEST.BUILD.10GEN.CC",
+  "seeds": [
+    "localhost.test.build.10gen.cc:27017",
+    "localhost.test.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "ssl": true
+  },
+  "ping": true
+}

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-uppercase-hostname.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/uri-with-uppercase-hostname.yml
@@ -1,0 +1,11 @@
+uri: "mongodb+srv://TEST1.TEST.BUILD.10GEN.CC"
+seeds:
+    - localhost.test.build.10gen.cc:27017
+    - localhost.test.build.10gen.cc:27018
+hosts:
+    - localhost:27017
+    - localhost:27018
+    - localhost:27019
+options:
+    ssl: true
+ping: true


### PR DESCRIPTION
[DRIVERS-2668](https://jira.mongodb.org/browse/DRIVERS-2668). Unfortunately, as noted in [DEVPROD-174](https://jira.mongodb.org/browse/DEVPROD-174), it's not possible to add the exact test case I envisioned for DRIVERS-2668 (where DNS returns uppercase letters in the SRV result). However we can still add this related test case with uppercase letters in the initial SRV hostname.


Please complete the following before merging:

- [X] Make sure there are generated JSON files from the YAML test files.
- [X] Test changes in at least one language driver. Python implementation here: https://github.com/mongodb/mongo-python-driver/pull/1423
- [X] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).
