### PR TITLE
DRIVERS-2250: Define Wire versions for host b in `too_new` and `too_old` tests

### DIFF
--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
@@ -1888,6 +1888,8 @@ oversaw the specification process.
 
 ## Changelog
 
+- 2024-08-16: Updated host b wire versions in `too_new` and `too_old` tests
+
 - 2024-08-09: Updated wire versions in tests to 4.0+.
 
 - 2024-05-08: Migrated from reStructuredText to Markdown.

--- a/source/server-discovery-and-monitoring/tests/rs/too_old.json
+++ b/source/server-discovery-and-monitoring/tests/rs/too_old.json
@@ -30,7 +30,9 @@
             "hosts": [
               "a:27017",
               "b:27017"
-            ]
+            ],
+            "minWireVersion": 999,
+            "maxWireVersion": 1000
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/rs/too_old.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/too_old.yml
@@ -18,7 +18,9 @@ phases: [
                     isWritablePrimary: false,
                     secondary: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 999,
+                    maxWireVersion: 1000
                 }]
         ],
         outcome: {

--- a/source/server-discovery-and-monitoring/tests/sharded/too_new.json
+++ b/source/server-discovery-and-monitoring/tests/sharded/too_new.json
@@ -21,7 +21,9 @@
             "ok": 1,
             "helloOk": true,
             "isWritablePrimary": true,
-            "msg": "isdbgrid"
+            "msg": "isdbgrid",
+            "minWireVersion": 7,
+            "maxWireVersion": 900
           }
         ]
       ],

--- a/source/server-discovery-and-monitoring/tests/sharded/too_new.yml
+++ b/source/server-discovery-and-monitoring/tests/sharded/too_new.yml
@@ -15,7 +15,9 @@ phases: [
                     ok: 1,
                     helloOk: true,
                     isWritablePrimary: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 7,
+                    maxWireVersion: 900
                 }]
         ],
         outcome: {


### PR DESCRIPTION
DRIVERS-2250 
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [X] Make sure there are generated JSON files from the YAML test files.
- [X] Test changes in at least one language driver.
- [X] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
