### PR TITLE
DRIVERS-2170 Server info on retryable errors must reflect the originating server

### DIFF
--- a/source/retryable-reads/retryable-reads.rst
+++ b/source/retryable-reads/retryable-reads.rst
@@ -331,6 +331,13 @@ other error originating from the server, that error should be raised instead as
 the caller can infer that an attempt was made and the second error is likely
 more relevant (with respect to the current topology state).
 
+If a driver associates server information (e.g. the server address or
+description) with an error, the driver MUST ensure the server information
+reported with that error corresponds to the server that was selected when the
+error occurred. Specifically, if a retry attempt fails, the server reported
+with the error MUST correspond to the server that was selected for the retry
+and MUST NOT simply be carried over from the original error.
+
 4. Implementation constraints
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/retryable-reads/retryable-reads.rst
+++ b/source/retryable-reads/retryable-reads.rst
@@ -712,6 +712,9 @@ degraded performance can simply disable ``retryableReads``.
 Changelog
 =========
 
+:2023-12-05: Add that any server information associated with retryable
+             exceptions MUST reflect the originating server, even in the
+             presence of retries.
 :2023-11-30: Add ReadConcernMajorityNotAvailableYet to the list of error codes
              that should be retried.
 :2023-11-28: Add ExceededTimeLimit to the list of error codes that should

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -845,6 +845,9 @@ inconsistent with the server and potentially confusing to developers.
 Changelog
 =========
 
+:2023-12-05: Add that any server information associated with retryable
+             exceptions MUST reflect the originating server, even in the
+             presence of retries.
 :2023-10-02: When CSOT is not enabled, one retry attempt occurs.
 :2023-08-26: Require that in a sharded cluster the server on which the
              operation failed MUST be provided to the server selection

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -411,6 +411,13 @@ from the driver) or the error is labeled "NoWritesPerformed", the error from
 the previous attempt should be raised. If all server errors are labeled
 "NoWritesPerformed", then the first error should be raised.
 
+If a driver associates server information (e.g. the server address or
+description) with an error, the driver MUST ensure the server information
+reported with that error corresponds to the server that was selected when the
+error occurred. Specifically, if a retry attempt fails, the server reported
+with the error MUST correspond to the server that was selected for the retry
+and MUST NOT simply be carried over from the original error.
+
 The above rules are implemented in the following pseudo-code:
 
 .. code-block:: typescript


### PR DESCRIPTION
Some drivers (e.g. Ruby) attach server information to certain errors for diagnostic purposes. This PR updates the language in the retryable reads and writes specifications to require that these drivers ensure that the server information that is associated with an exception reflects the server that actually originated the exception, even in the presence of one more more retries.
