### PR TITLE
DRIVERS-2776 document "range" as stable

### DIFF
--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -978,7 +978,6 @@ class ClientEncryption {
    //   {$and: [{$gt: [<fieldpath>, <value1>]}, {$lt: [<fieldpath>, <value2>]}]
    // $gt may also be $gte. $lt may also be $lte.
    // Only supported when queryType is "range" and algorithm is "Range".
-   // NOTE: The "range" queryType and "Range" algorithm are currently unstable API and subject to backwards breaking changes.
    encryptExpression(expr: Document, opts: EncryptOpts): Document;
 
    // Decrypts an encrypted value (BSON binary of subtype 6).
@@ -1163,7 +1162,6 @@ class EncryptOpts {
    rangeOpts: Optional<RangeOpts>
 }
 
-// NOTE: RangeOpts is currently unstable API and subject to backwards breaking changes.
 // RangeOpts specifies index options for a Queryable Encryption field supporting "range" queries.
 // min, max, trimFactor, sparsity, and precision must match the values set in the encryptedFields of the destination collection.
 // For double and decimal128, min/max/precision must all be set, or all be unset.
@@ -1200,7 +1198,7 @@ One of the strings:
 - "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
 - "Indexed"
 - "Unindexed"
-- "Range" (unstable)
+- "Range"
 
 The result of explicit encryption with the "Indexed" or "Range" algorithm must be processed by the server to insert or
 query. Drivers MUST document the following behavior:
@@ -1208,9 +1206,6 @@ query. Drivers MUST document the following behavior:
 > To insert or query with an "Indexed" or "Range" encrypted payload, use a `MongoClient` configured with
 > `AutoEncryptionOpts`. `AutoEncryptionOpts.bypassQueryAnalysis` may be true. `AutoEncryptionOpts.bypassAutoEncryption`
 > must be false.
-
-> [!NOTE]
-> The "Range" algorithm is currently unstable API and subject to backwards breaking changes.
 
 #### contentionFactor
 
@@ -1227,16 +1222,10 @@ One of the strings:
 queryType only applies when algorithm is "Indexed" or "Range". libmongocrypt returns an error if queryType is set for a
 non-applicable queryType.
 
-> [!NOTE]
-> The "range" queryType is currently unstable API and subject to backwards breaking changes.
-
 #### rangeOpts
 
 rangeOpts only applies when algorithm is "range". libmongocrypt returns an error if rangeOpts is set for a
 non-applicable algorithm.
-
-> [!NOTE]
-> rangeOpts is currently unstable API and subject to backwards breaking changes.
 
 ## User facing API: When Auto Encryption Fails
 
@@ -2382,6 +2371,8 @@ on. To support concurrent access of the key vault collection, the key management
 explicit session parameter as described in the [Drivers Sessions Specification](../sessions/driver-sessions.md).
 
 ## Changelog
+
+- 2024-07-29: Document range as stable.
 
 - 2024-07-22: Make `trimFactor` and `sparsity` optional.
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -2819,7 +2819,7 @@ The Range Explicit Encryption tests require MongoDB server 8.0+.
 
 > [!NOTE]
 > MongoDB Server 8.0 introduced a backwards breaking change to the Queryable Encryption (QE) range protocol: QE Range V2
-> libmongocrypt 1.10.0 is required to use the QE Range V2.
+> libmongocrypt 1.11.0 is required to use the QE Range V2.
 
 > [!NOTE]
 > MongoDB Server 7.0 introduced a backwards breaking change to the Queryable Encryption (QE) protocol: QEv2.


### PR DESCRIPTION
# Summary

Document "range" as stable. Resolves DRIVERS-2776.

# Background & Motivation

Drivers are expected to document "range" as stable for the upcoming server 8.0 releases. I expect drivers must wait to release until after libmongocrypt 1.11.0 is released (pending [MONGOCRYPT-662](https://jira.mongodb.org/browse/MONGOCRYPT-662)).

---

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- ~~[ ] Make sure there are generated JSON files from the YAML test files.~~ **N/A. No spec tests changed**
- ~~[ ] Test changes in at least one language driver.~~ **N/A. No tests changed**
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).~~ **N/A. No tests changed**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
