### PR TITLE
DRIVERS-2816: Gossip cluster time from internal MongoClient to session entities

### DIFF
--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -2941,8 +2941,8 @@ command to create the collection with the specified options. The test runner MUS
 topology is sharded, the test runner SHOULD use a single mongos for handling [initialData](#initialData) to avoid
 possible runtime errors.
 
-If the test might execute a sharded transaction, the test runner MUST collect the latest cluster time from processing
-[initialData](#initialData). See
+If the test might execute a transaction against a sharded deployment, the test runner MUST collect the latest cluster
+time from processing [initialData](#initialData). See
 [MigrationConflict Errors on Sharded Clusters](#migrationconflict-errors-on-sharded-clusters) for more information.
 
 Create a new [Entity Map](#entity-map) that will be used for this test. If [createEntities](#createentities) is
@@ -2951,8 +2951,9 @@ sharded cluster, the test runner MUST handle [useMultipleMongoses](<>) according
 entities. If the topology type is `LoadBalanced`, client entities MUST be initialized with the appropriate load balancer
 connection string as discussed in [useMultipleMongoses](<>).
 
-If the test might execute a sharded transaction, the test runner MUST advance the cluster time of any session entities
-created during the test using the cluster time collected from processing [initialData](#initialData). See
+If the test might execute a transaction against a sharded deployment, the test runner MUST advance the cluster time of
+any session entities created during the test using the cluster time collected from processing
+[initialData](#initialData). See
 [MigrationConflict Errors on Sharded Clusters](#migrationconflict-errors-on-sharded-clusters) for more information.
 
 If the test might execute a `distinct` command within a sharded transaction, for each target collection the test runner
@@ -3122,7 +3123,7 @@ Depending on the test runner implementation, the cluster time may be collected i
 - Execute all operations for [initialData](#initialData) using an explicit session and read its cluster time after the
   last operation.
 
-This logic is only necessary for tests that might execute a sharded transaction (i.e.
+This logic is only necessary for tests that might execute a transaction against a sharded deployment transaction (i.e.
 [test.operations](#test_operations) includes `startTransaction` or `withTransaction` and the topology is sharded or
 load-balanced). To ease the implementation, test runners MAY apply this logic to *every* test.
 

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -3111,15 +3111,15 @@ Transaction fe0b9a7d-4b64-4e38-aad2-4c7dd5ab0c2b - 47DEQpj8HBSa+/TImW+5JCeuQeRkm
 ```
 
 To work around this issue, a test runner MUST collect the latest cluster time from processing
-[initialData](#initialData), which is executed using the internal MongoClient, and use it to advance the cluster time
-of every session entity created during the test, by either [createEntities](#createentities) or the
+[initialData](#initialData), which is executed using the internal MongoClient, and use it to advance the cluster time of
+every session entity created during the test, by either [createEntities](#createentities) or the
 [special test operation](#operation_createEntities)). This will ensure that the cluster time is gossipped to any other
 mongo hosts that may be used to execute a transaction during the test.
 
 Depending on the test runner implementation, the cluster time may be collected in various ways. For example:
 
-- Execute a `ping` command against the same mongos host used for [initialData](#initialData) and read the
-  `$clusterTime` response field
+- Execute a `ping` command against the same mongos host used for [initialData](#initialData) and read the `$clusterTime`
+  response field
 - Execute all operations for [initialData](#initialData) using an explicit session and read its cluster time after the
   last operation.
 

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -3353,7 +3353,7 @@ other specs *and* collating spec changes developed in parallel or during the sam
 
 ## Changelog
 
-- 2024-02-21: Require test runners to gossip cluster time from internal MongoClient to each session entity.
+- 2024-02-23: Require test runners to gossip cluster time from internal MongoClient to each session entity.
 
 - 2024-02-14: Clarify that errors raised from callback operations should always propagate to `withTransaction`.
 

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -2937,11 +2937,11 @@ runner MUST first drop the collection. If a `createOptions` document is present,
 command to create the collection with the specified options. The test runner MUST then insert the specified documents
 (if any). If no documents are present and `createOptions` is not set, the test runner MUST create the collection. If the
 topology is sharded, the test runner SHOULD use a single mongos for handling [initialData](#initialData) to avoid
-possible runtime errors. 
+possible runtime errors.
 
-After dropping, creating and populating initial data for all collections, the test runner MUST get the latest cluster time 
-from the internal MongoClient and store it for later use when creating session entities. A simple way to get the latest 
-cluster time is to execute a `ping` command and get the value of the `$clusterTime` field in the reply.
+After dropping, creating and populating initial data for all collections, the test runner MUST get the latest cluster
+time from the internal MongoClient and store it for later use when creating session entities. A simple way to get the
+latest cluster time is to execute a `ping` command and get the value of the `$clusterTime` field in the reply.
 
 Create a new [Entity Map](#entity-map) that will be used for this test. If [createEntities](#createentities) is
 specified, the test runner MUST create each [entity](#entity) accordingly and add it to the map. If the topology is a
@@ -2949,8 +2949,8 @@ sharded cluster, the test runner MUST handle [useMultipleMongoses](<>) according
 entities. If the topology type is `LoadBalanced`, client entities MUST be initialized with the appropriate load balancer
 connection string as discussed in [useMultipleMongoses](<>).
 
-For each session entity, advance the cluster time of the `ClientSession` to the latest cluster time (recorded earlier after 
-populating initial data)
+For each session entity, advance the cluster time of the `ClientSession` to the latest cluster time (recorded earlier
+after populating initial data)
 
 If the test might execute a `distinct` command within a sharded transaction, for each target collection the test runner
 SHOULD execute a non-transactional `distinct` command on each mongos server using an internal MongoClient. See

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -3110,14 +3110,14 @@ Transaction fe0b9a7d-4b64-4e38-aad2-4c7dd5ab0c2b - 47DEQpj8HBSa+/TImW+5JCeuQeRkm
 ```
 
 To work around this issue, a test runner MUST collect the latest cluster time from processing
-[initialData](#initialData), which is executed using the internal MongoClient, and use it to advance the cluster of time
+[initialData](#initialData), which is executed using the internal MongoClient, and use it to advance the cluster time
 of every session entity created during the test, by either [createEntities](#createentities) or the
 [special test operation](#operation_createEntities)). This will ensure that the cluster time is gossipped to any other
 mongo hosts that may be used to execute a transaction during the test.
 
 Depending on the test runner implementation, the cluster time may be collected in various ways. For example:
 
-- Executing a `ping` command against the same mongos host used for [initialData](#initialData) and read the
+- Execute a `ping` command against the same mongos host used for [initialData](#initialData) and read the
   `$clusterTime` response field
 - Execute all operations for [initialData](#initialData) using an explicit session and read its cluster time after the
   last operation.

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -2937,13 +2937,20 @@ runner MUST first drop the collection. If a `createOptions` document is present,
 command to create the collection with the specified options. The test runner MUST then insert the specified documents
 (if any). If no documents are present and `createOptions` is not set, the test runner MUST create the collection. If the
 topology is sharded, the test runner SHOULD use a single mongos for handling [initialData](#initialData) to avoid
-possible runtime errors.
+possible runtime errors. 
+
+After dropping, creating and populating initial data for all collections, the test runner MUST get the latest cluster time 
+from the internal MongoClient and store it for later use when creating session entities. A simple way to get the latest 
+cluster time is to execute a `ping` commmand and get the value of the `$clusterTime` field in the reply.
 
 Create a new [Entity Map](#entity-map) that will be used for this test. If [createEntities](#createentities) is
 specified, the test runner MUST create each [entity](#entity) accordingly and add it to the map. If the topology is a
 sharded cluster, the test runner MUST handle [useMultipleMongoses](<>) accordingly if it is specified for any client
 entities. If the topology type is `LoadBalanced`, client entities MUST be initialized with the appropriate load balancer
 connection string as discussed in [useMultipleMongoses](<>).
+
+For each session entity, advance the cluster time of the `ClientSession` to the latest cluster time (recorded earlier after 
+populating initial data)
 
 If the test might execute a `distinct` command within a sharded transaction, for each target collection the test runner
 SHOULD execute a non-transactional `distinct` command on each mongos server using an internal MongoClient. See
@@ -3315,6 +3322,8 @@ operations and arguments. This is a concession until such time that better proce
 other specs *and* collating spec changes developed in parallel or during the same release cycle.
 
 ## Changelog
+
+- 2024-02-21: Require test runners to gossip cluster time from internal MongoClient to each session entity.
 
 - 2024-02-14: Clarify that errors raised from callback operations should always propagate to `withTransaction`.
 

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -2941,7 +2941,7 @@ possible runtime errors.
 
 After dropping, creating and populating initial data for all collections, the test runner MUST get the latest cluster time 
 from the internal MongoClient and store it for later use when creating session entities. A simple way to get the latest 
-cluster time is to execute a `ping` commmand and get the value of the `$clusterTime` field in the reply.
+cluster time is to execute a `ping` command and get the value of the `$clusterTime` field in the reply.
 
 Create a new [Entity Map](#entity-map) that will be used for this test. If [createEntities](#createentities) is
 specified, the test runner MUST create each [entity](#entity) accordingly and add it to the map. If the topology is a


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [N/A] Make sure there are generated JSON files from the YAML test files.
- [N/A] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

Based on discussions in DRIVERS-2816 this change should be sufficient.
