### PR TITLE
DRIVERS-2797 Check for substring in Index Management error asserts

### DIFF
--- a/source/index-management/tests/createSearchIndex.json
+++ b/source/index-management/tests/createSearchIndex.json
@@ -55,7 +55,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -102,7 +102,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/source/index-management/tests/createSearchIndex.yml
+++ b/source/index-management/tests/createSearchIndex.yml
@@ -30,8 +30,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:
@@ -50,8 +51,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:

--- a/source/index-management/tests/createSearchIndexes.json
+++ b/source/index-management/tests/createSearchIndexes.json
@@ -49,7 +49,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -89,7 +89,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -138,7 +138,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/source/index-management/tests/createSearchIndexes.yml
+++ b/source/index-management/tests/createSearchIndexes.yml
@@ -30,8 +30,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:
@@ -51,8 +52,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:
@@ -71,8 +73,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:

--- a/source/index-management/tests/dropSearchIndex.json
+++ b/source/index-management/tests/dropSearchIndex.json
@@ -49,7 +49,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/source/index-management/tests/dropSearchIndex.yml
+++ b/source/index-management/tests/dropSearchIndex.yml
@@ -30,8 +30,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:

--- a/source/index-management/tests/listSearchIndexes.json
+++ b/source/index-management/tests/listSearchIndexes.json
@@ -46,7 +46,7 @@
           "object": "collection0",
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -81,7 +81,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -122,7 +122,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/source/index-management/tests/listSearchIndexes.yml
+++ b/source/index-management/tests/listSearchIndexes.yml
@@ -28,8 +28,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:
@@ -48,8 +49,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:
@@ -71,8 +73,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:

--- a/source/index-management/tests/searchIndexIgnoresReadWriteConcern.json
+++ b/source/index-management/tests/searchIndexIgnoresReadWriteConcern.json
@@ -59,7 +59,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -105,7 +105,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -143,7 +143,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -178,7 +178,7 @@
           "object": "collection0",
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],
@@ -220,7 +220,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/source/index-management/tests/searchIndexIgnoresReadWriteConcern.yml
+++ b/source/index-management/tests/searchIndexIgnoresReadWriteConcern.yml
@@ -34,8 +34,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:
@@ -57,8 +58,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:
@@ -80,8 +82,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:
@@ -101,8 +104,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:
@@ -125,8 +129,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:

--- a/source/index-management/tests/updateSearchIndex.json
+++ b/source/index-management/tests/updateSearchIndex.json
@@ -50,7 +50,7 @@
           },
           "expectError": {
             "isError": true,
-            "errorContains": "Search index commands are only supported with Atlas"
+            "errorContains": "Atlas"
           }
         }
       ],

--- a/source/index-management/tests/updateSearchIndex.yml
+++ b/source/index-management/tests/updateSearchIndex.yml
@@ -31,8 +31,9 @@ tests:
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
           isError: true
-          errorContains: Search index commands are only supported with Atlas
+          errorContains: Atlas
     expectEvents:
       - client: *client0
         events:


### PR DESCRIPTION
# Summary

Check for substring in Index Management error asserts

# Background & Motivation

Atlas Search Index specification tests expect an error returned from a non-Atlas server. [Example](https://github.com/mongodb/specifications/blob/0b47194538aa817978fae0f77f684f6d5e62ebab/source/index-management/tests/createSearchIndex.yml#L34):

```yml
        expectError:
          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
          # that the driver constructs and sends the correct command.
          isError: true
          errorContains: Search index commands are only supported with Atlas
```


SERVER-83290 changed the error message from:

> Search index commands are only supported with Atlas

to: 

> Using Atlas Search Database Commands and the $listSearchIndexes aggregation stage requires additional configuration. Please connect to Atlas or an AtlasCLI local deployment to enable. For more information on how to connect, see https://dochub.mongodb.org/core/atlas-cli-deploy-local-reqs

The message change causes this test to fail in driver tests with latest server builds.

This PR proposes using "Atlas" as a common substring in both errors.

Updated tests were verified in C driver:
https://spruce.mongodb.com/version/6581c5d12a60ed6df70bbe25

---

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ N/A.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested in [C](https://spruce.mongodb.com/version/6581c5d12a60ed6df70bbe25)**
- ~~[] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).~~ **Tested with replica set and sharded cluster. Tests are not run in C driver load balancer tasks**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

