### PR TITLE
Use Markdown image instead of HTML image, fixes path on mkdocs

### DIFF
--- a/source/transactions/transactions.md
+++ b/source/transactions/transactions.md
@@ -258,8 +258,7 @@ ClientSession is in one of five states: "no transaction", "starting transaction"
 "transaction committed", and "transaction aborted". It transitions among these states according to the following
 diagram:
 
-<img src="client-session-transaction-states.png"
-style="width:6.5in;height:3.68056in" alt="states" />
+![ClientSession transaction states](client-session-transaction-states.png)
 ([GraphViz source](client-session-transaction-states.dot))
 
 When a ClientSession is created it starts in the "no transaction" state. Starting, committing, and aborting a


### PR DESCRIPTION
This fixes a broken image on the mkdocs / readthedocs build of the Transactions spec.
It's the one remaining place where the specs used an HTML image tag inside Markdown.

The image included some custom CSS style to set the size, which explains why it wasn't converted before: but that style is ignored by GitHub. Both the before and after generate effectively the same HTML on GitHub's viewer.

In mkdocs, this increases the image size to the full width of the page (default) and un-breaks the relative path by allowing mkdocs to add an extra "../" component needed to account for the directory containing each rendered Markdown document as an "index.html".