### PR TITLE
DRIVERS-2802: Fix insertedId expectations in insertOne-errorLabels

### DIFF
--- a/source/retryable-writes/tests/legacy/insertOne-errorLabels.json
+++ b/source/retryable-writes/tests/legacy/insertOne-errorLabels.json
@@ -116,7 +116,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -157,7 +157,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -198,7 +198,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -239,7 +239,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -280,7 +280,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -321,7 +321,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -362,7 +362,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -403,7 +403,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -444,7 +444,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -485,7 +485,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -526,7 +526,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -567,7 +567,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -610,7 +610,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -653,7 +653,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -696,7 +696,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [
@@ -739,7 +739,7 @@
       },
       "outcome": {
         "result": {
-          "insertedId": 3
+          "insertedId": 1
         },
         "collection": {
           "data": [

--- a/source/retryable-writes/tests/legacy/insertOne-errorLabels.yml
+++ b/source/retryable-writes/tests/legacy/insertOne-errorLabels.yml
@@ -58,7 +58,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -78,7 +78,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -98,7 +98,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -118,7 +118,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -138,7 +138,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -158,7 +158,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -178,7 +178,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -198,7 +198,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -218,7 +218,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -238,7 +238,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -258,7 +258,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -278,7 +278,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -299,7 +299,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -320,7 +320,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -341,7 +341,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }
@@ -362,7 +362,7 @@ tests:
               document: { _id: 1, x: 11 }
       outcome:
           result:
-              insertedId: 3
+              insertedId: 1
           collection:
               data:
                   - { _id: 1, x: 11 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2802

This corrects a mistake introduced in 5fc23f40f79d18f0693e7159eba81f0e7b276715 when these tests were originally moved from insertOne-serverErrors

This was missed in the POC for #1489 since libmongoc doesn't report inserted IDs (see: [json-test-operations.c](https://github.com/mongodb/mongo-c-driver/blob/1.25.4/src/libmongoc/tests/json-test-operations.c#L370)).

POC for this change: https://github.com/mongodb/mongo-php-library/pull/1214

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).