### PR TITLE
DRIVERS-2915 Add authMechanism option to tests where needed

### DIFF
--- a/source/connection-string/connection-string-spec.md
+++ b/source/connection-string/connection-string-spec.md
@@ -224,10 +224,10 @@ The values in connection options MUST be URL decoded by the parser. The values c
   ?readPreferenceTags=dc:ny,rack:1
   ```
 
-  Drivers MUST handle unencoded colon signs (":") within the value. For example, given the connection string:
+  Drivers MUST handle unencoded colon signs (":") within the value. For example, given the connection string option:
 
   ```
-  ?authMechanismProperties=TOKEN_RESOURCE:mongodb://foo
+  authMechanismProperties=TOKEN_RESOURCE:mongodb://foo
   ```
 
   the driver MUST interpret the key as `TOKEN_RESOURCE` and the value as `mongodb://foo`.

--- a/source/connection-string/tests/valid-options.json
+++ b/source/connection-string/tests/valid-options.json
@@ -40,7 +40,7 @@
     },
     {
       "description": "Colon in a key value pair",
-      "uri": "mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster",
+      "uri": "mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster",
       "valid": true,
       "warning": false,
       "hosts": [

--- a/source/connection-string/tests/valid-options.yml
+++ b/source/connection-string/tests/valid-options.yml
@@ -30,7 +30,7 @@ tests:
               tls: true
     -
         description: Colon in a key value pair
-        uri: mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster
+        uri: mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster
         valid: true
         warning: false
         hosts:
@@ -40,5 +40,5 @@ tests:
                 port: ~
         auth: ~
         options:
-        authmechanismProperties:
-            TOKEN_RESOURCE: 'mongodb://test-cluster'
+            authmechanismProperties:
+                TOKEN_RESOURCE: 'mongodb://test-cluster'

--- a/source/connection-string/tests/valid-warnings.json
+++ b/source/connection-string/tests/valid-warnings.json
@@ -96,7 +96,7 @@
     },
     {
       "description": "Comma in a key value pair causes a warning",
-      "uri": "mongodb://example.com?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2",
+      "uri": "mongodb://localhost?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2",
       "valid": true,
       "warning": true,
       "hosts": [

--- a/source/connection-string/tests/valid-warnings.json
+++ b/source/connection-string/tests/valid-warnings.json
@@ -93,10 +93,10 @@
       ],
       "auth": null,
       "options": null
-    }, 
+    },
     {
       "description": "Comma in a key value pair causes a warning",
-      "uri": "mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2",
+      "uri": "mongodb://example.com?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2",
       "valid": true,
       "warning": true,
       "hosts": [

--- a/source/connection-string/tests/valid-warnings.yml
+++ b/source/connection-string/tests/valid-warnings.yml
@@ -75,7 +75,7 @@ tests:
         options: ~
     -
         description: Comma in a key value pair causes a warning
-        uri: mongodb://example.com?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2
+        uri: mongodb://localhost?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2
         valid: true
         warning: true
         hosts:

--- a/source/connection-string/tests/valid-warnings.yml
+++ b/source/connection-string/tests/valid-warnings.yml
@@ -75,7 +75,7 @@ tests:
         options: ~
     -
         description: Comma in a key value pair causes a warning
-        uri: mongodb://example.com?authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2
+        uri: mongodb://example.com?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2
         valid: true
         warning: true
         hosts:


### PR DESCRIPTION
DRIVERS-2915 (followup)

At least one driver (Java) requires `authMechanism` to be provided when `authMechanismProperties` are provided. Minor clarification, but no changes to substance of the spec. Fixes/narrows tests, including a formatting issue.