### PR TITLE
DRIVERS-1368: Use null when options shouldn't be asserted against

### DIFF
--- a/source/uri-options/tests/compression-options.json
+++ b/source/uri-options/tests/compression-options.json
@@ -35,7 +35,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low zlibCompressionLevel causes a warning",
@@ -44,7 +44,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too high zlibCompressionLevel causes a warning",
@@ -53,7 +53,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     }
   ]
 }

--- a/source/uri-options/tests/compression-options.yml
+++ b/source/uri-options/tests/compression-options.yml
@@ -7,7 +7,7 @@ tests:
         hosts: ~
         auth: ~
         options:
-            compressors: 
+            compressors:
               - "zlib"
             zlibCompressionLevel: 9
     -
@@ -28,7 +28,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low zlibCompressionLevel causes a warning"
         uri: "mongodb://example.com/?compressors=zlib&zlibCompressionLevel=-2"
@@ -36,7 +36,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too high zlibCompressionLevel causes a warning"
         uri: "mongodb://example.com/?compressors=zlib&zlibCompressionLevel=10"
@@ -44,5 +44,5 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
 

--- a/source/uri-options/tests/concern-options.json
+++ b/source/uri-options/tests/concern-options.json
@@ -43,7 +43,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low wTimeoutMS causes a warning",
@@ -52,7 +52,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Invalid journal causes a warning",
@@ -61,7 +61,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     }
   ]
 }

--- a/source/uri-options/tests/concern-options.yml
+++ b/source/uri-options/tests/concern-options.yml
@@ -36,7 +36,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low wTimeoutMS causes a warning"
         uri: "mongodb://example.com/?wTimeoutMS=-2"
@@ -44,7 +44,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Invalid journal causes a warning"
         uri: "mongodb://example.com/?journal=invalid"
@@ -52,4 +52,4 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~

--- a/source/uri-options/tests/connection-options.json
+++ b/source/uri-options/tests/connection-options.json
@@ -27,7 +27,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low connectTimeoutMS causes a warning",
@@ -36,7 +36,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Non-numeric heartbeatFrequencyMS causes a warning",
@@ -45,7 +45,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low heartbeatFrequencyMS causes a warning",
@@ -54,7 +54,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Non-numeric localThresholdMS causes a warning",
@@ -63,7 +63,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low localThresholdMS causes a warning",
@@ -72,7 +72,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Invalid retryWrites causes a warning",
@@ -81,7 +81,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Non-numeric serverSelectionTimeoutMS causes a warning",
@@ -90,7 +90,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low serverSelectionTimeoutMS causes a warning",
@@ -99,7 +99,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Non-numeric socketTimeoutMS causes a warning",
@@ -108,7 +108,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low socketTimeoutMS causes a warning",
@@ -117,7 +117,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "directConnection=true",
@@ -137,7 +137,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "directConnection=false",
@@ -168,7 +168,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "loadBalanced=true",
@@ -211,7 +211,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "loadBalanced=true with multiple hosts causes an error",
@@ -220,7 +220,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "loadBalanced=true with directConnection=true causes an error",
@@ -229,7 +229,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "loadBalanced=true with replicaSet causes an error",
@@ -238,7 +238,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "timeoutMS=0",
@@ -258,7 +258,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low timeoutMS causes a warning",
@@ -267,7 +267,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     }
   ]
 }

--- a/source/uri-options/tests/connection-options.yml
+++ b/source/uri-options/tests/connection-options.yml
@@ -24,7 +24,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low connectTimeoutMS causes a warning"
         uri: "mongodb://example.com/?connectTimeoutMS=-2"
@@ -32,7 +32,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Non-numeric heartbeatFrequencyMS causes a warning"
         uri: "mongodb://example.com/?heartbeatFrequencyMS=invalid"
@@ -40,7 +40,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low heartbeatFrequencyMS causes a warning"
         uri: "mongodb://example.com/?heartbeatFrequencyMS=-2"
@@ -48,7 +48,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Non-numeric localThresholdMS causes a warning"
         uri: "mongodb://example.com/?localThresholdMS=invalid"
