### PR TITLE
DRIVERS-2978 Fix `server-selection/tests/logging/operation-id.json:Failed client bulkWrite operation: log messages have operationIds`

### DIFF
--- a/source/server-selection/tests/logging/operation-id.json
+++ b/source/server-selection/tests/logging/operation-id.json
@@ -345,7 +345,7 @@
           }
         },
         {
-          "name": "bulkWrite",
+          "name": "clientBulkWrite",
           "object": "client",
           "arguments": {
             "models": [

--- a/source/server-selection/tests/logging/operation-id.yml
+++ b/source/server-selection/tests/logging/operation-id.yml
@@ -191,7 +191,7 @@ tests:
               newDescription:
                 type: Unknown
           count: 1
-      - name: bulkWrite
+      - name: clientBulkWrite
         object: *client
         arguments:
           models:


### PR DESCRIPTION


<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
