### PR TITLE
test(DRIVERS-2511): update wire versions for 4.0+

### DIFF
--- a/source/max-staleness/max-staleness.md
+++ b/source/max-staleness/max-staleness.md
@@ -469,6 +469,8 @@ client-side setting.
 
 ## Changelog
 
+- 2024-08-09: Updated wire versions in tests to 4.0+.
+
 - 2024-04-30: Migrated from reStructuredText to Markdown.
 
 - 2022-10-05: Remove spec front matter and revise changelog.

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/DefaultNoMaxStaleness.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/DefaultNoMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -37,7 +37,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -49,7 +49,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -63,7 +63,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/DefaultNoMaxStaleness.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/DefaultNoMaxStaleness.yml
@@ -8,14 +8,14 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1000001"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Very stale.
 read_preference:
   mode: Nearest

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/LastUpdateTime.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/LastUpdateTime.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/LastUpdateTime.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/LastUpdateTime.yml
@@ -8,21 +8,21 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 1
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 25002  # Not used when there's no primary.
     lastWrite: {lastWriteDate: {$numberLong: "2"}}  # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &3
     address: c:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 25001
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
 read_preference:
   mode: Nearest
   maxStalenessSeconds: 150

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/Nearest.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/Nearest.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/Nearest.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/Nearest.yml
@@ -8,21 +8,21 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "2"}}  # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &3
     address: c:27017
     avg_rtt_ms: 5
     lastUpdateTime: 0
     type: RSSecondary
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
 read_preference:
   mode: Nearest
   maxStalenessSeconds: 150

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/Nearest2.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/Nearest2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/Nearest2.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/Nearest2.yml
@@ -8,21 +8,21 @@ topology_description:
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "2"}}  # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &3
     address: c:27017
     avg_rtt_ms: 5
     lastUpdateTime: 0
     type: RSSecondary
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
 read_preference:
   mode: Nearest
   maxStalenessSeconds: 150

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/OneKnownTwoUnavailable.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/OneKnownTwoUnavailable.json
@@ -17,7 +17,7 @@
       {
         "address": "c:27017",
         "type": "RSSecondary",
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "avg_rtt_ms": 5,
         "lastWrite": {
           "lastWriteDate": {
@@ -35,7 +35,7 @@
     {
       "address": "c:27017",
       "type": "RSSecondary",
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "avg_rtt_ms": 5,
       "lastWrite": {
         "lastWriteDate": {
@@ -48,7 +48,7 @@
     {
       "address": "c:27017",
       "type": "RSSecondary",
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "avg_rtt_ms": 5,
       "lastWrite": {
         "lastWriteDate": {

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/OneKnownTwoUnavailable.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/OneKnownTwoUnavailable.yml
@@ -15,7 +15,7 @@ topology_description:
   - &3
     address: c:27017
     type: RSSecondary
-    maxWireVersion: 6
+    maxWireVersion: 21
     avg_rtt_ms: 5
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/PrimaryPreferred.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/PrimaryPreferred.json
@@ -8,7 +8,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -53,7 +53,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/PrimaryPreferred.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/PrimaryPreferred.yml
@@ -9,14 +9,14 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1000001"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Very stale.
 read_preference:
   mode: PrimaryPreferred

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/PrimaryPreferred_tags.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/PrimaryPreferred_tags.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "tokyo"
         }
@@ -28,7 +28,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "nyc"
         }
@@ -58,7 +58,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }
@@ -75,7 +75,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/PrimaryPreferred_tags.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/PrimaryPreferred_tags.yml
@@ -12,7 +12,7 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
     tags:
       data_center: tokyo  # Matches second tag set.
   - &2
@@ -21,7 +21,7 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
     tags:
       data_center: nyc
 read_preference:

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/Secondary.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/Secondary.json
@@ -8,7 +8,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -23,7 +23,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -38,7 +38,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -53,7 +53,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -80,7 +80,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -97,7 +97,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/Secondary.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/Secondary.yml
@@ -9,7 +9,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
     tags:
       data_center: tokyo  # No match, but its lastWriteDate is used in estimate.
@@ -18,7 +18,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}  # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
     tags:
       data_center: nyc
@@ -27,7 +27,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
     tags:
       data_center: nyc
@@ -36,7 +36,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
     tags:
       data_center: tokyo  # No match.

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/SecondaryPreferred.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/SecondaryPreferred.json
@@ -7,7 +7,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -38,7 +38,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -52,7 +52,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/SecondaryPreferred.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/SecondaryPreferred.yml
@@ -8,14 +8,14 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1000001"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Very stale.
 read_preference:
   mode: SecondaryPreferred

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/SecondaryPreferred_tags.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/SecondaryPreferred_tags.json
@@ -8,7 +8,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -23,7 +23,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -38,7 +38,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -53,7 +53,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -80,7 +80,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -97,7 +97,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/SecondaryPreferred_tags.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/SecondaryPreferred_tags.yml
@@ -9,7 +9,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
     tags:
       data_center: tokyo  # No match, but its lastWriteDate is used in estimate.
@@ -18,7 +18,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}  # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
     tags:
       data_center: nyc
@@ -27,7 +27,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
     tags:
       data_center: nyc
@@ -36,7 +36,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
     tags:
       data_center: tokyo  # No match.

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/ZeroMaxStaleness.json
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/ZeroMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/source/max-staleness/tests/ReplicaSetNoPrimary/ZeroMaxStaleness.yml
+++ b/source/max-staleness/tests/ReplicaSetNoPrimary/ZeroMaxStaleness.yml
@@ -8,14 +8,14 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:
   mode: Nearest

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/DefaultNoMaxStaleness.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/DefaultNoMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -37,7 +37,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -49,7 +49,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -63,7 +63,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/DefaultNoMaxStaleness.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/DefaultNoMaxStaleness.yml
@@ -8,14 +8,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1000001"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Very stale.
 read_preference:
   mode: Nearest

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/LastUpdateTime.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/LastUpdateTime.json
@@ -13,7 +13,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/LastUpdateTime.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/LastUpdateTime.yml
@@ -8,7 +8,7 @@ topology_description:
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 1
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &2
     address: b:27017
     type: RSSecondary
@@ -17,14 +17,14 @@ topology_description:
     # Updated 125 sec after primary, so 125 sec stale.
     # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &3
     address: c:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 125001
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
 read_preference:
   mode: Nearest
   maxStalenessSeconds: 150

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/LongHeartbeat.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/LongHeartbeat.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -51,7 +51,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -65,7 +65,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/LongHeartbeat.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/LongHeartbeat.yml
@@ -10,14 +10,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:
   mode: Nearest

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/LongHeartbeat2.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/LongHeartbeat2.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/LongHeartbeat2.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/LongHeartbeat2.yml
@@ -10,14 +10,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:
   mode: Nearest

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessTooSmall.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessTooSmall.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessTooSmall.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessTooSmall.yml
@@ -11,14 +11,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:
   mode: Nearest

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/MaxStalenessWithModePrimary.yml
@@ -9,14 +9,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:
   maxStalenessSeconds: 120

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest.yml
@@ -8,21 +8,21 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "2"}}  # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &3
     address: c:27017
     avg_rtt_ms: 5
     lastUpdateTime: 0
     type: RSSecondary
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
 read_preference:
   mode: Nearest
   maxStalenessSeconds: 150

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest2.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "c:27017",
@@ -37,7 +37,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },
@@ -56,7 +56,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     },
     {
       "address": "b:27017",
@@ -68,7 +68,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ],
   "in_latency_window": [
@@ -82,7 +82,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6
+      "maxWireVersion": 21
     }
   ]
 }

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest2.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest2.yml
@@ -8,21 +8,21 @@ topology_description:
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "2"}}  # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &3
     address: c:27017
     avg_rtt_ms: 5
     lastUpdateTime: 0
     type: RSSecondary
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
 read_preference:
   mode: Nearest
   maxStalenessSeconds: 150

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest_tags.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest_tags.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "tokyo"
         }
