### PR TITLE
chore(DRIVERS-2730): remove support for non primary read preference

### DIFF
--- a/source/transactions/transactions.md
+++ b/source/transactions/transactions.md
@@ -232,8 +232,6 @@ with client.start_session() as s:
         coll.find_one(session=s)  # Error: "read preference in a transaction must be primary"
 ```
 
-In the future, we might relax this restriction and allow any read preference on a transaction.
-
 #### maxCommitTimeMS
 
 NOTE: This option is deprecated in favor of
@@ -926,6 +924,11 @@ won't be possible in the future for startTransaction to check that the read pref
 application will perform in the transaction. Therefore, we specify now that the readPreference must be checked
 per-operation. (However, we have not completely planned how read preference validation will behave in MongoDB 4.2.)
 
+*Update 28.Oct.20214*
+
+Note this section is retained in the spec for historical reasons and that the read preference in transactions must
+always be primary.
+
 ### Users cannot pass readConcern or writeConcern to operations in transactions
 
 For drivers that allow readConcern and/or writeConcern to be passed to a particular operation, If the driver did not
@@ -1069,6 +1072,8 @@ has been disabled, drivers can readily trust that a majority write concern is du
 objective of avoiding duplicate commits.
 
 ## **Changelog**
+
+- 2024-10-28: Note read preference must always be primary in a transaction.
 
 - 2024-05-08: Add bulkWrite to the list of commands allowed in transactions.
 


### PR DESCRIPTION
Remove note on future non-primary read preference support.

Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
