### PR TITLE
DRIVERS-2951 Test serverMonitoringMode=poll waits after a successful heartbeat

### DIFF
--- a/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.json
+++ b/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.json
@@ -444,6 +444,70 @@
           ]
         }
       ]
+    },
+    {
+      "description": "poll waits after successful heartbeat",
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "uriOptions": {
+                    "serverMonitoringMode": "poll",
+                    "heartbeatFrequencyMS": 1000000
+                  },
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "serverHeartbeatStartedEvent",
+                    "serverHeartbeatSucceededEvent",
+                    "serverHeartbeatFailedEvent"
+                  ]
+                }
+              },
+              {
+                "database": {
+                  "id": "db",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatSucceededEvent": {}
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "wait",
+          "object": "testRunner",
+          "arguments": {
+            "ms": 500
+          }
+        },
+        {
+          "name": "assertEventCount",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "serverHeartbeatStartedEvent": {}
+            },
+            "count": 1
+          }
+        }
+      ]
     }
   ]
 }

--- a/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.json
+++ b/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.json
@@ -463,8 +463,7 @@
                   "useMultipleMongoses": false,
                   "observeEvents": [
                     "serverHeartbeatStartedEvent",
-                    "serverHeartbeatSucceededEvent",
-                    "serverHeartbeatFailedEvent"
+                    "serverHeartbeatSucceededEvent"
                   ]
                 }
               },

--- a/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.yml
@@ -212,4 +212,3 @@ tests:
           event:
             serverHeartbeatStartedEvent: {}
           count: 1
-#    expectEvents: *streamingStartedEvents

--- a/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.yml
@@ -187,7 +187,6 @@ tests:
                 observeEvents:
                   - serverHeartbeatStartedEvent
                   - serverHeartbeatSucceededEvent
-                  - serverHeartbeatFailedEvent
             - database:
                 id: db
                 client: client

--- a/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/serverMonitoringMode.yml
@@ -171,3 +171,45 @@ tests:
       # Wait for the second serverHeartbeatStartedEvent to ensure we do not stream.
       - *waitForSecondHeartbeatStarted
     expectEvents: *pollingStartedEvents
+
+  - description: "poll waits after successful heartbeat"
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: client
+                uriOptions:
+                  serverMonitoringMode: "poll"
+                  heartbeatFrequencyMS: 1000000
+                useMultipleMongoses: false
+                observeEvents:
+                  - serverHeartbeatStartedEvent
+                  - serverHeartbeatSucceededEvent
+                  - serverHeartbeatFailedEvent
+            - database:
+                id: db
+                client: client
+                databaseName: sdam-tests
+      # Wait for the first serverHeartbeatSucceededEvent to ensure we start polling.
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: client
+          event:
+            serverHeartbeatSucceededEvent: {}
+          count: 1
+      # Wait for a bit longer to ensure we wait heartbeatFrequencyMS before starting the next check.
+      - name: wait
+        object: testRunner
+        arguments:
+          ms: 500
+      - name: assertEventCount
+        object: testRunner
+        arguments:
+          client: client
+          event:
+            serverHeartbeatStartedEvent: {}
+          count: 1
+#    expectEvents: *streamingStartedEvents


### PR DESCRIPTION
Fixes DRIVERS-2951.

Please complete the following before merging:

- [X] Make sure there are generated JSON files from the YAML test files.
- [X] Test changes in at least one language driver.
- [X] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).


Question, should we still update the prose test [here](https://github.com/mongodb/specifications/blob/master/source/server-discovery-and-monitoring/server-discovery-and-monitoring-tests.md#monitors-sleep-at-least-minheartbeatfrequencyms-between-checks) added in [DRIVERS-1251](https://jira.mongodb.org/browse/DRIVERS-1251) to run on both streaming and polling? Currently it implicitly tests polling on <4.4 servers.
