### PR TITLE
DRIVERS-716 skip `bulkWrite` tests on Atlas Serverless

### DIFF
--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.json
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.7",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.yml
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.yml
@@ -4,6 +4,7 @@ schemaVersion: "1.7"
 
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -781,6 +781,10 @@ the initial implementation and testing of the new bulk write API, but may be rev
 
 ## Q&A
 
+### Is `bulkWrite` supported on Atlas Serverless?
+
+No. See [CLOUDP-256344](https://jira.mongodb.org/browse/CLOUDP-256344)
+
 ### Why are we adding a new bulk write API rather than updating the `MongoCollection.bulkWrite` implementation?
 
 The new `bulkWrite` command is only available in MongoDB 8.0+, so it cannot function as a drop-in replacement for the

--- a/source/crud/tests/README.md
+++ b/source/crud/tests/README.md
@@ -276,7 +276,8 @@ Assert that a CommandStartedEvent was observed for the `getMore` command.
 Test that `MongoClient.bulkWrite` executed within a transaction properly iterates the results cursor when `getMore` is
 required.
 
-This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless. This test must not be run against standalone servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless. This test must not be run
+against standalone servers.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -603,8 +604,8 @@ remainingBulkWriteBytes = maxMessageSizeBytes - 1122
 Test that `MongoClient.bulkWrite` returns an error if an operation provided exceeds `maxMessageSizeBytes` such that an
 empty `ops` payload would be sent.
 
-This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless. This test may be skipped by drivers that are not able to construct
-arbitrarily large documents.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless. This test may be skipped by
+drivers that are not able to construct arbitrarily large documents.
 
 Construct a `MongoClient` (referred to as `client`). Perform a `hello` command using `client` and record the
 `maxMessageSizeBytes` value contained in the response.

--- a/source/crud/tests/README.md
+++ b/source/crud/tests/README.md
@@ -70,7 +70,7 @@ WriteError's `details` property.
 Test that `MongoClient.bulkWrite` properly handles `writeModels` inputs containing a number of writes greater than
 `maxWriteBatchSize`.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -98,7 +98,7 @@ command. Assert that the length of `firstEvent.command.ops` is `maxWriteBatchSiz
 Test that `MongoClient.bulkWrite` properly handles a `writeModels` input which constructs an `ops` array larger than
 `maxMessageSizeBytes`.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -137,7 +137,7 @@ driver exposes `operationId`s in its CommandStartedEvents, assert that `firstEve
 
 Test that `MongoClient.bulkWrite` properly collects and reports `writeConcernError`s returned in separate batches.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with `retryWrites: false` configured and
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -182,7 +182,7 @@ Assert that two CommandStartedEvents were observed for the `bulkWrite` command.
 
 Test that `MongoClient.bulkWrite` handles individual write errors across batches for ordered and unordered bulk writes.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -237,7 +237,7 @@ Assert that one CommandStartedEvent was observed for the `bulkWrite` command.
 
 Test that `MongoClient.bulkWrite` properly iterates the results cursor when `getMore` is required.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -276,7 +276,7 @@ Assert that a CommandStartedEvent was observed for the `getMore` command.
 Test that `MongoClient.bulkWrite` executed within a transaction properly iterates the results cursor when `getMore` is
 required.
 
-This test must only be run on 8.0+ servers. This test must not be run against standalone servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless. This test must not be run against standalone servers.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -318,7 +318,7 @@ Assert that a CommandStartedEvent was observed for the `getMore` command.
 
 Test that `MongoClient.bulkWrite` properly handles a failure that occurs when attempting a `getMore`.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) with
 [command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.rst) enabled to observe
