### PR TITLE
DRIVERS-3011 test relaxed encoding of dates after year 9999

### DIFF
--- a/source/bson-corpus/tests/datetime.json
+++ b/source/bson-corpus/tests/datetime.json
@@ -24,6 +24,7 @@
         {
             "description" : "Y10K",
             "canonical_bson" : "1000000009610000DC1FD277E6000000",
+            "relaxed_extjson" : "{\"a\":{\"$date\":{\"$numberLong\":\"253402300800000\"}}}",
             "canonical_extjson" : "{\"a\":{\"$date\":{\"$numberLong\":\"253402300800000\"}}}"
         },
         {


### PR DESCRIPTION
# Summary

Test encoding dates after year 9999 with Relaxed Extended JSON

# Background & Motivation

The extended JSON spec notes:

> | **BSON 1.1 Type or Convention**                                                            | **Canonical Extended JSON Format**                                                                                                                                                                                                                                                                                                                                                                                         | **Relaxed Extended JSON Format**                                                                                                            |
> | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
> ...
> | Datetime \[year before 1970 or after 9999\]                                                | {"$date": {"$numberLong": \<64-bit signed integer giving millisecs relative to the epoch, as a _string_>}}                                                                                                                                                                                                                                                                                                                 | \<Same as Canonical Extended JSON\>                                                                                                         |

This test reveals a bug in the C driver encoding: [CDRIVER-5759](https://jira.mongodb.org/browse/CDRIVER-5759).

<!-- Thanks for contributing! -->

Please complete the following before merging:

~~- [ ] Update changelog.~~
~~- [ ] Make sure there are generated JSON files from the YAML test files.~~
- [x] Test changes in at least one language driver. **Verified by [C driver tests](https://spruce.mongodb.com/version/67117b1eb138970007cc034b) with fix**
~~- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
  clusters, and serverless).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
