### PR TITLE
DRIVERS-2828 Update mongos redirection prose tests to workaround SDAM behavior

### DIFF
--- a/source/retryable-reads/tests/README.rst
+++ b/source/retryable-reads/tests/README.rst
@@ -238,71 +238,87 @@ Retrying Reads in a Sharded Cluster
 These tests will be used to ensure drivers properly retry reads on a different
 mongos.
 
-Retryable Reads Are Retried on a Different mongos if One is Available
----------------------------------------------------------------------
+Note: this test cannot reliably distinguish "retry on a different mongos due to
+server deprioritization" (the behavior intended to be tested) from "retry on a
+different mongos due to normal SDAM behavior of randomized suitable server
+selection". Verify relevant code paths are correctly executed by the tests using
+external means such as a logging, debugger, code coverage tool, etc.
+
+Retryable Reads Are Retried on a Different mongos When One is Available
+-----------------------------------------------------------------------
 
 This test MUST be executed against a sharded cluster that has at least two
-mongos instances.
+mongos instances, supports ``retryReads=true``, and has enabled the
+``configureFailPoint`` command (MongoDB 4.2+).
 
-1. Ensure that a test is run against a sharded cluster that has at least two
-   mongoses. If there are more than two mongoses in the cluster, pick two to
-   test against.
+1. Create two clients ``s0`` and ``s1`` that each connect to a single mongos
+   from the sharded cluster. They must not connect to the same mongos.
 
-2. Create a client per mongos using the direct connection, and configure the
-   following fail points on each mongos::
-
-     {
-         configureFailPoint: "failCommand",
-         mode: { times: 1 },
-         data: {
-             failCommands: ["find"],
-             errorCode: 6,
-             closeConnection: true
-         }
-     }
-
-3. Create a client with ``retryReads=true`` that connects to the cluster,
-   providing the two selected mongoses as seeds.
-
-4. Enable command monitoring, and execute a ``find`` command that is
-   supposed to fail on both mongoses.
-
-5. Asserts that there were failed command events from each mongos.
-
-6. Disable the fail points.
-
-
-Retryable Reads Are Retried on the Same mongos if No Others are Available
--------------------------------------------------------------------------
-
-1. Ensure that a test is run against a sharded cluster. If there are multiple
-   mongoses in the cluster, pick one to test against.
-
-2. Create a client that connects to the mongos using the direct connection,
-   and configure the following fail point on the mongos::
+2. Configure the following fail point for both ``s0`` and ``s1``::
 
      {
          configureFailPoint: "failCommand",
          mode: { times: 1 },
          data: {
              failCommands: ["find"],
-             errorCode: 6,
-             closeConnection: true
+             errorCode: 6
          }
      }
 
-3. Create a client with ``retryReads=true`` that connects to the cluster,
-   providing the selected mongos as the seed.
+3. Create a client ``client`` with ``retryReads=true`` that connects to the
+   cluster with both mongoses used by ``s0`` and ``s1`` in the initial seed
+   list.
 
-4. Enable command monitoring, and execute a ``find`` command.
+4. Enable failed command event monitoring for ``client``.
 
-5. Asserts that there was a failed command and a successful command event.
+5. Execute a ``find`` command with ``client``. Assert that the command failed.
 
-6. Disable the fail point.
+6. Assert that two failed command events occurred. Assert that both events
+   occurred on different mongoses.
+
+7. Disable the fail point on both ``s0`` and ``s1``.
+
+
+Retryable Reads Are Retried on the Same mongos When No Others are Available
+---------------------------------------------------------------------------
+
+This test MUST be executed against a sharded cluster that supports
+``retryReads=true`` and has enabled the ``configureFailPoint`` command 
+(MongoDB 4.2+).
+
+1. Create a client ``s0`` that connects to a single mongos from the cluster.
+
+2. Configure the following fail point for ``s0``::
+
+     {
+         configureFailPoint: "failCommand",
+         mode: { times: 1 },
+         data: {
+             failCommands: ["find"],
+             errorCode: 6
+         }
+     }
+
+3. Create a client ``client`` with ``directConnection=false`` (when not set by
+   default) and ``retryReads=true`` that connects to the cluster using the same
+   single mongos as ``s0``.
+
+4. Enable succeeded and failed command event monitoring for ``client``.
+
+4. Execute a ``find`` command with ``client``. Assert that the command
+   succeeded.
+
+5. Assert that exactly one failed command event and one succeeded command event
+   occurred. Assert that both events occurred on the same mongos.
+
+6. Disable the fail point on ``s0``.
 
 
 Changelog
 =========
+
+:2024-02-06: Update mongos redirection prose tests to workaround SDAM behavior
+             preventing execution of deprioritization code paths.
 
 :2023-08-26 Add prose tests for retrying in a sharded cluster.
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. (CDRIVER-4099)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

## Description

This PR proposes changes to the mongos redirection prose tests introduced in DRIVERS-2828 to workaround SDAM behavior preventing execution of server deprioritization code paths.

## SDAM Network Error Handling

SDAM error handling behavior labels a server as Unknown [when a post-handshake non-timeout network error occurs](https://github.com/mongodb/specifications/blob/3b8e7e4135f2615fedef1ea6cd2046f5be5a1725/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#L1443). This makes the server ineligible during server selection during the retry operation before the "on other mongos" prose tests have a chance to deprioritize the intended server (only one suitable server). This appears to be caused by the `closeConnection: true` field in the configured fail points. Therefore, this PR proposes their removal.

## Randomized Server Selection

Normal SDAM behavior randomly selects a server from the list of suitable servers. Consequently, the "on other mongos" prose tests cannot distinguish that a different mongos was used during the retry operation due to deprioritization (the behavior intended to be tested) from lucky randomized server selection. A note is added to the prose tests encouraging Drivers to manually inspect and ensure the deprioritization code paths are being executed by the prose tests as intended.

If Drivers have an alternative means of verifying that deprioritization code paths were executed, such as capturing debug/trace log output, they can do so, but this is not noted in the proposed PR due to falling outside the spec. This can be included in the note as an encouragement to Drivers if preferred, but I believe it unnecessary.

## Initial TopologyType

There is variation among Drivers w.r.t. how they handle the [directConnection](https://github.com/mongodb/specifications/blob/3b8e7e4135f2615fedef1ea6cd2046f5be5a1725/source/server-discovery-and-monitoring/server-discovery-and-monitoring.rst#L400) URI option. Many Drivers appear to use `directConnection=true` by default, which means, given only a single host in the initial seed list, many Drivers will consider the topology of a single mongos connection to be Single rather than Sharded. Server deprioritization is only applicable for Sharded topologies. Therefore, the "on same mongos" prose test is likely not executing deprioritization code paths on many Drivers as currently written. Therefore, this PR adds the requirement that `directConnection=false` be included in the URI options when it not the default.