### PR TITLE
DRIVERS-2511: Update maxWireVersion from 6 to 21

### DIFF
--- a/source/resources
+++ b/source/resources
@@ -1,0 +1,1 @@
+/Users/jeff.yemin/git/mongo-java-driver/driver-core/src/test/resources

--- a/source/resources
+++ b/source/resources
@@ -1,1 +1,0 @@
-/Users/jeff.yemin/git/mongo-java-driver/driver-core/src/test/resources

--- a/source/server-discovery-and-monitoring/tests/rs/compatible.json
+++ b/source/server-discovery-and-monitoring/tests/rs/compatible.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/source/server-discovery-and-monitoring/tests/rs/compatible.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/compatible.yml
@@ -12,7 +12,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
                 ["b:27017", {
                     ok: 1,

--- a/source/server-discovery-and-monitoring/tests/rs/compatible_unknown.json
+++ b/source/server-discovery-and-monitoring/tests/rs/compatible_unknown.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/compatible_unknown.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/compatible_unknown.yml
@@ -12,7 +12,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/sharded/compatible.json
+++ b/source/server-discovery-and-monitoring/tests/sharded/compatible.json
@@ -23,7 +23,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/sharded/compatible.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/compatible.yml
@@ -17,7 +17,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/single/compatible.json
+++ b/source/server-discovery-and-monitoring/tests/single/compatible.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/compatible.yml
+++ b/source/server-discovery-and-monitoring/tests/single/compatible.yml
@@ -8,7 +8,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/single/too_old_then_upgraded.json
+++ b/source/server-discovery-and-monitoring/tests/single/too_old_then_upgraded.json
@@ -1,5 +1,5 @@
 {
-  "description": "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 6",
+  "description": "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 21",
   "uri": "mongodb://a",
   "phases": [
     {
@@ -35,7 +35,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/too_old_then_upgraded.yml
+++ b/source/server-discovery-and-monitoring/tests/single/too_old_then_upgraded.yml
@@ -1,4 +1,4 @@
-description: "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 6"
+description: "Standalone with default maxWireVersion of 0 is upgraded to one with maxWireVersion 21"
 uri: "mongodb://a"
 phases: [
     {
@@ -29,7 +29,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
         outcome: {


### PR DESCRIPTION
Once a driver removes support for MongoDB 3.6 and updates its minWireVersion from 6 to 7, these tests start to fail due to the wire version compatibility check required by the test runner.

Bumping from 6 to 21 (MongoDB 7.0 maxWireVersion) should hold us for a while.

Note: I don't think the intention of any of these tests were to check the minWireVersion of the driver, as they have been at 6 long before 6 was the minWireVersion.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ N/A] Update changelog.
- [ Done] Make sure there are generated JSON files from the YAML test files.
- [ Done (Java)] Test changes in at least one language driver.
- [ N/A] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
