### PR TITLE
Regenerate all JSON tests

### DIFF
--- a/.github/workflows/json-regenerate-check.yml
+++ b/.github/workflows/json-regenerate-check.yml
@@ -31,4 +31,4 @@ jobs:
           python3 ./source/client-side-encryption/etc/generate-test.py ./source/client-side-encryption/etc/test-templates/*.template ./source/client-side-encryption/tests/legacy
           python3 ./source/client-side-operations-timeout/etc/generate-basic-tests.py ./source/client-side-operations-timeout/etc/templates ./source/client-side-operations-timeout/tests
           python3 ./source/etc/generate-handshakeError-tests.py
-          cd source && make && git diff --exit-code
+          cd source && make -B && git diff --exit-code

--- a/source/server-discovery-and-monitoring/tests/rs/null_election_id-pre-6.0.json
+++ b/source/server-discovery-and-monitoring/tests/rs/null_election_id-pre-6.0.json
@@ -66,7 +66,7 @@
               "$oid": "000000000000000000000002"
             },
             "minWireVersion": 0,
-            "maxWireVersion": 21
+            "maxWireVersion": 7
           }
         ]
       ],

--- a/source/unified-test-format/tests/invalid/runOnRequirement-authMechanism-type.json
+++ b/source/unified-test-format/tests/invalid/runOnRequirement-authMechanism-type.json
@@ -9,9 +9,7 @@
   "tests": [
     {
       "description": "foo",
-      "operations": [
-
-      ]
+      "operations": []
     }
   ]
 }


### PR DESCRIPTION
This PR aims to fix an issue introduced in #1660. By using `make -B` we can unconditionally make all targets, meaning that file modification times don't come into effect. This should catch issues as the one in #1660, as re-running `make` without modifying the original YAML file did not yield an updated JSON file.

This also resulted in two additional JSON tests being updated with changes introduced a while back.