### PR TITLE
DRIVERS-1256: specify how drivers set timeouts on explain commands

### DIFF
--- a/source/client-side-operations-timeout/client-side-operations-timeout.md
+++ b/source/client-side-operations-timeout/client-side-operations-timeout.md
@@ -430,8 +430,8 @@ See [runCommand behavior](#runcommand-behavior).
 
 ### Explain Helpers
 
-If a driver provides an explain helper, drivers MUST take care to ensure that timeoutMS is correctly applied to the top-level
-explain command, when specified.  Care should be taken by drivers with a fluent API - the following example
+If a driver provides an explain helper, drivers MUST take care to ensure that timeoutMS is correctly applied to the
+top-level explain command, when specified. Care should be taken by drivers with a fluent API - the following example
 should apply a timeoutMS of 1000 to the `explain` command:
 
 ```typescript

--- a/source/client-side-operations-timeout/client-side-operations-timeout.md
+++ b/source/client-side-operations-timeout/client-side-operations-timeout.md
@@ -665,7 +665,7 @@ timeout for each database operation. This would mimic using `timeoutMode=ITERATI
 
 ## Changelog
 
-- 2024-08-23: Specify that explain helpers support support timeoutMS.
+- 2024-09-12: Specify that explain helpers support support timeoutMS.
 - 2023-12-07: Migrated from reStructuredText to Markdown.
 - 2022-11-17: Use minimum RTT for maxTimeMS calculation instead of 90th percentile RTT.
 - 2022-10-05: Remove spec front matter.

--- a/source/client-side-operations-timeout/client-side-operations-timeout.md
+++ b/source/client-side-operations-timeout/client-side-operations-timeout.md
@@ -428,6 +428,16 @@ check the command document for the presence of a `maxTimeMS` field.
 
 See [runCommand behavior](#runcommand-behavior).
 
+### Explain Helpers
+
+If a driver provides an explain helper, drivers MUST take care to ensure that timeoutMS is correctly applied to the top-level
+explain command, when specified.  Care should be taken by drivers with a fluent API - the following example
+should apply a timeoutMS of 1000 to the `explain` command:
+
+```typescript
+collection.find({}, { timeoutMS: 1000 }).explain();
+```
+
 ## Test Plan
 
 See the [README.rst](tests/README.md) in the tests directory.
@@ -651,6 +661,7 @@ timeout for each database operation. This would mimic using `timeoutMode=ITERATI
 
 ## Changelog
 
+- 2024-08-23: Specify that explain helpers support support timeoutMS.
 - 2023-12-07: Migrated from reStructuredText to Markdown.
 - 2022-11-17: Use minimum RTT for maxTimeMS calculation instead of 90th percentile RTT.
 - 2022-10-05: Remove spec front matter.

--- a/source/client-side-operations-timeout/client-side-operations-timeout.md
+++ b/source/client-side-operations-timeout/client-side-operations-timeout.md
@@ -433,12 +433,13 @@ See [runCommand behavior](#runcommand-behavior).
 > [!NOTE]
 > This portion of the specification is only relevant for drivers that provide `explain` helpers.
 
-When `timeoutMS` is specified, drivers MUST take care to ensure that timeoutMS is correctly applied to the top-level
-explain command. Care should be taken by drivers with a fluent API - the following example should apply a timeoutMS of
-1000 to the `explain` command:
+When `timeoutMS` is specified, drivers MUST provide a way to specify timeoutMS that results in maxTimeMS being set on
+the `explain` command. For example, Node's implementation might look like:
 
 ```typescript
-collection.find({}, { timeoutMS: 1000 }).explain();
+collection.find({}).explain({ timeoutMS: 1000 });
+// sends:
+{ explain: { find: ... }, maxTimeMS: <remaining timeoutMS - min rtt>}
 ```
 
 ## Test Plan

--- a/source/client-side-operations-timeout/client-side-operations-timeout.md
+++ b/source/client-side-operations-timeout/client-side-operations-timeout.md
@@ -428,11 +428,14 @@ check the command document for the presence of a `maxTimeMS` field.
 
 See [runCommand behavior](#runcommand-behavior).
 
-### Explain Helpers
+### Explain
 
-If a driver provides an explain helper, drivers MUST take care to ensure that timeoutMS is correctly applied to the
-top-level explain command, when specified. Care should be taken by drivers with a fluent API - the following example
-should apply a timeoutMS of 1000 to the `explain` command:
+> [!NOTE]
+> This portion of the specification is only relevant for drivers that provide `explain` helpers.
+
+When `timeoutMS` is specified, drivers MUST take care to ensure that timeoutMS is correctly applied to the top-level
+explain command. Care should be taken by drivers with a fluent API - the following example should apply a timeoutMS of
+1000 to the `explain` command:
 
 ```typescript
 collection.find({}, { timeoutMS: 1000 }).explain();

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2217,8 +2217,8 @@ interface ExplainOptions {
 }
 ```
 
-If a driver does provide explain helpers, the driver MUST ensure that its helper permits users to specify a timeout
-(maxTimeMS or timeoutMS) for the explain command specifically. An example, using Node, might look like:
+Drivers MUST ensure that its helper permits users to specify a timeout (maxTimeMS or timeoutMS) for the explain command
+specifically. An example, using Node, might look like:
 
 ```typescript
 collection.find({ name: 'john doe' }).explain({ maxTimeMS: 1000 });

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2201,8 +2201,24 @@ the [$readPreference global command argument](../message/OP_MSG.md#global-comman
 
 ### Explain
 
-Drivers MAY provide explain helpers. If a driver does provide explain helpers, the driver MUST ensure that its helper
-permits users to specify maxTimeMS for the explain command specifically. An example, using Node, might look like:
+> [!NOTE]
+> Explain helpers are optional. Drivers that do not provide explain helpers may ignore this section.
+
+```typescript
+interface ExplainOptions {
+  /**
+   * The maximum amount of time to allow the explain to run.
+   *
+   * This option is sent only if the caller explicitly provides a value. The default is to not send a value.
+   *
+   * NOTE: This option is deprecated in favor of timeoutMS.
+   */
+  maxTimeMS: Optional<Int64>;
+}
+```
+
+If a driver does provide explain helpers, the driver MUST ensure that its helper permits users to specify a timeout
+(maxTimeMS or timeoutMS) for the explain command specifically. An example, using Node, might look like:
 
 ```typescript
 collection.find({ name: 'john doe' }).explain({ maxTimeMS: 1000 });
@@ -2212,7 +2228,18 @@ collection.find({ name: 'john doe' }).explain({ maxTimeMS: 1000 });
   explain: { find: <collection>, query: { name: 'john doe' } },
   maxTimeMS: 1000
 }
+
+collection.find({ name: 'john doe' }).explain({ timeoutMS: 1000 });
+
+// sends:
+{ 
+  explain: { find: <collection>, query: { name: 'john doe' } },
+  maxTimeMS: <1000 - average rtt>
+}
 ```
+
+This ensures that users have a mechanism to apply timeouts to `explain` specifically. Drivers MUST take care to ensure
+that
 
 Drivers MUST document how users can specify options on their explain helpers.
 

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -105,7 +105,7 @@ Drivers MUST enforce timeouts for all operations per the
 operations that return cursors MUST support the timeout options documented in the
 [Cursors](../client-side-operations-timeout/client-side-operations-timeout.md#cursors) section of that specification.
 All explain helpers MUST support the timeout options documented in the
-[Explain Helpers](../client-side-operations-timeout/client-side-operations-timeout.md#explain_helpers) section of that
+[Explain Helpers](../client-side-operations-timeout/client-side-operations-timeout.md#explain) section of that
 specification.
 
 ### API

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -104,6 +104,9 @@ Drivers MUST enforce timeouts for all operations per the
 [Client Side Operations Timeout](../client-side-operations-timeout/client-side-operations-timeout.md) specification. All
 operations that return cursors MUST support the timeout options documented in the
 [Cursors](../client-side-operations-timeout/client-side-operations-timeout.md#cursors) section of that specification.
+All explain helpers MUST support the timeout options documented in the
+[Explain Helpers](../client-side-operations-timeout/client-side-operations-timeout.md#explain_helpers) section of that
+specification.
 
 ### API
 
@@ -177,9 +180,6 @@ interface Collection {
    * contain other meta operators like $maxScan. However, do not validate this document
    * as it would be impossible to be forwards and backwards compatible. Let the server
    * handle the validation.
-   *
-   * Note: If $explain is specified in the modifiers, the return value is a single
-   * document. This could cause problems for static languages using strongly typed entities.
    *
    * Note: result iteration should be backed by a cursor. Depending on the implementation,
    * the cursor may back the returned Iterable instance or an iterator that it produces.

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2234,7 +2234,7 @@ collection.find({ name: 'john doe' }).explain({ timeoutMS: 1000 });
 // sends:
 { 
   explain: { find: <collection>, query: { name: 'john doe' } },
-  maxTimeMS: <1000 - average rtt>
+  maxTimeMS: <1000 - min rtt>
 }
 ```
 

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2330,12 +2330,10 @@ deprecate it and drivers that have not built it should not do so.
 
 Q: Should drivers offer explain helpers?\
 Originally, it was determined that explain should not be exposed via
-specialized APIs in drivers (runCommand was always an option after server 3.0).
-
-Explain helpers are not required because it has been determined to be not a normal use-case for a driver. We'd like
-users to use the shell for this purpose. However, explain is still possible from a driver. Aggregate can be run using a
-runCommand method passing the explain option. In addition, server 3.0 offers an explain command that can be run using a
-runCommand method. However, some drivers historically have offered explain APIs and continue to do so.
+specialized APIs in drivers because it it was deemed to be an unusual use-case for a driver. We'd like users to use the
+shell for this purpose. However, explain is still possible from a driver. Some drivers have historically provided
+explain helpers and continue to do so. Drivers that do not offer explain helpers can run explain commands using the
+runCommand API.
 
 Q: What about explain?
 

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2199,6 +2199,26 @@ the [$readPreference global command argument](../message/OP_MSG.md#global-comman
 [passing read preference to mongos and load balancers](../server-selection/server-selection.md#passing-read-preference-to-mongos-and-load-balancers)
 (if applicable).
 
+
+### Explain
+
+Drivers MAY provide explain helpers.  If a driver does provide explain helpers, the driver MUST ensure that its helper permits users to
+specify maxTimeMS for the explain command specifically.  An example, using Node, might look like:
+
+```typescript
+collection.find({ name: 'john doe' }).explain({ maxTimeMS: 1000 });
+
+// sends:
+{ 
+  explain: { find: <collection>, query: { name: 'john doe' } },
+  maxTimeMS: 1000
+}
+```
+
+Drivers SHOULD be careful to 
+
+Drivers MUST document how users can specify options on their explain helpers.
+
 ## Test Plan
 
 See the [README](tests/README.md) for tests.
@@ -2311,6 +2331,15 @@ api be consistent with the rest of the methods in the CRUD family of operations.
 able to be used as this change is non-backwards breaking. Any driver which implemented the fluent bulk API should
 deprecate it and drivers that have not built it should not do so.
 
+Q: Should drivers offer explain helpers?\
+Originally, it was determined that explain should not be exposed via specialized APIs in drivers (runCommand was always an option after server 3.0.).  However, some drivers historically have offered explain APIs and continue to do
+so.  
+
+Explain helpers are not required because it has been determined to be not a normal use-case for a driver. We'd like users to use the
+shell for this purpose. However, explain is still possible from a driver. For find, it can be passed as a modifier.
+Aggregate can be run using a runCommand method passing the explain option. In addition, server 3.0 offers an explain
+command that can be run using a runCommand method.
+
 Q: What about explain?
 
 Explain has been determined to be not a normal use-case for a driver. We'd like users to use the shell for this purpose.
@@ -2379,6 +2408,8 @@ the Stable API, it was decided that this change was acceptable to make in minor 
 aforementioned allowance in the SemVer spec.
 
 ## Changelog
+
+- 2024-08-23: Specify that explain helpers support maxTimeMS.
 
 - 2024-02-20: Migrated from reStructuredText to Markdown.
 

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2238,9 +2238,6 @@ collection.find({ name: 'john doe' }).explain({ timeoutMS: 1000 });
 }
 ```
 
-This ensures that users have a mechanism to apply timeouts to `explain` specifically. Drivers MUST take care to ensure
-that
-
 Drivers MUST document how users can specify options on their explain helpers.
 
 ## Test Plan

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2201,8 +2201,8 @@ the [$readPreference global command argument](../message/OP_MSG.md#global-comman
 
 ### Explain
 
-Drivers MAY provide explain helpers.  If a driver does provide explain helpers, the driver MUST ensure that its helper permits users to
-specify maxTimeMS for the explain command specifically.  An example, using Node, might look like:
+Drivers MAY provide explain helpers. If a driver does provide explain helpers, the driver MUST ensure that its helper
+permits users to specify maxTimeMS for the explain command specifically. An example, using Node, might look like:
 
 ```typescript
 collection.find({ name: 'john doe' }).explain({ maxTimeMS: 1000 });
@@ -2329,13 +2329,14 @@ able to be used as this change is non-backwards breaking. Any driver which imple
 deprecate it and drivers that have not built it should not do so.
 
 Q: Should drivers offer explain helpers?\
-Originally, it was determined that explain should not be exposed via specialized APIs in drivers (runCommand was always an option after server 3.0.).  However, some drivers historically have offered explain APIs and continue to do
-so.
+Originally, it was determined that explain should not be exposed via
+specialized APIs in drivers (runCommand was always an option after server 3.0.). However, some drivers historically have
+offered explain APIs and continue to do so.
 
-Explain helpers are not required because it has been determined to be not a normal use-case for a driver. We'd like users to use the
-shell for this purpose. However, explain is still possible from a driver. For find, it can be passed as a modifier.
-Aggregate can be run using a runCommand method passing the explain option. In addition, server 3.0 offers an explain
-command that can be run using a runCommand method.
+Explain helpers are not required because it has been determined to be not a normal use-case for a driver. We'd like
+users to use the shell for this purpose. However, explain is still possible from a driver. For find, it can be passed as
+a modifier. Aggregate can be run using a runCommand method passing the explain option. In addition, server 3.0 offers an
+explain command that can be run using a runCommand method.
 
 Q: What about explain?
 

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2428,7 +2428,7 @@ aforementioned allowance in the SemVer spec.
 
 ## Changelog
 
-- 2024-08-23: Specify that explain helpers support maxTimeMS.
+- 2024-09-12: Specify that explain helpers support maxTimeMS.
 
 - 2024-02-20: Migrated from reStructuredText to Markdown.
 

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2199,7 +2199,6 @@ the [$readPreference global command argument](../message/OP_MSG.md#global-comman
 [passing read preference to mongos and load balancers](../server-selection/server-selection.md#passing-read-preference-to-mongos-and-load-balancers)
 (if applicable).
 
-
 ### Explain
 
 Drivers MAY provide explain helpers.  If a driver does provide explain helpers, the driver MUST ensure that its helper permits users to
@@ -2214,8 +2213,6 @@ collection.find({ name: 'john doe' }).explain({ maxTimeMS: 1000 });
   maxTimeMS: 1000
 }
 ```
-
-Drivers SHOULD be careful to 
 
 Drivers MUST document how users can specify options on their explain helpers.
 
@@ -2333,7 +2330,7 @@ deprecate it and drivers that have not built it should not do so.
 
 Q: Should drivers offer explain helpers?\
 Originally, it was determined that explain should not be exposed via specialized APIs in drivers (runCommand was always an option after server 3.0.).  However, some drivers historically have offered explain APIs and continue to do
-so.  
+so.
 
 Explain helpers are not required because it has been determined to be not a normal use-case for a driver. We'd like users to use the
 shell for this purpose. However, explain is still possible from a driver. For find, it can be passed as a modifier.

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -2330,13 +2330,12 @@ deprecate it and drivers that have not built it should not do so.
 
 Q: Should drivers offer explain helpers?\
 Originally, it was determined that explain should not be exposed via
-specialized APIs in drivers (runCommand was always an option after server 3.0.). However, some drivers historically have
-offered explain APIs and continue to do so.
+specialized APIs in drivers (runCommand was always an option after server 3.0).
 
 Explain helpers are not required because it has been determined to be not a normal use-case for a driver. We'd like
-users to use the shell for this purpose. However, explain is still possible from a driver. For find, it can be passed as
-a modifier. Aggregate can be run using a runCommand method passing the explain option. In addition, server 3.0 offers an
-explain command that can be run using a runCommand method.
+users to use the shell for this purpose. However, explain is still possible from a driver. Aggregate can be run using a
+runCommand method passing the explain option. In addition, server 3.0 offers an explain command that can be run using a
+runCommand method. However, some drivers historically have offered explain APIs and continue to do so.
 
 Q: What about explain?
 

--- a/source/crud/tests/README.md
+++ b/source/crud/tests/README.md
@@ -680,8 +680,8 @@ Execute `bulkWrite` on `client` with `model`. Assert that an error (referred to 
 
 ### 14. `explain` helpers allow users to specify `maxTimeMS`
 
-Drivers that provide a multiple APIs to specify explain should ensure this test is run at least once with each distinct
-API. For example, the Node driver runs this test with option API (`collection.find({}, { explain: ... })`)git and the
+Drivers that provide multiple APIs to specify explain should ensure this test is run at least once with each distinct
+API. For example, the Node driver runs this test with option API (`collection.find({}, { explain: ... })`) and the
 fluent API (`collection.find({}).explain(...)`).
 
 Create a MongoClient with command monitoring enabled (referred to as `client`).

--- a/source/crud/tests/README.md
+++ b/source/crud/tests/README.md
@@ -684,7 +684,8 @@ Create a MongoClient with command monitoring enabled (referred to as `client`).
 
 Create a collection, referred to as `collection`, with the namespace `explain-test.collection`.
 
-Run an explained find on `collection`.  The find will have the query predicate `{ name: 'john doe' }`.  Specify
-a maxTimeMS value of 2000ms for the `explain`.
+Run an explained find on `collection`. The find will have the query predicate `{ name: 'john doe' }`. Specify a
+maxTimeMS value of 2000ms for the `explain`.
 
-Obtain the command started event for the explain.  Confirm that the top-level explain command should has a `maxTimeMS` value of `2000`.
+Obtain the command started event for the explain. Confirm that the top-level explain command should has a `maxTimeMS`
+value of `2000`.

--- a/source/crud/tests/README.md
+++ b/source/crud/tests/README.md
@@ -677,3 +677,14 @@ InsertOne {
 
 Execute `bulkWrite` on `client` with `model`. Assert that an error (referred to as `error`) is returned. Assert that
 `error` is a client error containing the message: "bulkWrite does not currently support automatic encryption".
+
+### 14. `explain` helpers allow users to specify `maxTimeMS`
+
+Create a MongoClient with command monitoring enabled (referred to as `client`).
+
+Create a collection, referred to as `collection`, with the namespace `explain-test.collection`.
+
+Run an explained find on `collection`.  The find will have the query predicate `{ name: 'john doe' }`.  Specify
+a maxTimeMS value of 2000ms for the `explain`.
+
+Obtain the command started event for the explain.  Confirm that the top-level explain command should has a `maxTimeMS` value of `2000`.

--- a/source/crud/tests/README.md
+++ b/source/crud/tests/README.md
@@ -680,6 +680,10 @@ Execute `bulkWrite` on `client` with `model`. Assert that an error (referred to 
 
 ### 14. `explain` helpers allow users to specify `maxTimeMS`
 
+Drivers that provide a multiple APIs to specify explain should ensure this test is run at least once with each distinct
+API. For example, the Node driver runs this test with option API (`collection.find({}, { explain: ... })`)git and the
+fluent API (`collection.find({}).explain(...)`).
+
 Create a MongoClient with command monitoring enabled (referred to as `client`).
 
 Create a collection, referred to as `collection`, with the namespace `explain-test.collection`.


### PR DESCRIPTION
This PR specifies that drivers with explain helpers must provide a mechanism to set timeouts on the explain command.

Node POC: https://github.com/mongodb/node-mongodb-native/pull/4207
Please complete the following before merging:

- [x] Update changelog.
- [N/A] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
