### PR TITLE
DRIVERS-1641: pre-4.4 mongos writeConcernError does not determine retryability

### DIFF
--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -861,7 +861,7 @@ inconsistent with the server and potentially confusing to developers.
 Changelog
 =========
 
-:2024-01-02: Do not use ``writeConcernError.code`` in pre-4.4 mongos response to
+:2024-01-16: Do not use ``writeConcernError.code`` in pre-4.4 mongos response to
              determine retryability. Do not use ``writeErrors[].code`` in
              pre-4.4 server responses to determine retryability.
 :2023-12-06: Clarify that writes are not retried within transactions.

--- a/source/retryable-writes/retryable-writes.rst
+++ b/source/retryable-writes/retryable-writes.rst
@@ -252,7 +252,8 @@ The RetryableWriteError label might be added to an error in a variety of ways:
   errors that meet the following criteria if the retryWrites option is set to
   true on the client performing the relevant operation:
 
-  - a server error response with any the following codes:
+  - a mongod or mongos response with any the following error codes in the
+    top-level ``code`` field:
 
     .. list-table::
       :header-rows: 1
@@ -284,8 +285,14 @@ The RetryableWriteError label might be added to an error in a variety of ways:
       * - ExceededTimeLimit
         - 262
 
-  - a server response with a write concern error response containing any of the
-    previously listed codes
+  - a mongod response with any of the previously listed codes in the
+    ``writeConcernError.code`` field.
+
+  Drivers MUST NOT add a RetryableWriteError label based on the following:
+
+  - any ``writeErrors[].code`` fields in a mongod or mongos response
+
+  - the ``writeConcernError.code`` field in a mongos response
 
   The criteria for retryable errors is similar to the discussion in the SDAM
   spec's section on `Error Handling`_, but includes additional error codes. See
@@ -854,6 +861,9 @@ inconsistent with the server and potentially confusing to developers.
 Changelog
 =========
 
+:2024-01-02: Do not use ``writeConcernError.code`` in pre-4.4 mongos response to
+             determine retryability. Do not use ``writeErrors[].code`` in
+             pre-4.4 server responses to determine retryability.
 :2023-12-06: Clarify that writes are not retried within transactions.
 :2023-12-05: Add that any server information associated with retryable
              exceptions MUST reflect the originating server, even in the

--- a/source/retryable-writes/tests/unified/insertOne-serverErrors.json
+++ b/source/retryable-writes/tests/unified/insertOne-serverErrors.json
@@ -165,6 +165,309 @@
           ]
         }
       ]
+    },
+    {
+      "description": "RetryableWriteError label is added based on top-level code in pre-4.4 server response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "replicaset",
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "errorCode": 189
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "RetryableWriteError label is added based on writeConcernError in pre-4.4 mongod response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "replicaset"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 2
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsContain": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "RetryableWriteError label is not added based on writeConcernError in pre-4.4 mongos response",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2",
+          "maxServerVersion": "4.2.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client0",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "insert"
+                ],
+                "writeConcernError": {
+                  "code": 91,
+                  "errmsg": "Replication is being shut down"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 3,
+              "x": 33
+            }
+          },
+          "expectError": {
+            "errorLabelsOmit": [
+              "RetryableWriteError"
+            ]
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 3,
+                      "x": 33
+                    }
+                  ]
+                },
+                "commandName": "insert",
+                "databaseName": "retryable-writes-tests"
+              }
+            }
+          ]
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "coll",
+          "databaseName": "retryable-writes-tests",
+          "documents": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": 2,
+              "x": 22
+            },
+            {
+              "_id": 3,
+              "x": 33
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/source/retryable-writes/tests/unified/insertOne-serverErrors.yml
+++ b/source/retryable-writes/tests/unified/insertOne-serverErrors.yml
@@ -75,3 +75,123 @@ tests:
           - { _id: 1, x: 11 }
           - { _id: 2, x: 22 }
           - { _id: 3, x: 33 }  # The write was still applied
+
+  - description: "RetryableWriteError label is added based on top-level code in pre-4.4 server response"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.2.99"
+        topologies: [ replicaset, sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            # Trigger the fail point twice to allow asserting the error label in
+            # the retry attempt's response.
+            mode: { times: 2 }
+            data:
+              failCommands: [ "insert" ]
+              errorCode: 189 # PrimarySteppedDown
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          errorLabelsContain: [ "RetryableWriteError" ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: &insertCommandStartedEvent
+              command:
+                insert: *collectionName
+                documents: [{ _id: 3, x: 33 }]
+              commandName: insert
+              databaseName: *databaseName
+          - commandStartedEvent: *insertCommandStartedEvent
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+
+  - description: "RetryableWriteError label is added based on writeConcernError in pre-4.4 mongod response"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.2.99"
+        topologies: [ replicaset ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            # Trigger the fail point twice to allow asserting the error label in
+            # the retry attempt's response.
+            mode: { times: 2 }
+            data:
+              failCommands: [ "insert" ]
+              writeConcernError:
+                code: 91 # ShutdownInProgress
+                errmsg: "Replication is being shut down"
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          errorLabelsContain: [ "RetryableWriteError" ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: *insertCommandStartedEvent
+          - commandStartedEvent: *insertCommandStartedEvent
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          # writeConcernError doesn't prevent the server from applying the write
+          - { _id: 3, x: 33 }
+
+  - description: "RetryableWriteError label is not added based on writeConcernError in pre-4.4 mongos response"
+    runOnRequirements:
+      - minServerVersion: "4.2"
+        maxServerVersion: "4.2.99"
+        topologies: [ sharded ]
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *client0
+          failPoint:
+            configureFailPoint: failCommand
+            # Trigger the fail point only once since a RetryableWriteError label
+            # will not be added and the write will not be retried.
+            mode: { times: 1 }
+            data:
+              failCommands: [ "insert" ]
+              writeConcernError:
+                code: 91 # ShutdownInProgress
+                errmsg: "Replication is being shut down"
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 3, x: 33 }
+        expectError:
+          errorLabelsOmit: [ "RetryableWriteError" ]
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent: *insertCommandStartedEvent
+    outcome:
+      - collectionName: *collectionName
+        databaseName: *databaseName
+        documents:
+          - { _id: 1, x: 11 }
+          - { _id: 2, x: 22 }
+          # writeConcernError doesn't prevent the server from applying the write
+          - { _id: 3, x: 33 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-1641

Also clarify that pre-4.4 writeErrors[].code should never be used to determine retryability. This is intentionally untested because failCommand does not provide a way to mock writeErrors.

POC: https://github.com/mongodb/mongo-c-driver/pull/1501

Patch build: https://spruce.mongodb.com/version/65a19aa461837db75d4d8efe/tasks (4.2-replica-auth and 4.2-sharded-auth are the relevant tasks).

----

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

