### PR TITLE
DRIVERS-2993 specify behavior of `w:0` with `MongoClient.bulkWrite`

### DIFF
--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.json
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.json
@@ -91,7 +91,8 @@
                   }
                 }
               }
-            ]
+            ],
+            "ordered": false
           },
           "expectResult": {
             "insertedCount": {
@@ -158,7 +159,7 @@
                 "command": {
                   "bulkWrite": 1,
                   "errorsOnly": true,
-                  "ordered": true,
+                  "ordered": false,
                   "ops": [
                     {
                       "insert": 0,

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.yml
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.yml
@@ -50,6 +50,7 @@ tests:
                 namespace: *namespace
                 filter: { _id: 3 }
                 update: { $set: { x: 333 } }
+          ordered: false
         expectResult:
           insertedCount:
             $$unsetOrMatches: 0
@@ -89,7 +90,7 @@ tests:
               command:
                 bulkWrite: 1
                 errorsOnly: true
-                ordered: true
+                ordered: false
                 ops:
                   - insert: 0
                     document: { _id: 4, x: 44 }

--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -614,6 +614,11 @@ returned. This field is optional and defaults to false on the server.
 value for `verboseResults`, drivers MUST define `errorsOnly` as the opposite of `verboseResults`. If the user did not
 specify a value for `verboseResults`, drivers MUST define `errorsOnly` as `true`.
 
+Drivers MUST return a client-side error if `verboseResults` is true with an unacknowledged write concern containing the
+following message:
+
+> Cannot request unacknowledged write concern and verbose results
+
 ### `ordered`
 
 The `ordered` field defines whether writes should be executed in the order in which they were specified, and, if an
@@ -621,6 +626,11 @@ error occurs, whether the server should halt execution of further writes. It is 
 server. Drivers MUST explicitly define `ordered` as `true` in the `bulkWrite` command if a value is not specified in
 `BulkWriteOptions`. This is required to avoid inconsistencies between server and driver behavior if the server default
 changes in the future.
+
+Drivers MUST return a client-side error if `ordered` is true (including when default is applied) with an unacknowledged
+write concern containing the following message:
+
+> Cannot request unacknowledged write concern and ordered writes
 
 ### Size Limits
 

--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -935,6 +935,8 @@ batch-splitting to standardize implementations across drivers and simplify batch
 
 ## **Changelog**
 
+- 2024-10-07: Error if `w:0` is used with `ordered=true` or `verboseResults=true`.
+
 - 2024-10-01: Add sort option to `replaceOne` and `updateOne`.
 
 - 2024-09-30: Define more options for modeling summary vs. verbose results.

--- a/source/crud/tests/README.md
+++ b/source/crud/tests/README.md
@@ -397,7 +397,8 @@ InsertOne: {
 
 Construct as list of write models (referred to as `models`) with the one `model`.
 
-Call `MongoClient.bulkWrite` with `models` and `BulkWriteOptions.writeConcern` set to an unacknowledged write concern.
+Call `MongoClient.bulkWrite` with `models`. Pass `BulkWriteOptions` with `ordered` set to `false` and `writeConcern` set
+to an unacknowledged write concern.
 
 Expect a client-side error due the size.
 
@@ -415,7 +416,8 @@ ReplaceOne: {
 
 Construct as list of write models (referred to as `models`) with the one `model`.
 
-Call `MongoClient.bulkWrite` with `models` and `BulkWriteOptions.writeConcern` set to an unacknowledged write concern.
+Call `MongoClient.bulkWrite` with `models`. Pass `BulkWriteOptions` with `ordered` set to `false` and `writeConcern` set
+to an unacknowledged write concern.
 
 Expect a client-side error due the size.
 

--- a/source/crud/tests/README.md
+++ b/source/crud/tests/README.md
@@ -704,8 +704,8 @@ If testing with a sharded cluster, only connect to one mongos. This is intended 
 uses the same connection as the `bulkWrite` to get the correct connection count. (See
 [DRIVERS-2921](https://jira.mongodb.org/browse/DRIVERS-2921)).
 
-Construct a `MongoClient` (referred to as `client`) with [command
-monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
+Construct a `MongoClient` (referred to as `client`) with
+[command monitoring](../../command-logging-and-monitoring/command-logging-and-monitoring.md) enabled to observe
 CommandStartedEvents. Perform a `hello` command using `client` and record the `maxBsonObjectSize` and
 `maxMessageSizeBytes` values in the response.
 
@@ -731,8 +731,8 @@ an unacknowledged write concern. Assert no error occurred. Assert the result ind
 Assert that two CommandStartedEvents (referred to as `firstEvent` and `secondEvent`) were observed for the `bulkWrite`
 command. Assert that the length of `firstEvent.command.ops` is `maxMessageSizeBytes / maxBsonObjectSize`. Assert that
 the length of `secondEvent.command.ops` is 1. If the driver exposes `operationId`s in its CommandStartedEvents, assert
-that `firstEvent.operationId` is equal to `secondEvent.operationId`. Assert both commands include `writeConcern: {w:
-0}`.
+that `firstEvent.operationId` is equal to `secondEvent.operationId`. Assert both commands include
+`writeConcern: {w: 0}`.
 
 To force completion of the `w:0` writes, execute `coll.countDocuments` and expect the returned count is
 `maxMessageSizeBytes / maxBsonObjectSize + 1`. This is intended to avoid incomplete writes interfering with other tests

--- a/source/crud/tests/unified/client-bulkWrite-errors.json
+++ b/source/crud/tests/unified/client-bulkWrite-errors.json
@@ -450,6 +450,64 @@
           }
         }
       ]
+    },
+    {
+      "description": "Requesting unacknowledged write with verboseResults is a client-side error",
+      "operations": [
+        {
+          "name": "clientBulkWrite",
+          "object": "client0",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 10
+                  }
+                }
+              }
+            ],
+            "verboseResults": true,
+            "ordered": false,
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "expectError": {
+            "isClientError": true,
+            "errorContains": "Cannot request unacknowledged write concern and verbose results"
+          }
+        }
+      ]
+    },
+    {
+      "description": "Requesting unacknowledged write with ordered is a client-side error",
+      "operations": [
+        {
+          "name": "clientBulkWrite",
+          "object": "client0",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud-tests.coll0",
+                  "document": {
+                    "_id": 10
+                  }
+                }
+              }
+            ],
+            "writeConcern": {
+              "w": 0
+            }
+          },
+          "expectError": {
+            "isClientError": true,
+            "errorContains": "Cannot request unacknowledged write concern and ordered writes"
+          }
+        }
+      ]
     }
   ]
 }

