### PR TITLE
Specify that CSOT prose test 11 only runs on standalone servers

### DIFF
--- a/source/client-side-operations-timeout/tests/README.md
+++ b/source/client-side-operations-timeout/tests/README.md
@@ -606,7 +606,7 @@ Tests in this section MUST only run against replica sets and sharded clusters wi
 
 This test MUST only run against server versions 8.0+. This test must be skipped on Atlas Serverless.
 
-This test MUST only run against standalones. The insertMany call takes an exceedingly long time on replicasets and
+This test MUST only run against standalones. The bulkWrite call takes an exceedingly long time on replicasets and
 sharded clusters. Drivers MAY adjust the timeouts used in this test to allow for differing bulk encoding performance.
 
 1. Using `internalClient`, drop the `db.coll` collection.

--- a/source/client-side-operations-timeout/tests/README.md
+++ b/source/client-side-operations-timeout/tests/README.md
@@ -606,6 +606,10 @@ Tests in this section MUST only run against replica sets and sharded clusters wi
 
 This test MUST only run against server versions 8.0+. This test must be skipped on Atlas Serverless.
 
+This test MUST only run against standalones on server versions 4.4 and higher. The insertMany call takes an exceedingly
+long time on replicasets and sharded clusters. Drivers MAY adjust the timeouts used in this test to allow for differing
+bulk encoding performance.
+
 1. Using `internalClient`, drop the `db.coll` collection.
 
 2. Using `internalClient`, set the following fail point:

--- a/source/client-side-operations-timeout/tests/README.md
+++ b/source/client-side-operations-timeout/tests/README.md
@@ -606,9 +606,8 @@ Tests in this section MUST only run against replica sets and sharded clusters wi
 
 This test MUST only run against server versions 8.0+. This test must be skipped on Atlas Serverless.
 
-This test MUST only run against standalones on server versions 4.4 and higher. The insertMany call takes an exceedingly
-long time on replicasets and sharded clusters. Drivers MAY adjust the timeouts used in this test to allow for differing
-bulk encoding performance.
+This test MUST only run against standalones. The insertMany call takes an exceedingly long time on replicasets and
+sharded clusters. Drivers MAY adjust the timeouts used in this test to allow for differing bulk encoding performance.
 
 1. Using `internalClient`, drop the `db.coll` collection.
 


### PR DESCRIPTION
This PR restricts CSOT prose test 11 to only run on standalone servers.

Tests passing in Node's implementation: https://spruce.mongodb.com/version/67056335720d470007b68379/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=8.0

[Node's implementation](https://github.com/mongodb/node-mongodb-native/pull/4261) includes the changes in this PR.