@@ -28,7 +28,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "nyc"
         }
@@ -58,7 +58,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }
@@ -75,7 +75,7 @@
           "$numberLong": "125002"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest_tags.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Nearest_tags.yml
@@ -12,7 +12,7 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
     tags:
       data_center: tokyo
   - &2
@@ -21,7 +21,7 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
     tags:
       data_center: nyc
 read_preference:

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/PrimaryPreferred.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/PrimaryPreferred.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -53,7 +53,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/PrimaryPreferred.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/PrimaryPreferred.yml
@@ -9,14 +9,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:
   mode: PrimaryPreferred

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -38,7 +38,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -52,7 +52,7 @@
       "type": "RSPrimary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred.yml
@@ -8,14 +8,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1000001"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Very stale.
 read_preference:
   mode: SecondaryPreferred

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred_tags.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred_tags.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -35,7 +35,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 1,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -50,7 +50,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -65,7 +65,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -92,7 +92,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -107,7 +107,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 1,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -124,7 +124,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred_tags.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred_tags.yml
@@ -9,14 +9,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}  # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
     tags:
       data_center: nyc
@@ -25,7 +25,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 1
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1000001"}}  # Not used in estimate since we have a primary.
     tags:
       data_center: nyc
@@ -34,7 +34,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
     tags:
       data_center: nyc
@@ -43,7 +43,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
     tags:
       data_center: tokyo  # No match.

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred_tags2.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred_tags2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "tokyo"
         }
@@ -40,7 +40,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "nyc"
         }
@@ -70,7 +70,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }
@@ -87,7 +87,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred_tags2.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/SecondaryPreferred_tags2.yml
@@ -12,14 +12,14 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
     tags:
       data_center: tokyo
   - &3
@@ -28,7 +28,7 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
     tags:
       data_center: nyc
 read_preference:

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Secondary_tags.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Secondary_tags.json
@@ -8,7 +8,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "125002"
@@ -20,7 +20,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -35,7 +35,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 1,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1000001"
@@ -50,7 +50,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -65,7 +65,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -92,7 +92,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"
@@ -107,7 +107,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 1,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1000001"
@@ -124,7 +124,7 @@
       "type": "RSSecondary",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "2"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Secondary_tags.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Secondary_tags.yml
@@ -9,14 +9,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}  # 125 sec stale + 25 sec heartbeat <= 150 sec maxStaleness.
     tags:
       data_center: nyc
@@ -25,7 +25,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 1
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1000001"}}  # Not used in estimate since we have a primary.
     tags:
       data_center: nyc
@@ -34,7 +34,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
     tags:
       data_center: nyc
@@ -43,7 +43,7 @@ topology_description:
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
     tags:
       data_center: tokyo  # No match.

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Secondary_tags2.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Secondary_tags2.json
@@ -13,7 +13,7 @@
             "$numberLong": "125002"
           }
         },
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       },
       {
         "address": "b:27017",
@@ -25,7 +25,7 @@
             "$numberLong": "2"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "tokyo"
         }
@@ -40,7 +40,7 @@
             "$numberLong": "1"
           }
         },
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "tags": {
           "data_center": "nyc"
         }
@@ -70,7 +70,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }
@@ -87,7 +87,7 @@
           "$numberLong": "2"
         }
       },
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "tags": {
         "data_center": "tokyo"
       }

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/Secondary_tags2.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/Secondary_tags2.yml
@@ -12,14 +12,14 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "125002"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
-    maxWireVersion: 6
+    maxWireVersion: 21
     tags:
       data_center: tokyo
   - &3
@@ -28,7 +28,7 @@ topology_description:
     avg_rtt_ms: 5
     lastUpdateTime: 0
     lastWrite: {lastWriteDate: {$numberLong: "1"}}  # Too stale.
-    maxWireVersion: 6
+    maxWireVersion: 21
     tags:
       data_center: nyc
 read_preference:

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/ZeroMaxStaleness.json
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/ZeroMaxStaleness.json
@@ -7,7 +7,7 @@
         "type": "RSPrimary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "2"
@@ -19,7 +19,7 @@
         "type": "RSSecondary",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"

--- a/source/max-staleness/tests/ReplicaSetWithPrimary/ZeroMaxStaleness.yml
+++ b/source/max-staleness/tests/ReplicaSetWithPrimary/ZeroMaxStaleness.yml
@@ -8,14 +8,14 @@ topology_description:
     type: RSPrimary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "2"}}
   - &2
     address: b:27017
     type: RSSecondary
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:
   mode: Nearest