@@ -56,7 +56,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low localThresholdMS causes a warning"
         uri: "mongodb://example.com/?localThresholdMS=-2"
@@ -64,15 +64,15 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
-    - 
+        options: ~
+    -
         description: "Invalid retryWrites causes a warning"
         uri: "mongodb://example.com/?retryWrites=invalid"
         valid: true
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Non-numeric serverSelectionTimeoutMS causes a warning"
         uri: "mongodb://example.com/?serverSelectionTimeoutMS=invalid"
@@ -80,7 +80,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low serverSelectionTimeoutMS causes a warning"
         uri: "mongodb://example.com/?serverSelectionTimeoutMS=-2"
@@ -88,7 +88,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Non-numeric socketTimeoutMS causes a warning"
         uri: "mongodb://example.com/?socketTimeoutMS=invalid"
@@ -96,7 +96,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low socketTimeoutMS causes a warning"
         uri: "mongodb://example.com/?socketTimeoutMS=-2"
@@ -104,7 +104,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
       description: directConnection=true
       uri: "mongodb://example.com/?directConnection=true"
@@ -121,7 +121,7 @@ tests:
       warning: false
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     -
       description: directConnection=false
       uri: "mongodb://example.com/?directConnection=false"
@@ -147,7 +147,7 @@ tests:
       warning: true
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     -
       description: loadBalanced=true
       uri: "mongodb://example.com/?loadBalanced=true"
@@ -183,7 +183,7 @@ tests:
       warning: true
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     -
       description: loadBalanced=true with multiple hosts causes an error
       uri: "mongodb://example1,example2/?loadBalanced=true"
@@ -191,7 +191,7 @@ tests:
       warning: false
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     -
       description: loadBalanced=true with directConnection=true causes an error
       uri: "mongodb://example.com/?loadBalanced=true&directConnection=true"
@@ -199,7 +199,7 @@ tests:
       warning: false
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     -
       description: loadBalanced=true with replicaSet causes an error
       uri: "mongodb://example.com/?loadBalanced=true&replicaSet=replset"
@@ -207,7 +207,7 @@ tests:
       warning: false
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     -
         description: "timeoutMS=0"
         uri: "mongodb://example.com/?timeoutMS=0"
@@ -224,7 +224,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low timeoutMS causes a warning"
         uri: "mongodb://example.com/?timeoutMS=-2"
@@ -232,4 +232,4 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~

--- a/source/uri-options/tests/connection-pool-options.json
+++ b/source/uri-options/tests/connection-pool-options.json
@@ -21,7 +21,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low maxIdleTimeMS causes a warning",
@@ -30,7 +30,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "maxPoolSize=0 does not error",
@@ -61,7 +61,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "maxConnecting<0 causes a warning",
@@ -70,7 +70,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     }
   ]
 }

--- a/source/uri-options/tests/connection-pool-options.yml
+++ b/source/uri-options/tests/connection-pool-options.yml
@@ -18,7 +18,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low maxIdleTimeMS causes a warning"
         uri: "mongodb://example.com/?maxIdleTimeMS=-2"
@@ -26,7 +26,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
 
     -
       description: "maxPoolSize=0 does not error"
@@ -46,7 +46,7 @@ tests:
       hosts: ~
       auth: ~
       options:
-          minPoolSize: 0 
+          minPoolSize: 0
 
     -
       description: "maxConnecting=0 causes a warning"
@@ -55,7 +55,7 @@ tests:
       warning: true
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
 
     -
       description: "maxConnecting<0 causes a warning"
@@ -64,4 +64,4 @@ tests:
       warning: true
       hosts: ~
       auth: ~
-      options: {}
+      options: ~

--- a/source/uri-options/tests/proxy-options.json
+++ b/source/uri-options/tests/proxy-options.json
@@ -7,7 +7,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "proxyUsername without proxyHost",
@@ -16,7 +16,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "proxyPassword without proxyHost",
@@ -25,7 +25,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "all other proxy options without proxyHost",
@@ -34,7 +34,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "proxyUsername without proxyPassword",
@@ -43,7 +43,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "proxyPassword without proxyUsername",
@@ -52,7 +52,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "multiple proxyHost parameters",
@@ -61,7 +61,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "multiple proxyPort parameters",
@@ -70,7 +70,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "multiple proxyUsername parameters",
@@ -79,7 +79,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "multiple proxyPassword parameters",
@@ -88,7 +88,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "only host present",

