### PR TITLE
DRIVERS-2900 Test that durations are included on relevant pool events.

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/cmap-format/README.md
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/README.md
@@ -46,6 +46,7 @@ All Unit Tests have some of the following fields:
   - `type`: The type of event emitted
   - `address`: The address of the pool emitting the event
   - `connectionId`: The id of a connection associated with the event
+  - `duration`: The event duration
   - `options`: Options used to create the pool
   - `reason`: A reason giving more information on why the event was emitted
 - `ignore`: An array of event names to ignore

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkin-make-available.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkin-make-available.json
@@ -22,7 +22,8 @@
     {
       "type": "ConnectionCheckedOut",
       "connectionId": 1,
-      "address": 42
+      "address": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionCheckedIn",
@@ -32,7 +33,8 @@
     {
       "type": "ConnectionCheckedOut",
       "connectionId": 1,
-      "address": 42
+      "address": 42,
+      "duration": 42
     }
   ],
   "ignore": [

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkin-make-available.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkin-make-available.yml
@@ -12,12 +12,14 @@ events:
   - type: ConnectionCheckedOut
     connectionId: 1
     address: 42
+    duration: 42
   - type: ConnectionCheckedIn
     connectionId: 1
     address: 42
   - type: ConnectionCheckedOut
     connectionId: 1
     address: 42
+    duration: 42
 ignore:
   - ConnectionPoolCreated
   - ConnectionPoolReady

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-connection.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-connection.json
@@ -23,12 +23,14 @@
     {
       "type": "ConnectionReady",
       "connectionId": 1,
-      "address": 42
+      "address": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionCheckedOut",
       "connectionId": 1,
-      "address": 42
+      "address": 42,
+      "duration": 42
     }
   ],
   "ignore": [

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-connection.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-connection.yml
@@ -13,9 +13,11 @@ events:
   - type: ConnectionReady
     connectionId: 1
     address: 42
+    duration: 42
   - type: ConnectionCheckedOut
     connectionId: 1
     address: 42
+    duration: 42
 ignore:
   - ConnectionPoolReady
   - ConnectionPoolCreated

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-error-closed.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-error-closed.json
@@ -38,7 +38,8 @@
     {
       "type": "ConnectionCheckedOut",
       "address": 42,
-      "connectionId": 42
+      "connectionId": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionCheckedIn",
@@ -56,6 +57,7 @@
     {
       "type": "ConnectionCheckOutFailed",
       "address": 42,
+      "duration": 42,
       "reason": "poolClosed"
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-error-closed.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-error-closed.yml
@@ -21,6 +21,7 @@ events:
   - type: ConnectionCheckedOut
     address: 42
     connectionId: 42
+    duration: 42
   - type: ConnectionCheckedIn
     address: 42
     connectionId: 42
@@ -30,6 +31,7 @@ events:
     address: 42
   - type: ConnectionCheckOutFailed
     address: 42
+    duration: 42
     reason: poolClosed
 ignore:
   - ConnectionPoolReady

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.json
@@ -89,7 +89,8 @@
     {
       "type": "ConnectionCheckOutFailed",
       "reason": "timeout",
-      "address": 42
+      "address": 42,
+      "duration": 42
     }
   ],
   "ignore": [

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.yml
@@ -60,6 +60,7 @@ events:
   - type: ConnectionCheckOutFailed
     reason: timeout
     address: 42
+    duration: 42
 ignore:
   - ConnectionCreated
   - ConnectionCheckedIn

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-clears-waitqueue.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-clears-waitqueue.json
@@ -59,7 +59,8 @@
     },
     {
       "type": "ConnectionCheckedOut",
-      "address": 42
+      "address": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionCheckOutStarted",
@@ -76,17 +77,20 @@
     {
       "type": "ConnectionCheckOutFailed",
       "reason": "connectionError",
-      "address": 42
+      "address": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionCheckOutFailed",
       "reason": "connectionError",
-      "address": 42
+      "address": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionCheckOutFailed",
       "reason": "connectionError",
-      "address": 42
+      "address": 42,
+      "duration": 42
     }
   ],
   "ignore": [

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-clears-waitqueue.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-clears-waitqueue.yml
@@ -38,6 +38,7 @@ events:
     address: 42
   - type: ConnectionCheckedOut
     address: 42
+    duration: 42
   - type: ConnectionCheckOutStarted
     address: 42
   - type: ConnectionCheckOutStarted
@@ -47,12 +48,15 @@ events:
   - type: ConnectionCheckOutFailed
     reason: connectionError
     address: 42
+    duration: 42
   - type: ConnectionCheckOutFailed
     reason: connectionError
     address: 42
+    duration: 42
   - type: ConnectionCheckOutFailed
     reason: connectionError
     address: 42
+    duration: 42
 ignore:
   - ConnectionPoolReady
   - ConnectionPoolCleared

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-ready.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-ready.json
@@ -40,7 +40,8 @@
     {
       "type": "ConnectionCheckedOut",
       "address": 42,
-      "connectionId": 42
+      "connectionId": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionPoolCleared",
@@ -49,6 +50,7 @@
     {
       "type": "ConnectionCheckOutFailed",
       "address": 42,
+      "duration": 42,
       "reason": "connectionError"
     },
     {
@@ -57,7 +59,8 @@
     },
     {
       "type": "ConnectionCheckedOut",
-      "address": 42
+      "address": 42,
+      "duration": 42
     }
   ],
   "ignore": [

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-ready.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-ready.yml
@@ -20,15 +20,18 @@ events:
   - type: ConnectionCheckedOut
     address: 42
     connectionId: 42
+    duration: 42
   - type: ConnectionPoolCleared
     address: 42
   - type: ConnectionCheckOutFailed
     address: 42
+    duration: 42
     reason: connectionError
   - type: ConnectionPoolReady
     address: 42
   - type: ConnectionCheckedOut
     address: 42
+    duration: 42
 ignore:
   - ConnectionPoolCreated
   - ConnectionReady

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-ready.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-ready.json
@@ -31,7 +31,8 @@
     {
       "type": "ConnectionCheckOutFailed",
       "reason": "connectionError",
-      "address": 42
+      "address": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionPoolReady",
@@ -47,7 +48,8 @@
     },
     {
       "type": "ConnectionCheckedOut",
-      "address": 42
+      "address": 42,
+      "duration": 42
     }
   ],
   "ignore": [

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-ready.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-ready.yml
@@ -17,6 +17,7 @@ events:
   - type: ConnectionCheckOutFailed
     reason: connectionError
     address: 42
+    duration: 42
   - type: ConnectionPoolReady
     address: 42
   - type: ConnectionCheckOutStarted
@@ -25,6 +26,7 @@ events:
     address: 42
   - type: ConnectionCheckedOut
     address: 42
+    duration: 42
 ignore:
   - ConnectionPoolCreated
   - ConnectionReady

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/wait-queue-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/wait-queue-timeout.json
@@ -48,7 +48,8 @@
     {
       "type": "ConnectionCheckedOut",
       "connectionId": 42,
-      "address": 42
+      "address": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionCheckOutStarted",
@@ -57,7 +58,8 @@
     {
       "type": "ConnectionCheckOutFailed",
       "reason": "timeout",
-      "address": 42
+      "address": 42,
+      "duration": 42
     },
     {
       "type": "ConnectionCheckedIn",

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/wait-queue-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/wait-queue-timeout.yml
@@ -32,11 +32,13 @@ events:
   - type: ConnectionCheckedOut
     connectionId: 42
     address: 42
+    duration: 42
   - type: ConnectionCheckOutStarted
     address: 42
   - type: ConnectionCheckOutFailed
     reason: timeout
     address: 42
+    duration: 42
   - type: ConnectionCheckedIn
     connectionId: 42
     address: 42


### PR DESCRIPTION
<!-- Thanks for contributing! -->

[DRIVERS-2900](https://jira.mongodb.org/browse/DRIVERS-2900)

The CMAP logging tests currently check for durations to be set , but the CMAP pool event tests do not. Test that durations are included on relevant pool events.

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
