### PR TITLE
DRIVERS-2874: fix flaky maxConnecting-is-enforced CMAP test

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.json
@@ -19,7 +19,7 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 750
+      "blockTimeMS": 800
     }
   },
   "poolOptions": {
@@ -53,7 +53,7 @@
     },
     {
       "name": "wait",
-      "ms": 100
+      "ms": 400
     },
     {
       "name": "checkOut",

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
@@ -13,7 +13,7 @@ failPoint:
     failCommands: ["isMaster","hello"]
     closeConnection: false
     blockConnection: true
-    blockTimeMS: 750
+    blockTimeMS: 800
 poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
@@ -36,7 +36,7 @@ operations:
     count: 1
   # wait some more time to ensure thread1 has begun establishing a Connection
   - name: wait
-    ms: 100
+    ms: 400
   # start 2 check out requests. Only one thread should
   # start creating a Connection and the other one should be
   # waiting for pendingConnectionCount to be less than maxConnecting,


### PR DESCRIPTION
Updates the blocktime and wait time for the maxConnecting-is-enforced test to make the test less flaky. 

Node implementation: https://github.com/mongodb/node-mongodb-native/pull/4074

Please complete the following before merging:

- [ ] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

DRIVERS-2874