### PR TITLE
DRIVERS-2914: Don't create output collection in aggregate tests

### DIFF
--- a/source/crud/tests/unified/aggregate-write-readPreference.json
+++ b/source/crud/tests/unified/aggregate-write-readPreference.json
@@ -78,11 +78,6 @@
           "x": 33
         }
       ]
-    },
-    {
-      "collectionName": "coll1",
-      "databaseName": "db0",
-      "documents": []
     }
   ],
   "tests": [

--- a/source/crud/tests/unified/aggregate-write-readPreference.yml
+++ b/source/crud/tests/unified/aggregate-write-readPreference.yml
@@ -51,9 +51,6 @@ initialData:
       - { _id: 1, x: 11 }
       - { _id: 2, x: 22 }
       - { _id: 3, x: 33 }
-  - collectionName: *collection1Name
-    databaseName: *database0Name
-    documents: []
 
 tests:
   - description: "Aggregate with $out includes read preference for 5.0+ server"
@@ -78,12 +75,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: &outcome
-      - collectionName: *collection1Name
-        databaseName: *database0Name
-        documents:
-          - { _id: 2, x: 22 }
-          - { _id: 3, x: 33 }
 
   - description: "Aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -108,7 +99,6 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Aggregate with $merge includes read preference for 5.0+ server"
     runOnRequirements:
@@ -131,7 +121,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Aggregate with $merge omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -152,4 +141,3 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome

--- a/source/crud/tests/unified/db-aggregate-write-readPreference.json
+++ b/source/crud/tests/unified/db-aggregate-write-readPreference.json
@@ -52,13 +52,6 @@
       }
     }
   ],
-  "initialData": [
-    {
-      "collectionName": "coll0",
-      "databaseName": "db0",
-      "documents": []
-    }
-  ],
   "tests": [
     {
       "description": "Database-level aggregate with $out includes read preference for 5.0+ server",

--- a/source/crud/tests/unified/db-aggregate-write-readPreference.json
+++ b/source/crud/tests/unified/db-aggregate-write-readPreference.json
@@ -134,17 +134,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
-            }
-          ]
-        }
       ]
     },
     {
@@ -225,17 +214,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }
@@ -325,17 +303,6 @@
             }
           ]
         }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
-            }
-          ]
-        }
       ]
     },
     {
@@ -419,17 +386,6 @@
                   }
                 }
               }
-            }
-          ]
-        }
-      ],
-      "outcome": [
-        {
-          "collectionName": "coll0",
-          "databaseName": "db0",
-          "documents": [
-            {
-              "_id": 1
             }
           ]
         }

--- a/source/crud/tests/unified/db-aggregate-write-readPreference.yml
+++ b/source/crud/tests/unified/db-aggregate-write-readPreference.yml
@@ -43,11 +43,6 @@ createEntities:
       database: *database0
       collectionName: &collection0Name coll0
 
-initialData:
-  - collectionName: *collection0Name
-    databaseName: *database0Name
-    documents: []
-
 tests:
   - description: "Database-level aggregate with $out includes read preference for 5.0+ server"
     runOnRequirements:

--- a/source/crud/tests/unified/db-aggregate-write-readPreference.yml
+++ b/source/crud/tests/unified/db-aggregate-write-readPreference.yml
@@ -68,11 +68,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: &outcome
-      - collectionName: *collection0Name
-        databaseName: *database0Name
-        documents:
-          - { _id: 1 }
 
   - description: "Database-level aggregate with $out omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -97,7 +92,6 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Database-level aggregate with $merge includes read preference for 5.0+ server"
     runOnRequirements:
@@ -122,7 +116,6 @@ tests:
                 $readPreference: *readPreference
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome
 
   - description: "Database-level aggregate with $merge omits read preference for pre-5.0 server"
     runOnRequirements:
@@ -143,4 +136,3 @@ tests:
                 $readPreference: { $$exists: false }
                 readConcern: *readConcern
                 writeConcern: *writeConcern
-    outcome: *outcome


### PR DESCRIPTION
This PR fixes errors when running the aggregate-write-readPreference tests on MongoDB 8.0. The error can be avoided by not creating the output collection during test setup. In addition, I removed the outcome assertions as the tests were flaky on sharded clusters; sometimes the query run to validate the outcome would yield no results, while they were available a split-second later. Tests were run using PHP, and I'd like @comandeo-mongo to confirm the changes fix the failures that Ruby is experiencing.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