--- a/source/max-staleness/tests/Sharded/SmallMaxStaleness.json
+++ b/source/max-staleness/tests/Sharded/SmallMaxStaleness.json
@@ -8,7 +8,7 @@
         "type": "Mongos",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -20,7 +20,7 @@
         "type": "Mongos",
         "avg_rtt_ms": 50,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -39,7 +39,7 @@
       "type": "Mongos",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -51,7 +51,7 @@
       "type": "Mongos",
       "avg_rtt_ms": 50,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -65,7 +65,7 @@
       "type": "Mongos",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/source/max-staleness/tests/Sharded/SmallMaxStaleness.yml
+++ b/source/max-staleness/tests/Sharded/SmallMaxStaleness.yml
@@ -9,14 +9,14 @@ topology_description:
     type: Mongos
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
   - &2
     address: b:27017
     type: Mongos
     avg_rtt_ms: 50  # Too far.
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:
   mode: Nearest

--- a/source/max-staleness/tests/Single/SmallMaxStaleness.json
+++ b/source/max-staleness/tests/Single/SmallMaxStaleness.json
@@ -8,7 +8,7 @@
         "type": "Standalone",
         "avg_rtt_ms": 5,
         "lastUpdateTime": 0,
-        "maxWireVersion": 6,
+        "maxWireVersion": 21,
         "lastWrite": {
           "lastWriteDate": {
             "$numberLong": "1"
@@ -27,7 +27,7 @@
       "type": "Standalone",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"
@@ -41,7 +41,7 @@
       "type": "Standalone",
       "avg_rtt_ms": 5,
       "lastUpdateTime": 0,
-      "maxWireVersion": 6,
+      "maxWireVersion": 21,
       "lastWrite": {
         "lastWriteDate": {
           "$numberLong": "1"

--- a/source/max-staleness/tests/Single/SmallMaxStaleness.yml
+++ b/source/max-staleness/tests/Single/SmallMaxStaleness.yml
@@ -9,7 +9,7 @@ topology_description:
     type: Standalone
     avg_rtt_ms: 5
     lastUpdateTime: 0
-    maxWireVersion: 6
+    maxWireVersion: 21
     lastWrite: {lastWriteDate: {$numberLong: "1"}}
 read_preference:
   mode: Nearest

--- a/source/max-staleness/tests/Unknown/SmallMaxStaleness.json
+++ b/source/max-staleness/tests/Unknown/SmallMaxStaleness.json
@@ -6,7 +6,7 @@
       {
         "address": "a:27017",
         "type": "Unknown",
-        "maxWireVersion": 6
+        "maxWireVersion": 21
       }
     ]
   },

--- a/source/max-staleness/tests/Unknown/SmallMaxStaleness.yml
+++ b/source/max-staleness/tests/Unknown/SmallMaxStaleness.yml
@@ -7,7 +7,7 @@ topology_description:
   - &1
     address: a:27017
     type: Unknown
-    maxWireVersion: 6
+    maxWireVersion: 21
 read_preference:
   mode: Nearest
   maxStalenessSeconds: 1

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
@@ -1888,6 +1888,8 @@ oversaw the specification process.
 
 ## Changelog
 
+- 2024-08-09: Updated wire versions in tests to 4.0+.
+
 - 2024-05-08: Migrated from reStructuredText to Markdown.
 
 - 2015-12-17: Require clients to compare (setVersion, electionId) tuples.

--- a/source/server-discovery-and-monitoring/tests/monitoring/discovered_standalone.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/discovered_standalone.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/monitoring/discovered_standalone.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/discovered_standalone.yml
@@ -5,7 +5,7 @@ phases:
     responses:
       -
         - "a:27017"
-        - { ok: 1, helloOk: true, isWritablePrimary: true, minWireVersion: 0, maxWireVersion: 6 }
+        - { ok: 1, helloOk: true, isWritablePrimary: true, minWireVersion: 0, maxWireVersion: 21 }
 
     outcome:
       events:

--- a/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_no_primary.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_no_primary.json
@@ -19,7 +19,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_no_primary.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_no_primary.yml
@@ -17,7 +17,7 @@ phases:
             - "a:27017"
             - "b:27017"
           minWireVersion: 0
-          maxWireVersion: 6
+          maxWireVersion: 21
     outcome:
       events:
         -

--- a/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_primary.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_primary.json
@@ -18,7 +18,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_primary.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_primary.yml
@@ -16,7 +16,7 @@ phases:
             - "a:27017"
             - "b:27017"
           minWireVersion: 0
-          maxWireVersion: 6
+          maxWireVersion: 21
     outcome:
       events:
         -

--- a/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_removal.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_removal.json
@@ -69,7 +69,7 @@
               "a:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_removal.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/replica_set_with_removal.yml
@@ -50,7 +50,7 @@ phases:
             primary: "a:27017",
             hosts: [ "a:27017" ],
             minWireVersion: 0,
-            maxWireVersion: 6
+            maxWireVersion: 21
           }
       -
         - "b:27017"

--- a/source/server-discovery-and-monitoring/tests/monitoring/required_replica_set.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/required_replica_set.json
@@ -18,7 +18,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/monitoring/required_replica_set.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/required_replica_set.yml
@@ -14,7 +14,7 @@ phases:
             primary: "a:27017",
             hosts: [ "a:27017", "b:27017" ],
             minWireVersion: 0,
-            maxWireVersion: 6
+            maxWireVersion: 21
           }
     outcome:
       events:

--- a/source/server-discovery-and-monitoring/tests/monitoring/standalone.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/standalone.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/monitoring/standalone.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/standalone.yml
@@ -5,7 +5,7 @@ phases:
     responses:
       -
         - "a:27017"
-        - { ok: 1, helloOk: true, isWritablePrimary: true, minWireVersion: 0, maxWireVersion: 6 }
+        - { ok: 1, helloOk: true, isWritablePrimary: true, minWireVersion: 0, maxWireVersion: 21 }
 
     outcome:
       events:

--- a/source/server-discovery-and-monitoring/tests/monitoring/standalone_suppress_equal_description_changes.json
+++ b/source/server-discovery-and-monitoring/tests/monitoring/standalone_suppress_equal_description_changes.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -21,7 +21,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/monitoring/standalone_suppress_equal_description_changes.yml
+++ b/source/server-discovery-and-monitoring/tests/monitoring/standalone_suppress_equal_description_changes.yml
@@ -5,10 +5,10 @@ phases:
     responses:
       -
         - "a:27017"
