### PR TITLE
DRIVERS-2768 skip search index tests on 7.1

### DIFF
--- a/source/index-management/tests/createSearchIndex.json
+++ b/source/index-management/tests/createSearchIndex.json
@@ -28,7 +28,17 @@
   ],
   "runOnRequirements": [
     {
-      "minServerVersion": "7.0.0",
+      "minServerVersion": "7.0.5",
+      "maxServerVersion": "7.0.99",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    },
+    {
+      "minServerVersion": "7.2.0",
       "topologies": [
         "replicaset",
         "load-balanced",

--- a/source/index-management/tests/createSearchIndex.yml
+++ b/source/index-management/tests/createSearchIndex.yml
@@ -16,7 +16,13 @@ createEntities:
       collectionName: *collection0
 
 runOnRequirements:
-  - minServerVersion: "7.0.0"
+  # Skip server versions without fix of SERVER-83107 to avoid error message "BSON field 'createSearchIndexes.indexes.type' is an unknown field."
+  # SERVER-83107 was not backported to 7.1.
+  - minServerVersion: "7.0.5"
+    maxServerVersion: "7.0.99"
+    topologies: [ replicaset, load-balanced, sharded ]
+    serverless: forbid
+  - minServerVersion: "7.2.0"
     topologies: [ replicaset, load-balanced, sharded ]
     serverless: forbid
 

--- a/source/index-management/tests/createSearchIndexes.json
+++ b/source/index-management/tests/createSearchIndexes.json
@@ -28,7 +28,17 @@
   ],
   "runOnRequirements": [
     {
-      "minServerVersion": "7.0.0",
+      "minServerVersion": "7.0.5",
+      "maxServerVersion": "7.0.99",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    },
+    {
+      "minServerVersion": "7.2.0",
       "topologies": [
         "replicaset",
         "load-balanced",

--- a/source/index-management/tests/createSearchIndexes.yml
+++ b/source/index-management/tests/createSearchIndexes.yml
@@ -16,7 +16,13 @@ createEntities:
       collectionName: *collection0
 
 runOnRequirements:
-  - minServerVersion: "7.0.0"
+  # Skip server versions without fix of SERVER-83107 to avoid error message "BSON field 'createSearchIndexes.indexes.type' is an unknown field."
+  # SERVER-83107 was not backported to 7.1.
+  - minServerVersion: "7.0.5"
+    maxServerVersion: "7.0.99"
+    topologies: [ replicaset, load-balanced, sharded ]
+    serverless: forbid
+  - minServerVersion: "7.2.0"
     topologies: [ replicaset, load-balanced, sharded ]
     serverless: forbid
 

--- a/source/index-management/tests/searchIndexIgnoresReadWriteConcern.json
+++ b/source/index-management/tests/searchIndexIgnoresReadWriteConcern.json
@@ -32,7 +32,17 @@
   ],
   "runOnRequirements": [
     {
-      "minServerVersion": "7.0.0",
+      "minServerVersion": "7.0.5",
+      "maxServerVersion": "7.0.99",
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ],
+      "serverless": "forbid"
+    },
+    {
+      "minServerVersion": "7.2.0",
       "topologies": [
         "replicaset",
         "load-balanced",

--- a/source/index-management/tests/searchIndexIgnoresReadWriteConcern.yml
+++ b/source/index-management/tests/searchIndexIgnoresReadWriteConcern.yml
@@ -20,7 +20,13 @@ createEntities:
       collectionName: *collection0
 
 runOnRequirements:
-  - minServerVersion: "7.0.0"
+  # Skip server versions without fix of SERVER-83107 to avoid error message "BSON field 'createSearchIndexes.indexes.type' is an unknown field."
+  # SERVER-83107 was not backported to 7.1.
+  - minServerVersion: "7.0.5"
+    maxServerVersion: "7.0.99"
+    topologies: [ replicaset, load-balanced, sharded ]
+    serverless: forbid
+  - minServerVersion: "7.2.0"
     topologies: [ replicaset, load-balanced, sharded ]
     serverless: forbid
 


### PR DESCRIPTION
# Summary
Follow-up to https://github.com/mongodb/specifications/pull/1541

Skip search index tests on server 7.1.

# Background & Motivation

This PR is intended to fix failing tests in the C driver using server version 7.1.0 (latest available on Ubuntu 18.04). An [example failure](https://spruce.mongodb.com/task/mongo_c_driver_gcc75_test_coverage_latest_replica_set_auth_sasl_openssl_fc243b90046371f09d8f50547bf3e7f25846d406_24_08_16_18_18_44/logs?execution=0) logs:

> expected error to contain "Atlas", but got: "BSON field 'createSearchIndexes.indexes.type' is an unknown field."

The "unknown field" error message appears in server 7.1.0, but not 7.0.9 or 7.2.1:

With 7.0.5:
```
% mongosh --eval "print(db.version()); db.runCommand({createSearchIndexes: 'coll', indexes: [{definition: { mappings: { dynamic: true } }, type: 'search' }]});"
7.0.5
MongoServerError: Search index commands are only supported with Atlas.
```

With 7.1.0:

```
% mongosh --eval "print(db.version()); db.runCommand({createSearchIndexes: 'coll', indexes: [{definition: { mappings: { dynamic: true } }, type: 'search' }]});"
7.1.0
MongoServerError: BSON field 'createSearchIndexes.indexes.type' is an unknown field.
```

With 7.2.1:

```
% mongosh --eval "print(db.version()); db.runCommand({createSearchIndexes: 'coll', indexes: [{definition: { mappings: { dynamic: true } }, type: 'search' }]});"
7.2.1
MongoServerError: Search index commands are only supported with Atlas.
```

I expect this is because [SERVER-83107](https://jira.mongodb.org/browse/SERVER-83107) was backported to 7.0.5 and 7.2.1, but not to a 7.1 version.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ Not applicable. Test changes only.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
