### PR TITLE
DRIVERS-2776 skip serverless in range compact test 

### DIFF
--- a/source/client-side-encryption/etc/test-templates/fle2v2-Rangev2-Compact.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Rangev2-Compact.yml.template
@@ -3,6 +3,7 @@ runOn:
   - minServerVersion: "8.0.0" # Require range v2 support on server.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    serverless: forbid # Skip on serverless until CLOUDP-267864 is resolved.
 database_name: "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.json
@@ -6,7 +6,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.yml
@@ -3,6 +3,7 @@ runOn:
   - minServerVersion: "8.0.0" # Require range v2 support on server.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
+    serverless: forbid # Skip on serverless until CLOUDP-267864 is resolved.
 database_name: "default"
 collection_name: &collection_name "default"
 data: []


### PR DESCRIPTION
Add `serverless: forbid` to skip range compact test due to [CLOUDP-267864](https://jira.mongodb.org/browse/CLOUDP-267864).

---
<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ N/A test changes only.
- [x] Make sure there are generated JSON files from the YAML test files.
- ~~[ ] Test changes in at least one language driver.~~ C does not test CSFLE with serverless.
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).~~ C does not test CSFLE with serverless.

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
