### PR TITLE
DRIVERS-2776 test compact with "range"

### DIFF
--- a/source/client-side-encryption/etc/test-templates/fle2v2-Compact.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Compact.yml.template
@@ -22,6 +22,8 @@ tests:
         arguments:
           command:
             compactStructuredEncryptionData: *collection_name
+        result:
+          ok: 1
     expectations:
       - command_started_event:
           command:

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Compact.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Compact.yml.template
@@ -1,4 +1,4 @@
-# Requires libmongocrypt 1.8.0.
+# Requires libmongocrypt 1.8.0. libmongocrypt 1.10.0 has a bug (MONGOCRYPT-699) that may cause this test to fail on server version 7.
 runOn:
   - minServerVersion: "7.0.0"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.

--- a/source/client-side-encryption/etc/test-templates/fle2v2-Rangev2-Compact.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Rangev2-Compact.yml.template
@@ -1,0 +1,93 @@
+# Requires libmongocrypt 1.10.1.
+runOn:
+  - minServerVersion: "8.0.0" # Require range v2 support on server.
+    # FLE 2 Encrypted collections are not supported on standalone.
+    topology: [ "replicaset", "sharded", "load-balanced" ]
+database_name: "default"
+collection_name: &collection_name "default"
+data: []
+encrypted_fields: &encrypted_fields {{ yamlfile("range-encryptedFields-Int.json") }}
+key_vault_data: [ {{ yamlfile("keys/key1-document.json") }} ]
+tests:
+  - description: "Compact works with 'range' fields"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {{ local_provider() }}
+    operations:
+      # Insert before running compact to ensure the server errors if `encryptionInformation` is incorrectly omitted.
+      - name: insertOne
+        arguments:
+          document: { _id: 0, encryptedInt: { $numberInt: "0" } }
+      - name: runCommand
+        object: database
+        command_name: compactStructuredEncryptionData
+        arguments:
+          command:
+            compactStructuredEncryptionData: *collection_name
+        result:
+          ok: 1
+    expectations:
+      - command_started_event:
+          command:
+            listCollections: 1
+            filter:
+              name: *collection_name
+          command_name: listCollections
+      - command_started_event:
+          command:
+            find: datakeys
+            filter: {
+                  "$or": [
+                      {
+                          "_id": {
+                              "$in": [
+                                {{ yamlfile("keys/key1-id.json") }}
+                              ]
+                          }
+                      },
+                      {
+                          "keyAltNames": {
+                              "$in": []
+                          }
+                      }
+                  ]
+              }
+            $db: keyvault
+            readConcern: { level: "majority" }
+          command_name: find
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { "_id": 0, "encryptedInt": { $$type: "binData" } }
+            ordered: true
+            encryptionInformation: &encryptionInformation
+              type: 1
+              schema:
+                default.default:
+                  # libmongocrypt applies escCollection and ecocCollection to outgoing command.
+                  escCollection: "enxcol_.default.esc"
+                  ecocCollection: "enxcol_.default.ecoc"
+                  <<: *encrypted_fields
+          command_name: insert
+      - command_started_event:
+          command:
+            compactStructuredEncryptionData: *collection_name
+            compactionTokens:
+              "encryptedInt": {
+                "ecoc": {
+                    "$binary": {
+                        "base64": "noN+05JsuO1oDg59yypIGj45i+eFH6HOTXOPpeZ//Mk=",
+                        "subType": "00"
+                    }
+                },
+                "anchorPaddingToken": {
+                    "$binary": {
+                        "base64": "QxKJD2If48p0l8NAXf2Kr0aleMd/dATSjBK6hTpNMyc=",
+                        "subType": "00"
+                    }
+                }
+              }
+            encryptionInformation: *encryptionInformation
+          command_name: compactStructuredEncryptionData

--- a/source/client-side-encryption/tests/legacy/fle2v2-Compact.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Compact.json
@@ -130,6 +130,9 @@
             "command": {
               "compactStructuredEncryptionData": "default"
             }
