### PR TITLE
Formatting fix for client-side-encryption/tests/README.md

### DIFF
--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -2821,7 +2821,8 @@ The Range Explicit Encryption tests require MongoDB server 8.0+.
 > MongoDB Server 8.0 introduced a backwards breaking change to the Queryable Encryption (QE) range protocol: QE Range V2
 > libmongocrypt 1.10.0 is required to use the QE Range V2.
 
-> [!NOTE] MongoDB Server 7.0 introduced a backwards breaking change to the Queryable Encryption (QE) protocol: QEv2.
+> [!NOTE]
+> MongoDB Server 7.0 introduced a backwards breaking change to the Queryable Encryption (QE) protocol: QEv2.
 > libmongocrypt 1.8.0 is configured to use the QEv2 protocol.
 
 Each of the following test cases must pass for each of the supported types (`DecimalNoPrecision`, `DecimalPrecision`,


### PR DESCRIPTION
A missing newline from https://github.com/mongodb/specifications/commit/9bfa512e41c1231a51f83260f5672a36626d9bcd caused mdformat to crash.