### PR TITLE
DRIVERS-2830 - Record both FaaS and container metadata when both are present

### DIFF
--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -513,7 +513,7 @@ the following sets of environment variables:
 | -------------------- | ----- |
 | `AWS_EXECUTION_ENV`  | `EC2` |
 
-9. Valid container and FaaS provider
+9. Valid container and FaaS provider. This test MUST verify that only the container metadata is present in `client.env`.
 
 | Environment Variable              | Value              |
 | --------------------------------- | ------------------ |

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -604,7 +604,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
-- 2024-010-09: Clarify that FaaS metadata must not be populated when a container is also present.
+- 2024-10-09: Clarify that FaaS metadata must not be populated when a container is also present.
 - 2024-08-16: Migrated from reStructuredText to Markdown.
 - 2019-11-13: Added section about supporting wrapping libraries
 - 2020-02-12: Added section about speculative authentication

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -327,6 +327,8 @@ Depending on which `client.env.name` has been selected, other FaaS fields in `cl
 Missing variables or variables with values not matching the expected type MUST cause the corresponding `client.env`
 field to be omitted and MUST NOT cause a user-visible error.
 
+If any fields of `client.env.container` are populated, all FaaS values MUST be entirely omitted.
+
 ##### Container
 
 Container runtime information is captured in `client.env.container`.
@@ -511,6 +513,15 @@ the following sets of environment variables:
 | -------------------- | ----- |
 | `AWS_EXECUTION_ENV`  | `EC2` |
 
+9. Valid container and FaaS provider
+
+| Environment Variable              | Value              |
+| --------------------------------- | ------------------ |
+| `AWS_EXECUTION_ENV`               | `AWS_Lambda_java8` |
+| `AWS_REGION`                      | `us-east-2`        |
+| `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` | `1024`             |
+| `KUBERNETES_SERVICE_HOST`         | `1`                |
+
 ## Motivation For Change
 
 Being able to annotate individual connections with custom data will allow users and sysadmins to easily correlate events
@@ -593,6 +604,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
+- 2024-010-09: Clarify that FaaS metadata must not be populated when a container is also present.
 - 2024-08-16: Migrated from reStructuredText to Markdown.
 - 2019-11-13: Added section about supporting wrapping libraries
 - 2020-02-12: Added section about speculative authentication

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -327,8 +327,6 @@ Depending on which `client.env.name` has been selected, other FaaS fields in `cl
 Missing variables or variables with values not matching the expected type MUST cause the corresponding `client.env`
 field to be omitted and MUST NOT cause a user-visible error.
 
-If any fields of `client.env.container` are populated, all FaaS values MUST be entirely omitted.
-
 ##### Container
 
 Container runtime information is captured in `client.env.container`.
@@ -513,7 +511,8 @@ the following sets of environment variables:
 | -------------------- | ----- |
 | `AWS_EXECUTION_ENV`  | `EC2` |
 
-9. Valid container and FaaS provider. This test MUST verify that only the container metadata is present in `client.env`.
+9. Valid container and FaaS provider. This test MUST verify that both the container metadata and the AWS Lambda metadata
+   is present in `client.env`.
 
 | Environment Variable              | Value              |
 | --------------------------------- | ------------------ |
@@ -604,7 +603,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
-- 2024-10-09: Clarify that FaaS metadata must not be populated when a container is also present.
+- 2024-10-09: Clarify that FaaS and container metadata must both be populated when both are present.
 - 2024-08-16: Migrated from reStructuredText to Markdown.
 - 2019-11-13: Added section about supporting wrapping libraries
 - 2020-02-12: Added section about speculative authentication

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -338,6 +338,9 @@ is populated.
 
 If no fields of `client.env.container` would be populated, `client.env.container` MUST be entirely omitted.
 
+If the runtime environment has both FaaS and container information, both must have their metadata included in
+`client.env`.
+
 ### Speculative Authentication
 
 - Since: 4.4


### PR DESCRIPTION
DRIVERS-2830 Summary of changes:

- If both a FaaS provider and a container are present, both metadatas must be recorded. 

Python implementation: https://github.com/mongodb/mongo-python-driver/pull/1908.
