### PR TITLE
Fix definition for bulk write update operation

### DIFF
--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -518,9 +518,14 @@ If the document to be inserted does not contain an `_id` field, drivers MUST gen
     "multi": Optional<Boolean>,
     "upsert": Optional<Boolean>,
     "arrayFilters": Optional<Array>,
-    "hint": Optional<Document | String>
+    "hint": Optional<Document | String>,
+    "collation": Optional<Document>
 }
 ```
+
+The `update` command document is used for update and replace operations. For update operations, the `updateMods` field
+corresponds to the `update` field in `UpdateOneModel` and `UpdateManyModel`. For replace operations, the `updateMods`
+field corresponds to the `replacement` field in `ReplaceOneModel`.
 
 #### Delete
 

--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -871,6 +871,8 @@ batch-splitting to standardize implementations across drivers and simplify batch
 
 ## **Changelog**
 
+- 2024-09-25: Add `collation` field to `update` document and clarify usage of `updateMods`.
+
 - 2024-09-25: Update the `partialResult` population logic to account for ordered bulk writes.
 
 - 2024-09-18: Relax numeric type requirements for indexes.


### PR DESCRIPTION
<!-- Thanks for contributing! -->

The `collation` field was inadvertently left out of the definition for the `update` operation document. This PR adds it in and clarifies how the `updateMods` field should be populated (see [this thread](https://mongodb.slack.com/archives/C035ZJL6CQN/p1727285353068969)). `collation` is already present in the update/replace write models and is tested in [this spec test](https://github.com/mongodb/specifications/blob/64c1692b8872301e552f04e6532029ac65666861/source/crud/tests/unified/client-bulkWrite-update-options.yml#L110).

Please complete the following before merging:

- [x] Update changelog.
- [ ] Make sure there are generated JSON files from the YAML test files.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
