### PR TITLE
DRIVERS-2768 [Vector Search GA] Add support for types in search index creation

### DIFF
--- a/source/index-management/index-management.md
+++ b/source/index-management/index-management.md
@@ -666,15 +666,6 @@ interface IndexOptions {
   name: String;
   
   /**
-   * Optionally specify a type for the index. Defaults to "search" if not provided.
-   * Either "search" for regular search indexes or "vectorSearch" for vector search indexes.
-   *
-   * Note that to create a vector search index using a helper method, the type "vectorSearch" must be provided.
-   *
-   */
-  type: String;
-
-  /**
    * Optionally tells the index to only reference documents with the specified field in
    * the index.
    */
@@ -912,6 +903,9 @@ interface SearchIndexModel {
 
   // The name for this index, if present.
   name: Optional<string>;
+     
+  // The type for this index, if present. Can be either "search" or "vectorSearch", defaulting to "search".  
+  type: Optional<string>;
 }
 
 interface SearchIndexOptions {

--- a/source/index-management/index-management.md
+++ b/source/index-management/index-management.md
@@ -664,6 +664,15 @@ interface IndexOptions {
    * @example For an index of name: 1, age: -1, the generated name would be "name_1_age_-1".
    */
   name: String;
+  
+  /**
+   * Optionally specify a type for the index. Defaults to "search" if not provided.
+   * Either "search" for regular search indexes or "vectorSearch" for vector search indexes.
+   *
+   * Note that to create a vector search index using a helper method, the type "vectorSearch" must be provided.
+   *
+   */
+  type: String;
 
   /**
    * Optionally tells the index to only reference documents with the specified field in

--- a/source/index-management/index-management.md
+++ b/source/index-management/index-management.md
@@ -904,7 +904,7 @@ interface SearchIndexModel {
   // The name for this index, if present.
   name: Optional<string>;
      
-  // The type for this index, if present. Can be either "search" or "vectorSearch", defaulting to "search".  
+  // The type for this index, if present. Can be either "search" or "vectorSearch".  
   type: Optional<string>;
 }
 

--- a/source/index-management/index-management.rst
+++ b/source/index-management/index-management.rst
@@ -1159,3 +1159,4 @@ Changelog
 :2023-07-27: Add search index management clarifications.
 :2023-11-08: Clarify that ``readConcern`` and ``writeConcern`` must not be
              applied to search index management commands.
+:2024-03-06: Update tests to include search index typing.

--- a/source/index-management/index-management.rst
+++ b/source/index-management/index-management.rst
@@ -694,6 +694,16 @@ Common API Components
     name: String;
 
     /**
+     * Optionally specify a type for the index. Defaults to "search" if not provided.
+     * Either "search" for regular search indexes or "vectorSearch" for vector search indexes.
+     *
+     * Note that to create a vector search index using a helper method, the type "vectorSearch" must be provided.
+     *
+     */
+    type: String;
+
+
+    /**
      * Optionally tells the index to only reference documents with the specified field in
      * the index.
      */

--- a/source/index-management/tests/README.md
+++ b/source/index-management/tests/README.md
@@ -283,23 +283,23 @@ This test fails if it times out waiting for the deletion to succeed.
 
 10. Create a new vector search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
 
-```typescript
+    ```typescript
 
-  {
-    name: 'test-search-index-case7-vector',
-    type: 'vectorSearch',
-    definition: {
-      "fields": [
-         {
-             "type": "vector",
-             "path": "plot_embedding",
-             "numDimensions": 1536,
-             "similarity": "euclidean",
-         },
-      ]
-    }
-  }
-```
+      {
+        name: 'test-search-index-case7-vector',
+        type: 'vectorSearch',
+        definition: {
+          fields: [
+             {
+                 type: 'vector',
+                 path: 'plot_embedding',
+                 numDimensions: 1536,
+                 similarity: 'euclidean',
+             },
+          ]
+        }
+      }
+    ```
 
 11. Assert that the command returns the name of the index: `"test-search-index-case7-vector"`.
 
@@ -311,23 +311,28 @@ This test fails if it times out waiting for the deletion to succeed.
 
 13. Assert that `index3` has a property `type` whose value is `vectorSearch`.
 
-14. Create a new vector search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
+#### Case 8: Driver requires explicit type to create a vector search index
 
-```typescript
+1. Create a collection with the "create" command using a randomly generated name (referred to as `coll0`).
 
-  {
-    name: 'test-search-index-case7-error',
-    definition: {
-      "fields": [
-         {
-             "type": "vector",
-             "path": "plot_embedding",
-             "numDimensions": 1536,
-             "similarity": "euclidean",
-         },
-      ]
-    }
-  }
-```
+2. Create a new vector search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
 
-15. Assert that the command throws an exception due to the `mappings` field missing.
+   ```typescript
+
+     {
+       name: 'test-search-index-case8-error',
+       definition: {
+         fields: [
+            {
+                type: 'vector',
+                path: 'plot_embedding',
+                numDimensions: 1536,
+                similarity: 'euclidean',
+            },
+         ]
+       }
+     }
+   ```
+
+3. Assert that the command throws an exception containing the string "Attribute mappings missing" due to the `mappings`
+   field missing.

--- a/source/index-management/tests/README.md
+++ b/source/index-management/tests/README.md
@@ -234,94 +234,100 @@ This test fails if it times out waiting for the deletion to succeed.
 
 #### Case 7: Driver can successfully handle search index types when creating indexes
 
-1. Create a collection with the "create" command using a randomly generated name (referred to as ``coll0``).
+01. Create a collection with the "create" command using a randomly generated name (referred to as `coll0`).
 
-2. Create a new search index on ``coll0`` with the ``createSearchIndex`` helper. Use the following definition:
+02. Create a new search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
 
-   ```typescript
+    ```typescript
 
-     {
-       name: 'test-search-index-case7-implicit',
-       definition: {
-         mappings: { dynamic: false }
-       }
-     }
-   ```
+      {
+        name: 'test-search-index-case7-implicit',
+        definition: {
+          mappings: { dynamic: false }
+        }
+      }
+    ```
 
-3. Assert that the command returns the name of the index: ``"test-search-index-case7-implicit"``.
+03. Assert that the command returns the name of the index: `"test-search-index-case7-implicit"`.
 
-4. Run ``coll0.listSearchIndexes('test-search-index-case7-implicit')`` repeatedly every 5 seconds until the following condition is satisfied and store the value in a variable ``index1``:
+04. Run `coll0.listSearchIndexes('test-search-index-case7-implicit')` repeatedly every 5 seconds until the following
+    condition is satisfied and store the value in a variable `index1`:
 
-   - An index with the ``name`` of ``test-search-index-case7-implicit`` is present and the index has a field ``queryable`` with a value of ``true``.
+    - An index with the `name` of `test-search-index-case7-implicit` is present and the index has a field `queryable`
+      with a value of `true`.
 
-5. Assert that ``index1`` has a property ``type`` whose value is ``search``
+05. Assert that `index1` has a property `type` whose value is `search`.
 
-6. Create a new search index on ``coll0`` with the ``createSearchIndex`` helper. Use the following definition:
+06. Create a new search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
 
-   ```typescript
+    ```typescript
 
-     {
-       name: 'test-search-index-case7-explicit',
-       type: 'search',
-       definition: {
-         mappings: { dynamic: false }
-       }
-     }
-   ```
+      {
+        name: 'test-search-index-case7-explicit',
+        type: 'search',
+        definition: {
+          mappings: { dynamic: false }
+        }
+      }
+    ```
 
-7. Assert that the command returns the name of the index: ``"test-search-index-case7-explicit"``.
+07. Assert that the command returns the name of the index: `"test-search-index-case7-explicit"`.
 
-8. Run ``coll0.listSearchIndexes('test-search-index-case7-explicit')`` repeatedly every 5 seconds until the following condition is satisfied and store the value in a variable ``index2``:
+08. Run `coll0.listSearchIndexes('test-search-index-case7-explicit')` repeatedly every 5 seconds until the following
+    condition is satisfied and store the value in a variable `index2`:
 
-   - An index with the ``name`` of ``test-search-index-case7-explicit`` is present and the index has a field ``queryable`` with a value of ``true``.
+    - An index with the `name` of `test-search-index-case7-explicit` is present and the index has a field `queryable`
+      with a value of `true`.
 
-9. Assert that ``index2`` has a property ``type`` whose value is ``search``
+09. Assert that `index2` has a property `type` whose value is `search`.
 
-10. Create a new vector search index on ``coll0`` with the ``createSearchIndex`` helper. Use the following definition:
+10. Create a new vector search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
 
-   ```typescript
+```typescript
 
-     {
-       name: 'test-search-index-case7-vector',
-       type: 'vectorSearch',
-       definition: {
-         "fields": [
-            {
-                "type": "vector",
-                "path": "plot_embedding",
-                "numDimensions": 1536,
-                "similarity": "euclidean",
-            },
-         ]
-       }
-     }
-   ```
+  {
+    name: 'test-search-index-case7-vector',
+    type: 'vectorSearch',
+    definition: {
+      "fields": [
+         {
+             "type": "vector",
+             "path": "plot_embedding",
+             "numDimensions": 1536,
+             "similarity": "euclidean",
+         },
+      ]
+    }
+  }
+```
 
-11. Assert that the command returns the name of the index: ``"test-search-index-case7-vector"``.
+11. Assert that the command returns the name of the index: `"test-search-index-case7-vector"`.
 
-12. Run ``coll0.listSearchIndexes('test-search-index-case7-vector')`` repeatedly every 5 seconds until the following condition is satisfied and store the value in a variable ``index3``:
-     
-    - An index with the ``name`` of ``test-search-index-case7-vector`` is present and the index has a field ``queryable`` with a value of ``true``.
+12. Run `coll0.listSearchIndexes('test-search-index-case7-vector')` repeatedly every 5 seconds until the following
+    condition is satisfied and store the value in a variable `index3`:
 
-13. Assert that ``index3`` has a property ``type`` whose value is ``vectorSearch``
+    - An index with the `name` of `test-search-index-case7-vector` is present and the index has a field `queryable` with
+      a value of `true`.
 
-14. Create a new vector search index on ``coll0`` with the ``createSearchIndex`` helper. Use the following definition:
+13. Assert that `index3` has a property `type` whose value is `vectorSearch`.
 
-   ```typescript
+14. Create a new vector search index on `coll0` with the `createSearchIndex` helper. Use the following definition:
 
-     {
-       name: 'test-search-index-case7-error',
-       definition: {
-         "fields": [
-            {
-                "type": "vector",
-                "path": "plot_embedding",
-                "numDimensions": 1536,
-                "similarity": "euclidean",
-            },
-         ]
-       }
-     }
-   ```
+```typescript
 
-15. Assert that the command throws an exception due to the ``mappings`` field missing.
+  {
+    name: 'test-search-index-case7-error',
+    definition: {
+      "fields": [
+         {
+             "type": "vector",
+             "path": "plot_embedding",
+             "numDimensions": 1536,
+             "similarity": "euclidean",
+         },
+      ]
+    }
+  }
+```
+
+15. Assert that the command throws an exception due to the `mappings` field missing.

--- a/source/index-management/tests/README.md
+++ b/source/index-management/tests/README.md
@@ -231,3 +231,97 @@ This test fails if it times out waiting for the deletion to succeed.
      of `true`.
 
 6. Assert that `index` has a property `latestDefinition` whose value is `{ 'mappings': { 'dynamic': false } }`
+
+#### Case 7: Driver can successfully handle search index types when creating indexes
+
+1. Create a collection with the "create" command using a randomly generated name (referred to as ``coll0``).
+
+2. Create a new search index on ``coll0`` with the ``createSearchIndex`` helper. Use the following definition:
+
+   ```typescript
+
+     {
+       name: 'test-search-index-case7-implicit',
+       definition: {
+         mappings: { dynamic: false }
+       }
+     }
+   ```
+
+3. Assert that the command returns the name of the index: ``"test-search-index-case7-implicit"``.
+
+4. Run ``coll0.listSearchIndexes('test-search-index-case7-implicit')`` repeatedly every 5 seconds until the following condition is satisfied and store the value in a variable ``index1``:
+
+   - An index with the ``name`` of ``test-search-index-case7-implicit`` is present and the index has a field ``queryable`` with a value of ``true``.
+
+5. Assert that ``index1`` has a property ``type`` whose value is ``search``
+
+6. Create a new search index on ``coll0`` with the ``createSearchIndex`` helper. Use the following definition:
+
+   ```typescript
+
+     {
+       name: 'test-search-index-case7-explicit',
+       type: 'search',
+       definition: {
+         mappings: { dynamic: false }
+       }
+     }
+   ```
+
+7. Assert that the command returns the name of the index: ``"test-search-index-case7-explicit"``.
+
+8. Run ``coll0.listSearchIndexes('test-search-index-case7-explicit')`` repeatedly every 5 seconds until the following condition is satisfied and store the value in a variable ``index2``:
+
+   - An index with the ``name`` of ``test-search-index-case7-explicit`` is present and the index has a field ``queryable`` with a value of ``true``.
+
+9. Assert that ``index2`` has a property ``type`` whose value is ``search``
+
+10. Create a new vector search index on ``coll0`` with the ``createSearchIndex`` helper. Use the following definition:
+
+   ```typescript
+
+     {
+       name: 'test-search-index-case7-vector',
+       type: 'vectorSearch',
+       definition: {
+         "fields": [
+            {
+                "type": "vector",
+                "path": "plot_embedding",
+                "numDimensions": 1536,
+                "similarity": "euclidean",
+            },
+         ]
+       }
+     }
+   ```
+
+11. Assert that the command returns the name of the index: ``"test-search-index-case7-vector"``.
+
+12. Run ``coll0.listSearchIndexes('test-search-index-case7-vector')`` repeatedly every 5 seconds until the following condition is satisfied and store the value in a variable ``index3``:
+     
+    - An index with the ``name`` of ``test-search-index-case7-vector`` is present and the index has a field ``queryable`` with a value of ``true``.
+
+13. Assert that ``index3`` has a property ``type`` whose value is ``vectorSearch``
+
+14. Create a new vector search index on ``coll0`` with the ``createSearchIndex`` helper. Use the following definition:
+
+   ```typescript
+
+     {
+       name: 'test-search-index-case7-error',
+       definition: {
+         "fields": [
+            {
+                "type": "vector",
+                "path": "plot_embedding",
+                "numDimensions": 1536,
+                "similarity": "euclidean",
+            },
+         ]
+       }
+     }
+   ```
+
+15. Assert that the command throws an exception due to the ``mappings`` field missing.

--- a/source/index-management/tests/createSearchIndex.json
+++ b/source/index-management/tests/createSearchIndex.json
@@ -135,6 +135,66 @@
           ]
         }
       ]
