### PR TITLE
DRIVERS-2847 Update CSOT encryption test for listCollections

### DIFF
--- a/source/client-side-encryption/etc/test-templates/timeoutMS.yml.template
+++ b/source/client-side-encryption/etc/test-templates/timeoutMS.yml.template
@@ -38,8 +38,10 @@ tests:
           command_name: listCollections
 
   # Test that timeoutMS applies to the sum of all operations done for client-side encryption. This is done by blocking
-  # listCollections and find for 20ms each and running an insertOne with timeoutMS=50. There should be two
-  # listCollections commands and one "find" command, so the sum should take more than timeoutMS.
+  # listCollections and find for 30ms each and running an insertOne with timeoutMS=50. There should be one
+  # listCollections command and one "find" command, so the sum should take more than timeoutMS. A second listCollections
+  # event doesn't occur due to the internal MongoClient lacking configured auto encryption, plus libmongocrypt holds the
+  # collection schema in cache for a minute.
   #
   # This test does not include command monitoring expectations because the exact command sequence is dependent on the
   # amount of time taken by mongocryptd communication. In slow runs, mongocryptd communication can breach the timeout
@@ -47,11 +49,11 @@ tests:
   - description: "remaining timeoutMS applied to find to get keyvault data"
     failPoint:
       configureFailPoint: failCommand
-      mode: { times: 3 }
+      mode: { times: 2 }
       data:
         failCommands: ["listCollections", "find"]
         blockConnection: true
-        blockTimeMS: 20
+        blockTimeMS: 30
     clientOptions:
       autoEncryptOpts:
         kmsProviders:

--- a/source/client-side-encryption/tests/legacy/timeoutMS.json
+++ b/source/client-side-encryption/tests/legacy/timeoutMS.json
@@ -161,7 +161,7 @@
       "failPoint": {
         "configureFailPoint": "failCommand",
         "mode": {
-          "times": 3
+          "times": 2
         },
         "data": {
           "failCommands": [
@@ -169,7 +169,7 @@
             "find"
           ],
           "blockConnection": true,
-          "blockTimeMS": 20
+          "blockTimeMS": 30
         }
       },
       "clientOptions": {

--- a/source/client-side-encryption/tests/legacy/timeoutMS.yml
+++ b/source/client-side-encryption/tests/legacy/timeoutMS.yml
@@ -38,8 +38,10 @@ tests:
           command_name: listCollections
 
   # Test that timeoutMS applies to the sum of all operations done for client-side encryption. This is done by blocking
-  # listCollections and find for 20ms each and running an insertOne with timeoutMS=50. There should be two
-  # listCollections commands and one "find" command, so the sum should take more than timeoutMS.
+  # listCollections and find for 30ms each and running an insertOne with timeoutMS=50. There should be one
+  # listCollections command and one "find" command, so the sum should take more than timeoutMS. A second listCollections
+  # event doesn't occur due to the internal MongoClient lacking configured auto encryption, plus libmongocrypt holds the
+  # collection schema in cache for a minute.
   #
   # This test does not include command monitoring expectations because the exact command sequence is dependent on the
   # amount of time taken by mongocryptd communication. In slow runs, mongocryptd communication can breach the timeout
@@ -47,11 +49,11 @@ tests:
   - description: "remaining timeoutMS applied to find to get keyvault data"
     failPoint:
       configureFailPoint: failCommand
-      mode: { times: 3 }
+      mode: { times: 2 }
       data:
         failCommands: ["listCollections", "find"]
         blockConnection: true
-        blockTimeMS: 20
+        blockTimeMS: 30
     clientOptions:
       autoEncryptOpts:
         kmsProviders:


### PR DESCRIPTION
DRIVERS-2847

- Fix client-side encryption test in timeoutMS.yml by correcting the number of expected listCollections operations to one, based on libmongocrypt's caching behavior. 
- Update description to reflect that the internal MongoClient, not configured for auto encryption, does not generate extra listCollections events.

Please complete the following before merging:

- [ ] Update changelog. (no changelog) 
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. 
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

Tested in Java driver https://github.com/mongodb/mongo-java-driver/pull/1363.
<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
