### PR TITLE
 DRIVERS-2975 Fix logic for populating `BulkWriteException.partialResult`

### DIFF
--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -866,7 +866,7 @@ batch-splitting to standardize implementations across drivers and simplify batch
 
 ## **Changelog**
 
-- 2024-09-20: Update the `partialResult` population logic to account for ordered bulk writes.
+- 2024-09-23: Update the `partialResult` population logic to account for ordered bulk writes.
 
 - 2024-09-18: Relax numeric type requirements for indexes.
 

--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -866,7 +866,7 @@ batch-splitting to standardize implementations across drivers and simplify batch
 
 ## **Changelog**
 
-- 2024-09-23: Update the `partialResult` population logic to account for ordered bulk writes.
+- 2024-09-25: Update the `partialResult` population logic to account for ordered bulk writes.
 
 - 2024-09-18: Relax numeric type requirements for indexes.
 

--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -683,9 +683,16 @@ The server's response to `bulkWrite` has the following format:
 }
 ```
 
-If any operations were successful (i.e. `nErrors` is less than the number of operations that were sent), drivers MUST
-record the summary count fields in a `BulkWriteResult` to be returned to the user or embedded in a `BulkWriteException`.
-Drivers MUST NOT populate the `partialResult` field in `BulkWriteException` if no operations were successful.
+Drivers MUST record the summary count fields in a `BulkWriteResult` to be returned to the user or embedded in a
+`BulkWriteException` if the response indicates that at least one write was successful:
+
+- For ordered bulk writes, at least one write was successful if `nErrors` is 0 or the `idx` value for the write error
+  in `cursor.firstBatch` is greater than 0.
+- For unordered bulk writes, at least one write was successful if `nErrors` is less than the number of operations that
+  were included in the `bulkWrite` command.
+
+Drivers MUST NOT populate the `partialResult` field in `BulkWriteException` if it cannot be determined that at least
+one write was successfully performed.
 
 Drivers MUST attempt to consume the contents of the cursor returned in the server's `bulkWrite` response before
 returning to the user. This is required regardless of whether the user requested verbose or summary results, as the
@@ -858,6 +865,8 @@ Drivers are required to use this value even if they are capable of determining t
 batch-splitting to standardize implementations across drivers and simplify batch-splitting testing.
 
 ## **Changelog**
+
+- 2024-09-20: Update the `partialResult` population logic to account for ordered bulk writes.
 
 - 2024-09-18: Relax numeric type requirements for indexes.
 

--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -686,13 +686,13 @@ The server's response to `bulkWrite` has the following format:
 Drivers MUST record the summary count fields in a `BulkWriteResult` to be returned to the user or embedded in a
 `BulkWriteException` if the response indicates that at least one write was successful:
 
-- For ordered bulk writes, at least one write was successful if `nErrors` is 0 or the `idx` value for the write error
-  in `cursor.firstBatch` is greater than 0.
+- For ordered bulk writes, at least one write was successful if `nErrors` is 0 or the `idx` value for the write error in
+  `cursor.firstBatch` is greater than 0.
 - For unordered bulk writes, at least one write was successful if `nErrors` is less than the number of operations that
   were included in the `bulkWrite` command.
 
-Drivers MUST NOT populate the `partialResult` field in `BulkWriteException` if it cannot be determined that at least
-one write was successfully performed.
+Drivers MUST NOT populate the `partialResult` field in `BulkWriteException` if it cannot be determined that at least one
+write was successfully performed.
 
 Drivers MUST attempt to consume the contents of the cursor returned in the server's `bulkWrite` response before
 returning to the user. This is required regardless of whether the user requested verbose or summary results, as the

--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -686,8 +686,8 @@ The server's response to `bulkWrite` has the following format:
 Drivers MUST record the summary count fields in a `BulkWriteResult` to be returned to the user or embedded in a
 `BulkWriteException` if the response indicates that at least one write was successful:
 
-- For ordered bulk writes, at least one write was successful if `nErrors` is 0 or the `idx` value for the write error in
-  `cursor.firstBatch` is greater than 0.
+- For ordered bulk writes, at least one write was successful if `nErrors` is 0 or if the `idx` value for the write error
+  returned in the results cursor is greater than 0.
 - For unordered bulk writes, at least one write was successful if `nErrors` is less than the number of operations that
   were included in the `bulkWrite` command.
 

--- a/source/crud/tests/unified/client-bulkWrite-partialResults.json
+++ b/source/crud/tests/unified/client-bulkWrite-partialResults.json
@@ -143,7 +143,32 @@
           },
           "expectError": {
             "expectResult": {
-              "$$unsetOrMatches": {}
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
             }
           }
         }

--- a/source/crud/tests/unified/client-bulkWrite-partialResults.json
+++ b/source/crud/tests/unified/client-bulkWrite-partialResults.json
@@ -10,10 +10,7 @@
   "createEntities": [
     {
       "client": {
-        "id": "client0",
-        "observeEvents": [
-          "commandStartedEvent"
-        ]
+        "id": "client0"
       }
     },
     {

--- a/source/crud/tests/unified/client-bulkWrite-partialResults.json
+++ b/source/crud/tests/unified/client-bulkWrite-partialResults.json
@@ -1,0 +1,468 @@
+{
+  "description": "client bulkWrite partial results",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.0",
+      "serverless": "forbid"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "crud-tests",
+      "documents": [
+        {
+          "_id": 1,
+          "x": 11
+        }
+      ]
+    }
+  ],
+  "_yamlAnchors": {
+    "namespace": "crud-tests.coll0",
+    "newDocument": {
+      "_id": 2,
+      "x": 22
+    }
+  },
+  "tests": [
+    {
+      "description": "partialResult is unset when first operation fails during an ordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is unset when first operation fails during an ordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an ordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "0": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an ordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": true,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is unset when all operations fail during an unordered bulk write",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false
+          },
+          "expectError": {
+            "expectResult": {
+              "$$unsetOrMatches": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "1": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when second operation fails during an unordered bulk write (verbose)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": true
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "0": {
+                  "insertedId": 2
+                }
+              },
+              "updateResults": {},
+              "deleteResults": {}
+            }
+          }
+        }
+      ]
+    },
+    {
+      "description": "partialResult is set when first operation fails during an unordered bulk write (summary)",
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 2,
+                    "x": 22
+                  }
+                }
+              },
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 1,
+                    "x": 11
+                  }
+                }
+              }
+            ],
+            "ordered": false,
+            "verboseResults": false
+          },
+          "expectError": {
+            "expectResult": {
+              "insertedCount": 1,
+              "upsertedCount": 0,
+              "matchedCount": 0,
+              "modifiedCount": 0,
+              "deletedCount": 0,
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/client-bulkWrite-partialResults.json
+++ b/source/crud/tests/unified/client-bulkWrite-partialResults.json
@@ -80,7 +80,32 @@
           },
           "expectError": {
             "expectResult": {
-              "$$unsetOrMatches": {}
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
             }
           }
         }
@@ -255,7 +280,32 @@
           },
           "expectError": {
             "expectResult": {
-              "$$unsetOrMatches": {}
+              "$$unsetOrMatches": {
+                "insertedCount": {
+                  "$$exists": false
+                },
+                "upsertedCount": {
+                  "$$exists": false
+                },
+                "matchedCount": {
+                  "$$exists": false
+                },
+                "modifiedCount": {
+                  "$$exists": false
+                },
+                "deletedCount": {
+                  "$$exists": false
+                },
+                "insertResults": {
+                  "$$exists": false
+                },
+                "updateResults": {
+                  "$$exists": false
+                },
+                "deleteResults": {
+                  "$$exists": false
+                }
+              }
             }
           }
         }

--- a/source/crud/tests/unified/client-bulkWrite-partialResults.yml
+++ b/source/crud/tests/unified/client-bulkWrite-partialResults.yml
@@ -68,7 +68,15 @@ tests:
           verboseResults: false
         expectError:
           expectResult:
-            $$unsetOrMatches: {}
+            $$unsetOrMatches:
+              insertedCount: { $$exists: false }
+              upsertedCount: { $$exists: false }
+              matchedCount: { $$exists: false }
+              modifiedCount: { $$exists: false }
+              deletedCount: { $$exists: false }
+              insertResults: { $$exists: false }
+              updateResults: { $$exists: false }
+              deleteResults: { $$exists: false }
   - description: "partialResult is set when second operation fails during an ordered bulk write (verbose)"
     operations:
       - object: *client0

--- a/source/crud/tests/unified/client-bulkWrite-partialResults.yml
+++ b/source/crud/tests/unified/client-bulkWrite-partialResults.yml
@@ -1,0 +1,239 @@
+description: "client bulkWrite partial results"
+schemaVersion: "1.4" # To support `serverless: forbid`
+runOnRequirements:
+  - minServerVersion: "8.0"
+    serverless: forbid
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - &existingDocument { _id: 1, x: 11 }
+
+_yamlAnchors:
+  namespace: &namespace "crud-tests.coll0"
+  newDocument: &newDocument { _id: 2, x: 22 }
+
+tests:
+  - description: "partialResult is unset when first operation fails during an ordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: true
+          verboseResults: true
+        expectError:
+          expectResult:
+            $$unsetOrMatches: {}
+  - description: "partialResult is unset when first operation fails during an ordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: true
+          verboseResults: false
+        expectError:
+          expectResult:
+            $$unsetOrMatches: {}
+  - description: "partialResult is set when second operation fails during an ordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: true
+          verboseResults: true
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              0:
+                insertedId: 2
+            updateResults: {}
+            deleteResults: {}
+  - description: "partialResult is set when second operation fails during an ordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: true
+          verboseResults: false
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              $$unsetOrMatches: {}
+            updateResults:
+              $$unsetOrMatches: {}
+            deleteResults:
+              $$unsetOrMatches: {}
+  - description: "partialResult is unset when all operations fail during an unordered bulk write"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: false
+        expectError:
+          expectResult:
+            $$unsetOrMatches: {}
+  - description: "partialResult is set when first operation fails during an unordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: false
+          verboseResults: true
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              1:
+                insertedId: 2
+            updateResults: {}
+            deleteResults: {}
+  - description: "partialResult is set when first operation fails during an unordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+          ordered: false
+          verboseResults: false
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              $$unsetOrMatches: {}
+            updateResults:
+              $$unsetOrMatches: {}
+            deleteResults:
+              $$unsetOrMatches: {}
+  - description: "partialResult is set when second operation fails during an unordered bulk write (verbose)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: false
+          verboseResults: true
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              0:
+                insertedId: 2
+            updateResults: {}
+            deleteResults: {}
+  - description: "partialResult is set when first operation fails during an unordered bulk write (summary)"
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: *newDocument
+            - insertOne:
+                namespace: *namespace
+                document: *existingDocument
+          ordered: false
+          verboseResults: false
+        expectError:
+          expectResult:
+            insertedCount: 1
+            upsertedCount: 0
+            matchedCount: 0
+            modifiedCount: 0
+            deletedCount: 0
+            insertResults:
+              $$unsetOrMatches: {}
+            updateResults:
+              $$unsetOrMatches: {}
+            deleteResults:
+              $$unsetOrMatches: {}

--- a/source/crud/tests/unified/client-bulkWrite-partialResults.yml
+++ b/source/crud/tests/unified/client-bulkWrite-partialResults.yml
@@ -43,7 +43,15 @@ tests:
           verboseResults: true
         expectError:
           expectResult:
-            $$unsetOrMatches: {}
+            $$unsetOrMatches:
+              insertedCount: { $$exists: false }
+              upsertedCount: { $$exists: false }
+              matchedCount: { $$exists: false }
+              modifiedCount: { $$exists: false }
+              deletedCount: { $$exists: false }
+              insertResults: { $$exists: false }
+              updateResults: { $$exists: false }
+              deleteResults: { $$exists: false }
   - description: "partialResult is unset when first operation fails during an ordered bulk write (summary)"
     operations:
       - object: *client0
@@ -129,7 +137,15 @@ tests:
           ordered: false
         expectError:
           expectResult:
-            $$unsetOrMatches: {}
+            $$unsetOrMatches:
+              insertedCount: { $$exists: false }
+              upsertedCount: { $$exists: false }
+              matchedCount: { $$exists: false }
+              modifiedCount: { $$exists: false }
+              deletedCount: { $$exists: false }
+              insertResults: { $$exists: false }
+              updateResults: { $$exists: false }
+              deleteResults: { $$exists: false }
   - description: "partialResult is set when first operation fails during an unordered bulk write (verbose)"
     operations:
       - object: *client0

--- a/source/crud/tests/unified/client-bulkWrite-partialResults.yml
+++ b/source/crud/tests/unified/client-bulkWrite-partialResults.yml
@@ -7,7 +7,6 @@ runOnRequirements:
 createEntities:
   - client:
       id: &client0 client0
-      observeEvents: [ commandStartedEvent ]
   - database:
       id: &database0 database0
       client: *client0


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
