### PR TITLE
DRIVERS-2877: Follow w: 0 write with a find in spec tests

### DIFF
--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
@@ -53,11 +53,27 @@
               "_id": 2
             }
           }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            }
+          ]
         }
       ],
       "expectLogMessages": [
         {
           "client": "client",
+          "ignoreExtraMessages": true,
           "messages": [
             {
               "level": "debug",

--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledged-write",
-  "schemaVersion": "1.13",
+  "schemaVersion": "1.16",
   "createEntities": [
     {
       "client": {

--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
@@ -1,6 +1,6 @@
 description: "unacknowledged-write"
 
-schemaVersion: "1.13"
+schemaVersion: "1.16"
 
 createEntities:
   - client:

--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
@@ -31,8 +31,18 @@ tests:
         object: *collection
         arguments:
           document: { _id: 2 }
+      # Force completion of the w: 0 write by executing a find on the same connection
+      - name: find
+        object: *collection
+        arguments:
+          filter: { }
+        expectResult: [
+          { _id: 1 },
+          { _id: 2 }
+        ]
     expectLogMessages:
       - client: *client
+        ignoreExtraMessages: true
         messages:
           - level: debug
             component: command

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
@@ -64,11 +64,29 @@
             ],
             "ordered": false
           }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {}
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": 11
+            },
+            {
+              "_id": "unorderedBulkWriteInsertW0",
+              "x": 44
+            }
+          ]
         }
       ],
       "expectEvents": [
         {
           "client": "client",
+          "ignoreExtraEvents": true,
           "events": [
             {
               "commandStartedEvent": {

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
@@ -1,6 +1,6 @@
 {
   "description": "unacknowledgedBulkWrite",
-  "schemaVersion": "1.0",
+  "schemaVersion": "1.7",
   "createEntities": [
     {
       "client": {

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
@@ -36,8 +36,18 @@ tests:
             - insertOne:
                 document: { _id: "unorderedBulkWriteInsertW0", x: 44 }
           ordered: false
+      # Force completion of the w: 0 write by executing a find on the same connection
+      - name: find
+        object: *collection
+        arguments:
+          filter: { }
+        expectResult: [
+          { _id: 1, x: 11 },
+          { _id: "unorderedBulkWriteInsertW0", x: 44 }
+        ]
     expectEvents:
       - client: *client
+        ignoreExtraEvents: true
         events:
           - commandStartedEvent:
               command:

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
@@ -1,6 +1,6 @@
 description: "unacknowledgedBulkWrite"
 
-schemaVersion: "1.0"
+schemaVersion: "1.7"
 
 createEntities:
   - client:


### PR DESCRIPTION
This will force completion of the w: 0 write, which addresses a TCP-based race condition in the tests

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [N/A] Update changelog.
- [Done] Make sure there are generated JSON files from the YAML test files.
- [Done] Test changes in at least one language driver.
- [Done] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

Note: there are other w: 0 writes in the unified tests but none that appear to be causing issues so leaving them alone for now.