--- a/source/uri-options/tests/proxy-options.yml
+++ b/source/uri-options/tests/proxy-options.yml
@@ -6,7 +6,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "proxyUsername without proxyHost"
         uri: "mongodb://localhost/?proxyUsername=abc"
@@ -14,7 +14,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "proxyPassword without proxyHost"
         uri: "mongodb://localhost/?proxyPassword=def"
@@ -22,7 +22,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "all other proxy options without proxyHost"
         uri: "mongodb://localhost/?proxyPort=1080&proxyUsername=abc&proxyPassword=def"
@@ -30,7 +30,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "proxyUsername without proxyPassword"
         uri: "mongodb://localhost/?proxyHost=localhost&proxyUsername=abc"
@@ -38,7 +38,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "proxyPassword without proxyUsername"
         uri: "mongodb://localhost/?proxyHost=localhost&proxyPassword=def"
@@ -46,7 +46,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "multiple proxyHost parameters"
         uri: "mongodb://localhost/?proxyHost=localhost&proxyHost=localhost2"
@@ -54,7 +54,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "multiple proxyPort parameters"
         uri: "mongodb://localhost/?proxyHost=localhost&proxyPort=1234&proxyPort=12345"
@@ -62,7 +62,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "multiple proxyUsername parameters"
         uri: "mongodb://localhost/?proxyHost=localhost&proxyUsername=abc&proxyUsername=def&proxyPassword=123"
@@ -70,7 +70,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "multiple proxyPassword parameters"
         uri: "mongodb://localhost/?proxyHost=localhost&proxyUsername=abc&proxyPassword=123&proxyPassword=456"
@@ -78,7 +78,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "only host present"
         uri: "mongodb://localhost/?proxyHost=localhost"

--- a/source/uri-options/tests/read-preference-options.json
+++ b/source/uri-options/tests/read-preference-options.json
@@ -43,7 +43,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Non-numeric maxStalenessSeconds causes a warning",
@@ -52,7 +52,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Too low maxStalenessSeconds causes a warning",
@@ -61,7 +61,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     }
   ]
 }

--- a/source/uri-options/tests/read-preference-options.yml
+++ b/source/uri-options/tests/read-preference-options.yml
@@ -33,7 +33,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Non-numeric maxStalenessSeconds causes a warning"
         uri: "mongodb://example.com/?maxStalenessSeconds=invalid"
@@ -41,7 +41,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "Too low maxStalenessSeconds causes a warning"
         uri: "mongodb://example.com/?maxStalenessSeconds=-2"
@@ -49,5 +49,5 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
 

--- a/source/uri-options/tests/sdam-options.json
+++ b/source/uri-options/tests/sdam-options.json
@@ -40,7 +40,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     }
   ]
 }

--- a/source/uri-options/tests/sdam-options.yml
+++ b/source/uri-options/tests/sdam-options.yml
@@ -32,4 +32,4 @@ tests:
       warning: true
       hosts: ~
       auth: ~
-      options: {}
+      options: ~

--- a/source/uri-options/tests/single-threaded-options.json
+++ b/source/uri-options/tests/single-threaded-options.json
@@ -18,7 +18,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     }
   ]
 }

--- a/source/uri-options/tests/single-threaded-options.yml
+++ b/source/uri-options/tests/single-threaded-options.yml
@@ -15,4 +15,4 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~

--- a/source/uri-options/tests/srv-options.json
+++ b/source/uri-options/tests/srv-options.json
@@ -18,7 +18,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "SRV URI with srvMaxHosts",
@@ -38,7 +38,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "SRV URI with invalid type for srvMaxHosts",
@@ -47,7 +47,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "Non-SRV URI with srvMaxHosts",
@@ -56,7 +56,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "SRV URI with positive srvMaxHosts and replicaSet",
@@ -65,7 +65,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "SRV URI with positive srvMaxHosts and loadBalanced=true",
@@ -74,7 +74,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "SRV URI with positive srvMaxHosts and loadBalanced=false",

