### PR TITLE
Remove result expectation in command monitoring tests

### DIFF
--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.json
@@ -71,17 +71,7 @@
           "object": "collection",
           "arguments": {
             "filter": {}
-          },
-          "expectResult": [
-            {
-              "_id": 1,
-              "x": 11
-            },
-            {
-              "_id": "unorderedBulkWriteInsertW0",
-              "x": 44
-            }
-          ]
+          }
         }
       ],
       "expectEvents": [

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledgedBulkWrite.yml
@@ -42,10 +42,6 @@ tests:
         object: *collection
         arguments:
           filter: { }
-        expectResult: [
-          { _id: 1, x: 11 },
-          { _id: "unorderedBulkWriteInsertW0", x: 44 }
-        ]
     expectEvents:
       - client: *client
         ignoreExtraEvents: true


### PR DESCRIPTION
- [ ] ~Update changelog.~
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

This removes a command expectation for a find command in the command monitoring tests. We've observed frequent failures on sharded clusters, which we assume are related to replication lag. Since the goal of the test is to test command monitoring for writes with `w: 0` and not the successful execution of such writes, I assume it's safe to remove the result expectation to reduce flakiness.
