### PR TITLE
DRIVERS-2799: Use more permissive top-level runOnRequirements

### DIFF
--- a/source/retryable-writes/tests/unified/bulkWrite-serverErrors.json
+++ b/source/retryable-writes/tests/unified/bulkWrite-serverErrors.json
@@ -3,9 +3,15 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
-      "minServerVersion": "3.6",
+      "minServerVersion": "4.0",
       "topologies": [
         "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
       ]
     }
   ],
@@ -53,20 +59,6 @@
   "tests": [
     {
       "description": "BulkWrite succeeds after retryable writeConcernError in first batch",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.0",
-          "topologies": [
-            "replicaset"
-          ]
-        },
-        {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "sharded"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/retryable-writes/tests/unified/bulkWrite-serverErrors.yml
+++ b/source/retryable-writes/tests/unified/bulkWrite-serverErrors.yml
@@ -3,8 +3,10 @@ description: "retryable-writes bulkWrite serverErrors"
 schemaVersion: "1.0"
 
 runOnRequirements:
-  - minServerVersion: "3.6"
+  - minServerVersion: "4.0"
     topologies: [ replicaset ]
+  - minServerVersion: "4.1.7"
+    topologies: [ sharded ]
 
 createEntities:
   - client:
@@ -29,11 +31,6 @@ initialData:
 
 tests:
   - description: "BulkWrite succeeds after retryable writeConcernError in first batch"
-    runOnRequirements:
-      - minServerVersion: "4.0"
-        topologies: [ replicaset ]
-      - minServerVersion: "4.1.7"
-        topologies: [ sharded ]
     operations:
       - name: failPoint
         object: testRunner

--- a/source/retryable-writes/tests/unified/insertOne-serverErrors.json
+++ b/source/retryable-writes/tests/unified/insertOne-serverErrors.json
@@ -3,9 +3,15 @@
   "schemaVersion": "1.0",
   "runOnRequirements": [
     {
-      "minServerVersion": "3.6",
+      "minServerVersion": "4.0",
       "topologies": [
         "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.7",
+      "topologies": [
+        "sharded"
       ]
     }
   ],
@@ -53,20 +59,6 @@
   "tests": [
     {
       "description": "InsertOne succeeds after retryable writeConcernError",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.0",
-          "topologies": [
-            "replicaset"
-          ]
-        },
-        {
-          "minServerVersion": "4.1.7",
-          "topologies": [
-            "sharded"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/retryable-writes/tests/unified/insertOne-serverErrors.yml
+++ b/source/retryable-writes/tests/unified/insertOne-serverErrors.yml
@@ -3,8 +3,10 @@ description: "retryable-writes insertOne serverErrors"
 schemaVersion: "1.0"
 
 runOnRequirements:
-  - minServerVersion: "3.6"
+  - minServerVersion: "4.0"
     topologies: [ replicaset ]
+  - minServerVersion: "4.1.7"
+    topologies: [ sharded ]
 
 createEntities:
   - client:
@@ -29,11 +31,6 @@ initialData:
 
 tests:
   - description: "InsertOne succeeds after retryable writeConcernError"
-    runOnRequirements:
-      - minServerVersion: "4.0"
-        topologies: [ replicaset ]
-      - minServerVersion: "4.1.7"
-        topologies: [ sharded ]
     operations:
       - name: failPoint
         object: testRunner

--- a/source/unified-test-format/tests/valid-pass/poc-retryable-writes.json
+++ b/source/unified-test-format/tests/valid-pass/poc-retryable-writes.json
@@ -1,14 +1,6 @@
 {
   "description": "poc-retryable-writes",
   "schemaVersion": "1.0",
-  "runOnRequirements": [
-    {
-      "minServerVersion": "3.6",
-      "topologies": [
-        "replicaset"
-      ]
-    }
-  ],
   "createEntities": [
     {
       "client": {
@@ -79,6 +71,14 @@
   "tests": [
     {
       "description": "FindOneAndUpdate is committed on first attempt",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -132,6 +132,14 @@
     },
     {
       "description": "FindOneAndUpdate is not committed on first attempt",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -188,6 +196,14 @@
     },
     {
       "description": "FindOneAndUpdate is never committed",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "3.6",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/unified-test-format/tests/valid-pass/poc-retryable-writes.json
+++ b/source/unified-test-format/tests/valid-pass/poc-retryable-writes.json
@@ -449,6 +449,9 @@
                 "failCommands": [
                   "insert"
                 ],
+                "errorLabels": [
+                  "RetryableWriteError"
+                ],
                 "writeConcernError": {
                   "code": 91,
                   "errmsg": "Replication is being shut down"

--- a/source/unified-test-format/tests/valid-pass/poc-retryable-writes.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-retryable-writes.yml
@@ -2,10 +2,6 @@ description: "poc-retryable-writes"
 
 schemaVersion: "1.0"
 
-runOnRequirements:
-  - minServerVersion: "3.6"
-    topologies: [ replicaset ]
-
 createEntities:
   - client:
       id: &client0 client0
@@ -42,6 +38,9 @@ initialData:
 
 tests:
   - description: "FindOneAndUpdate is committed on first attempt"
+    runOnRequirements: &onPrimaryTransactionalWrite_requirements
+      - minServerVersion: "3.6"
+        topologies: [ replicaset ]
     operations:
       - name: failPoint
         object: testRunner
@@ -65,6 +64,7 @@ tests:
           - { _id: 2, x: 22 }
 
   - description: "FindOneAndUpdate is not committed on first attempt"
+    runOnRequirements: *onPrimaryTransactionalWrite_requirements
     operations:
       - name: failPoint
         object: testRunner
@@ -89,6 +89,7 @@ tests:
           - { _id: 2, x: 22 }
 
   - description: "FindOneAndUpdate is never committed"
+    runOnRequirements: *onPrimaryTransactionalWrite_requirements
     operations:
       - name: failPoint
         object: testRunner

--- a/source/unified-test-format/tests/valid-pass/poc-retryable-writes.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-retryable-writes.yml
@@ -191,6 +191,7 @@ tests:
             mode: { times: 2 }
             data:
               failCommands: [ insert ]
+              errorLabels: [ RetryableWriteError ]
               writeConcernError:
                 code: 91 # ShutdownInProgress
                 errmsg: "Replication is being shut down"


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2799

This also fixes an outstanding inconsistency in one of the retryable writes POC tests for the unified test runner, which would otherwise start failing once [DRIVERS-1641](https://jira.mongodb.org/browse/DRIVERS-1641) is implemented.

PHPLIB POC: https://github.com/mongodb/mongo-php-library/pull/1210

----

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

