### PR TITLE
DRIVERS-2915 OIDC: Disallow comma character in authMechanismProperties connection string value

### DIFF
--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -1201,11 +1201,6 @@ in the MONGODB-OIDC specification, including sections or blocks that specificall
 
 #### [MongoCredential](#mongocredential) Properties
 
-> [!NOTE]
-> Drivers MUST parse the `TOKEN_RESOURCE` by splitting only on the first `:` character. Drivers MUST document that users
-> must specify `TOKEN_RESOURCE` as part of a `MongoClient` option it contains a comma `,` character, since it would
-> interfere with the parsing rules for `authMechanismProperties`.
-
 - username\
   MAY be specified. Its meaning varies depending on the OIDC provider integration used.
 

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -1202,13 +1202,9 @@ in the MONGODB-OIDC specification, including sections or blocks that specificall
 #### [MongoCredential](#mongocredential) Properties
 
 > [!NOTE]
-> Drivers MUST NOT url-decode the entire `authMechanismProperties` given in an connection string when the
-> `authMechanism` is `MONGODB-OIDC`. This is because the `TOKEN_RESOURCE` itself will typically be a URL and may contain
-> a `,` character. The values of the individual `authMechanismProperties` MUST still be url-decoded when given as part
-> of the connection string, and MUST NOT be url-decoded when not given as part of the connection string, such as through
-> a `MongoClient` or `Credential` property. Drivers MUST parse the `TOKEN_RESOURCE` by splitting only on the first `:`
-> character. Drivers MUST document that users must url-encode `TOKEN_RESOURCE` when it is provided in the connection
-> string and it contains and of the special characters in \[`,`, `+`, `&`, `%`\].
+> Drivers MUST parse the `TOKEN_RESOURCE` by splitting only on the first `:` character. Drivers MUST document that users
+> must use `TOKEN_RESOURCE` as part of a `MongoClient` option it contains a comma `,` character, since it would
+> interfere with the parsing rules for `authMechanismProperties`.
 
 - username\
   MAY be specified. Its meaning varies depending on the OIDC provider integration used.

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -2045,6 +2045,8 @@ to EC2 instance metadata in ECS, for security reasons, Amazon states it's best p
 
 ## Changelog
 
+- 2024-05-29: Disallow comma character when `TOKEN_RESOURCE` is given in a connection string.
+
 - 2024-05-03: Clarify timeout behavior for OIDC machine callback. Add `serverless:forbid` to OIDC unified tests. Add an
   additional prose test for the behavior of `ALLOWED_HOSTS`.
 

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -1203,7 +1203,7 @@ in the MONGODB-OIDC specification, including sections or blocks that specificall
 
 > [!NOTE]
 > Drivers MUST parse the `TOKEN_RESOURCE` by splitting only on the first `:` character. Drivers MUST document that users
-> must use `TOKEN_RESOURCE` as part of a `MongoClient` option it contains a comma `,` character, since it would
+> must specify `TOKEN_RESOURCE` as part of a `MongoClient` option it contains a comma `,` character, since it would
 > interfere with the parsing rules for `authMechanismProperties`.
 
 - username\

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -1224,7 +1224,9 @@ in the MONGODB-OIDC specification, including sections or blocks that specificall
   - TOKEN_RESOURCE\
     The URI of the target resource. If `TOKEN_RESOURCE` is provided and `ENVIRONMENT` is not one of
     `["azure", "gcp"]` or `TOKEN_RESOURCE` is not provided and `ENVIRONMENT` is one of `["azure", "gcp"]`, the driver