--- a/source/crud/tests/unified/client-bulkWrite-errors.yml
+++ b/source/crud/tests/unified/client-bulkWrite-errors.yml
@@ -239,3 +239,32 @@ tests:
           verboseResults: true
         expectError:
           isClientError: true
+  - description: "Requesting unacknowledged write with verboseResults is a client-side error"
+    operations:
+      - name: clientBulkWrite
+        object: *client0
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: { _id: 10 }
+          verboseResults: true
+          ordered: false
+          writeConcern: { w: 0 }
+        expectError:
+          isClientError: true
+          errorContains: "Cannot request unacknowledged write concern and verbose results"
+  - description: "Requesting unacknowledged write with ordered is a client-side error"
+    operations:
+      - name: clientBulkWrite
+        object: *client0
+        arguments:
+          models:
+            - insertOne:
+                namespace: *namespace
+                document: { _id: 10 }
+          # Omit `ordered` option. Defaults to true.
+          writeConcern: { w: 0 }
+        expectError:
+          isClientError: true
+          errorContains: "Cannot request unacknowledged write concern and ordered writes"


### PR DESCRIPTION
# Summary

Specify behavior with unacknowledged writes for `MongoClient.bulkWrite`:
- Return error if verbose results are requested.
- Return error if ordered writes are requested.
- Apply `w:0` to each batch.

Existing spec and prose tests using `MongoClient.bulkWrite` with unacknowledged write concern have been updated to use `ordered: false`. The default (`ordered: true`) is now expected to result in a client-side error.

# Background & Motivation

See DRIVERS-2993 for motivation.

This PR expects the OP_MSG moreToCome bit is always set for all batches. This agrees with [OP_MSG](https://github.com/mongodb/specifications/blob/1de6a19410f9f03899676176f53a3c77de234a34/source/message/OP_MSG.md#moretocome-on-requests):

> Clients doing unacknowledged writes MUST set the `moreToCome` flag, and MUST set the writeConcern to `w=0`.

## Prose Test

A CRUD prose test is added to insert 100,001 documents with `w:0` write concern to test multi-batch unacknowledged write.

The resulting collection count is checked to ensure the unacknowledged writes completes and avoid interfering with later tests. This was similarly done in DRIVERS-2877.

The prose test includes a step to create the collection with the `create` command as a workaround for [SERVER-95537](https://jira.mongodb.org/browse/SERVER-95537).



---

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).

Tests verified with the C driver in https://github.com/mongodb/mongo-c-driver/pull/1752

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