--- a/source/uri-options/tests/srv-options.yml
+++ b/source/uri-options/tests/srv-options.yml
@@ -13,7 +13,7 @@ tests:
       warning: false
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     - description: "SRV URI with srvMaxHosts"
       uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2"
       valid: true
@@ -28,21 +28,21 @@ tests:
       warning: true
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     - description: "SRV URI with invalid type for srvMaxHosts"
       uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=foo"
       valid: true
       warning: true
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     - description: "Non-SRV URI with srvMaxHosts"
       uri: "mongodb://example.com/?srvMaxHosts=2"
       valid: false
       warning: false
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     # Note: Testing URI validation for srvMaxHosts conflicting with either
     # loadBalanced=true or replicaSet specified via TXT records is covered by
     # the Initial DNS Seedlist Discovery test suite.
@@ -52,14 +52,14 @@ tests:
       warning: false
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     - description: "SRV URI with positive srvMaxHosts and loadBalanced=true"
       uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=true"
       valid: false
       warning: false
       hosts: ~
       auth: ~
-      options: {}
+      options: ~
     - description: "SRV URI with positive srvMaxHosts and loadBalanced=false"
       uri: "mongodb+srv://test1.test.build.10gen.cc/?srvMaxHosts=2&loadBalanced=false"
       valid: true

--- a/source/uri-options/tests/tls-options.json
+++ b/source/uri-options/tests/tls-options.json
@@ -31,7 +31,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates is parsed correctly",
@@ -62,7 +62,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure is parsed correctly",
@@ -82,7 +82,7 @@
       "warning": true,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure and tlsAllowInvalidCertificates both present (and true) raises an error",