@@ -369,7 +369,7 @@ Assert that a CommandStartedEvent was observed for the `killCursors` command.
 
 ### 10. `MongoClient.bulkWrite` returns error for unacknowledged too-large insert
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`).
 
@@ -423,7 +423,7 @@ Expect a client-side error due the size.
 Test that `MongoClient.bulkWrite` batch splits a bulk write when the addition of a new namespace to `nsInfo` causes the
 size of the message to exceed `maxMessageSizeBytes - 1000`.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Repeat the following setup for each test case:
 
@@ -603,7 +603,7 @@ remainingBulkWriteBytes = maxMessageSizeBytes - 1122
 Test that `MongoClient.bulkWrite` returns an error if an operation provided exceeds `maxMessageSizeBytes` such that an
 empty `ops` payload would be sent.
 
-This test must only be run on 8.0+ servers. This test may be skipped by drivers that are not able to construct
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless. This test may be skipped by drivers that are not able to construct
 arbitrarily large documents.
 
 Construct a `MongoClient` (referred to as `client`). Perform a `hello` command using `client` and record the
@@ -649,7 +649,7 @@ This test is expected to be removed when [DRIVERS-2888](https://jira.mongodb.org
 
 Test that `MongoClient.bulkWrite` returns an error if the client has auto-encryption configured.
 
-This test must only be run on 8.0+ servers.
+This test must only be run on 8.0+ servers. This test must be skipped on Atlas Serverless.
 
 Construct a `MongoClient` (referred to as `client`) configured with the following `AutoEncryptionOpts`:
 

--- a/source/crud/tests/unified/client-bulkWrite-delete-options.json
+++ b/source/crud/tests/unified/client-bulkWrite-delete-options.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite delete options",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",

--- a/source/crud/tests/unified/client-bulkWrite-delete-options.json
+++ b/source/crud/tests/unified/client-bulkWrite-delete-options.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/crud/tests/unified/client-bulkWrite-delete-options.yml
+++ b/source/crud/tests/unified/client-bulkWrite-delete-options.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite delete options"
 schemaVersion: "1.1"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/client-bulkWrite-delete-options.yml
+++ b/source/crud/tests/unified/client-bulkWrite-delete-options.yml
@@ -1,5 +1,5 @@
 description: "client bulkWrite delete options"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
     serverless: forbid

--- a/source/crud/tests/unified/client-bulkWrite-errorResponse.json
+++ b/source/crud/tests/unified/client-bulkWrite-errorResponse.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.12",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/crud/tests/unified/client-bulkWrite-errorResponse.yml
+++ b/source/crud/tests/unified/client-bulkWrite-errorResponse.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite errorResponse"
 schemaVersion: "1.12"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/client-bulkWrite-errors.json
+++ b/source/crud/tests/unified/client-bulkWrite-errors.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.21",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/crud/tests/unified/client-bulkWrite-errors.yml
+++ b/source/crud/tests/unified/client-bulkWrite-errors.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite errors"
 schemaVersion: "1.21"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/client-bulkWrite-mixed-namespaces.json
+++ b/source/crud/tests/unified/client-bulkWrite-mixed-namespaces.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/crud/tests/unified/client-bulkWrite-mixed-namespaces.json
+++ b/source/crud/tests/unified/client-bulkWrite-mixed-namespaces.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite with mixed namespaces",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",

--- a/source/crud/tests/unified/client-bulkWrite-mixed-namespaces.yml
+++ b/source/crud/tests/unified/client-bulkWrite-mixed-namespaces.yml
@@ -1,5 +1,5 @@
 description: "client bulkWrite with mixed namespaces"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
     serverless: forbid

--- a/source/crud/tests/unified/client-bulkWrite-mixed-namespaces.yml
+++ b/source/crud/tests/unified/client-bulkWrite-mixed-namespaces.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite with mixed namespaces"
 schemaVersion: "1.1"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/client-bulkWrite-options.json
+++ b/source/crud/tests/unified/client-bulkWrite-options.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite top-level options",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",

--- a/source/crud/tests/unified/client-bulkWrite-options.json
+++ b/source/crud/tests/unified/client-bulkWrite-options.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/crud/tests/unified/client-bulkWrite-options.yml
+++ b/source/crud/tests/unified/client-bulkWrite-options.yml
@@ -1,5 +1,5 @@
 description: "client bulkWrite top-level options"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
     serverless: forbid

--- a/source/crud/tests/unified/client-bulkWrite-options.yml
+++ b/source/crud/tests/unified/client-bulkWrite-options.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite top-level options"
 schemaVersion: "1.1"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/client-bulkWrite-ordered.json
+++ b/source/crud/tests/unified/client-bulkWrite-ordered.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/crud/tests/unified/client-bulkWrite-ordered.json
+++ b/source/crud/tests/unified/client-bulkWrite-ordered.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite with ordered option",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",

--- a/source/crud/tests/unified/client-bulkWrite-ordered.yml
+++ b/source/crud/tests/unified/client-bulkWrite-ordered.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite with ordered option"
 schemaVersion: "1.1"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/client-bulkWrite-ordered.yml
+++ b/source/crud/tests/unified/client-bulkWrite-ordered.yml
@@ -1,5 +1,5 @@
 description: "client bulkWrite with ordered option"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
     serverless: forbid

--- a/source/crud/tests/unified/client-bulkWrite-results.json
+++ b/source/crud/tests/unified/client-bulkWrite-results.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/crud/tests/unified/client-bulkWrite-results.json
+++ b/source/crud/tests/unified/client-bulkWrite-results.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite results",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",

--- a/source/crud/tests/unified/client-bulkWrite-results.yml
+++ b/source/crud/tests/unified/client-bulkWrite-results.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite results"
 schemaVersion: "1.1"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/client-bulkWrite-results.yml
+++ b/source/crud/tests/unified/client-bulkWrite-results.yml
@@ -1,5 +1,5 @@
 description: "client bulkWrite results"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
     serverless: forbid

--- a/source/crud/tests/unified/client-bulkWrite-update-options.json
+++ b/source/crud/tests/unified/client-bulkWrite-update-options.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite update options",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",

--- a/source/crud/tests/unified/client-bulkWrite-update-options.json
+++ b/source/crud/tests/unified/client-bulkWrite-update-options.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/crud/tests/unified/client-bulkWrite-update-options.yml
+++ b/source/crud/tests/unified/client-bulkWrite-update-options.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite update options"
 schemaVersion: "1.1"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/crud/tests/unified/client-bulkWrite-update-options.yml
+++ b/source/crud/tests/unified/client-bulkWrite-update-options.yml
@@ -1,5 +1,5 @@
 description: "client bulkWrite update options"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
     serverless: forbid

--- a/source/crud/tests/unified/client-bulkWrite-update-pipeline.json
+++ b/source/crud/tests/unified/client-bulkWrite-update-pipeline.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite update pipeline",
-  "schemaVersion": "1.1",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",

--- a/source/crud/tests/unified/client-bulkWrite-update-pipeline.json
+++ b/source/crud/tests/unified/client-bulkWrite-update-pipeline.json
@@ -3,7 +3,8 @@
   "schemaVersion": "1.1",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.0"
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/crud/tests/unified/client-bulkWrite-update-pipeline.yml
+++ b/source/crud/tests/unified/client-bulkWrite-update-pipeline.yml
@@ -1,5 +1,5 @@
 description: "client bulkWrite update pipeline"
-schemaVersion: "1.1"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
     serverless: forbid

--- a/source/crud/tests/unified/client-bulkWrite-update-pipeline.yml
+++ b/source/crud/tests/unified/client-bulkWrite-update-pipeline.yml
@@ -2,6 +2,7 @@ description: "client bulkWrite update pipeline"
 schemaVersion: "1.1"
 runOnRequirements:
   - minServerVersion: "8.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
@@ -54,6 +54,7 @@ tests:
     {%- if (operation.operation_name == 'clientBulkWrite') %}
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     {%- endif %}
     operations:
       - name: failPoint
@@ -102,6 +103,7 @@ tests:
     {%- if (operation.operation_name == 'clientBulkWrite') %}
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     {%- endif %}
     operations:
       - name: failPoint

--- a/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
+++ b/source/retryable-writes/tests/etc/templates/handshakeError.yml.template
@@ -2,7 +2,7 @@
 
 description: "retryable writes handshake failures"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4" # For `serverless: forbid`
 
 runOnRequirements:
   - minServerVersion: "4.2"

--- a/source/retryable-writes/tests/unified/client-bulkWrite-clientErrors.json
+++ b/source/retryable-writes/tests/unified/client-bulkWrite-clientErrors.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/retryable-writes/tests/unified/client-bulkWrite-clientErrors.yml
+++ b/source/retryable-writes/tests/unified/client-bulkWrite-clientErrors.yml
@@ -6,6 +6,7 @@ runOnRequirements:
       - replicaset
       - sharded
       - load-balanced
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/retryable-writes/tests/unified/client-bulkWrite-serverErrors.json
+++ b/source/retryable-writes/tests/unified/client-bulkWrite-serverErrors.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/retryable-writes/tests/unified/client-bulkWrite-serverErrors.yml
+++ b/source/retryable-writes/tests/unified/client-bulkWrite-serverErrors.yml
@@ -6,6 +6,7 @@ runOnRequirements:
       - replicaset
       - sharded
       - load-balanced
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/retryable-writes/tests/unified/handshakeError.json
+++ b/source/retryable-writes/tests/unified/handshakeError.json
@@ -57,7 +57,8 @@
       "description": "client.clientBulkWrite succeeds after retryable handshake network error",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -165,7 +166,8 @@
       "description": "client.clientBulkWrite succeeds after retryable handshake server error (ShutdownInProgress)",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/source/retryable-writes/tests/unified/handshakeError.json
+++ b/source/retryable-writes/tests/unified/handshakeError.json
@@ -1,6 +1,6 @@
 {
   "description": "retryable writes handshake failures",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "4.2",

--- a/source/retryable-writes/tests/unified/handshakeError.yml
+++ b/source/retryable-writes/tests/unified/handshakeError.yml
@@ -2,7 +2,7 @@
 
 description: "retryable writes handshake failures"
 
-schemaVersion: "1.3"
+schemaVersion: "1.4" # For `serverless: forbid`
 
 runOnRequirements:
   - minServerVersion: "4.2"

--- a/source/retryable-writes/tests/unified/handshakeError.yml
+++ b/source/retryable-writes/tests/unified/handshakeError.yml
@@ -53,6 +53,7 @@ tests:
   - description: "client.clientBulkWrite succeeds after retryable handshake network error"
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -98,6 +99,7 @@ tests:
   - description: "client.clientBulkWrite succeeds after retryable handshake server error (ShutdownInProgress)"
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/source/server-selection/tests/logging/operation-id.json
+++ b/source/server-selection/tests/logging/operation-id.json
@@ -232,7 +232,8 @@
       "description": "Successful client bulkWrite operation: log messages have operationIds",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [
@@ -304,7 +305,8 @@
       "description": "Failed client bulkWrite operation: log messages have operationIds",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/source/server-selection/tests/logging/operation-id.yml
+++ b/source/server-selection/tests/logging/operation-id.yml
@@ -128,6 +128,7 @@ tests:
   - description: "Successful client bulkWrite operation: log messages have operationIds"
     runOnRequirements:
       - minServerVersion: "8.0" # required for bulkWrite command
+        serverless: forbid
     operations:
       # ensure we've discovered the server so it is immediately available
       # and no extra "waiting for suitable server" messages are emitted.
@@ -165,6 +166,7 @@ tests:
   - description: "Failed client bulkWrite operation: log messages have operationIds"
     runOnRequirements:
       - minServerVersion: "8.0" # required for bulkWrite command
+        serverless: forbid
     operations:
       # fail all hello/legacy hello commands for the main client.
       - name: failPoint

--- a/source/transactions/tests/unified/client-bulkWrite.json
+++ b/source/transactions/tests/unified/client-bulkWrite.json
@@ -8,7 +8,8 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ]
+      ],
+      "serverless": "forbid"
     }
   ],
   "createEntities": [

--- a/source/transactions/tests/unified/client-bulkWrite.json
+++ b/source/transactions/tests/unified/client-bulkWrite.json
@@ -1,6 +1,6 @@
 {
   "description": "client bulkWrite transactions",
-  "schemaVersion": "1.3",
+  "schemaVersion": "1.4",
   "runOnRequirements": [
     {
       "minServerVersion": "8.0",

--- a/source/transactions/tests/unified/client-bulkWrite.yml
+++ b/source/transactions/tests/unified/client-bulkWrite.yml
@@ -6,6 +6,7 @@ runOnRequirements:
       - replicaset
       - sharded
       - load-balanced
+    serverless: forbid
 
 createEntities:
   - client:

--- a/source/transactions/tests/unified/client-bulkWrite.yml
+++ b/source/transactions/tests/unified/client-bulkWrite.yml
@@ -1,5 +1,5 @@
 description: "client bulkWrite transactions"
-schemaVersion: "1.3"
+schemaVersion: "1.4" # To support `serverless: forbid`
 runOnRequirements:
   - minServerVersion: "8.0"
     topologies:

--- a/source/transactions/tests/unified/mongos-pin-auto-tests.py
+++ b/source/transactions/tests/unified/mongos-pin-auto-tests.py
@@ -322,6 +322,7 @@ def create_pin_test(op_name, error_name):
     if op_name == 'clientBulkWrite':
         test += '    runOnRequirements:\n'
         test += '      - minServerVersion: "8.0" # `bulkWrite` added to server 8.0"\n'
+        test += '        serverless: forbid\n'
     return test
 
 
@@ -337,6 +338,7 @@ def create_unpin_test(op_name, error_name):
     if op_name == 'clientBulkWrite':
         test += '    runOnRequirements:\n'
         test += '      - minServerVersion: "8.0" # `bulkWrite` added to server 8.0"\n'
+        test += '        serverless: forbid\n'
     return test
 
 

--- a/source/versioned-api/tests/crud-api-version-1.json
+++ b/source/versioned-api/tests/crud-api-version-1.json
@@ -431,7 +431,8 @@
       "description": "client bulkWrite appends declared API version",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.0"
+          "minServerVersion": "8.0",
+          "serverless": "forbid"
         }
       ],
       "operations": [

--- a/source/versioned-api/tests/crud-api-version-1.yml
+++ b/source/versioned-api/tests/crud-api-version-1.yml
@@ -160,6 +160,7 @@ tests:
   - description: "client bulkWrite appends declared API version"
     runOnRequirements:
       - minServerVersion: "8.0" # `bulkWrite` added to server 8.0
+        serverless: forbid
     operations:
       - name: clientBulkWrite
         object: *client


### PR DESCRIPTION
# Summary
Follow-up to https://github.com/mongodb/specifications/pull/1534. Skip tests running `bulkWrite` on Atlas Serverless.

# Background & Motivation
[CLOUDP-256344](https://jira.mongodb.org/browse/CLOUDP-256344) blocks `bulkWrite` in Atlas Serverless. This can be seen with mongosh:
```
Atlas test> db.version()
8.0.0-rc17
Atlas test> db.adminCommand({bulkWrite: 1, ops: [{insert: 0, document: {foo: "bar"}}], nsInfo: [{ns: "db.coll"}]})
MongoServerError[AtlasError]: (Unauthorized) not authorized on admin to execute command { bulkWrite: 1, ops: [[{insert 0} {document [{foo bar}]}]], nsInfo: [[{ns db.coll}]], lsid: { id: {4 [149 137 108 46 117 126 74 218 185 29 250 199 40 40 23 131]} }, $clusterTime: { clusterTime: {1724242370 2}, signature: { hash: {0 [31 9 179 21 13 4 43 10 142 148 251 52 224 5 220 242 224 236 216 151]}, keyId: 7364078628537106432.000000 } }, $db: "admin" }
```

Some unified tests required increasing `schemaVersion` to `1.4` to include support specifying `serverless` as a `runOnRequirement`.

---

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. (Tested in Python)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->


