### PR TITLE
DRIVERS-716 skip CSOT `bulkWrite` prose test on serverless

### DIFF
--- a/source/client-side-operations-timeout/tests/README.md
+++ b/source/client-side-operations-timeout/tests/README.md
@@ -600,7 +600,7 @@ Tests in this section MUST only run against replica sets and sharded clusters wi
 
 ### 11. Multi-batch bulkWrites
 
-This test MUST only run against server versions 8.0+.
+This test MUST only run against server versions 8.0+. This test must be skipped on Atlas Serverless.
 
 1. Using `internalClient`, drop the `db.coll` collection.
 


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/specifications/pull/1636. Skip Atlas Serverless on CSOT prose test 11 using `bulkWrite`.
<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- ~~[ ] Make sure there are generated JSON files from the YAML test files.~~
- ~~[ ] Test changes in at least one language driver.~~
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
