### PR TITLE
DRIVERS-2938: Remove MONGODB-CR from spec tests

### DIFF
--- a/source/auth/tests/legacy/connection-string.json
+++ b/source/auth/tests/legacy/connection-string.json
@@ -164,47 +164,6 @@
       "valid": false
     },
     {
-      "description": "should recognize the mechanism (MONGODB-CR)",
-      "uri": "mongodb://user:password@localhost/?authMechanism=MONGODB-CR",
-      "valid": true,
-      "credential": {
-        "username": "user",
-        "password": "password",
-        "source": "admin",
-        "mechanism": "MONGODB-CR",
-        "mechanism_properties": null
-      }
-    },
-    {
-      "description": "should use the database when no authSource is specified (MONGODB-CR)",
-      "uri": "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR",
-      "valid": true,
-      "credential": {
-        "username": "user",
-        "password": "password",
-        "source": "foo",
-        "mechanism": "MONGODB-CR",
-        "mechanism_properties": null
-      }
-    },
-    {
-      "description": "should use the authSource when specified (MONGODB-CR)",
-      "uri": "mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR&authSource=bar",
-      "valid": true,
-      "credential": {
-        "username": "user",
-        "password": "password",
-        "source": "bar",
-        "mechanism": "MONGODB-CR",
-        "mechanism_properties": null
-      }
-    },
-    {
-      "description": "should throw an exception if no username is supplied (MONGODB-CR)",
-      "uri": "mongodb://localhost/?authMechanism=MONGODB-CR",
-      "valid": false
-    },
-    {
       "description": "should recognize the mechanism (MONGODB-X509)",
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509",
       "valid": true,

--- a/source/auth/tests/legacy/connection-string.yml
+++ b/source/auth/tests/legacy/connection-string.yml
@@ -116,36 +116,6 @@ tests:
 - description: should throw an exception if no username (GSSAPI)
   uri: mongodb://localhost/?authMechanism=GSSAPI
   valid: false
-- description: should recognize the mechanism (MONGODB-CR)
-  uri: mongodb://user:password@localhost/?authMechanism=MONGODB-CR
-  valid: true
-  credential:
-    username: user
-    password: password
-    source: admin
-    mechanism: MONGODB-CR
-    mechanism_properties:
-- description: should use the database when no authSource is specified (MONGODB-CR)
-  uri: mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR
-  valid: true
-  credential:
-    username: user
-    password: password
-    source: foo
-    mechanism: MONGODB-CR
-    mechanism_properties:
-- description: should use the authSource when specified (MONGODB-CR)
-  uri: mongodb://user:password@localhost/foo?authMechanism=MONGODB-CR&authSource=bar
-  valid: true
-  credential:
-    username: user
-    password: password
-    source: bar
-    mechanism: MONGODB-CR
-    mechanism_properties:
-- description: should throw an exception if no username is supplied (MONGODB-CR)
-  uri: mongodb://localhost/?authMechanism=MONGODB-CR
-  valid: false
 - description: should recognize the mechanism (MONGODB-X509)
   uri: mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509
   valid: true

--- a/source/connection-string/tests/valid-auth.json
+++ b/source/connection-string/tests/valid-auth.json
@@ -220,29 +220,8 @@
       "options": null
     },
     {
-      "description": "Escaped user info and database (MONGODB-CR)",
-      "uri": "mongodb://%24am:f%3Azzb%40z%2Fz%3D@127.0.0.1/admin%3F?authMechanism=MONGODB-CR",
-      "valid": true,
-      "warning": false,
-      "hosts": [
-        {
-          "type": "ipv4",
-          "host": "127.0.0.1",
-          "port": null
-        }
-      ],
-      "auth": {
-        "username": "$am",
-        "password": "f:zzb@z/z=",
-        "db": "admin?"
-      },
-      "options": {
-        "authmechanism": "MONGODB-CR"
-      }
-    },
-    {
-      "description": "Subdelimiters in user/pass don't need escaping (MONGODB-CR)",
-      "uri": "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=MONGODB-CR",
+      "description": "Subdelimiters in user/pass don't need escaping (PLAIN)",
+      "uri": "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=PLAIN",
       "valid": true,
       "warning": false,
       "hosts": [
@@ -258,7 +237,7 @@
         "db": "admin"
       },
       "options": {
-        "authmechanism": "MONGODB-CR"
+        "authmechanism": "PLAIN"
       }
     },
     {

--- a/source/connection-string/tests/valid-auth.yml
+++ b/source/connection-string/tests/valid-auth.yml
@@ -173,24 +173,8 @@ tests:
             db: "my=db"
         options: ~
     -
-        description: "Escaped user info and database (MONGODB-CR)"
-        uri: "mongodb://%24am:f%3Azzb%40z%2Fz%3D@127.0.0.1/admin%3F?authMechanism=MONGODB-CR"
-        valid: true
-        warning: false
-        hosts:
-            -
-                type: "ipv4"
-                host: "127.0.0.1"
-                port: ~
-        auth:
-            username: "$am"
-            password: "f:zzb@z/z="
-            db: "admin?"
-        options:
-            authmechanism: "MONGODB-CR"
-    -
-        description: "Subdelimiters in user/pass don't need escaping (MONGODB-CR)"
-        uri: "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=MONGODB-CR"
+        description: "Subdelimiters in user/pass don't need escaping (PLAIN)"
+        uri: "mongodb://!$&'()*+,;=:!$&'()*+,;=@127.0.0.1/admin?authMechanism=PLAIN"
         valid: true
         warning: false
         hosts:
@@ -203,7 +187,7 @@ tests:
             password: "!$&'()*+,;="
             db: "admin"
         options:
-            authmechanism: "MONGODB-CR"
+            authmechanism: "PLAIN"
     -
         description: "Escaped username (MONGODB-X509)"
         uri: "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509"

--- a/source/connection-string/tests/valid-options.json
+++ b/source/connection-string/tests/valid-options.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "Option names are normalized to lowercase",
-      "uri": "mongodb://alice:secret@example.com/admin?AUTHMechanism=MONGODB-CR",
+      "uri": "mongodb://alice:secret@example.com/admin?AUTHMechanism=PLAIN",
       "valid": true,
       "warning": false,
       "hosts": [
@@ -18,7 +18,7 @@
         "db": "admin"
       },
       "options": {
-        "authmechanism": "MONGODB-CR"
+        "authmechanism": "PLAIN"
       }
     },
     {

--- a/source/connection-string/tests/valid-options.yml
+++ b/source/connection-string/tests/valid-options.yml
@@ -1,7 +1,7 @@
 tests:
     -
         description: "Option names are normalized to lowercase"
-        uri: "mongodb://alice:secret@example.com/admin?AUTHMechanism=MONGODB-CR"
+        uri: "mongodb://alice:secret@example.com/admin?AUTHMechanism=PLAIN"
         valid: true
         warning: false
         hosts:
@@ -14,7 +14,7 @@ tests:
             password: "secret"
             db: "admin"
         options:
-            authmechanism: "MONGODB-CR"
+            authmechanism: "PLAIN"
     -
         description: "Missing delimiting slash between hosts and options"
         uri: "mongodb://example.com?tls=true"


### PR DESCRIPTION
Changes to spec tests to close the [DRIVERS-2938](https://jira.mongodb.org/browse/DRIVERS-2938) Remove MONGODB-CR from spec tests

Please complete the following before merging:

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver (tested in custom patch for CSharp Driver, will update with PR once other MongoDB 4.0 related issues will get sorted).
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).