### PR TITLE
DRIVERS-2855: Skip $out and mapReduce tests on serverless

### DIFF
--- a/source/read-write-concern/tests/operation/default-write-concern-3.4.json
+++ b/source/read-write-concern/tests/operation/default-write-concern-3.4.json
@@ -1,6 +1,6 @@
 {
   "description": "default-write-concern-3.4",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "3.4"
@@ -55,6 +55,11 @@
   "tests": [
     {
       "description": "Aggregate with $out omits default write concern",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "object": "collection0",
@@ -220,6 +225,11 @@
     },
     {
       "description": "MapReduce omits default write concern",
+      "runOnRequirements": [
+        {
+          "serverless": "forbid"
+        }
+      ],
       "operations": [
         {
           "name": "mapReduce",

--- a/source/read-write-concern/tests/operation/default-write-concern-3.4.yml
+++ b/source/read-write-concern/tests/operation/default-write-concern-3.4.yml
@@ -3,7 +3,7 @@
 
 description: default-write-concern-3.4
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "3.4"
@@ -40,6 +40,9 @@ initialData:
 tests:
   -
     description: Aggregate with $out omits default write concern
+    # Serverless does not support $out stage
+    runOnRequirements:
+      - serverless: forbid
     operations:
       -
         object: *collection0
@@ -116,6 +119,9 @@ tests:
                 writeConcern: { $$exists: false }
   -
     description: MapReduce omits default write concern
+    # Serverless does not support mapReduce operation
+    runOnRequirements:
+      - serverless: forbid
     operations:
       -
         name: mapReduce


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2855

This was missed in #1547 (bfb6a841819e117aa7f066beae4cfa9da7690a1b)

> [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and _serverless_).

...and that was a lie.

See: https://github.com/mongodb/mongo-php-library/pull/1253#discussion_r1523355940

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).