+    },
+        {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "fields": [
+                  {
+                    "type": "vector",
+                    "path": "plot_embedding",
+                    "numDimensions": 1536,
+                    "similarity": "euclidean"
+                  }
+                ]
+              },
+              "name": "test index",
+              "type": "vectorSearch"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/source/index-management/tests/createSearchIndex.json
+++ b/source/index-management/tests/createSearchIndex.json
@@ -136,7 +136,7 @@
         }
       ]
     },
-        {
+    {
       "description": "create a vector search index",
       "operations": [
         {

--- a/source/index-management/tests/createSearchIndex.json
+++ b/source/index-management/tests/createSearchIndex.json
@@ -50,54 +50,8 @@
                 "mappings": {
                   "dynamic": true
                 }
-              }
-            }
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndex",
-          "object": "collection0",
-          "arguments": {
-            "model": {
-              "definition": {
-                "mappings": {
-                  "dynamic": true
-                }
               },
-              "name": "test index"
+              "type": "search"
             }
           },
           "expectError": {
@@ -121,7 +75,57 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndex",
+          "object": "collection0",
+          "arguments": {
+            "model": {
+              "definition": {
+                "mappings": {
+                  "dynamic": true
+                }
+              },
+              "name": "test index",
+              "type": "search"
+            }
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
                     }
                   ],
                   "$db": "database0"

--- a/source/index-management/tests/createSearchIndex.yml
+++ b/source/index-management/tests/createSearchIndex.yml
@@ -68,7 +68,7 @@ tests:
       - name: createSearchIndex
         object: *collection0
         arguments:
-          model: { definition: &definition { fields: {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} }
+          model: { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ] }
             , name: 'test index', type: 'vectorSearch' }
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting

--- a/source/index-management/tests/createSearchIndex.yml
+++ b/source/index-management/tests/createSearchIndex.yml
@@ -62,3 +62,25 @@ tests:
                 createSearchIndexes: *collection0
                 indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
                 $db: *database0
+
+  - description: "create a vector search index"
+    operations:
+      - name: createSearchIndex
+        object: *collection0
+        arguments:
+          model: { definition: &definition { fields: {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} }
+            , name: 'test index', type: 'vectorSearch' }
+        expectError:
+          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
+          # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
+          isError: true
+          errorContains: Atlas
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createSearchIndexes: *collection0
+                indexes: [ { definition: *definition, name: 'test index', type: 'vectorSearch' } ]
+                $db: *database0

--- a/source/index-management/tests/createSearchIndex.yml
+++ b/source/index-management/tests/createSearchIndex.yml
@@ -26,7 +26,7 @@ tests:
       - name: createSearchIndex
         object: *collection0
         arguments:
-          model: { definition: &definition { mappings: { dynamic: true } } }
+          model: { definition: &definition { mappings: { dynamic: true } } , type: 'search' }
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -39,7 +39,7 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition } ]
+                indexes: [ { definition: *definition, type: 'search'} ]
                 $db: *database0
 
   - description: "name provided for an index definition"
