### PR TITLE
DRIVERS-2870 Regenerate close-cursors.json

### DIFF
--- a/source/client-side-operations-timeout/tests/close-cursors.json
+++ b/source/client-side-operations-timeout/tests/close-cursors.json
@@ -75,7 +75,7 @@
                   "getMore"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 200
+                "blockTimeMS": 250
               }
             }
           }
@@ -175,7 +175,7 @@
                   "killCursors"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 30
+                "blockTimeMS": 250
               }
             }
           }
@@ -186,7 +186,7 @@
           "arguments": {
             "filter": {},
             "batchSize": 2,
-            "timeoutMS": 20
+            "timeoutMS": 200
           },
           "saveResultAsEntity": "cursor"
         },
@@ -194,7 +194,7 @@
           "name": "close",
           "object": "cursor",
           "arguments": {
-            "timeoutMS": 40
+            "timeoutMS": 400
           }
         }
       ],


### PR DESCRIPTION
Somehow close-cursors.json was not generated correctly in [DRIVERS-2870](https://jira.mongodb.org/browse/DRIVERS-2870) (https://github.com/mongodb/specifications/pull/1552). 

@rozza Could you confirm the new test is correct?