### PR TITLE
Commit generated files automatically

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,6 @@
 Please complete the following before merging:
 
 - [ ] Update changelog.
-- [ ] Make sure there are generated JSON files from the YAML test files.
 - [ ] Test changes in at least one language driver.
 - [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
     clusters, and serverless).

--- a/.github/workflows/json-regenerate-check.yml
+++ b/.github/workflows/json-regenerate-check.yml
@@ -31,4 +31,9 @@ jobs:
           python3 ./source/client-side-encryption/etc/generate-test.py ./source/client-side-encryption/etc/test-templates/*.template ./source/client-side-encryption/tests/legacy
           python3 ./source/client-side-operations-timeout/etc/generate-basic-tests.py ./source/client-side-operations-timeout/etc/templates ./source/client-side-operations-timeout/tests
           python3 ./source/etc/generate-handshakeError-tests.py
-          cd source && make -B && git diff --exit-code
+          cd source && make -B
+
+      - name: "Commit the changes"
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Update generated files"


### PR DESCRIPTION
Instead of asking us to regenerate files locally when forgotten, it might as well be done directly by the GitHub Action.

Example of commit: https://github.com/mongodb/specifications/commit/7f27d57440da24c28afadea6b143993b17d692f0