@@ -91,7 +91,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure and tlsAllowInvalidCertificates both present (and false) raises an error",
@@ -100,7 +100,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates and tlsInsecure both present (and true) raises an error",
@@ -109,7 +109,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates and tlsInsecure both present (and false) raises an error",
@@ -118,7 +118,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure and tlsAllowInvalidHostnames both present (and true) raises an error",
@@ -127,7 +127,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure and tlsAllowInvalidHostnames both present (and false) raises an error",
@@ -136,7 +136,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidHostnames and tlsInsecure both present (and true) raises an error",
@@ -145,7 +145,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidHostnames and tlsInsecure both present (and false) raises an error",
@@ -154,7 +154,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tls=true and ssl=true doesn't warn",
@@ -199,7 +199,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tls=true and ssl=false raises error",
@@ -208,7 +208,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "ssl=false and tls=true raises error",
@@ -217,7 +217,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "ssl=true and tls=false raises error",
@@ -226,7 +226,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck can be set to true",
@@ -259,7 +259,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates=true and tlsDisableCertificateRevocationCheck=false raises an error",
@@ -268,7 +268,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates=false and tlsDisableCertificateRevocationCheck=true raises an error",
@@ -277,7 +277,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates and tlsDisableCertificateRevocationCheck both present (and false) raises an error",
@@ -286,7 +286,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck and tlsAllowInvalidCertificates both present (and true) raises an error",
@@ -295,7 +295,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck=true and tlsAllowInvalidCertificates=false raises an error",
@@ -304,7 +304,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck=false and tlsAllowInvalidCertificates=true raises an error",
@@ -313,7 +313,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck and tlsAllowInvalidCertificates both present (and false) raises an error",
@@ -322,7 +322,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure and tlsDisableCertificateRevocationCheck both present (and true) raises an error",
@@ -331,7 +331,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure=true and tlsDisableCertificateRevocationCheck=false raises an error",
@@ -340,7 +340,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure=false and tlsDisableCertificateRevocationCheck=true raises an error",
@@ -349,7 +349,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure and tlsDisableCertificateRevocationCheck both present (and false) raises an error",
@@ -358,7 +358,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck and tlsInsecure both present (and true) raises an error",
@@ -367,7 +367,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck=true and tlsInsecure=false raises an error",
@@ -376,7 +376,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck=false and tlsInsecure=true raises an error",
@@ -385,7 +385,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck and tlsInsecure both present (and false) raises an error",
@@ -394,7 +394,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck and tlsDisableOCSPEndpointCheck both present (and true) raises an error",
@@ -403,7 +403,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck=true and tlsDisableOCSPEndpointCheck=false raises an error",
@@ -412,7 +412,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck=false and tlsDisableOCSPEndpointCheck=true raises an error",
@@ -421,7 +421,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableCertificateRevocationCheck and tlsDisableOCSPEndpointCheck both present (and false) raises an error",
@@ -430,7 +430,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck and tlsDisableCertificateRevocationCheck both present (and true) raises an error",
@@ -439,7 +439,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck=true and tlsDisableCertificateRevocationCheck=false raises an error",
@@ -448,7 +448,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck=false and tlsDisableCertificateRevocationCheck=true raises an error",
@@ -457,7 +457,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck and tlsDisableCertificateRevocationCheck both present (and false) raises an error",
@@ -466,7 +466,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck can be set to true",
@@ -499,7 +499,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure=true and tlsDisableOCSPEndpointCheck=false raises an error",
@@ -508,7 +508,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure=false and tlsDisableOCSPEndpointCheck=true raises an error",
@@ -517,7 +517,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and false) raises an error",
@@ -526,7 +526,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and true) raises an error",
@@ -535,7 +535,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck=true and tlsInsecure=false raises an error",
@@ -544,7 +544,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck=false and tlsInsecure=true raises an error",
@@ -553,7 +553,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and false) raises an error",
@@ -562,7 +562,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates and tlsDisableOCSPEndpointCheck both present (and true) raises an error",
@@ -571,7 +571,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates=true and tlsDisableOCSPEndpointCheck=false raises an error",
@@ -580,7 +580,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates=false and tlsDisableOCSPEndpointCheck=true raises an error",
@@ -589,7 +589,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsAllowInvalidCertificates and tlsDisableOCSPEndpointCheck both present (and false) raises an error",
@@ -598,7 +598,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck and tlsAllowInvalidCertificates both present (and true) raises an error",
@@ -607,7 +607,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck=true and tlsAllowInvalidCertificates=false raises an error",
@@ -616,7 +616,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck=false and tlsAllowInvalidCertificates=true raises an error",
@@ -625,7 +625,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     },
     {
       "description": "tlsDisableOCSPEndpointCheck and tlsAllowInvalidCertificates both present (and false) raises an error",
@@ -634,7 +634,7 @@
       "warning": false,
       "hosts": null,
       "auth": null,
-      "options": {}
+      "options": null
     }
   ]
 }

--- a/source/uri-options/tests/tls-options.yml
+++ b/source/uri-options/tests/tls-options.yml
@@ -26,7 +26,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidCertificates is parsed correctly"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true"
@@ -52,7 +52,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure is parsed correctly"
         uri: "mongodb://example.com/?tlsInsecure=true"
@@ -69,7 +69,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure and tlsAllowInvalidCertificates both present (and true) raises an error"
         uri: "mongodb://example.com/?tlsInsecure=true&tlsAllowInvalidCertificates=true"
@@ -77,7 +77,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure and tlsAllowInvalidCertificates both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsInsecure=false&tlsAllowInvalidCertificates=false"
@@ -85,7 +85,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidCertificates and tlsInsecure both present (and true) raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsInsecure=true"
@@ -93,7 +93,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidCertificates and tlsInsecure both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsInsecure=false"
@@ -101,7 +101,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure and tlsAllowInvalidHostnames both present (and true) raises an error"
         uri: "mongodb://example.com/?tlsInsecure=true&tlsAllowInvalidHostnames=true"
