### PR TITLE
DRIVERS-2875: add support for TopologyDescriptionChangedEvent to expectEvents

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring.rst
@@ -111,6 +111,11 @@ Initial Server Description
 
 ``ServerDescription`` objects MUST be initialized with a default description in an “unknown” state, guaranteeing that the previous description in the events and log messages will never be null.
 
+
+Initial Topology Description
+----------------------------
+The first ``TopologyDescriptionChangedEvent`` to be emitted from a monitored Topology MUST set its ``previousDescription`` property to be a ``TopologyDescription`` object in the "unknown" state.
+
 ----------
 Events API
 ----------
@@ -698,6 +703,8 @@ See the `README <https://github.com/mongodb/specifications/server-discovery-and-
 Changelog
 =========
 
+:2024-03-29: Updated to clarify expected initial value of TopologyDescriptionChangedEvent's
+             previousDescription field
 :2024-01-04: Updated to clarify when ServerHeartbeatStartedEvent should be emitted
 :2023-03-31: Renamed to include "logging" in the title. Reorganized contents and made consistent with CLAM spec, and added requirements
              for SDAM log messages. 

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring.rst
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring.rst
@@ -114,6 +114,7 @@ Initial Server Description
 
 Initial Topology Description
 ----------------------------
+
 The first ``TopologyDescriptionChangedEvent`` to be emitted from a monitored Topology MUST set its ``previousDescription`` property to be a ``TopologyDescription`` object in the "unknown" state.
 
 ----------

--- a/source/unified-test-format/schema-1.20.json
+++ b/source/unified-test-format/schema-1.20.json
@@ -1,0 +1,1097 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Unified Test Format",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "description",
+    "schemaVersion",
+    "tests"
+  ],
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "$ref": "#/definitions/version"
+    },
+    "runOnRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/runOnRequirement"
+      }
+    },
+    "createEntities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/entity"
+      }
+    },
+    "initialData": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/collectionData"
+      }
+    },
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/test"
+      }
+    },
+    "_yamlAnchors": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "definitions": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+    },
+    "runOnRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "maxServerVersion": {
+          "$ref": "#/definitions/version"
+        },
+        "minServerVersion": {
+          "$ref": "#/definitions/version"
+        },
+        "topologies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "single",
+              "replicaset",
+              "sharded",
+              "sharded-replicaset",
+              "load-balanced"
+            ]
+          }
+        },
+        "serverless": {
+          "type": "string",
+          "enum": [
+            "require",
+            "forbid",
+            "allow"
+          ]
+        },
+        "serverParameters": {
+          "type": "object",
+          "minProperties": 1
+        },
+        "auth": {
+          "type": "boolean"
+        },
+        "authMechanism": {
+          "type": "string"
+        },
+        "csfle": {
+          "type": "boolean"
+        }
+      }
+    },
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "client": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "uriOptions": {
+              "type": "object"
+            },
+            "useMultipleMongoses": {
+              "type": "boolean"
+            },
+            "observeEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "commandStartedEvent",
+                  "commandSucceededEvent",
+                  "commandFailedEvent",
+                  "poolCreatedEvent",
+                  "poolReadyEvent",
+                  "poolClearedEvent",
+                  "poolClosedEvent",
+                  "connectionCreatedEvent",
+                  "connectionReadyEvent",
+                  "connectionClosedEvent",
+                  "connectionCheckOutStartedEvent",
+                  "connectionCheckOutFailedEvent",
+                  "connectionCheckedOutEvent",
+                  "connectionCheckedInEvent",
+                  "serverDescriptionChangedEvent",
+                  "topologyDescriptionChangedEvent"
+                ]
+              }
+            },
+            "ignoreCommandMonitoringEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "storeEventsAsEntities": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/storeEventsAsEntity"
+              }
+            },
+            "observeLogMessages": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": false,
+              "properties": {
+                "command": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                },
+                "topology": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                },
+                "serverSelection": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                },
+                "connection": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                }
+              }
+            },
+            "serverApi": {
+              "$ref": "#/definitions/serverApi"
+            },
+            "observeSensitiveCommands": {
+              "type": "boolean"
+            }
+          }
+        },
+        "clientEncryption": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "clientEncryptionOpts"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "clientEncryptionOpts": {
+              "$ref": "#/definitions/clientEncryptionOpts"
+            }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "client",
+            "databaseName"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "client": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "databaseOptions": {
+              "$ref": "#/definitions/collectionOrDatabaseOptions"
+            }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "database",
+            "collectionName"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            },
+            "collectionName": {
+              "type": "string"
+            },
+            "collectionOptions": {
+              "$ref": "#/definitions/collectionOrDatabaseOptions"
+            }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "client"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "client": {
+              "type": "string"
+            },
+            "sessionOptions": {
+              "type": "object"
+            }
+          }
+        },
+        "bucket": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "database"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            },
+            "bucketOptions": {
+              "type": "object"
+            }
+          }
+        },
+        "thread": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "logComponent": {
+      "type": "string",
+      "enum": [
+        "command",
+        "topology",
+        "serverSelection",
+        "connection"
+      ]
+    },
+    "logSeverityLevel": {
+      "type": "string",
+      "enum": [
+        "emergency",
+        "alert",
+        "critical",
+        "error",
+        "warning",
+        "notice",
+        "info",
+        "debug",
+        "trace"
+      ]
+    },
+    "clientEncryptionOpts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keyVaultClient",
+        "keyVaultNamespace",
+        "kmsProviders"
+      ],
+      "properties": {
+        "keyVaultClient": {
+          "type": "string"
+        },
+        "keyVaultNamespace": {
+          "type": "string"
+        },
+        "kmsProviders": {
+          "$ref": "#/definitions/kmsProviders"
+        }
+      }
+    },
+    "kmsProviders": {
+      "$defs": {
+        "stringOrPlaceholder": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "$$placeholder"
+              ],
+              "properties": {
+                "$$placeholder": {}
+              }
+            }
+          ]
+        }
+      },
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^aws(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "accessKeyId": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "secretAccessKey": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "sessionToken": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^azure(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "tenantId": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "clientId": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "clientSecret": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "identityPlatformEndpoint": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^gcp(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "privateKey": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "endpoint": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^kmip(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "endpoint": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^local(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        }
+      }
+    },
+    "storeEventsAsEntity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "events"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "PoolCreatedEvent",
+              "PoolReadyEvent",
+              "PoolClearedEvent",
+              "PoolClosedEvent",
+              "ConnectionCreatedEvent",
+              "ConnectionReadyEvent",
+              "ConnectionClosedEvent",
+              "ConnectionCheckOutStartedEvent",
+              "ConnectionCheckOutFailedEvent",
+              "ConnectionCheckedOutEvent",
+              "ConnectionCheckedInEvent",
+              "CommandStartedEvent",
+              "CommandSucceededEvent",
+              "CommandFailedEvent",
+              "ServerDescriptionChangedEvent",
+              "TopologyDescriptionChangedEvent"
+            ]
+          }
+        }
+      }
+    },
+    "collectionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "collectionName",
+        "databaseName",
+        "documents"
+      ],
+      "properties": {
+        "collectionName": {
+          "type": "string"
+        },
+        "databaseName": {
+          "type": "string"
+        },
+        "createOptions": {
+          "type": "object",
+          "properties": {
+            "writeConcern": false
+          }
+        },
+        "documents": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "expectedEventsForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "client",
+        "events"
+      ],
+      "properties": {
+        "client": {
+          "type": "string"
+        },
+        "eventType": {
+          "type": "string",
+          "enum": [
+            "command",
+            "cmap",
+            "sdam"
+          ]
+        },
+        "events": {
+          "type": "array"
+        },
+        "ignoreExtraEvents": {
+          "type": "boolean"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "eventType"
+          ],
+          "properties": {
+            "eventType": {
+              "const": "command"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedCommandEvent"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "eventType"
+          ],
+          "properties": {
+            "eventType": {
+              "const": "cmap"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedCmapEvent"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "eventType"
+          ],
+          "properties": {
+            "eventType": {
+              "const": "sdam"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedSdamEvent"
+              }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "client": {
+              "type": "string"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedCommandEvent"
+              }
+            },
+            "ignoreExtraEvents": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "expectedCommandEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "commandStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "object"
+            },
+            "commandName": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "hasServerConnectionId": {
+              "type": "boolean"
+            }
+          }
+        },
+        "commandSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reply": {
+              "type": "object"
+            },
+            "commandName": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "hasServerConnectionId": {
+              "type": "boolean"
+            }
+          }
+        },
+        "commandFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "commandName": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "hasServerConnectionId": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "expectedCmapEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "poolCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolClearedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "interruptInUseConnections": {
+              "type": "boolean"
+            }
+          }
+        },
+        "poolClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": {
+              "type": "string"
+            }
+          }
+        },
+        "connectionCheckOutStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckOutFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": {
+              "type": "string"
+            }
+          }
+        },
+        "connectionCheckedOutEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckedInEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      }
+    },
+    "expectedSdamEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "serverDescriptionChangedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "previousDescription": {
+              "$ref": "#/definitions/serverDescription"
+            },
+            "newDescription": {
+              "$ref": "#/definitions/serverDescription"
+            }
+          }
+        },
+        "topologyDescriptionChangedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "previousDescription": {
+              "$ref": "#/definitions/topologyDescription"
+            },
+            "newDescription": {
+              "$ref": "#/definitions/topologyDescription"
+            }
+          }
+        },
+        "serverHeartbeatStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "awaited": {
+              "type": "boolean"
+            }
+          }
+        },
+        "serverHeartbeatSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "awaited": {
+              "type": "boolean"
+            }
+          }
+        },
+        "serverHeartbeatFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "awaited": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "serverDescription": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Standalone",
+            "Mongos",
+            "PossiblePrimary",
+            "RSPrimary",
+            "RSSecondary",
+            "RSOther",
+            "RSArbiter",
+            "RSGhost",
+            "LoadBalancer",
+            "Unknown"
+          ]
+        }
+      }
+    },
+    "topologyDescription": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Single",
+            "Unknown",
+            "ReplicaSetNoPrimary",
+            "ReplicaSetWithPrimary",
+            "Sharded",
+            "LoadBalanced"
+          ]
+        }
+      }
+    },
+    "expectedLogMessagesForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "client",
+        "messages"
+      ],
+      "properties": {
+        "client": {
+          "type": "string"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expectedLogMessage"
+          }
+        },
+        "ignoreExtraMessages": {
+          "type": "boolean"
+        },
+        "ignoreMessages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expectedLogMessage"
+          }
+        }
+      }
+    },
+    "expectedLogMessage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "level",
+        "component",
+        "data"
+      ],
+      "properties": {
+        "level": {
+          "$ref": "#/definitions/logSeverityLevel"
+        },
+        "component": {
+          "$ref": "#/definitions/logComponent"
+        },
+        "data": {
+          "type": "object"
+        },
+        "failureIsRedacted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "collectionOrDatabaseOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readConcern": {
+          "type": "object"
+        },
+        "readPreference": {
+          "type": "object"
+        },
+        "writeConcern": {
+          "type": "object"
+        },
+        "timeoutMS": {
+          "type": "integer"
+        }
+      }
+    },
+    "serverApi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "strict": {
+          "type": "boolean"
+        },
+        "deprecationErrors": {
+          "type": "boolean"
+        }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "object"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "arguments": {
+          "type": "object"
+        },
+        "ignoreResultAndError": {
+          "type": "boolean"
+        },
+        "expectError": {
+          "$ref": "#/definitions/expectedError"
+        },
+        "expectResult": {},
+        "saveResultAsEntity": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "not": {
+            "required": [
+              "expectError",
+              "expectResult"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "expectError",
+              "saveResultAsEntity"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "ignoreResultAndError",
+              "expectResult"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "ignoreResultAndError",
+              "expectError"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "ignoreResultAndError",
+              "saveResultAsEntity"
+            ]
+          }
+        }
+      ]
+    },
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "isError": {
+          "type": "boolean",
+          "const": true
+        },
+        "isClientError": {
+          "type": "boolean"
+        },
+        "isTimeoutError": {
+          "type": "boolean"
+        },
+        "errorContains": {
+          "type": "string"
+        },
+        "errorCode": {
+          "type": "integer"
+        },
+        "errorCodeName": {
+          "type": "string"
+        },
+        "errorLabelsContain": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "errorLabelsOmit": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "errorResponse": {
+          "type": "object"
+        },
+        "expectResult": {}
+      }
+    },
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "description",
+        "operations"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "runOnRequirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/runOnRequirement"
+          }
+        },
+        "skipReason": {
+          "type": "string"
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/operation"
+          }
+        },
+        "expectEvents": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/expectedEventsForClient"
+          }
+        },
+        "expectLogMessages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/expectedLogMessagesForClient"
+          }
+        },
+        "outcome": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/collectionData"
+          }
+        }
+      }
+    }
+  }
+}

--- a/source/unified-test-format/schema-1.20.json
+++ b/source/unified-test-format/schema-1.20.json
@@ -800,6 +800,16 @@
               "type": "boolean"
             }
           }
+        },
+        "topologyOpeningEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "topologyClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
         }
       }
     },

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -1,4 +1,4 @@
-SCHEMA=../schema-1.19.json
+SCHEMA=../schema-1.20.json
 
 .PHONY: all invalid valid-fail valid-pass atlas-data-lake versioned-api load-balancers gridfs transactions transactions-convenient-api crud collection-management read-write-concern retryable-reads retryable-writes sessions command-logging-and-monitoring client-side-operations-timeout HAS_AJV
 

--- a/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.json
+++ b/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.json
@@ -21,6 +21,9 @@
               {
                 "client": {
                   "id": "client",
+                  "uriOptions": {
+                    "directConnection": true
+                  },
                   "observeEvents": [
                     "topologyDescriptionChangedEvent"
                   ]
@@ -48,15 +51,12 @@
           "ignoreExtraEvents": true,
           "events": [
             {
-              "topologyOpeningEvent": {}
-            },
-            {
               "topologyDescriptionChangedEvent": {
                 "previousDescription": {
                   "type": "Unknown"
                 },
                 "newDescription": {
-                  "type": "ReplicaSetWithPrimary"
+                  "type": "Single"
                 }
               }
             }

--- a/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.json
+++ b/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.json
@@ -1,0 +1,87 @@
+{
+  "description": "expectedEventsForClient-topologyDescriptionChangedEvent.yml",
+  "schemaVersion": "1.20",
+  "runOnRequirements": [
+    {
+      "topologies": [
+        "replicaset"
+      ],
+      "minServerVersion": "4.4"
+    }
+  ],
+  "tests": [
+    {
+      "description": "can assert on values of newDescription and previousDescription fields",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {}
+            },
+            "count": 4
+          }
+        },
+        {
+          "name": "close",
+          "object": "client"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "sdam",
+          "ignoreExtraEvents": false,
+          "events": [
+            {
+              "topologyOpeningEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {}
+            },
+            {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "ReplicaSetWithPrimary"
+                },
+                "newDescription": {
+                  "type": "Unknown"
+                }
+              }
+            },
+            {
+              "topologyClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.json
+++ b/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.json
@@ -1,5 +1,5 @@
 {
-  "description": "expectedEventsForClient-topologyDescriptionChangedEvent.yml",
+  "description": "expectedEventsForClient-topologyDescriptionChangedEvent",
   "schemaVersion": "1.20",
   "runOnRequirements": [
     {
@@ -51,12 +51,13 @@
               "topologyOpeningEvent": {}
             },
             {
-              "topologyDescriptionChangedEvent": null,
-              "previousDescription": {
-                "type": "Unknown"
-              },
-              "newDescription": {
-                "type": "ReplicaSetWithPrimary"
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "ReplicaSetWithPrimary"
+                }
               }
             }
           ]

--- a/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.json
+++ b/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.json
@@ -37,47 +37,27 @@
             "event": {
               "topologyDescriptionChangedEvent": {}
             },
-            "count": 4
+            "count": 1
           }
-        },
-        {
-          "name": "close",
-          "object": "client"
         }
       ],
       "expectEvents": [
         {
           "client": "client",
           "eventType": "sdam",
-          "ignoreExtraEvents": false,
+          "ignoreExtraEvents": true,
           "events": [
             {
               "topologyOpeningEvent": {}
             },
             {
-              "topologyDescriptionChangedEvent": {}
-            },
-            {
-              "topologyDescriptionChangedEvent": {}
-            },
-            {
-              "topologyDescriptionChangedEvent": {}
-            },
-            {
-              "topologyDescriptionChangedEvent": {}
-            },
-            {
-              "topologyDescriptionChangedEvent": {
-                "previousDescription": {
-                  "type": "ReplicaSetWithPrimary"
-                },
-                "newDescription": {
-                  "type": "Unknown"
-                }
+              "topologyDescriptionChangedEvent": null,
+              "previousDescription": {
+                "type": "Unknown"
+              },
+              "newDescription": {
+                "type": "ReplicaSetWithPrimary"
               }
-            },
-            {
-              "topologyClosedEvent": {}
             }
           ]
         }

--- a/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.yml
+++ b/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.yml
@@ -34,8 +34,8 @@ tests:
         events:
           - topologyOpeningEvent: {}
           - topologyDescriptionChangedEvent: 
-            previousDescription:
-              type: "Unknown"
-            newDescription:
-              type: "ReplicaSetWithPrimary"
+              previousDescription:
+                type: "Unknown"
+              newDescription:
+                type: "ReplicaSetWithPrimary"
 

--- a/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.yml
+++ b/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.yml
@@ -1,0 +1,48 @@
+description: "expectedEventsForClient-topologyDescriptionChangedEvent.yml"
+
+schemaVersion: "1.20"
+
+runOnRequirements:
+  - topologies:
+      - replicaset
+    minServerVersion: "4.4" # awaitable hello
+
+tests:
+  - description: "can assert on values of newDescription and previousDescription fields"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+      # ensure the topology has been fully discovered before closing the client.
+      # expected events are initial server discovery and 3 server connect events.
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent: {}
+          count: 4
+      - name: close
+        object: *client
+    expectEvents:
+      - client: *client
+        eventType: sdam
+        ignoreExtraEvents: false
+        events:
+          - topologyOpeningEvent: {}
+          - topologyDescriptionChangedEvent: {} # unknown -> replset no primary
+          - topologyDescriptionChangedEvent: {} # server connected
+          - topologyDescriptionChangedEvent: {} # server connected
+          - topologyDescriptionChangedEvent: {} # server connected
+          - topologyDescriptionChangedEvent:  # replicaset -> unknown
+              previousDescription:
+                type: "ReplicaSetWithPrimary"
+              newDescription:
+                type: "Unknown"
+          - topologyClosedEvent: {}
+

--- a/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.yml
+++ b/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.yml
@@ -26,23 +26,16 @@ tests:
           client: *client
           event:
             topologyDescriptionChangedEvent: {}
-          count: 4
-      - name: close
-        object: *client
+          count: 1
     expectEvents:
       - client: *client
         eventType: sdam
-        ignoreExtraEvents: false
+        ignoreExtraEvents: true 
         events:
           - topologyOpeningEvent: {}
-          - topologyDescriptionChangedEvent: {} # unknown -> replset no primary
-          - topologyDescriptionChangedEvent: {} # server connected
-          - topologyDescriptionChangedEvent: {} # server connected
-          - topologyDescriptionChangedEvent: {} # server connected
-          - topologyDescriptionChangedEvent:  # replicaset -> unknown
-              previousDescription:
-                type: "ReplicaSetWithPrimary"
-              newDescription:
-                type: "Unknown"
-          - topologyClosedEvent: {}
+          - topologyDescriptionChangedEvent: 
+            previousDescription:
+              type: "Unknown"
+            newDescription:
+              type: "ReplicaSetWithPrimary"
 

--- a/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.yml
+++ b/source/unified-test-format/tests/valid-pass/expectedEventsForClient-topologyDescriptionChangedEvent.yml
@@ -16,10 +16,10 @@ tests:
           entities:
             - client:
                 id: &client client
+                uriOptions:
+                  directConnection: true
                 observeEvents:
                   - topologyDescriptionChangedEvent
-      # ensure the topology has been fully discovered before closing the client.
-      # expected events are initial server discovery and 3 server connect events.
       - name: waitForEvent
         object: testRunner
         arguments:
@@ -32,10 +32,9 @@ tests:
         eventType: sdam
         ignoreExtraEvents: true 
         events:
-          - topologyOpeningEvent: {}
           - topologyDescriptionChangedEvent: 
               previousDescription:
                 type: "Unknown"
               newDescription:
-                type: "ReplicaSetWithPrimary"
+                type: "Single"
 

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -417,8 +417,8 @@ The structure of this object is as follows:
 
     Note also that when specifying `directConnection` as true, the connection string used to instantiate a client MUST
     only have a single seed and MUST NOT specify the `replicaSet` option. See the
-    [`directConnection` specification](../uri-options/uri-options.rst#directconnection-uri-option-with-multiple-seeds-or-srv-uri)
-    for more information.
+    [URI Options spec](../uri-options/uri-options.rst#directconnection-uri-option-with-multiple-seeds-or-srv-uri) for
+    more information.
 
     Any field in `uriOptions` may be a [$$placeholder](#placeholder) document and the test runner MUST support replacing
     the placeholder document with values loaded from the test environment. For example:

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -1162,10 +1162,28 @@ The structure of this object is as follows:
 
 <span id="expectedEvent_topologyDescriptionChangedEvent" />
 
-- `topologyDescriptionChangedEvent`: Optional object. If present, this object MUST be an empty document as no assertions
-  are currently supported for
+- `topologyDescriptionChangedEvent`: Optional object. Assertions for one 
   [TopologyDescriptionChangedEvent](../server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring.rst#events)
-  fields.
+  object.
+
+  The structure of this object is as follows:
+
+  - `previousDescription`: Optional Object. A value corresponding to the topology description as it
+    was before the change that triggered the event.
+  - `newDescription` : Optional Object. A value corresponding to the topology description as it
+    is after the change that triggered the event.
+
+    Test runners SHOULD ignore any other fields than the `previousDescription` and `newDescription`
+    fields.
+
+    The structure of a topology description object (which the `previousDescription` and
+    `newDescription` fields contain is as follows:
+
+    - `type`: Optional string. The type of the topology in the description. Test runners MUST assert
+      that the type in the published event matches this value. See [SDAM: TopologyType](../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#topologytype) for a list of valid values.
+
+    Test runners SHOULD ignore any other fields present on the `previousDescription` and
+    `newDescription` fields of the captured `topologyDescriptionChangedEvent`.
 
 ##### hasServiceId
 

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -1162,28 +1162,30 @@ The structure of this object is as follows:
 
 <span id="expectedEvent_topologyDescriptionChangedEvent" />
 
-- `topologyDescriptionChangedEvent`: Optional object. Assertions for one 
+- `topologyDescriptionChangedEvent`: Optional object. Assertions for one
   [TopologyDescriptionChangedEvent](../server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring.rst#events)
   object.
 
   The structure of this object is as follows:
 
-  - `previousDescription`: Optional Object. A value corresponding to the topology description as it
-    was before the change that triggered the event.
-  - `newDescription` : Optional Object. A value corresponding to the topology description as it
-    is after the change that triggered the event.
+  - `previousDescription`: Optional Object. A value corresponding to the topology description as it was before the
+    change that triggered the event.
 
-    Test runners SHOULD ignore any other fields than the `previousDescription` and `newDescription`
-    fields.
+  - `newDescription` : Optional Object. A value corresponding to the topology description as it is after the change that
+    triggered the event.
 
-    The structure of a topology description object (which the `previousDescription` and
-    `newDescription` fields contain is as follows:
+    Test runners SHOULD ignore any other fields than the `previousDescription` and `newDescription` fields.
 
-    - `type`: Optional string. The type of the topology in the description. Test runners MUST assert
-      that the type in the published event matches this value. See [SDAM: TopologyType](../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#topologytype) for a list of valid values.
+    The structure of a topology description object (which the `previousDescription` and `newDescription` fields contain
+    is as follows:
 
-    Test runners SHOULD ignore any other fields present on the `previousDescription` and
-    `newDescription` fields of the captured `topologyDescriptionChangedEvent`.
+    - `type`: Optional string. The type of the topology in the description. Test runners MUST assert that the type in
+      the published event matches this value. See
+      [SDAM: TopologyType](../server-discovery-and-monitoring/server-discovery-and-monitoring.rst#topologytype) for a
+      list of valid values.
+
+    Test runners SHOULD ignore any other fields present on the `previousDescription` and `newDescription` fields of the
+    captured `topologyDescriptionChangedEvent`.
 
 ##### hasServiceId
 
@@ -3414,8 +3416,8 @@ other specs *and* collating spec changes developed in parallel or during the sam
 ## Changelog
 
 - 2024-03-25: **Schema version 1.20.**\
-  Add `previousDescription` and `newDescription` assertions to `topologyDescriptionChangedEvent`
-  when checking events with `expectEvents`
+  Add `previousDescription` and `newDescription` assertions to
+  `topologyDescriptionChangedEvent` when checking events with `expectEvents`
 
 - 2024-03-11: Note that `killAllSessions` should not be executed on Atlas Data Lake
 

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -415,6 +415,11 @@ The structure of this object is as follows:
     notable exception: if `readPreferenceTags` is specified in this object, the key will map to an array of strings,
     each representing a tag set, since it is not feasible to define multiple `readPreferenceTags` keys in the object.
 
+    Note also that when specifying `directConnection` as true, the connection string used to
+    instantiate a client MUST only have a single seed and MUST NOT specify the `replicaSet` option.
+    See the [`directConnection` specification](../uri-options/uri-options.rst#directconnection-uri-option-with-multiple-seeds-or-srv-uri)
+    for more information.
+
     Any field in `uriOptions` may be a [$$placeholder](#placeholder) document and the test runner MUST support replacing
     the placeholder document with values loaded from the test environment. For example:
 
@@ -3414,6 +3419,9 @@ operations and arguments. This is a concession until such time that better proce
 other specs *and* collating spec changes developed in parallel or during the same release cycle.
 
 ## Changelog
+
+- 2024-04-15: Note that when `directConnection` is set to true test runners should only provide a
+  single seed.
 
 - 2024-03-25: **Schema version 1.20.**\
   Add `previousDescription` and `newDescription` assertions to

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -415,9 +415,9 @@ The structure of this object is as follows:
     notable exception: if `readPreferenceTags` is specified in this object, the key will map to an array of strings,
     each representing a tag set, since it is not feasible to define multiple `readPreferenceTags` keys in the object.
 
-    Note also that when specifying `directConnection` as true, the connection string used to
-    instantiate a client MUST only have a single seed and MUST NOT specify the `replicaSet` option.
-    See the [`directConnection` specification](../uri-options/uri-options.rst#directconnection-uri-option-with-multiple-seeds-or-srv-uri)
+    Note also that when specifying `directConnection` as true, the connection string used to instantiate a client MUST
+    only have a single seed and MUST NOT specify the `replicaSet` option. See the
+    [`directConnection` specification](../uri-options/uri-options.rst#directconnection-uri-option-with-multiple-seeds-or-srv-uri)
     for more information.
 
     Any field in `uriOptions` may be a [$$placeholder](#placeholder) document and the test runner MUST support replacing
@@ -3420,8 +3420,7 @@ other specs *and* collating spec changes developed in parallel or during the sam
 
 ## Changelog
 
-- 2024-04-15: Note that when `directConnection` is set to true test runners should only provide a
-  single seed.
+- 2024-04-15: Note that when `directConnection` is set to true test runners should only provide a single seed.
 
 - 2024-03-25: **Schema version 1.20.**\
   Add `previousDescription` and `newDescription` assertions to

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -3413,6 +3413,10 @@ other specs *and* collating spec changes developed in parallel or during the sam
 
 ## Changelog
 
+- 2024-03-25: **Schema version 1.20.**\
+  Add `previousDescription` and `newDescription` assertions to `topologyDescriptionChangedEvent`
+  when checking events with `expectEvents`
+
 - 2024-03-11: Note that `killAllSessions` should not be executed on Atlas Data Lake
 
 - 2024-02-27: Document `onPrimaryTransactionalWrite` fail point, which is used in retryable writes tests.


### PR DESCRIPTION
<!-- Thanks for contributing! -->

- Updated unified test format spec to detail how assertions on `topologyDescriptionChangedEvents` should be done
- Updated schema to support this spec change
- Added valid pass test for addition to schema
- Bumped schema version in makefile for unified test runner

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
