### PR TITLE
DRIVERS-2768 revert skip of 7.1 to `searchIndexIgnoresReadWriteConcern`

### DIFF
--- a/source/index-management/tests/searchIndexIgnoresReadWriteConcern.json
+++ b/source/index-management/tests/searchIndexIgnoresReadWriteConcern.json
@@ -32,17 +32,7 @@
   ],
   "runOnRequirements": [
     {
-      "minServerVersion": "7.0.5",
-      "maxServerVersion": "7.0.99",
-      "topologies": [
-        "replicaset",
-        "load-balanced",
-        "sharded"
-      ],
-      "serverless": "forbid"
-    },
-    {
-      "minServerVersion": "7.2.0",
+      "minServerVersion": "7.0.0",
       "topologies": [
         "replicaset",
         "load-balanced",

--- a/source/index-management/tests/searchIndexIgnoresReadWriteConcern.yml
+++ b/source/index-management/tests/searchIndexIgnoresReadWriteConcern.yml
@@ -20,13 +20,7 @@ createEntities:
       collectionName: *collection0
 
 runOnRequirements:
-  # Skip server versions without fix of SERVER-83107 to avoid error message "BSON field 'createSearchIndexes.indexes.type' is an unknown field."
-  # SERVER-83107 was not backported to 7.1.
-  - minServerVersion: "7.0.5"
-    maxServerVersion: "7.0.99"
-    topologies: [ replicaset, load-balanced, sharded ]
-    serverless: forbid
-  - minServerVersion: "7.2.0"
+  - minServerVersion: "7.0.0"
     topologies: [ replicaset, load-balanced, sharded ]
     serverless: forbid
 


### PR DESCRIPTION
The skip was added as part of 8be1189abcc9b879a081f1f606159f3d2578cb27. The skip is not necessary since the test does not specify `SearchIndexOptions.type`.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver. **Tested locally with C++ driver**
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
