### PR TITLE
Fix wrong test description

### DIFF
--- a/source/index-management/tests/searchIndexIgnoresReadWriteConcern.json
+++ b/source/index-management/tests/searchIndexIgnoresReadWriteConcern.json
@@ -95,7 +95,7 @@
       ]
     },
     {
-      "description": "createSearchIndex ignores read and write concern",
+      "description": "createSearchIndexes ignores read and write concern",
       "operations": [
         {
           "name": "createSearchIndexes",

--- a/source/index-management/tests/searchIndexIgnoresReadWriteConcern.yml
+++ b/source/index-management/tests/searchIndexIgnoresReadWriteConcern.yml
@@ -49,11 +49,11 @@ tests:
                 writeConcern: { $$exists: false }
                 readConcern: { $$exists: false }
 
-  - description: "createSearchIndex ignores read and write concern"
+  - description: "createSearchIndexes ignores read and write concern"
     operations:
       - name: createSearchIndexes
         object: *collection0
-        arguments: 
+        arguments:
           models: []
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

This fixes a wrong test name in the Atlas Search Indexes tests. The duplicate description causes errors when running these tests on PHP. Drivers that don't encounter issues when running these tests don't need to sync them right away.