-    MUST raise an error.
+    MUST raise an error. Note: because the `TOKEN_RESOURCE` is often itself a URL, drivers MUST document that a
+    `TOKEN_RESOURCE` with a comma `,` must be given as a `MongoClient` configuration and not as part of the connection
+    string, and that the `TOKEN_RESOURCE` value can contain a colon `:` character.
 
   - OIDC_CALLBACK\
     An [OIDC Callback](#oidc-callback) that returns OIDC credentials. Drivers MAY allow the user to

--- a/source/auth/tests/legacy/connection-string.json
+++ b/source/auth/tests/legacy/connection-string.json
@@ -602,7 +602,7 @@
     {
       "description": "should handle a complicated url-encoded TOKEN_RESOURCE (MONGODB-OIDC)",
       "uri": "mongodb://user@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:abcd%25ef%3Ag%26hi",
-      "valid": false,
+      "valid": true,
       "credential": {
         "username": "user",
         "password": null,

--- a/source/auth/tests/legacy/connection-string.json
+++ b/source/auth/tests/legacy/connection-string.json
@@ -600,21 +600,6 @@
       }
     },
     {
-      "description": "should handle a complicated url-encoded TOKEN_RESOURCE (MONGODB-OIDC)",
-      "uri": "mongodb://user@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:abc%2Cd%25ef%3Ag%26hi",
-      "valid": true,
-      "credential": {
-        "username": "user",
-        "password": null,
-        "source": "$external",
-        "mechanism": "MONGODB-OIDC",
-        "mechanism_properties": {
-          "ENVIRONMENT": "azure",
-          "TOKEN_RESOURCE": "abc,d%ef:g&hi"
-        }
-      }
-    },
-    {
       "description": "should url-encode a TOKEN_RESOURCE (MONGODB-OIDC)",
       "uri": "mongodb://user@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:a$b",
       "valid": true,

--- a/source/auth/tests/legacy/connection-string.json
+++ b/source/auth/tests/legacy/connection-string.json
@@ -600,6 +600,21 @@
       }
     },
     {
+      "description": "should handle a complicated url-encoded TOKEN_RESOURCE (MONGODB-OIDC)",
+      "uri": "mongodb://user@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:abcd%25ef%3Ag%26hi",
+      "valid": false,
+      "credential": {
+        "username": "user",
+        "password": null,
+        "source": "$external",
+        "mechanism": "MONGODB-OIDC",
+        "mechanism_properties": {
+          "ENVIRONMENT": "azure",
+          "TOKEN_RESOURCE": "abcd%ef:g&hi"
+        }
+      }
+    },
+    {
       "description": "should url-encode a TOKEN_RESOURCE (MONGODB-OIDC)",
       "uri": "mongodb://user@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:a$b",
       "valid": true,

--- a/source/auth/tests/legacy/connection-string.yml
+++ b/source/auth/tests/legacy/connection-string.yml
@@ -434,6 +434,17 @@ tests:
     mechanism_properties:
       ENVIRONMENT: azure
       TOKEN_RESOURCE: 'mongodb://test-cluster'
+- description: should handle a complicated url-encoded TOKEN_RESOURCE (MONGODB-OIDC)
+  uri: mongodb://user@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:abcd%25ef%3Ag%26hi
+  valid: true
+  credential:
+    username: user
+    password: null
+    source: $external
+    mechanism: MONGODB-OIDC
+    mechanism_properties:
+      ENVIRONMENT: azure
+      TOKEN_RESOURCE: 'abcd%ef:g&hi'
 - description: should url-encode a TOKEN_RESOURCE (MONGODB-OIDC)
   uri: mongodb://user@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:a$b
   valid: true

--- a/source/auth/tests/legacy/connection-string.yml
+++ b/source/auth/tests/legacy/connection-string.yml
@@ -434,17 +434,6 @@ tests:
     mechanism_properties:
       ENVIRONMENT: azure
       TOKEN_RESOURCE: 'mongodb://test-cluster'
-- description: should handle a complicated url-encoded TOKEN_RESOURCE (MONGODB-OIDC)
-  uri: mongodb://user@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:abc%2Cd%25ef%3Ag%26hi
-  valid: true
-  credential:
-    username: user
-    password: null
-    source: $external
-    mechanism: MONGODB-OIDC
-    mechanism_properties:
-      ENVIRONMENT: azure
-      TOKEN_RESOURCE: 'abc,d%ef:g&hi'
 - description: should url-encode a TOKEN_RESOURCE (MONGODB-OIDC)
   uri: mongodb://user@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:azure,TOKEN_RESOURCE:a$b
   valid: true

--- a/source/auth/tests/mongodb-oidc.md
+++ b/source/auth/tests/mongodb-oidc.md
@@ -178,7 +178,7 @@ source the `secrets-export.sh` file and use the associated env variables in your
 - Assert that the callback was called 2 times.
 - Close the client.
 
-\*\*4.3 Write Commands Fail If Reauthentication Fails
+#### 4.3 Write Commands Fail If Reauthentication Fails
 
 - Create a `MongoClient` whose OIDC callback returns one good token and then bad tokens after the first call.
 - Perform an `insert` operation that succeeds.

--- a/source/connection-string/connection-string-spec.md
+++ b/source/connection-string/connection-string-spec.md
@@ -216,8 +216,7 @@ The values in connection options MUST be URL decoded by the parser. The values c
   ```
 
 - Key value pairs: A value that represents one or more key and value pairs. Multiple key value pairs are delimited by a
-  comma (","). The key is everything up to the first colon sign (":") and the value is everything afterwards. Reserved
-  characters such as ':' must be escaped according to [RFC 2396](https://www.rfc-editor.org/rfc/rfc2396)
+  comma (","). The key is everything up to the first colon sign (":") and the value is everything afterwards.
 
   For example:
 
@@ -225,14 +224,16 @@ The values in connection options MUST be URL decoded by the parser. The values c
   ?readPreferenceTags=dc:ny,rack:1
   ```
 
-  Drivers MUST handle unencoded colon signs (":") within the value. For example:
+  Drivers MUST handle unencoded colon signs (":") within the value. For example, given the encoded input:
 
   ```
-  ?authMechanismProperties=TOKEN_RESOURCE:mongodb%3A%2F%2F...
+  ?authMechanismProperties=TOKEN_RESOURCE%3Amongodb%3A%2F%2Ffoo
   ```
 
-  If any keys or values contain a comma (",") they MUST not be provided as part of the connection string, since it would
-  interfere with parsing.
+  the driver MUST interpret the key as `TOKEN_RESOURCE` and the value as `mongodb://foo`.
+
+  Drivers MUST document that if keys or values contain a comma (",") they MUST not be provided as part of the connection
+  string, since it would interfere with parsing.
 
 Any invalid Values for a given key MUST be ignored and MUST log a WARN level message. For example:
 

--- a/source/connection-string/connection-string-spec.md
+++ b/source/connection-string/connection-string-spec.md
@@ -216,8 +216,11 @@ The values in connection options MUST be URL decoded by the parser. The values c
   ```
 
 - Key value pairs: A value that represents one or more key and value pairs. Multiple key value pairs are delimited by a
-  comma (","). The key is everything up to the first colon sign (":") and the value is everything afterwards. If any
-  keys or values containing a comma (",") or a colon (":") they must be URL encoded. For example:
+  comma (","). The key is everything up to the first colon sign (":") and the value is everything afterwards. Drivers
+  MUST handle subsequent colon signs (":") within the value, unless otherwise specified in this document.\
+  If any keys
+  or values contain a comma (",") they MUST not be provided as part of the connection string, since it would interfere
+  with parsing. For example:
 
   ```
   ?readPreferenceTags=dc:ny,rack:1

--- a/source/connection-string/connection-string-spec.md
+++ b/source/connection-string/connection-string-spec.md
@@ -227,7 +227,7 @@ The values in connection options MUST be URL decoded by the parser. The values c
   Drivers MUST handle unencoded colon signs (":") within the value. For example, given the connection string:
 
   ```
-  ?authMechanismProperties=TOKEN_RESOURCE%3Amongodb%3A%2F%2Ffoo
+  ?authMechanismProperties=TOKEN_RESOURCE:mongodb://foo
   ```
 
   the driver MUST interpret the key as `TOKEN_RESOURCE` and the value as `mongodb://foo`.

--- a/source/connection-string/connection-string-spec.md
+++ b/source/connection-string/connection-string-spec.md
@@ -232,8 +232,8 @@ The values in connection options MUST be URL decoded by the parser. The values c
 
   the driver MUST interpret the key as `TOKEN_RESOURCE` and the value as `mongodb://foo`.
 
-  Drivers MUST document that if keys or values contain a comma (",") they MUST not be provided as part of the connection
-  string, since it would interfere with parsing.
+  For any option key-value pair that may contain a comma (such as `TOKEN_RESOURCE`), drivers MUST document that: a value containing a comma (",") MUST NOT be provided as part of the connection
+  string. This prevents use of values that would interfere with parsing.
 
 Any invalid Values for a given key MUST be ignored and MUST log a WARN level message. For example:
 

--- a/source/connection-string/connection-string-spec.md
+++ b/source/connection-string/connection-string-spec.md
@@ -216,15 +216,23 @@ The values in connection options MUST be URL decoded by the parser. The values c
   ```
 
 - Key value pairs: A value that represents one or more key and value pairs. Multiple key value pairs are delimited by a
-  comma (","). The key is everything up to the first colon sign (":") and the value is everything afterwards. Drivers
-  MUST handle subsequent colon signs (":") within the value, unless otherwise specified in this document.\
-  If any keys
-  or values contain a comma (",") they MUST not be provided as part of the connection string, since it would interfere
-  with parsing. Key value pair example:
+  comma (","). The key is everything up to the first colon sign (":") and the value is everything afterwards. Reserved
+  characters such as ':' must be escaped according to [RFC 2396](https://www.rfc-editor.org/rfc/rfc2396)
+
+  For example:
 
   ```
   ?readPreferenceTags=dc:ny,rack:1
   ```
+
+  Drivers MUST handle unencoded colon signs (":") within the value. For example:
+
+  ```
+  ?authMechanismProperties=TOKEN_RESOURCE:mongodb%3A%2F%2F...
+  ```
+
+  If any keys or values contain a comma (",") they MUST not be provided as part of the connection string, since it would
+  interfere with parsing.
 
 Any invalid Values for a given key MUST be ignored and MUST log a WARN level message. For example:
 
@@ -446,6 +454,8 @@ than `+`, this will be portable across all implementations. Implementations MAY 
 many languages treat strings as `x-www-form-urlencoded` data by default.
 
 ## Changelog
+
+- 2024-05-29: Clarify handling of key-value pairs and add specification test.
 
 - 2024-02-15: Migrated from reStructuredText to Markdown.
 

--- a/source/connection-string/connection-string-spec.md
+++ b/source/connection-string/connection-string-spec.md
@@ -232,8 +232,9 @@ The values in connection options MUST be URL decoded by the parser. The values c
 
   the driver MUST interpret the key as `TOKEN_RESOURCE` and the value as `mongodb://foo`.
 
-  For any option key-value pair that may contain a comma (such as `TOKEN_RESOURCE`), drivers MUST document that: a value containing a comma (",") MUST NOT be provided as part of the connection
-  string. This prevents use of values that would interfere with parsing.
+  For any option key-value pair that may contain a comma (such as `TOKEN_RESOURCE`), drivers MUST document that: a value
+  containing a comma (",") MUST NOT be provided as part of the connection string. This prevents use of values that would
+  interfere with parsing.
 
 Any invalid Values for a given key MUST be ignored and MUST log a WARN level message. For example:
 

--- a/source/connection-string/connection-string-spec.md
+++ b/source/connection-string/connection-string-spec.md
@@ -220,7 +220,7 @@ The values in connection options MUST be URL decoded by the parser. The values c
   MUST handle subsequent colon signs (":") within the value, unless otherwise specified in this document.\
   If any keys
   or values contain a comma (",") they MUST not be provided as part of the connection string, since it would interfere
-  with parsing. For example:
+  with parsing. Key value pair example:
 
   ```
   ?readPreferenceTags=dc:ny,rack:1

--- a/source/connection-string/connection-string-spec.md
+++ b/source/connection-string/connection-string-spec.md
@@ -224,7 +224,7 @@ The values in connection options MUST be URL decoded by the parser. The values c
   ?readPreferenceTags=dc:ny,rack:1
   ```
 
-  Drivers MUST handle unencoded colon signs (":") within the value. For example, given the encoded input:
+  Drivers MUST handle unencoded colon signs (":") within the value. For example, given the connection string:
 
   ```
   ?authMechanismProperties=TOKEN_RESOURCE%3Amongodb%3A%2F%2Ffoo

--- a/source/connection-string/tests/invalid-uris.yml
+++ b/source/connection-string/tests/invalid-uris.yml
@@ -249,5 +249,3 @@ tests:
         hosts: ~
         auth: ~
         options: ~
-
-    

--- a/source/connection-string/tests/valid-options.json
+++ b/source/connection-string/tests/valid-options.json
@@ -40,7 +40,7 @@
     },
     {
       "description": "Colon in a key value pair",
-      "uri": "mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb%3A%2F%2Ftest-cluster",
+      "uri": "mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster",
       "valid": true,
       "warning": false,
       "hosts": [

--- a/source/connection-string/tests/valid-options.json
+++ b/source/connection-string/tests/valid-options.json
@@ -37,6 +37,25 @@
       "options": {
         "tls": true
       }
+    },
+    {
+      "description": "Colon in a key value pair",
+      "uri": "mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb%3A%2F%2Ftest-cluster",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "authmechanismProperties": {
+          "TOKEN_RESOURCE": "mongodb://test-cluster"
+        }
+      }
     }
   ]
 }

--- a/source/connection-string/tests/valid-options.yml
+++ b/source/connection-string/tests/valid-options.yml
@@ -30,7 +30,7 @@ tests:
               tls: true
     -
         description: Colon in a key value pair
-        uri: mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb%3A%2F%2Ftest-cluster
+        uri: mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster
         valid: true
         warning: false
         hosts:

--- a/source/connection-string/tests/valid-options.yml
+++ b/source/connection-string/tests/valid-options.yml
@@ -28,3 +28,17 @@ tests:
         auth: ~
         options:
               tls: true
+    -
+        description: Colon in a key value pair
+        uri: mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb%3A%2F%2Ftest-cluster
+        valid: true
+        warning: false
+        hosts:
+            - 
+                type: hostname
+                host: example.com
+                port: ~
+        auth: ~
+        options:
+        authmechanismProperties:
+            TOKEN_RESOURCE: 'mongodb://test-cluster'

--- a/source/connection-string/tests/valid-warnings.json
+++ b/source/connection-string/tests/valid-warnings.json
@@ -93,6 +93,21 @@
       ],
       "auth": null,
       "options": null
+    }, 
+    {
+      "description": "Comma in a key value pair causes a warning",
+      "uri": "mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
     }
   ]
 }

--- a/source/connection-string/tests/valid-warnings.yml
+++ b/source/connection-string/tests/valid-warnings.yml
@@ -73,3 +73,15 @@ tests:
                 port: ~
         auth: ~
         options: ~
+    -
+        description: Comma in a key value pair causes a warning
+        uri: mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2
+        valid: true
+        warning: true
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~


### PR DESCRIPTION

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