@@ -47,7 +47,7 @@ tests:
       - name: createSearchIndex
         object: *collection0
         arguments: 
-          model: { definition: &definition { mappings: { dynamic: true } } , name: 'test index' }
+          model: { definition: &definition { mappings: { dynamic: true } } , name: 'test index', type: 'search' }
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -60,5 +60,5 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition, name: 'test index' } ]
+                indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
                 $db: *database0

--- a/source/index-management/tests/createSearchIndexes.json
+++ b/source/index-management/tests/createSearchIndexes.json
@@ -83,56 +83,8 @@
                   "mappings": {
                     "dynamic": true
                   }
-                }
-              }
-            ]
-          },
-          "expectError": {
-            "isError": true,
-            "errorContains": "Atlas"
-          }
-        }
-      ],
-      "expectEvents": [
-        {
-          "client": "client0",
-          "events": [
-            {
-              "commandStartedEvent": {
-                "command": {
-                  "createSearchIndexes": "collection0",
-                  "indexes": [
-                    {
-                      "definition": {
-                        "mappings": {
-                          "dynamic": true
-                        }
-                      }
-                    }
-                  ],
-                  "$db": "database0"
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "name provided for an index definition",
-      "operations": [
-        {
-          "name": "createSearchIndexes",
-          "object": "collection0",
-          "arguments": {
-            "models": [
-              {
-                "definition": {
-                  "mappings": {
-                    "dynamic": true
-                  }
                 },
-                "name": "test index"
+                "type": "search"
               }
             ]
           },
@@ -157,7 +109,59 @@
                           "dynamic": true
                         }
                       },
-                      "name": "test index"
+                      "type": "search"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "name provided for an index definition",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "mappings": {
+                    "dynamic": true
+                  }
+                },
+                "name": "test index",
+                "type": "search"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "mappings": {
+                          "dynamic": true
+                        }
+                      },
+                      "name": "test index",
+                      "type": "search"
                     }
                   ],
                   "$db": "database0"

--- a/source/index-management/tests/createSearchIndexes.json
+++ b/source/index-management/tests/createSearchIndexes.json
@@ -172,7 +172,7 @@
         }
       ]
     },
