### PR TITLE
quote "arn" strings

### DIFF
--- a/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
+++ b/source/client-side-encryption/tests/unified/createDataKey-kms_providers-invalid.yml
@@ -58,7 +58,7 @@ tests:
           kmsProvider: aws
           opts:
             masterKey:
-              key: arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+              key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
               region: invalid
         expectError:
           isClientError: true

--- a/source/client-side-encryption/tests/unified/createDataKey.yml
+++ b/source/client-side-encryption/tests/unified/createDataKey.yml
@@ -44,7 +44,7 @@ tests:
           kmsProvider: aws
           opts:
             masterKey: &new_aws_masterkey
-              key: arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+              key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
               region: us-east-1
         expectResult: { $$type: binData }
     expectEvents:

--- a/source/client-side-encryption/tests/unified/deleteKey.yml
+++ b/source/client-side-encryption/tests/unified/deleteKey.yml
@@ -39,7 +39,7 @@ initialData:
         status: 1
         masterKey:
           provider: aws
-          key: arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+          key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
           region: us-east-1
       - &local_key_doc
         _id: &local_key_id { $binary: { base64: bG9jYWxrZXlsb2NhbGtleQ==, subType: "04" } }

--- a/source/client-side-encryption/tests/unified/getKey.yml
+++ b/source/client-side-encryption/tests/unified/getKey.yml
@@ -39,7 +39,7 @@ initialData:
         status: 1
         masterKey:
           provider: aws
-          key: arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+          key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
           region: us-east-1
       - &local_key_doc
         _id: &local_key_id { $binary: { base64: bG9jYWxrZXlsb2NhbGtleQ==, subType: "04" } }

--- a/source/client-side-encryption/tests/unified/getKeyByAltName.yml
+++ b/source/client-side-encryption/tests/unified/getKeyByAltName.yml
@@ -39,7 +39,7 @@ initialData:
         status: 1
         masterKey:
           provider: aws
-          key: arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+          key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
           region: us-east-1
       - &local_key_doc
         _id: { $binary: { base64: bG9jYWxrZXlsb2NhbGtleQ==, subType: "04" } }

--- a/source/client-side-encryption/tests/unified/rewrapManyDataKey-decrypt_failure.yml
+++ b/source/client-side-encryption/tests/unified/rewrapManyDataKey-decrypt_failure.yml
@@ -43,7 +43,7 @@ initialData:
         masterKey:
           provider: aws
           # "us-east-1" changed to "us-east-2" in both key and region.
-          key: arn:aws:kms:us-east-2:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+          key: "arn:aws:kms:us-east-2:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
           region: us-east-2
 
 tests:

--- a/source/client-side-encryption/tests/unified/rewrapManyDataKey-encrypt_failure.yml
+++ b/source/client-side-encryption/tests/unified/rewrapManyDataKey-encrypt_failure.yml
@@ -54,7 +54,7 @@ tests:
             provider: aws
             masterKey:
               # "us-east-1" changed to "us-east-2" in both key and region.
-              key: arn:aws:kms:us-east-2:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+              key: "arn:aws:kms:us-east-2:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
               region: us-east-2
         expectError:
           isClientError: true

--- a/source/client-side-encryption/tests/unified/rewrapManyDataKey.yml
+++ b/source/client-side-encryption/tests/unified/rewrapManyDataKey.yml
@@ -46,7 +46,7 @@ initialData:
         status: 1
         masterKey: &aws_masterkey
           provider: aws
-          key: arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+          key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
           region: us-east-1
       - _id: &azure_key_id { $binary: { base64: YXp1cmVhenVyZWF6dXJlYQ==, subType: "04" } }
         keyAltNames: ["azure_key"]
@@ -120,7 +120,7 @@ tests:
             provider: aws
             # Different key: 89fcc2c4-08b0-4bd9-9f25-e30687b580d0 -> 061334ae-07a8-4ceb-a813-8135540e837d.
             masterKey: &new_aws_masterkey
-              key: arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d
+              key: "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d"
               region: us-east-1
         expectResult:
           bulkWriteResult:


### PR DESCRIPTION
Intended to prevent YAML parsers from incorrectly parsing the colon as a key/value separator.

Requested in https://github.com/mongodb/specifications/pull/1492#discussion_r1456230649

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ Not applicable.
- [x] Make sure there are generated JSON files from the YAML test files.
- ~~[ ] Test changes in at least one language driver.~~ Not applicable.
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).~~ Not applicable.

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
