### PR TITLE
DRIVERS-2921: Use single mongos for unacknowledged write tests

### DIFF
--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.json
@@ -5,6 +5,7 @@
     {
       "client": {
         "id": "client",
+        "useMultipleMongoses": false,
         "observeLogMessages": {
           "command": "debug"
         }

--- a/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
+++ b/source/command-logging-and-monitoring/tests/logging/unacknowledged-write.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.16"
 createEntities:
   - client:
       id: &client client
+      useMultipleMongoses: false
       observeLogMessages:
         command: debug
   - database:

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
@@ -5,6 +5,7 @@
     {
       "client": {
         "id": "client",
+        "useMultipleMongoses": false,
         "observeEvents": [
           "commandStartedEvent",
           "commandSucceededEvent",

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
@@ -5,6 +5,7 @@ schemaVersion: "1.7"
 createEntities:
   - client:
       id: &client client
+      useMultipleMongoses: false
       observeEvents:
         - commandStartedEvent
         - commandSucceededEvent


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2921

cd08b7248eb4e3ab901a8f7905874da41b908f7c added find operations after a w:0 write to ensure it applies, but the client also needs useMultipleMongoses:false to ensure this happens on the same host.

Please complete the following before merging:

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

----

Patch build: https://spruce.mongodb.com/version/666093b08fe04300077b53b7/tasks