+          },
+          "result": {
+            "ok": 1
           }
         }
       ],

--- a/source/client-side-encryption/tests/legacy/fle2v2-Compact.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Compact.yml
@@ -1,4 +1,4 @@
-# Requires libmongocrypt 1.8.0.
+# Requires libmongocrypt 1.8.0. libmongocrypt 1.10.0 has a bug (MONGOCRYPT-699) that may cause this test to fail on server version 7.
 runOn:
   - minServerVersion: "7.0.0"
     # Skip QEv2 (also referred to as FLE2v2) tests on Serverless. Unskip once Serverless enables the QEv2 protocol.
@@ -22,6 +22,8 @@ tests:
         arguments:
           command:
             compactStructuredEncryptionData: *collection_name
+        result:
+          ok: 1
     expectations:
       - command_started_event:
           command:

--- a/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.json
@@ -1,0 +1,289 @@
+{
+  "runOn": [
+    {
+      "minServerVersion": "8.0.0",
+      "topology": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "database_name": "default",
+  "collection_name": "default",
+  "data": [],
+  "encrypted_fields": {
+    "fields": [
+      {
+        "keyId": {
+          "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+          }
+        },
+        "path": "encryptedInt",
+        "bsonType": "int",
+        "queries": {
+          "queryType": "range",
+          "contention": {
+            "$numberLong": "0"
+          },
+          "trimFactor": {
+            "$numberInt": "1"
+          },
+          "sparsity": {
+            "$numberLong": "1"
+          },
+          "min": {
+            "$numberInt": "0"
+          },
+          "max": {
+            "$numberInt": "200"
+          }
+        }
+      }
+    ]
+  },
+  "key_vault_data": [
+    {
+      "_id": {
+        "$binary": {
+          "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+          "subType": "04"
+        }
+      },
+      "keyMaterial": {
+        "$binary": {
+          "base64": "sHe0kz57YW7v8g9VP9sf/+K1ex4JqKc5rf/URX3n3p8XdZ6+15uXPaSayC6adWbNxkFskuMCOifDoTT+rkqMtFkDclOy884RuGGtUysq3X7zkAWYTKi8QAfKkajvVbZl2y23UqgVasdQu3OVBQCrH/xY00nNAs/52e958nVjBuzQkSb1T8pKJAyjZsHJ60+FtnfafDZSTAIBJYn7UWBCwQ==",
+          "subType": "00"
+        }
+      },
+      "creationDate": {
+        "$date": {
+          "$numberLong": "1648914851981"
+        }
+      },
+      "updateDate": {
+        "$date": {
+          "$numberLong": "1648914851981"
+        }
+      },
+      "status": {
+        "$numberInt": "0"
+      },
+      "masterKey": {
+        "provider": "local"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Compact works with 'range' fields",
+      "clientOptions": {
+        "autoEncryptOpts": {
+          "kmsProviders": {
+            "local": {
+              "key": {
+                "$binary": {
+                  "base64": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+                  "subType": "00"
+                }
+              }
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 0,
+              "encryptedInt": {
+                "$numberInt": "0"
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "command_name": "compactStructuredEncryptionData",
+          "arguments": {
+            "command": {
+              "compactStructuredEncryptionData": "default"
+            }
+          },
+          "result": {
+            "ok": 1
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "listCollections": 1,
+              "filter": {
+                "name": "default"
+              }
+            },
+            "command_name": "listCollections"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "find": "datakeys",
+              "filter": {
+                "$or": [
+                  {
+                    "_id": {
+                      "$in": [
+                        {
+                          "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "keyAltNames": {
+                      "$in": []
+                    }
+                  }
+                ]
+              },
+              "$db": "keyvault",
+              "readConcern": {
+                "level": "majority"
+              }
+            },
+            "command_name": "find"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "default",
+              "documents": [
+                {
+                  "_id": 0,
+                  "encryptedInt": {
+                    "$$type": "binData"
+                  }
+                }
+              ],
+              "ordered": true,
+              "encryptionInformation": {
+                "type": 1,
+                "schema": {
+                  "default.default": {
+                    "escCollection": "enxcol_.default.esc",
+                    "ecocCollection": "enxcol_.default.ecoc",
+                    "fields": [
+                      {
+                        "keyId": {
+                          "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                          }
+                        },
+                        "path": "encryptedInt",
+                        "bsonType": "int",
+                        "queries": {
+                          "queryType": "range",
+                          "contention": {
+                            "$numberLong": "0"
+                          },
+                          "trimFactor": {
+                            "$numberInt": "1"
+                          },
+                          "sparsity": {
+                            "$numberLong": "1"
+                          },
+                          "min": {
+                            "$numberInt": "0"
+                          },
+                          "max": {
+                            "$numberInt": "200"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "command_name": "insert"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "compactStructuredEncryptionData": "default",
+              "compactionTokens": {
+                "encryptedInt": {
+                  "ecoc": {
+                    "$binary": {
+                      "base64": "noN+05JsuO1oDg59yypIGj45i+eFH6HOTXOPpeZ//Mk=",
+                      "subType": "00"
+                    }
+                  },
+                  "anchorPaddingToken": {
+                    "$binary": {
+                      "base64": "QxKJD2If48p0l8NAXf2Kr0aleMd/dATSjBK6hTpNMyc=",
+                      "subType": "00"
+                    }
+                  }
+                }
+              },
+              "encryptionInformation": {
+                "type": 1,
+                "schema": {
+                  "default.default": {
+                    "escCollection": "enxcol_.default.esc",
+                    "ecocCollection": "enxcol_.default.ecoc",
+                    "fields": [
+                      {
+                        "keyId": {
+                          "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                          }
+                        },
+                        "path": "encryptedInt",
+                        "bsonType": "int",
+                        "queries": {
+                          "queryType": "range",
+                          "contention": {
+                            "$numberLong": "0"
+                          },
+                          "trimFactor": {
+                            "$numberInt": "1"
+                          },
+                          "sparsity": {
+                            "$numberLong": "1"
+                          },
+                          "min": {
+                            "$numberInt": "0"
+                          },
+                          "max": {
+                            "$numberInt": "200"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "command_name": "compactStructuredEncryptionData"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.yml
@@ -1,0 +1,93 @@
+# Requires libmongocrypt 1.10.1.
+runOn:
+  - minServerVersion: "8.0.0" # Require range v2 support on server.
+    # FLE 2 Encrypted collections are not supported on standalone.
+    topology: [ "replicaset", "sharded", "load-balanced" ]
+database_name: "default"
+collection_name: &collection_name "default"
+data: []
+encrypted_fields: &encrypted_fields {'fields': [{'keyId': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'path': 'encryptedInt', 'bsonType': 'int', 'queries': {'queryType': 'range', 'contention': {'$numberLong': '0'}, 'trimFactor': {'$numberInt': '1'}, 'sparsity': {'$numberLong': '1'}, 'min': {'$numberInt': '0'}, 'max': {'$numberInt': '200'}}}]}
+key_vault_data: [ {'_id': {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}, 'keyMaterial': {'$binary': {'base64': 'sHe0kz57YW7v8g9VP9sf/+K1ex4JqKc5rf/URX3n3p8XdZ6+15uXPaSayC6adWbNxkFskuMCOifDoTT+rkqMtFkDclOy884RuGGtUysq3X7zkAWYTKi8QAfKkajvVbZl2y23UqgVasdQu3OVBQCrH/xY00nNAs/52e958nVjBuzQkSb1T8pKJAyjZsHJ60+FtnfafDZSTAIBJYn7UWBCwQ==', 'subType': '00'}}, 'creationDate': {'$date': {'$numberLong': '1648914851981'}}, 'updateDate': {'$date': {'$numberLong': '1648914851981'}}, 'status': {'$numberInt': '0'}, 'masterKey': {'provider': 'local'}} ]
+tests:
+  - description: "Compact works with 'range' fields"
+    clientOptions:
+      autoEncryptOpts:
+        kmsProviders:
+          local: {'key': {'$binary': {'base64': 'Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk', 'subType': '00'}}}
+    operations:
+      # Insert before running compact to ensure the server errors if `encryptionInformation` is incorrectly omitted.
+      - name: insertOne
+        arguments:
+          document: { _id: 0, encryptedInt: { $numberInt: "0" } }
+      - name: runCommand
+        object: database
+        command_name: compactStructuredEncryptionData
+        arguments:
+          command:
+            compactStructuredEncryptionData: *collection_name
+        result:
+          ok: 1
+    expectations:
+      - command_started_event:
+          command:
+            listCollections: 1
+            filter:
+              name: *collection_name
+          command_name: listCollections
+      - command_started_event:
+          command:
+            find: datakeys
+            filter: {
+                  "$or": [
+                      {
+                          "_id": {
+                              "$in": [
+                                {'$binary': {'base64': 'EjRWeBI0mHYSNBI0VniQEg==', 'subType': '04'}}
+                              ]
+                          }
+                      },
+                      {
+                          "keyAltNames": {
+                              "$in": []
+                          }
+                      }
+                  ]
+              }
+            $db: keyvault
+            readConcern: { level: "majority" }
+          command_name: find
+      - command_started_event:
+          command:
+            insert: *collection_name
+            documents:
+              - { "_id": 0, "encryptedInt": { $$type: "binData" } }
+            ordered: true
+            encryptionInformation: &encryptionInformation
+              type: 1
+              schema:
+                default.default:
+                  # libmongocrypt applies escCollection and ecocCollection to outgoing command.
+                  escCollection: "enxcol_.default.esc"
+                  ecocCollection: "enxcol_.default.ecoc"
+                  <<: *encrypted_fields
+          command_name: insert
+      - command_started_event:
+          command:
+            compactStructuredEncryptionData: *collection_name
+            compactionTokens:
+              "encryptedInt": {
+                "ecoc": {
+                    "$binary": {
+                        "base64": "noN+05JsuO1oDg59yypIGj45i+eFH6HOTXOPpeZ//Mk=",
+                        "subType": "00"
+                    }
+                },
+                "anchorPaddingToken": {
+                    "$binary": {
+                        "base64": "QxKJD2If48p0l8NAXf2Kr0aleMd/dATSjBK6hTpNMyc=",
+                        "subType": "00"
+                    }
+                }
+              }
+            encryptionInformation: *encryptionInformation
+          command_name: compactStructuredEncryptionData


### PR DESCRIPTION
# Summary

- Assert successful response to `compactStructuredEncryptionData`.
- Add `fle2v2-Rangev2-Compact` to test compact with "range".

Partially resolves DRIVERS-2776.

# Background & Motivation

Spec tests are motivated by the bug fix in [MONGOCRYPT-699](https://jira.mongodb.org/browse/MONGOCRYPT-699).

Adding `result: { ok: 1 }` to the operation is to ensure test runners check the operation succeeded. The [test format](https://github.com/mongodb/specifications/blob/663db4db13c8acf415bb97259bf7f1909b32a670/source/transactions/tests/legacy-test-format.md#test-format) does not require checking the operation succeeded if `result` is not present.

An "insert" operation is added before `compactStructuredEncryptionData` for the range test. [The server check requiring `encryptionInformation`](https://github.com/10gen/mongo/blob/54e4cc6160eab62877d24a00a5cf2eee0dc2d4b5/src/mongo/db/commands/fle2_compact.cpp#L714-L718) appears to require data present to trigger the error.




<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ N/A. Test changes only.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. [Tested in C](https://spruce.mongodb.com/version/667dcae2c8c7e90007ead699).
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).~~ C driver does not currently test IUE with sharded or serverless.

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
