### PR TITLE
DRIVERS-2835 Increase interruptInUseConnections timeout to fix flaky test

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.json
@@ -17,7 +17,7 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 1000
+      "blockTimeMS": 10000
     }
   },
   "poolOptions": {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.yml
@@ -11,7 +11,7 @@ failPoint:
     failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
-    blockTimeMS: 1000
+    blockTimeMS: 10000
 poolOptions:
   minPoolSize: 0
 operations:


### PR DESCRIPTION
DRIVERS-2835. Testing in python here: https://github.com/mongodb/mongo-python-driver/pull/1528
