### PR TITLE
DRIVERS-2770 Add connection string tests for uppercase UNIX socket names

### DIFF
--- a/source/connection-string/tests/valid-unix_socket-absolute.json
+++ b/source/connection-string/tests/valid-unix_socket-absolute.json
@@ -31,6 +31,21 @@
       "options": null
     },
     {
+      "description": "Unix domain socket (mixed case)",
+      "uri": "mongodb://%2Ftmp%2FMongoDB-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/MongoDB-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
       "description": "Unix domain socket (absolute path with spaces in path)",
       "uri": "mongodb://%2Ftmp%2F %2Fmongodb-27017.sock",
       "valid": true,

--- a/source/connection-string/tests/valid-unix_socket-absolute.yml
+++ b/source/connection-string/tests/valid-unix_socket-absolute.yml
@@ -24,6 +24,18 @@ tests:
         auth: ~
         options: ~
     -
+        description: "Unix domain socket (mixed case)"
+        uri: "mongodb://%2Ftmp%2FMongoDB-27017.sock"
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: "unix"
+                host: "/tmp/MongoDB-27017.sock"
+                port: ~
+        auth: ~
+        options: ~
+    -
         description: "Unix domain socket (absolute path with spaces in path)"
         uri: "mongodb://%2Ftmp%2F %2Fmongodb-27017.sock"
         valid: true

--- a/source/connection-string/tests/valid-unix_socket-relative.json
+++ b/source/connection-string/tests/valid-unix_socket-relative.json
@@ -31,6 +31,21 @@
       "options": null
     },
     {
+      "description": "Unix domain socket (mixed case)",
+      "uri": "mongodb://rel%2FMongoDB-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/MongoDB-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
       "description": "Unix domain socket (relative path with spaces)",
       "uri": "mongodb://rel%2F %2Fmongodb-27017.sock",
       "valid": true,

--- a/source/connection-string/tests/valid-unix_socket-relative.yml
+++ b/source/connection-string/tests/valid-unix_socket-relative.yml
@@ -24,6 +24,18 @@ tests:
         auth: ~
         options: ~
     -
+        description: "Unix domain socket (mixed case)"
+        uri: "mongodb://rel%2FMongoDB-27017.sock"
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: "unix"
+                host: "rel/MongoDB-27017.sock"
+                port: ~
+        auth: ~
+        options: ~
+    -
         description: "Unix domain socket (relative path with spaces)"
         uri: "mongodb://rel%2F %2Fmongodb-27017.sock"
         valid: true


### PR DESCRIPTION
DRIVERS-2770 UNIX socket names should be case-sensitive.

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