-        {
+    {
       "description": "create a vector search index",
       "operations": [
         {

--- a/source/index-management/tests/createSearchIndexes.json
+++ b/source/index-management/tests/createSearchIndexes.json
@@ -171,6 +171,68 @@
           ]
         }
       ]
+    },
+        {
+      "description": "create a vector search index",
+      "operations": [
+        {
+          "name": "createSearchIndexes",
+          "object": "collection0",
+          "arguments": {
+            "models": [
+              {
+                "definition": {
+                  "fields": [
+                    {
+                      "type": "vector",
+                      "path": "plot_embedding",
+                      "numDimensions": 1536,
+                      "similarity": "euclidean"
+                    }
+                  ]
+                },
+                "name": "test index",
+                "type": "vectorSearch"
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true,
+            "errorContains": "Atlas"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createSearchIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "definition": {
+                        "fields": [
+                          {
+                            "type": "vector",
+                            "path": "plot_embedding",
+                            "numDimensions": 1536,
+                            "similarity": "euclidean"
+                          }
+                        ]
+                      },
+                      "name": "test index",
+                      "type": "vectorSearch"
+                    }
+                  ],
+                  "$db": "database0"
+                }
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/source/index-management/tests/createSearchIndexes.yml
+++ b/source/index-management/tests/createSearchIndexes.yml
@@ -61,7 +61,7 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition } ]
+                indexes: [ { definition: *definition, type: 'search'} ]
                 $db: *database0
 
   - description: "name provided for an index definition"
@@ -90,7 +90,7 @@ tests:
       - name: createSearchIndexes
         object: *collection0
         arguments:
-          models: [ { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ],
+          models: [ { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ] },
                                                 name: 'test index' , type: 'vectorSearch' } ]
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting

