### PR TITLE
DRIVERS-2732 Remove extra listCollections from KMIP delegated tests

### DIFF
--- a/source/client-side-encryption/etc/test-templates/kmipKMS.yml.template
+++ b/source/client-side-encryption/etc/test-templates/kmipKMS.yml.template
@@ -55,18 +55,12 @@ tests:
         arguments:
           document: &doc1 { _id: 1, encrypted_string_kmip_delegated: "string0" }
     expectations:
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: *collection_name
-        command_name: listCollections
     # Auto encryption will request the collection info.
     - command_started_event:
         command:
           listCollections: 1
           filter:
-            name: datakeys
+            name: *collection_name
         command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:

--- a/source/client-side-encryption/tests/legacy/kmipKMS.json
+++ b/source/client-side-encryption/tests/legacy/kmipKMS.json
@@ -297,17 +297,6 @@
         {
           "command_started_event": {
             "command": {
-              "listCollections": 1,
-              "filter": {
-                "name": "datakeys"
-              }
-            },
-            "command_name": "listCollections"
-          }
-        },
-        {
-          "command_started_event": {
-            "command": {
               "find": "datakeys",
               "filter": {
                 "$or": [

--- a/source/client-side-encryption/tests/legacy/kmipKMS.yml
+++ b/source/client-side-encryption/tests/legacy/kmipKMS.yml
@@ -55,18 +55,12 @@ tests:
         arguments:
           document: &doc1 { _id: 1, encrypted_string_kmip_delegated: "string0" }
     expectations:
-    - command_started_event:
-        command:
-          listCollections: 1
-          filter:
-            name: *collection_name
-        command_name: listCollections
     # Auto encryption will request the collection info.
     - command_started_event:
         command:
           listCollections: 1
           filter:
-            name: datakeys
+            name: *collection_name
         command_name: listCollections
     # Then key is fetched from the key vault.
     - command_started_event:


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] [Test changes in at least one language driver](https://spruce.mongodb.com/version/665e26d95beb620007908dd4)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

An extra `listCollections` event was included by mistake in the JSON test from KMIP delegated. The test passes with the C driver despite the inclusion because of a quirk in the C driver's test runner. Thanks @katcharov for spotting it.