### PR TITLE
DRIVERS-2958: Unskip fle2v2-Rangev2-Compact on serverless

### DIFF
--- a/source/client-side-encryption/etc/test-templates/fle2v2-Rangev2-Compact.yml.template
+++ b/source/client-side-encryption/etc/test-templates/fle2v2-Rangev2-Compact.yml.template
@@ -3,7 +3,6 @@ runOn:
   - minServerVersion: "8.0.0" # Require range v2 support on server.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
-    serverless: forbid # Skip on serverless until CLOUDP-267864 is resolved.
 database_name: "default"
 collection_name: &collection_name "default"
 data: []

--- a/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.json
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.json
@@ -6,8 +6,7 @@
         "replicaset",
         "sharded",
         "load-balanced"
-      ],
-      "serverless": "forbid"
+      ]
     }
   ],
   "database_name": "default",

--- a/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.yml
+++ b/source/client-side-encryption/tests/legacy/fle2v2-Rangev2-Compact.yml
@@ -3,7 +3,6 @@ runOn:
   - minServerVersion: "8.0.0" # Require range v2 support on server.
     # FLE 2 Encrypted collections are not supported on standalone.
     topology: [ "replicaset", "sharded", "load-balanced" ]
-    serverless: forbid # Skip on serverless until CLOUDP-267864 is resolved.
 database_name: "default"
 collection_name: &collection_name "default"
 data: []


### PR DESCRIPTION
Reverts mongodb/specifications#1633