--- a/source/index-management/tests/createSearchIndexes.yml
+++ b/source/index-management/tests/createSearchIndexes.yml
@@ -84,3 +84,25 @@ tests:
                 createSearchIndexes: *collection0
                 indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
                 $db: *database0
+
+  - description: "create a vector search index"
+    operations:
+      - name: createSearchIndexes
+        object: *collection0
+        arguments:
+          models: [ { definition: &definition { fields: [ {"type": "vector", "path": "plot_embedding", "numDimensions": 1536, "similarity": "euclidean"} ],
+                                                name: 'test index' , type: 'vectorSearch' } ]
+        expectError:
+          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
+          # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
+          isError: true
+          errorContains: Atlas
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createSearchIndexes: *collection0
+                indexes: [ { definition: *definition, name: 'test index', type: 'vectorSearch' } ]
+                $db: *database0

--- a/source/index-management/tests/createSearchIndexes.yml
+++ b/source/index-management/tests/createSearchIndexes.yml
@@ -48,7 +48,7 @@ tests:
       - name: createSearchIndexes
         object: *collection0
         arguments:
-          models: [ { definition: &definition { mappings: { dynamic: true } } } ]
+          models: [ { definition: &definition { mappings: { dynamic: true } } , type: 'search' } ]
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -69,7 +69,7 @@ tests:
       - name: createSearchIndexes
         object: *collection0
         arguments: 
-          models: [ { definition: &definition { mappings: { dynamic: true } } , name: 'test index' } ]
+          models: [ { definition: &definition { mappings: { dynamic: true } } , name: 'test index' , type: 'search' } ]
         expectError:
           # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
           # that the driver constructs and sends the correct command.
@@ -82,5 +82,5 @@ tests:
           - commandStartedEvent:
               command:
                 createSearchIndexes: *collection0
-                indexes: [ { definition: *definition, name: 'test index' } ]
+                indexes: [ { definition: *definition, name: 'test index', type: 'search' } ]
                 $db: *database0


### PR DESCRIPTION
[DRIVERS-2768](https://jira.mongodb.org/browse/DRIVERS-2768)

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