-        - { ok: 1, helloOk: true, isWritablePrimary: true, minWireVersion: 0, maxWireVersion: 6 }
+        - { ok: 1, helloOk: true, isWritablePrimary: true, minWireVersion: 0, maxWireVersion: 21 }
       -
         - "a:27017"
-        - { ok: 1, helloOk: true, isWritablePrimary: true, minWireVersion: 0, maxWireVersion: 6 }
+        - { ok: 1, helloOk: true, isWritablePrimary: true, minWireVersion: 0, maxWireVersion: 21 }
 
     outcome:
       events:

--- a/source/server-discovery-and-monitoring/tests/rs/discover_arbiters.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_arbiters.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_arbiters.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_arbiters.yml
@@ -16,7 +16,7 @@ phases: [
                     arbiters: ["b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_arbiters_replicaset.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_arbiters_replicaset.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_arbiters_replicaset.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_arbiters_replicaset.yml
@@ -16,7 +16,7 @@ phases: [
                     arbiters: ["b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_ghost.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_ghost.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": false,
             "isreplicaset": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_ghost.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_ghost.yml
@@ -14,7 +14,7 @@ phases: [
                     isWritablePrimary: false,
                     isreplicaset: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_ghost_replicaset.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_ghost_replicaset.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": false,
             "isreplicaset": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_ghost_replicaset.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_ghost_replicaset.yml
@@ -14,7 +14,7 @@ phases: [
                     isWritablePrimary: false,
                     isreplicaset: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_hidden.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_hidden.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_hidden.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_hidden.yml
@@ -17,7 +17,7 @@ phases: [
                     hosts: ["c:27017", "d:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_hidden_replicaset.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_hidden_replicaset.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_hidden_replicaset.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_hidden_replicaset.yml
@@ -17,7 +17,7 @@ phases: [
                     hosts: ["c:27017", "d:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_passives.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_passives.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -56,7 +56,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_passives.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_passives.yml
@@ -16,7 +16,7 @@ phases: [
                     passives: ["b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -55,7 +55,7 @@ phases: [
                     passives: ["b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_passives_replicaset.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_passives_replicaset.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -56,7 +56,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_passives_replicaset.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_passives_replicaset.yml
@@ -16,7 +16,7 @@ phases: [
                     passives: ["b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -55,7 +55,7 @@ phases: [
                     passives: ["b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_primary.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_primary.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_primary.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_primary.yml
@@ -15,7 +15,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_primary_replicaset.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_primary_replicaset.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_primary_replicaset.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_primary_replicaset.yml
@@ -15,7 +15,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_rsother.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_rsother.json
@@ -17,7 +17,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_rsother.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_rsother.yml
@@ -16,7 +16,7 @@ phases: [
                     hosts: ["c:27017", "d:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_rsother_replicaset.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_rsother_replicaset.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -34,7 +34,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_rsother_replicaset.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_rsother_replicaset.yml
@@ -17,7 +17,7 @@ phases: [
                     hosts: ["c:27017", "d:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
                 ["b:27017", {
 
@@ -28,7 +28,7 @@ phases: [
                     hosts: ["c:27017", "d:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_secondary.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_secondary.json
@@ -17,7 +17,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_secondary.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_secondary.yml
@@ -16,7 +16,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discover_secondary_replicaset.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_secondary_replicaset.json
@@ -17,7 +17,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discover_secondary_replicaset.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discover_secondary_replicaset.yml
@@ -16,7 +16,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/discovery.json
+++ b/source/server-discovery-and-monitoring/tests/rs/discovery.json
@@ -18,7 +18,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -59,7 +59,7 @@
               "d:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -103,7 +103,7 @@
               "e:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -147,7 +147,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/discovery.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/discovery.yml
@@ -17,7 +17,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017", "c:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -63,7 +63,7 @@ phases: [
                     primary: "d:27017",
                     hosts: ["b:27017", "c:27017", "d:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -113,7 +113,7 @@ phases: [
                     setName: "rs",
                     hosts: ["b:27017", "c:27017", "d:27017", "e:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -165,7 +165,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017", "c:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/equal_electionids.json
+++ b/source/server-discovery-and-monitoring/tests/rs/equal_electionids.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -39,7 +39,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/equal_electionids.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/equal_electionids.yml
@@ -16,7 +16,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }],
             ["b:27017", {
                 ok: 1,
@@ -27,7 +27,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/hosts_differ_from_seeds.json
+++ b/source/server-discovery-and-monitoring/tests/rs/hosts_differ_from_seeds.json
@@ -15,7 +15,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/hosts_differ_from_seeds.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/hosts_differ_from_seeds.yml
@@ -15,7 +15,7 @@ phases: [
                     setName: "rs",
                     hosts: ["b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_arbiter.json
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_arbiter.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_arbiter.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_arbiter.yml
@@ -12,7 +12,7 @@ phases:
           setName: "rs"
           hosts: ["a:27017", "b:27017"]
           minWireVersion: 0
-          maxWireVersion: 6
+          maxWireVersion: 21
       -
         - "b:27017"
         - ok: 1

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.json
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_ghost.yml
@@ -12,7 +12,7 @@ phases:
           setName: "rs"
           hosts: ["a:27017", "b:27017"]
           minWireVersion: 0
-          maxWireVersion: 6
+          maxWireVersion: 21
       -
         - "b:27017"
         - ok: 1

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_other.json
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_other.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/source/server-discovery-and-monitoring/tests/rs/incompatible_other.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/incompatible_other.yml
@@ -12,7 +12,7 @@ phases:
           setName: "rs"
           hosts: ["a:27017", "b:27017"]
           minWireVersion: 0
-          maxWireVersion: 6
+          maxWireVersion: 21
       -
         - "b:27017"
         - ok: 1

--- a/source/server-discovery-and-monitoring/tests/rs/ls_timeout.json
+++ b/source/server-discovery-and-monitoring/tests/rs/ls_timeout.json
@@ -20,7 +20,7 @@
             "setName": "rs",
             "logicalSessionTimeoutMinutes": 3,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -58,7 +58,7 @@
             "isWritablePrimary": false,
             "isreplicaset": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -104,7 +104,7 @@
             "setName": "rs",
             "arbiterOnly": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -152,7 +152,7 @@
             "setName": "rs",
             "logicalSessionTimeoutMinutes": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -194,7 +194,7 @@
             "hidden": true,
             "logicalSessionTimeoutMinutes": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -244,7 +244,7 @@
             "setName": "rs",
             "logicalSessionTimeoutMinutes": null,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/ls_timeout.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/ls_timeout.yml
@@ -14,7 +14,7 @@ phases: [
                 setName: "rs",
                 logicalSessionTimeoutMinutes: 3,
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }],
         ],
         outcome: {
@@ -51,7 +51,7 @@ phases: [
                 isWritablePrimary: false,
                 isreplicaset: true,
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }],
         ],
         outcome: {
@@ -90,7 +90,7 @@ phases: [
                 setName: "rs",
                 arbiterOnly: true,
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
         outcome: {
@@ -131,7 +131,7 @@ phases: [
                 setName: "rs",
                 logicalSessionTimeoutMinutes: 2,
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }],
         ],
         outcome: {
@@ -172,7 +172,7 @@ phases: [
                 hidden: true,
                 logicalSessionTimeoutMinutes: 1,
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }],
         ],
         outcome: {
@@ -214,7 +214,7 @@ phases: [
                 setName: "rs",
                 logicalSessionTimeoutMinutes: null,
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/member_reconfig.json
+++ b/source/server-discovery-and-monitoring/tests/rs/member_reconfig.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -49,7 +49,7 @@
               "a:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/member_reconfig.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/member_reconfig.yml
@@ -15,7 +15,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -52,7 +52,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/member_standalone.json
+++ b/source/server-discovery-and-monitoring/tests/rs/member_standalone.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -40,7 +40,7 @@
               "a:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/member_standalone.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/member_standalone.yml
@@ -13,7 +13,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -44,7 +44,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary.json
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -50,7 +50,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary.yml
@@ -15,7 +15,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -52,7 +52,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_new_electionid.json
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_new_electionid.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -67,7 +67,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -114,7 +114,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_new_electionid.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_new_electionid.yml
@@ -16,7 +16,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 
@@ -54,7 +54,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000002"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 
@@ -92,7 +92,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_new_setversion.json
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_new_setversion.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -67,7 +67,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -114,7 +114,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_new_setversion.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_new_setversion.yml
@@ -16,7 +16,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 
@@ -54,7 +54,7 @@ phases: [
                 setVersion: 2,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 
@@ -92,7 +92,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_wrong_set_name.json
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_wrong_set_name.json
@@ -16,7 +16,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -49,7 +49,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/new_primary_wrong_set_name.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/new_primary_wrong_set_name.yml
@@ -16,7 +16,7 @@ phases: [
                     hosts: ["a:27017", "b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -55,7 +55,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "wrong",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/non_rs_member.json
+++ b/source/server-discovery-and-monitoring/tests/rs/non_rs_member.json
@@ -10,7 +10,7 @@
             "ok": 1,
             "helloOk": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/non_rs_member.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/non_rs_member.yml
@@ -11,7 +11,7 @@ phases: [
                     ok: 1,
                     helloOk: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/normalize_case.json
+++ b/source/server-discovery-and-monitoring/tests/rs/normalize_case.json
@@ -21,7 +21,7 @@
               "C:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/normalize_case.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/normalize_case.yml
@@ -17,7 +17,7 @@ phases: [
                     passives: ["B:27017"],
                     arbiters: ["C:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/normalize_case_me.json
+++ b/source/server-discovery-and-monitoring/tests/rs/normalize_case_me.json
@@ -22,7 +22,7 @@
               "C:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -67,7 +67,7 @@
               "C:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/normalize_case_me.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/normalize_case_me.yml
@@ -18,7 +18,7 @@ phases: [
                     passives: ["B:27017"],
                     arbiters: ["C:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -66,7 +66,7 @@ phases: [
                     passives: ["B:27017"],
                     arbiters: ["C:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/null_election_id-pre-6.0.json
+++ b/source/server-discovery-and-monitoring/tests/rs/null_election_id-pre-6.0.json
@@ -18,7 +18,7 @@
             "setVersion": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -66,7 +66,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -116,7 +116,7 @@
             "setVersion": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -167,7 +167,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/null_election_id-pre-6.0.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/null_election_id-pre-6.0.yml
@@ -15,7 +15,7 @@ phases: [
                 setVersion: 1,
                 setName: "rs",
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 7
             }]
         ],
 
@@ -57,7 +57,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000002"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 7
             }]
         ],
 
@@ -99,7 +99,7 @@ phases: [
                 setVersion: 1,
                 setName: "rs",
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 7
             }]
         ],
         outcome: {
@@ -142,7 +142,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 7
             }]
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/rs/primary_becomes_ghost.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_becomes_ghost.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -41,7 +41,7 @@
             "isWritablePrimary": false,
             "isreplicaset": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_becomes_ghost.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_becomes_ghost.yml
@@ -15,7 +15,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -43,7 +43,7 @@ phases: [
                     isWritablePrimary: false,
                     isreplicaset: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/primary_becomes_mongos.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_becomes_mongos.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -41,7 +41,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_becomes_mongos.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_becomes_mongos.yml
@@ -15,7 +15,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -43,7 +43,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/primary_becomes_standalone.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_becomes_standalone.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -38,7 +38,7 @@
           {
             "ok": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_becomes_standalone.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_becomes_standalone.yml
@@ -15,7 +15,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -40,7 +40,7 @@ phases: [
                 ["a:27017", {
                     ok: 1,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/primary_changes_set_name.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_changes_set_name.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -44,7 +44,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_changes_set_name.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_changes_set_name.yml
@@ -16,7 +16,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -48,7 +48,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "wrong",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect.yml
@@ -15,7 +15,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_electionid.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_electionid.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -39,7 +39,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -115,7 +115,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -159,7 +159,7 @@
               "$oid": "000000000000000000000003"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -203,7 +203,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_electionid.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_electionid.yml
@@ -16,7 +16,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }],
             ["b:27017", {
                 ok: 1,
@@ -27,7 +27,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000002"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 
@@ -91,7 +91,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
         outcome: {
@@ -127,7 +127,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000003"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
         outcome: {
@@ -163,7 +163,7 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_setversion.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_setversion.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -39,7 +39,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -115,7 +115,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -159,7 +159,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -203,7 +203,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_setversion.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_disconnect_setversion.yml
@@ -16,7 +16,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }],
             ["b:27017", {
                 ok: 1,
@@ -27,7 +27,7 @@ phases: [
                 setVersion: 2,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 
@@ -91,7 +91,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
         outcome: {
@@ -127,7 +127,7 @@ phases: [
                 setVersion: 2,
                 electionId: {"$oid": "000000000000000000000002"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
         outcome: {
@@ -163,7 +163,7 @@ phases: [
                 hosts: ["a:27017", "b:27017"],
                 setName: "rs",
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/rs/primary_hint_from_secondary_with_mismatched_me.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_hint_from_secondary_with_mismatched_me.json
@@ -18,7 +18,7 @@
             "setName": "rs",
             "primary": "b:27017",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -48,7 +48,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_hint_from_secondary_with_mismatched_me.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_hint_from_secondary_with_mismatched_me.yml
@@ -17,7 +17,7 @@ phases: [
                 setName: "rs",
                 primary: "b:27017",
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 
@@ -45,7 +45,7 @@ phases: [
                 hosts: ["b:27017"],
                 setName: "rs",
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 21
             }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/primary_mismatched_me.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_mismatched_me.json
@@ -31,7 +31,7 @@
             "ok": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ]

--- a/source/server-discovery-and-monitoring/tests/rs/primary_mismatched_me.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_mismatched_me.yml
@@ -22,6 +22,6 @@ phases:
           ok: 1
           setName: rs
           minWireVersion: 0
-          maxWireVersion: 6
+          maxWireVersion: 21
 uri: 'mongodb://localhost:27017/?replicaSet=rs'
 

--- a/source/server-discovery-and-monitoring/tests/rs/primary_reports_new_member.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_reports_new_member.json
@@ -17,7 +17,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -51,7 +51,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -86,7 +86,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -127,7 +127,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_reports_new_member.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_reports_new_member.yml
@@ -17,7 +17,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -55,7 +55,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -93,7 +93,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017", "c:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -140,7 +140,7 @@ phases: [
                     primary: "b:27017",
                     hosts: ["a:27017", "b:27017", "c:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/primary_to_no_primary_mismatched_me.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_to_no_primary_mismatched_me.json
@@ -17,7 +17,7 @@
             "me": "a:27017",
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -52,7 +52,7 @@
             "me": "c:27017",
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_to_no_primary_mismatched_me.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_to_no_primary_mismatched_me.yml
@@ -16,7 +16,7 @@ phases: [
                     me: "a:27017",
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -53,7 +53,7 @@ phases: [
                     me : "c:27017",
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/primary_wrong_set_name.json
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_wrong_set_name.json
@@ -15,7 +15,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/primary_wrong_set_name.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/primary_wrong_set_name.yml
@@ -15,7 +15,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "wrong",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/repeated.json
+++ b/source/server-discovery-and-monitoring/tests/rs/repeated.json
@@ -18,7 +18,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -49,7 +49,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -84,7 +84,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -120,7 +120,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/repeated.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/repeated.yml
@@ -15,7 +15,7 @@ phases:
         hosts: ["a:27017", "c:27017"]
         setName: "rs"
         minWireVersion: 0
-        maxWireVersion: 6
+        maxWireVersion: 21
     outcome:
       servers:
         "a:27017":
@@ -39,7 +39,7 @@ phases:
         helloOk: true
         isWritablePrimary: true
         minWireVersion: 0
-        maxWireVersion: 6
+        maxWireVersion: 21
     outcome:
       servers:
         "a:27017":
@@ -64,7 +64,7 @@ phases:
         hosts: ["a:27017", "c:27017"]
         setName: "rs"
         minWireVersion: 0
-        maxWireVersion: 6
+        maxWireVersion: 21
     outcome:
       servers:
         "a:27017":
@@ -90,7 +90,7 @@ phases:
         hosts: ["a:27017", "c:27017"]
         setName: "rs"
         minWireVersion: 0
-        maxWireVersion: 6
+        maxWireVersion: 21
     outcome:
       servers:
         "a:27017":

--- a/source/server-discovery-and-monitoring/tests/rs/replicaset_rsnp.json
+++ b/source/server-discovery-and-monitoring/tests/rs/replicaset_rsnp.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/replicaset_rsnp.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/replicaset_rsnp.yml
@@ -11,7 +11,7 @@ phases:
         helloOk: true
         isWritablePrimary: true
         minWireVersion: 0
-        maxWireVersion: 6
+        maxWireVersion: 21
     outcome:
       # Server is removed because it's a standalone and the driver
       # started in RSNP topology

--- a/source/server-discovery-and-monitoring/tests/rs/response_from_removed.json
+++ b/source/server-discovery-and-monitoring/tests/rs/response_from_removed.json
@@ -15,7 +15,7 @@
               "a:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -46,7 +46,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/response_from_removed.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/response_from_removed.yml
@@ -15,7 +15,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -47,7 +47,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/sec_not_auth.json
+++ b/source/server-discovery-and-monitoring/tests/rs/sec_not_auth.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -32,7 +32,7 @@
               "c:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/sec_not_auth.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/sec_not_auth.yml
@@ -15,7 +15,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
 
                 ["b:27017", {
@@ -27,7 +27,7 @@ phases: [
                     setName: "rs",
                     hosts: ["b:27017", "c:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0-pre-6.0.json
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0-pre-6.0.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -32,7 +32,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -59,7 +59,7 @@
           {
             "ok": 0,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0-pre-6.0.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0-pre-6.0.yml
@@ -15,7 +15,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
                 ["b:27017", {
 
@@ -26,7 +26,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -59,7 +59,7 @@ phases: [
 
                     ok: 0,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.json
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -32,7 +32,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -59,7 +59,7 @@
           {
             "ok": 0,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_ignore_ok_0.yml
@@ -15,7 +15,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
                 ["b:27017", {
 
@@ -26,7 +26,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -59,7 +59,7 @@ phases: [
 
                     ok: 0,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_mismatched_me.json
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_mismatched_me.json
@@ -32,7 +32,7 @@
             "ok": 1,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ]

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_mismatched_me.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_mismatched_me.yml
@@ -25,4 +25,4 @@ phases:
           ok: 1
           setName: rs
           minWireVersion: 0
-          maxWireVersion: 6
+          maxWireVersion: 21

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_wrong_set_name.json
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_wrong_set_name.json
@@ -16,7 +16,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_wrong_set_name.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_wrong_set_name.yml
@@ -16,7 +16,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "wrong",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_wrong_set_name_with_primary.json
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_wrong_set_name_with_primary.json
@@ -16,7 +16,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -51,7 +51,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_wrong_set_name_with_primary.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_wrong_set_name_with_primary.yml
@@ -15,7 +15,7 @@ phases: [
                     hosts: ["a:27017", "b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -53,7 +53,7 @@ phases: [
                     hosts: ["a:27017", "b:27017"],
                     setName: "wrong",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/setversion_without_electionid-pre-6.0.json
+++ b/source/server-discovery-and-monitoring/tests/rs/setversion_without_electionid-pre-6.0.json
@@ -17,7 +17,7 @@
             "setName": "rs",
             "setVersion": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -56,7 +56,7 @@
             "setName": "rs",
             "setVersion": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/setversion_without_electionid-pre-6.0.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/setversion_without_electionid-pre-6.0.yml
@@ -15,7 +15,7 @@ phases: [
                 setName: "rs",
                 setVersion: 2,
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 7
             }]
         ],
 
@@ -52,7 +52,7 @@ phases: [
                 setName: "rs",
                 setVersion: 1,
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 7
             }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/stepdown_change_set_name.json
+++ b/source/server-discovery-and-monitoring/tests/rs/stepdown_change_set_name.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -45,7 +45,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/stepdown_change_set_name.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/stepdown_change_set_name.yml
@@ -16,7 +16,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -50,7 +50,7 @@ phases: [
                     hosts: ["a:27017"],
                     setName: "wrong",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/too_new.json
+++ b/source/server-discovery-and-monitoring/tests/rs/too_new.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/source/server-discovery-and-monitoring/tests/rs/too_new.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/too_new.yml
@@ -12,7 +12,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
                 ["b:27017", {
                     ok: 1,

--- a/source/server-discovery-and-monitoring/tests/rs/too_old.json
+++ b/source/server-discovery-and-monitoring/tests/rs/too_old.json
@@ -16,7 +16,7 @@
               "b:27017"
             ],
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/source/server-discovery-and-monitoring/tests/rs/too_old.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/too_old.yml
@@ -10,7 +10,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
                 ["b:27017", {
                     ok: 1,

--- a/source/server-discovery-and-monitoring/tests/rs/unexpected_mongos.json
+++ b/source/server-discovery-and-monitoring/tests/rs/unexpected_mongos.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/unexpected_mongos.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/unexpected_mongos.yml
@@ -14,7 +14,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/rs/use_setversion_without_electionid-pre-6.0.json
+++ b/source/server-discovery-and-monitoring/tests/rs/use_setversion_without_electionid-pre-6.0.json
@@ -20,7 +20,7 @@
               "$oid": "000000000000000000000001"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -64,7 +64,7 @@
             "setName": "rs",
             "setVersion": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],
@@ -108,7 +108,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 7
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/use_setversion_without_electionid-pre-6.0.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/use_setversion_without_electionid-pre-6.0.yml
@@ -16,7 +16,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000001"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 7
             }]
         ],
 
@@ -53,7 +53,7 @@ phases: [
                 setName: "rs",
                 setVersion: 2,
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 7
             }]
         ],
 
@@ -91,7 +91,7 @@ phases: [
                 setVersion: 1,
                 electionId: {"$oid": "000000000000000000000002"},
                 minWireVersion: 0,
-                maxWireVersion: 6
+                maxWireVersion: 7
             }]
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/rs/wrong_set_name.json
+++ b/source/server-discovery-and-monitoring/tests/rs/wrong_set_name.json
@@ -17,7 +17,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/wrong_set_name.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/wrong_set_name.yml
@@ -16,7 +16,7 @@ phases: [
                     hosts: ["b:27017", "c:27017"],
                     setName: "wrong",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/sharded/discover_single_mongos.json
+++ b/source/server-discovery-and-monitoring/tests/sharded/discover_single_mongos.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/sharded/discover_single_mongos.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/discover_single_mongos.yml
@@ -13,7 +13,7 @@ phases:
         isWritablePrimary: true
         msg: "isdbgrid"
         minWireVersion: 0
-        maxWireVersion: 6
+        maxWireVersion: 21
     
     outcome:
       servers:

--- a/source/server-discovery-and-monitoring/tests/sharded/ls_timeout_mongos.json
+++ b/source/server-discovery-and-monitoring/tests/sharded/ls_timeout_mongos.json
@@ -13,7 +13,7 @@
             "msg": "isdbgrid",
             "logicalSessionTimeoutMinutes": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -25,7 +25,7 @@
             "msg": "isdbgrid",
             "logicalSessionTimeoutMinutes": 2,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -56,7 +56,7 @@
             "msg": "isdbgrid",
             "logicalSessionTimeoutMinutes": 1,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -67,7 +67,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/sharded/ls_timeout_mongos.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/ls_timeout_mongos.yml
@@ -15,7 +15,7 @@ phases: [
                     msg: "isdbgrid",
                     logicalSessionTimeoutMinutes: 1,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
 
                 ["b:27017", {
@@ -26,7 +26,7 @@ phases: [
                     msg: "isdbgrid",
                     logicalSessionTimeoutMinutes: 2,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -63,7 +63,7 @@ phases: [
                     msg: "isdbgrid",
                     logicalSessionTimeoutMinutes: 1,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
 
                 ["b:27017", {
@@ -73,7 +73,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/sharded/mongos_disconnect.json
+++ b/source/server-discovery-and-monitoring/tests/sharded/mongos_disconnect.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -23,7 +23,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -76,7 +76,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/sharded/mongos_disconnect.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/mongos_disconnect.yml
@@ -14,7 +14,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
 
                 ["b:27017", {
@@ -24,7 +24,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 
@@ -85,7 +85,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
         ],
 

--- a/source/server-discovery-and-monitoring/tests/sharded/multiple_mongoses.json
+++ b/source/server-discovery-and-monitoring/tests/sharded/multiple_mongoses.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -23,7 +23,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/sharded/multiple_mongoses.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/multiple_mongoses.yml
@@ -14,7 +14,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
 
                 ["b:27017", {
@@ -24,7 +24,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/sharded/non_mongos_removed.json
+++ b/source/server-discovery-and-monitoring/tests/sharded/non_mongos_removed.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -26,7 +26,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/sharded/non_mongos_removed.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/non_mongos_removed.yml
@@ -14,7 +14,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
 
                 ["b:27017", {
@@ -25,7 +25,7 @@ phases: [
                     hosts: ["b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/sharded/too_old.json
+++ b/source/server-discovery-and-monitoring/tests/sharded/too_old.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 2,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [

--- a/source/server-discovery-and-monitoring/tests/sharded/too_old.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/too_old.yml
@@ -9,7 +9,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 2,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
                 ["b:27017", {
                     ok: 1,

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_external_ip.json
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_external_ip.json
@@ -15,7 +15,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_external_ip.yml
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_external_ip.yml
@@ -15,7 +15,7 @@ phases: [
                     hosts: ["b:27017"],  # Internal IP.
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_mongos.json
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_mongos.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "msg": "isdbgrid",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_mongos.yml
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_mongos.yml
@@ -14,7 +14,7 @@ phases: [
                     isWritablePrimary: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_replicaset.json
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_replicaset.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_replicaset.yml
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_replicaset.yml
@@ -12,7 +12,7 @@ phases:
         isWritablePrimary: true
         setName: rs
         minWireVersion: 0
-        maxWireVersion: 6
+        maxWireVersion: 21
     outcome:
       servers:
         "a:27017":

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_rsarbiter.json
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_rsarbiter.json
@@ -17,7 +17,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_rsarbiter.yml
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_rsarbiter.yml
@@ -16,7 +16,7 @@ phases: [
                    hosts: ["a:27017", "b:27017"],
                    setName: "rs",
                    minWireVersion: 0,
-                   maxWireVersion: 6
+                   maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_rsprimary.json
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_rsprimary.json
@@ -16,7 +16,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_rsprimary.yml
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_rsprimary.yml
@@ -15,7 +15,7 @@ phases: [
                    hosts: ["a:27017", "b:27017"],
                    setName: "rs",
                    minWireVersion: 0,
-                   maxWireVersion: 6
+                   maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_rssecondary.json
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_rssecondary.json
@@ -17,7 +17,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_rssecondary.yml
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_rssecondary.yml
@@ -16,7 +16,7 @@ phases: [
                     hosts: ["a:27017", "b:27017"],
                     setName: "rs",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_standalone.json
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_standalone.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_standalone.yml
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_standalone.yml
@@ -13,7 +13,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_wrong_set_name.json
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_wrong_set_name.json
@@ -16,7 +16,7 @@
             ],
             "setName": "wrong",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],
@@ -45,7 +45,7 @@
             ],
             "setName": "rs",
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/direct_connection_wrong_set_name.yml
+++ b/source/server-discovery-and-monitoring/tests/single/direct_connection_wrong_set_name.yml
@@ -11,7 +11,7 @@ phases:
       - b:27017
       setName: wrong
       minWireVersion: 0
-      maxWireVersion: 6
+      maxWireVersion: 21
   outcome:
     servers:
       a:27017:
@@ -29,7 +29,7 @@ phases:
       - b:27017
       setName: rs
       minWireVersion: 0
-      maxWireVersion: 6
+      maxWireVersion: 21
   outcome:
     servers:
       a:27017:

--- a/source/server-discovery-and-monitoring/tests/single/discover_standalone.json
+++ b/source/server-discovery-and-monitoring/tests/single/discover_standalone.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/discover_standalone.yml
+++ b/source/server-discovery-and-monitoring/tests/single/discover_standalone.yml
@@ -13,7 +13,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/ls_timeout_standalone.json
+++ b/source/server-discovery-and-monitoring/tests/single/ls_timeout_standalone.json
@@ -12,7 +12,7 @@
             "isWritablePrimary": true,
             "logicalSessionTimeoutMinutes": 7,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/ls_timeout_standalone.yml
+++ b/source/server-discovery-and-monitoring/tests/single/ls_timeout_standalone.yml
@@ -14,7 +14,7 @@ phases: [
                     isWritablePrimary: true,
                     logicalSessionTimeoutMinutes: 7,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/not_ok_response.json
+++ b/source/server-discovery-and-monitoring/tests/single/not_ok_response.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ],
         [
@@ -21,7 +21,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/not_ok_response.yml
+++ b/source/server-discovery-and-monitoring/tests/single/not_ok_response.yml
@@ -13,7 +13,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
 
                 ["a:27017", {
@@ -22,7 +22,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/standalone_removed.json
+++ b/source/server-discovery-and-monitoring/tests/single/standalone_removed.json
@@ -11,7 +11,7 @@
             "helloOk": true,
             "isWritablePrimary": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/standalone_removed.yml
+++ b/source/server-discovery-and-monitoring/tests/single/standalone_removed.yml
@@ -13,7 +13,7 @@ phases: [
                     helloOk: true,
                     isWritablePrimary: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 

--- a/source/server-discovery-and-monitoring/tests/single/standalone_using_legacy_hello.json
+++ b/source/server-discovery-and-monitoring/tests/single/standalone_using_legacy_hello.json
@@ -10,7 +10,7 @@
             "ok": 1,
             "ismaster": true,
             "minWireVersion": 0,
-            "maxWireVersion": 6
+            "maxWireVersion": 21
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/single/standalone_using_legacy_hello.yml
+++ b/source/server-discovery-and-monitoring/tests/single/standalone_using_legacy_hello.yml
@@ -12,7 +12,7 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }]
         ],
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

DRIVERS-2511 Updates the wire versions in the max staleness and SDAM test suites to support 4.0+ since 3.6 servers are no longer supported.

Node PR with spec tests passing: https://github.com/mongodb/node-mongodb-native/pull/4182

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
