### PR TITLE
DRIVERS-2767 skip `rangePreview` tests on server 8.0+

### DIFF
--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-Aggregate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-Correctness.yml.template
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-Delete.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-FindOneAndUpdate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-InsertFind.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Date-Update.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-Aggregate.yml.template
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-Correctness.yml.template
@@ -8,6 +8,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-Delete.yml.template
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-FindOneAndUpdate.yml.template
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-InsertFind.yml.template
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Decimal-Update.yml.template
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-Aggregate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-Correctness.yml.template
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-Delete.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-InsertFind.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DecimalPrecision-Update.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-Aggregate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-Correctness.yml.template
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-Delete.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-FindOneAndUpdate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-InsertFind.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Double-Update.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-Aggregate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-Correctness.yml.template
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-Delete.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-InsertFind.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-DoublePrecision-Update.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-Aggregate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-Correctness.yml.template
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-Delete.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-FindOneAndUpdate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-InsertFind.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Int-Update.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-Aggregate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-Aggregate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-Correctness.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-Correctness.yml.template
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-Delete.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-Delete.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-FindOneAndUpdate.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-FindOneAndUpdate.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-InsertFind.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-InsertFind.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-Update.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Range-Long-Update.yml.template
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -2815,7 +2815,12 @@ This test is continuation of the case 1 and provides a way to complete inserting
 
 ### 22. Range Explicit Encryption
 
-The Range Explicit Encryption tests require MongoDB server 7.0+. The tests must not run against a standalone.
+The Range Explicit Encryption tests require MongoDB server 7.0+. The tests must not run against a standalone. The tests
+must be skipped on MongoDB server 8.0+.
+
+> [!NOTE]
+> MongoDB Server 8.0 introduced a backwards breaking change to the Queryable Encryption (QE) range protocol: QE Range
+> V2. Skip tests using `rangePreview` when using Server 8.0 or newer until DRIVERS-2767 is addressed.
 
 > [!NOTE]
 > MongoDB Server 7.0 introduced a backwards breaking change to the Queryable Encryption (QE) protocol: QEv2.

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Date-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Aggregate.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Correctness.yml
@@ -8,6 +8,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Delete.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-FindOneAndUpdate.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-InsertFind.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.json
@@ -4,7 +4,8 @@
       "minServerVersion": "7.0.0",
       "topology": [
         "replicaset"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Decimal-Update.yml
@@ -6,6 +6,8 @@ runOn:
     # FLE 2 Encrypted collections are not supported on standalone.
     # Tests for Decimal (without precision) must only run against a replica set. Decimal (without precision) queries are expected to take a long time and may exceed the default mongos timeout.
     topology: [ "replicaset" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DecimalPrecision-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Double-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-DoublePrecision-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Int-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Aggregate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Correctness.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Delete.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-FindOneAndUpdate.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-InsertFind.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-Long-Update.yml
@@ -5,6 +5,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "maxServerVersion": "7.99.99"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Range-WrongType.yml
@@ -7,6 +7,8 @@ runOn:
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    # Skip tests for "rangePreview" algorithm on Server 8.0+. Server 8.0 drops "rangePreview" and adds "range".
+    maxServerVersion: "7.99.99"
 database_name: &database_name "default"
 collection_name: &collection_name "default"
 data: []


### PR DESCRIPTION
# Summary

Skip tests using the `rangePreview` algorithm for server 8.0+:
- Skip specification tests with the name `fle2v2-Range-*`
- Skip the prose test `22. Range Explicit Encryption`.

This PR does not resolve DRIVERS-2767. This PR is intended to prevent failures in driver of latest server builds until `range` tests are added.

# Background & Motivation

This [slack thread](https://mongodb.slack.com/archives/C0668RJBA0J/p1710193448307889?thread_ts=1709070435.222549&cid=C0668RJBA0J) notes:

> Upon this change hitting master, creating collections with the "rangePreview" query type will fail.

I expect driver tests will start to fail once https://github.com/10gen/mongo/pull/19645 is merged.

<!-- Thanks for contributing! -->

---

Please complete the following before merging:

- ~~[ ] Update changelog.~~ **N/A. Test changes only**
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested in [C](https://spruce.mongodb.com/version/65f06c270ae60677761ed38f), though server changes expected to fail are not-yet-available**
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).~~ **C QE tests do not run against sharded or serverless**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