@@ -109,7 +109,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure and tlsAllowInvalidHostnames both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsInsecure=false&tlsAllowInvalidHostnames=false"
@@ -117,7 +117,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidHostnames and tlsInsecure both present (and true) raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidHostnames=true&tlsInsecure=true"
@@ -125,7 +125,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidHostnames and tlsInsecure both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidHostnames=false&tlsInsecure=false"
@@ -133,7 +133,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tls=true and ssl=true doesn't warn"
         uri: "mongodb://example.com/?tls=true&ssl=true"
@@ -173,7 +173,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tls=true and ssl=false raises error"
         uri: "mongodb://example.com/?tls=true&ssl=false"
@@ -181,7 +181,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "ssl=false and tls=true raises error"
         uri: "mongodb://example.com/?ssl=false&tls=true"
@@ -189,7 +189,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "ssl=true and tls=false raises error"
         uri: "mongodb://example.com/?ssl=true&tls=false"
@@ -197,7 +197,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck can be set to true"
         uri: "mongodb://example.com/?tls=true&tlsDisableCertificateRevocationCheck=true"
@@ -226,7 +226,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidCertificates=true and tlsDisableCertificateRevocationCheck=false raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableCertificateRevocationCheck=false"
@@ -234,7 +234,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidCertificates=false and tlsDisableCertificateRevocationCheck=true raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableCertificateRevocationCheck=true"
@@ -242,7 +242,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidCertificates and tlsDisableCertificateRevocationCheck both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableCertificateRevocationCheck=false"
@@ -250,7 +250,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     # 4 permutations of [tlsDisableCertificateRevocationCheck=true/false, tlsAllowInvalidCertificates=true/false]
     -
         description: "tlsDisableCertificateRevocationCheck and tlsAllowInvalidCertificates both present (and true) raises an error"
@@ -259,7 +259,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck=true and tlsAllowInvalidCertificates=false raises an error"
         uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsAllowInvalidCertificates=false"
@@ -267,7 +267,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck=false and tlsAllowInvalidCertificates=true raises an error"
         uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsAllowInvalidCertificates=true"
@@ -275,7 +275,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck and tlsAllowInvalidCertificates both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsAllowInvalidCertificates=false"
@@ -283,7 +283,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     # 4 permutations of [tlsInsecure=true/false, tlsDisableCertificateRevocationCheck=true/false]
     -
         description: "tlsInsecure and tlsDisableCertificateRevocationCheck both present (and true) raises an error"
@@ -292,7 +292,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure=true and tlsDisableCertificateRevocationCheck=false raises an error"
         uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableCertificateRevocationCheck=false"
@@ -300,7 +300,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure=false and tlsDisableCertificateRevocationCheck=true raises an error"
         uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableCertificateRevocationCheck=true"
@@ -308,7 +308,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure and tlsDisableCertificateRevocationCheck both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableCertificateRevocationCheck=false"
@@ -316,7 +316,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     # 4 permutations of [tlsDisableCertificateRevocationCheck=true/false, tlsInsecure=true/false]
     -
         description: "tlsDisableCertificateRevocationCheck and tlsInsecure both present (and true) raises an error"
@@ -325,7 +325,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck=true and tlsInsecure=false raises an error"
         uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsInsecure=false"
@@ -333,7 +333,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck=false and tlsInsecure=true raises an error"
         uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsInsecure=true"
@@ -341,7 +341,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck and tlsInsecure both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsInsecure=false"
@@ -349,7 +349,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     # 4 permutations of [tlsDisableCertificateRevocationCheck=true/false, tlsDisableOCSPEndpointCheck=true/false]
     -
         description: "tlsDisableCertificateRevocationCheck and tlsDisableOCSPEndpointCheck both present (and true) raises an error"
@@ -358,7 +358,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck=true and tlsDisableOCSPEndpointCheck=false raises an error"
         uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=true&tlsDisableOCSPEndpointCheck=false"
@@ -366,7 +366,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck=false and tlsDisableOCSPEndpointCheck=true raises an error"
         uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsDisableOCSPEndpointCheck=true"
@@ -374,7 +374,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableCertificateRevocationCheck and tlsDisableOCSPEndpointCheck both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsDisableCertificateRevocationCheck=false&tlsDisableOCSPEndpointCheck=false"
@@ -382,7 +382,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     # 4 permutations of [tlsDisableOCSPEndpointCheck=true/false, tlsDisableCertificateRevocationCheck=true/false]
     -
         description: "tlsDisableOCSPEndpointCheck and tlsDisableCertificateRevocationCheck both present (and true) raises an error"
@@ -391,7 +391,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck=true and tlsDisableCertificateRevocationCheck=false raises an error"
         uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsDisableCertificateRevocationCheck=false"
@@ -399,7 +399,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck=false and tlsDisableCertificateRevocationCheck=true raises an error"
         uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsDisableCertificateRevocationCheck=true"
@@ -407,7 +407,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck and tlsDisableCertificateRevocationCheck both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsDisableCertificateRevocationCheck=false"
@@ -415,7 +415,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck can be set to true"
         uri: "mongodb://example.com/?tls=true&tlsDisableOCSPEndpointCheck=true"
@@ -444,7 +444,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure=true and tlsDisableOCSPEndpointCheck=false raises an error"
         uri: "mongodb://example.com/?tlsInsecure=true&tlsDisableOCSPEndpointCheck=false"
@@ -452,7 +452,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure=false and tlsDisableOCSPEndpointCheck=true raises an error"
         uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=true"
@@ -460,7 +460,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsInsecure and tlsDisableOCSPEndpointCheck both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsInsecure=false&tlsDisableOCSPEndpointCheck=false"
@@ -468,7 +468,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     # 4 permutations of [tlsDisableOCSPEndpointCheck=true/false, tlsInsecure=true/false]
     -
         description: "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and true) raises an error"
@@ -477,7 +477,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck=true and tlsInsecure=false raises an error"
         uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsInsecure=false"
@@ -485,7 +485,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck=false and tlsInsecure=true raises an error"
         uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=true"
@@ -493,7 +493,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck and tlsInsecure both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsInsecure=false"
@@ -501,7 +501,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     # 4 permutations of [tlsAllowInvalidCertificates=true/false, tlsDisableOCSPEndpointCheck=true/false]
     -
         description: "tlsAllowInvalidCertificates and tlsDisableOCSPEndpointCheck both present (and true) raises an error"
@@ -510,7 +510,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidCertificates=true and tlsDisableOCSPEndpointCheck=false raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true&tlsDisableOCSPEndpointCheck=false"
@@ -518,7 +518,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidCertificates=false and tlsDisableOCSPEndpointCheck=true raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableOCSPEndpointCheck=true"
@@ -526,7 +526,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsAllowInvalidCertificates and tlsDisableOCSPEndpointCheck both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=false&tlsDisableOCSPEndpointCheck=false"
@@ -534,7 +534,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     # 4 permutations of [tlsDisableOCSPEndpointCheck=true/false, tlsAllowInvalidCertificates=true/false]
     -
         description: "tlsDisableOCSPEndpointCheck and tlsAllowInvalidCertificates both present (and true) raises an error"
@@ -543,7 +543,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck=true and tlsAllowInvalidCertificates=false raises an error"
         uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=true&tlsAllowInvalidCertificates=false"
@@ -551,7 +551,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck=false and tlsAllowInvalidCertificates=true raises an error"
         uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsAllowInvalidCertificates=true"
@@ -559,7 +559,7 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~
     -
         description: "tlsDisableOCSPEndpointCheck and tlsAllowInvalidCertificates both present (and false) raises an error"
         uri: "mongodb://example.com/?tlsDisableOCSPEndpointCheck=false&tlsAllowInvalidCertificates=false"
@@ -567,4 +567,4 @@ tests:
         warning: false
         hosts: ~
         auth: ~
-        options: {}
+        options: ~


### PR DESCRIPTION
Please complete the following before merging:

- [ ] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver (tested in libmongoc)
- [ ] ~Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).~

This PR updates URI options tests where the URI is invalid or warnings are expected, and the options are unpredictable. In this case, we use `null` to indicate that the options should not be asserted against.