### PR TITLE
fix uri in username with test environment oidc test

### DIFF
--- a/source/auth/tests/legacy/connection-string.json
+++ b/source/auth/tests/legacy/connection-string.json
@@ -517,7 +517,7 @@
     },
     {
       "description": "should throw an exception if username is specified for test (MONGODB-OIDC)",
-      "uri": "mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&ENVIRONMENT:test",
+      "uri": "mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:test",
       "valid": false,
       "credential": null
     },

--- a/source/auth/tests/legacy/connection-string.yml
+++ b/source/auth/tests/legacy/connection-string.yml
@@ -375,7 +375,7 @@ tests:
   valid: false
   credential:
 - description: should throw an exception if username is specified for test (MONGODB-OIDC)
-  uri: mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&ENVIRONMENT:test
+  uri: mongodb://principalName@localhost/?authMechanism=MONGODB-OIDC&authMechanismProperties=ENVIRONMENT:test
   valid: false
   credential:
 - description: should throw an exception if specified environment is not supported (MONGODB-OIDC)


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

When implementing OIDC in the Ruby driver I noticed that the username with `ENVIRONMENT:test` spec test was not failing because of the username being present but rather the URI was actually invalid, since `ENVIRONMENT:test` was not in the `authMechanismProperties`. This fixes that test.

Tests running on this PR: https://github.com/mongodb/mongo-ruby-driver/pull/2873

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
