### PR TITLE
DRIVERS-1785: clarify ordering of CMAP events when pool is cleared

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-create-min-size-error.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-create-min-size-error.json
@@ -50,14 +50,14 @@
       "address": 42
     },
     {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
       "type": "ConnectionClosed",
       "address": 42,
       "connectionId": 42,
       "reason": "error"
-    },
-    {
-      "type": "ConnectionPoolCleared",
-      "address": 42
     }
   ],
   "ignore": [

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-create-min-size-error.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-create-min-size-error.yml
@@ -30,11 +30,11 @@ events:
     address: 42
   - type: ConnectionCreated
     address: 42
+  - type: ConnectionPoolCleared
+    address: 42
   - type: ConnectionClosed
     address: 42
     connectionId: 42
     reason: error
-  - type: ConnectionPoolCleared
-    address: 42
 ignore:
   - ConnectionPoolCreated

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
@@ -1241,10 +1241,11 @@ if and only if the error is "node is shutting down" or the error originated from
 and [other transient errors](#other-transient-errors) and
 [Why close connections when a node is shutting down?](#why-close-connections-when-a-node-is-shutting-down).)
 
-##### Authentication errors
+##### Authentication and Handshake errors
 
-If the authentication handshake fails for a connection, drivers MUST mark the server Unknown and clear the server's
-connection pool if the TopologyType is not LoadBalanced. (See
+If the driver encounters errors when establishing application connections (this includes the initial handshake and
+authentication), the driver MUST drivers MUST mark the server Unknown and clear the server's connection pool if the
+TopologyType is not LoadBalanced. (See
 [Why mark a server Unknown after an auth error?](#why-mark-a-server-unknown-after-an-auth-error))
 
 ### Monitoring SDAM events

--- a/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
+++ b/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md
@@ -1244,9 +1244,8 @@ and [other transient errors](#other-transient-errors) and
 ##### Authentication and Handshake errors
 
 If the driver encounters errors when establishing application connections (this includes the initial handshake and
-authentication), the driver MUST drivers MUST mark the server Unknown and clear the server's connection pool if the
-TopologyType is not LoadBalanced. (See
-[Why mark a server Unknown after an auth error?](#why-mark-a-server-unknown-after-an-auth-error))
+authentication), the driver MUST mark the server Unknown and clear the server's connection pool if the TopologyType is
+not LoadBalanced. (See [Why mark a server Unknown after an auth error?](#why-mark-a-server-unknown-after-an-auth-error))
 
 ### Monitoring SDAM events
 

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-application-error.json
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-application-error.json
@@ -1,0 +1,149 @@
+{
+  "description": "pool-clear-application-error",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.4",
+      "serverless": "forbid",
+      "topologies": [
+        "single",
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "setupClient",
+        "useMultipleMongoses": false
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "find-network-error",
+      "databaseName": "sdam-tests",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "Pool is cleared before application connection is checked into the pool",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "setupClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "find"
+                ],
+                "closeConnection": true,
+                "appName": "findNetworkErrorTest"
+              }
+            }
+          }
+        },
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "poolClearedEvent",
+                    "connectionCheckedInEvent"
+                  ],
+                  "uriOptions": {
+                    "retryWrites": false,
+                    "retryReads": false,
+                    "appname": "findNetworkErrorTest"
+                  }
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "sdam-tests"
+                }
+              },
+              {
+                "collection": {
+                  "id": "collection",
+                  "database": "database",
+                  "collectionName": "find-network-error"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "find",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            }
+          },
+          "expectError": {
+            "isError": true
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "poolClearedEvent": {}
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "connectionCheckedInEvent": {}
+            },
+            "count": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": [
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionCheckedInEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-application-error.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-application-error.yml
@@ -1,0 +1,88 @@
+---
+description: pool-clear-application-error
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  # failCommand appName requirements
+  - minServerVersion: "4.4"
+    serverless: forbid
+    topologies: [ single, replicaset, sharded ]
+
+createEntities:
+  - client:
+      id: &setupClient setupClient
+      useMultipleMongoses: false
+
+initialData: &initialData
+  - collectionName: &collectionName find-network-error
+    databaseName: &databaseName sdam-tests
+    documents:
+      - _id: 1
+      - _id: 2
+
+tests:
+  - description: Pool is cleared before application connection is checked into the pool
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *setupClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode:
+              times: 1
+            data:
+              failCommands:
+                - find
+              closeConnection: true
+              appName: findNetworkErrorTest
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                useMultipleMongoses: false
+                observeEvents:
+                  - poolClearedEvent
+                  - connectionCheckedInEvent
+                uriOptions:
+                  retryWrites: false
+                  retryReads: false
+                  appname: findNetworkErrorTest
+            - database:
+                id: &database database
+                client: *client
+                databaseName: *databaseName
+            - collection:
+                id: &collection collection
+                database: *database
+                collectionName: *collectionName
+      - name: find
+        object: *collection
+        arguments:
+          filter:
+            _id: 1
+        expectError:
+          isError: true
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            poolClearedEvent: {}
+          count: 1
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            connectionCheckedInEvent: {}
+          count: 1
+    expectEvents:
+      - client: *client
+        eventType: cmap
+        events:
+          - poolClearedEvent: {}
+          - connectionCheckedInEvent: {}

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.json
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.json
@@ -61,8 +61,7 @@
                   "observeEvents": [
                     "connectionCheckOutStartedEvent",
                     "poolClearedEvent",
-                    "connectionClosedEvent",
-                    "connectionCheckOutFailedEvent"
+                    "connectionClosedEvent"
                   ],
                   "uriOptions": {
                     "retryWrites": false,
@@ -140,9 +139,6 @@
             },
             {
               "connectionClosedEvent": {}
-            },
-            {
-              "connectionCheckOutFailedEvent": {}
             }
           ]
         }
@@ -171,7 +167,6 @@
                     "connectionCheckOutStartedEvent",
                     "poolClearedEvent",
                     "connectionClosedEvent",
-                    "connectionCheckOutFailedEvent",
                     "topologyDescriptionChangedEvent"
                   ],
                   "uriOptions": {
@@ -292,9 +287,6 @@
             },
             {
               "connectionClosedEvent": {}
-            },
-            {
-              "connectionCheckOutFailedEvent": {}
             }
           ]
         }

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.json
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.json
@@ -23,6 +23,11 @@
   "tests": [
     {
       "description": "Pool is cleared before connection is closed (authentication error)",
+      "runOnRequirements": [
+        {
+          "auth": true
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.json
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.json
@@ -1,0 +1,299 @@
+{
+  "description": "pool-clear-on-error-checkout",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.4",
+      "serverless": "forbid",
+      "topologies": [
+        "single",
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "setupClient",
+        "useMultipleMongoses": false
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Pool is cleared before connection is closed (authentication error)",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "setupClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "saslContinue"
+                ],
+                "appName": "authErrorTest",
+                "errorCode": 18
+              }
+            }
+          }
+        },
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "connectionCheckOutStartedEvent",
+                    "poolClearedEvent",
+                    "connectionClosedEvent",
+                    "connectionCheckOutFailedEvent"
+                  ],
+                  "uriOptions": {
+                    "retryWrites": false,
+                    "appname": "authErrorTest"
+                  }
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "foo"
+                }
+              },
+              {
+                "collection": {
+                  "id": "collection",
+                  "database": "database",
+                  "collectionName": "bar"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "poolClearedEvent": {}
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "connectionClosedEvent": {}
+            },
+            "count": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            },
+            {
+              "connectionCheckOutFailedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Pool is cleared connection is closed (handshake error)",
+      "runOnRequirements": [
+        {
+          "topologies": [
+            "single"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "useMultipleMongoses": false,
+                  "observeEvents": [
+                    "connectionCheckOutStartedEvent",
+                    "poolClearedEvent",
+                    "connectionClosedEvent",
+                    "connectionCheckOutFailedEvent",
+                    "topologyDescriptionChangedEvent"
+                  ],
+                  "uriOptions": {
+                    "retryWrites": false,
+                    "appname": "authErrorTest",
+                    "minPoolSize": 0,
+                    "serverMonitoringMode": "poll",
+                    "heartbeatFrequencyMS": 1000000
+                  }
+                }
+              },
+              {
+                "database": {
+                  "id": "database",
+                  "client": "client",
+                  "databaseName": "foo"
+                }
+              },
+              {
+                "collection": {
+                  "id": "collection",
+                  "database": "database",
+                  "collectionName": "bar"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Single"
+                }
+              }
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "setupClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "hello",
+                  "isMaster"
+                ],
+                "appName": "authErrorTest",
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 3
+              },
+              {
+                "_id": 4
+              }
+            ]
+          },
+          "expectError": {
+            "isError": true
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "poolClearedEvent": {}
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "connectionClosedEvent": {}
+            },
+            "count": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCheckOutStartedEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            },
+            {
+              "connectionCheckOutFailedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.json
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.json
@@ -149,7 +149,7 @@
       ]
     },
     {
-      "description": "Pool is cleared connection is closed (handshake error)",
+      "description": "Pool is cleared before connection is closed (handshake error)",
       "runOnRequirements": [
         {
           "topologies": [

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.yml
@@ -1,0 +1,177 @@
+---
+description: pool-clear-on-error-checkout
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  # failCommand appName requirements
+  - minServerVersion: "4.4"
+    serverless: forbid
+    topologies: [ single, replicaset, sharded ]
+
+createEntities:
+  - client:
+      id: &setupClient setupClient
+      useMultipleMongoses: false
+
+tests:
+  - description: Pool is cleared before connection is closed (authentication error)
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *setupClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode:
+              times: 1
+            data:
+              failCommands:
+                - saslContinue
+              appName: authErrorTest
+              errorCode: 18
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                useMultipleMongoses: false
+                observeEvents:
+                  - connectionCheckOutStartedEvent
+                  - poolClearedEvent
+                  - connectionClosedEvent
+                  - connectionCheckOutFailedEvent
+                uriOptions:
+                  retryWrites: false
+                  appname: authErrorTest
+            - database:
+                id: &database database
+                client: *client
+                databaseName: foo
+            - collection:
+                id: &collection collection
+                database: *database
+                collectionName: bar
+      - name: insertMany
+        object: *collection
+        arguments:
+          documents:
+            - _id: 3
+            - _id: 4
+        expectError:
+          isError: true
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            poolClearedEvent: {}
+          count: 1
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            connectionClosedEvent: {}
+          count: 1
+    expectEvents:
+      - client: *client
+        eventType: cmap
+        events:
+          - connectionCheckOutStartedEvent: {}
+          - poolClearedEvent: {}
+          - connectionClosedEvent: {}
+          - connectionCheckOutFailedEvent: {}
+
+  - description: Pool is cleared connection is closed (handshake error)
+    runOnRequirements:
+    - topologies: [ single ]
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                useMultipleMongoses: false
+                observeEvents:
+                  - connectionCheckOutStartedEvent
+                  - poolClearedEvent
+                  - connectionClosedEvent
+                  - connectionCheckOutFailedEvent
+                  - topologyDescriptionChangedEvent
+                uriOptions:
+                  retryWrites: false
+                  appname: authErrorTest
+                  minPoolSize: 0
+                  # ensure that once we've connected to the server, the failCommand won't
+                  # be triggered by monitors and will only be triggered by handshakes
+                  serverMonitoringMode: poll
+                  heartbeatFrequencyMS: 1000000
+            - database:
+                id: &database database
+                client: *client
+                databaseName: foo
+            - collection:
+                id: &collection collection
+                database: *database
+                collectionName: bar
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent:
+              previousDescription:
+                type: "Unknown"
+              newDescription:
+                type: "Single"          
+          count: 1
+
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *setupClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode:
+              times: 1
+            data:
+              failCommands:
+                - hello
+                - isMaster
+              appName: authErrorTest
+              closeConnection: true
+              
+      - name: insertMany
+        object: *collection
+        arguments:
+          documents:
+            - _id: 3
+            - _id: 4
+        expectError:
+          isError: true
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            poolClearedEvent: {}
+          count: 1
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            connectionClosedEvent: {}
+          count: 1
+    expectEvents:
+      - client: *client
+        eventType: cmap
+        events:
+          - connectionCheckOutStartedEvent: {}
+          - poolClearedEvent: {}
+          - connectionClosedEvent: {}
+          - connectionCheckOutFailedEvent: {}
+

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.yml
@@ -16,6 +16,9 @@ createEntities:
 
 tests:
   - description: Pool is cleared before connection is closed (authentication error)
+    runOnRequirements:
+      - auth: true
+
     operations:
       - name: failPoint
         object: testRunner

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.yml
@@ -44,7 +44,6 @@ tests:
                   - connectionCheckOutStartedEvent
                   - poolClearedEvent
                   - connectionClosedEvent
-                  - connectionCheckOutFailedEvent
                 uriOptions:
                   retryWrites: false
                   appname: authErrorTest
@@ -85,7 +84,6 @@ tests:
           - connectionCheckOutStartedEvent: {}
           - poolClearedEvent: {}
           - connectionClosedEvent: {}
-          - connectionCheckOutFailedEvent: {}
 
   - description: Pool is cleared before connection is closed (handshake error)
     runOnRequirements:
@@ -102,7 +100,6 @@ tests:
                   - connectionCheckOutStartedEvent
                   - poolClearedEvent
                   - connectionClosedEvent
-                  - connectionCheckOutFailedEvent
                   - topologyDescriptionChangedEvent
                 uriOptions:
                   retryWrites: false
@@ -176,5 +173,4 @@ tests:
           - connectionCheckOutStartedEvent: {}
           - poolClearedEvent: {}
           - connectionClosedEvent: {}
-          - connectionCheckOutFailedEvent: {}
 

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-checkout-error.yml
@@ -87,7 +87,7 @@ tests:
           - connectionClosedEvent: {}
           - connectionCheckOutFailedEvent: {}
 
-  - description: Pool is cleared connection is closed (handshake error)
+  - description: Pool is cleared before connection is closed (handshake error)
     runOnRequirements:
     - topologies: [ single ]
     operations:

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.json
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.json
@@ -6,9 +6,7 @@
       "minServerVersion": "4.4",
       "serverless": "forbid",
       "topologies": [
-        "single",
-        "replicaset",
-        "sharded"
+        "single"
       ]
     }
   ],
@@ -26,7 +24,8 @@
       "runOnRequirements": [
         {
           "minServerVersion": "4.4",
-          "serverless": "forbid"
+          "serverless": "forbid",
+          "auth": true
         }
       ],
       "operations": [
@@ -115,15 +114,6 @@
     },
     {
       "description": "Pool is cleared on handshake error during minPoolSize population",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "4.4",
-          "serverless": "forbid",
-          "topologies": [
-            "single"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "createEntities",

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.json
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.json
@@ -1,0 +1,242 @@
+{
+  "description": "pool-cleared-on-min-pool-size-population-error",
+  "schemaVersion": "1.4",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.4",
+      "serverless": "forbid",
+      "topologies": [
+        "single",
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "setupClient",
+        "useMultipleMongoses": false
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Pool is cleared on authentication error during minPoolSize population",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "setupClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "saslContinue"
+                ],
+                "appName": "authErrorTest",
+                "errorCode": 18
+              }
+            }
+          }
+        },
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "connectionCreatedEvent",
+                    "poolClearedEvent",
+                    "connectionClosedEvent"
+                  ],
+                  "uriOptions": {
+                    "appname": "authErrorTest",
+                    "minPoolSize": 1
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "poolClearedEvent": {}
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "connectionClosedEvent": {}
+            },
+            "count": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Pool is cleared on handshake error during minPoolSize population",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "serverless": "forbid",
+          "topologies": [
+            "single"
+          ]
+        }
+      ],
+      "operations": [
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "client": {
+                  "id": "client",
+                  "observeEvents": [
+                    "topologyDescriptionChangedEvent",
+                    "connectionCreatedEvent",
+                    "poolClearedEvent",
+                    "connectionClosedEvent",
+                    "connectionReadyEvent"
+                  ],
+                  "uriOptions": {
+                    "appname": "authErrorTest",
+                    "minPoolSize": 5,
+                    "maxConnecting": 1,
+                    "serverMonitoringMode": "poll",
+                    "heartbeatFrequencyMS": 1000000
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "topologyDescriptionChangedEvent": {
+                "previousDescription": {
+                  "type": "Unknown"
+                },
+                "newDescription": {
+                  "type": "Single"
+                }
+              }
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "setupClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 1
+              },
+              "data": {
+                "failCommands": [
+                  "hello",
+                  "isMaster"
+                ],
+                "appName": "authErrorTest",
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "poolClearedEvent": {}
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "connectionClosedEvent": {}
+            },
+            "count": 1
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": [
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "connectionReadyEvent": {}
+            },
+            {
+              "connectionCreatedEvent": {}
+            },
+            {
+              "poolClearedEvent": {}
+            },
+            {
+              "connectionClosedEvent": {}
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.json
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.json
@@ -23,8 +23,6 @@
       "description": "Pool is cleared on authentication error during minPoolSize population",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.4",
-          "serverless": "forbid",
           "auth": true
         }
       ],

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.yml
@@ -1,0 +1,150 @@
+---
+description: pool-cleared-on-min-pool-size-population-error
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  # failCommand appName requirements
+  - minServerVersion: "4.4"
+    serverless: forbid
+    topologies: [ single, replicaset, sharded ]
+
+createEntities:
+  - client:
+      id: &setupClient setupClient
+      useMultipleMongoses: false
+
+tests:
+  - description: Pool is cleared on authentication error during minPoolSize population
+    runOnRequirements:
+      # failCommand appName requirements
+      - minServerVersion: "4.4"
+        serverless: forbid
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *setupClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode:
+              times: 1
+            data:
+              failCommands:
+                - saslContinue
+              appName: authErrorTest
+              errorCode: 18
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - connectionCreatedEvent
+                  - poolClearedEvent
+                  - connectionClosedEvent
+                uriOptions:
+                  appname: authErrorTest
+                  minPoolSize: 1
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            poolClearedEvent: {}
+          count: 1
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            connectionClosedEvent: {}
+          count: 1
+    expectEvents:
+      - client: *client
+        eventType: cmap
+        events:
+          - connectionCreatedEvent: {}
+          - poolClearedEvent: {}
+          - connectionClosedEvent: {}
+
+  - description: Pool is cleared on handshake error during minPoolSize population
+    runOnRequirements:
+      # failCommand appName requirements
+      - minServerVersion: "4.4"
+        serverless: forbid
+        topologies: [ single ]
+    operations:
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - client:
+                id: &client client
+                observeEvents:
+                  - topologyDescriptionChangedEvent
+                  - connectionCreatedEvent
+                  - poolClearedEvent
+                  - connectionClosedEvent
+                  - connectionReadyEvent
+                uriOptions:
+                  appname: authErrorTest
+                  minPoolSize: 5
+                  maxConnecting: 1
+                  # ensure that once we've connected to the server, the failCommand won't
+                  # be triggered by monitors and will only be triggered by handshakes
+                  serverMonitoringMode: poll
+                  heartbeatFrequencyMS: 1000000
+
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            topologyDescriptionChangedEvent:
+              previousDescription:
+                type: "Unknown"
+              newDescription:
+                type: "Single"          
+          count: 1
+
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *setupClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode:
+              times: 1
+            data:
+              failCommands:
+                - hello
+                - isMaster
+              appName: authErrorTest
+              closeConnection: true
+
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            poolClearedEvent: {}
+          count: 1
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            connectionClosedEvent: {}
+          count: 1
+    expectEvents:
+      - client: *client
+        eventType: cmap
+        events:
+          - connectionCreatedEvent: {}
+          - connectionReadyEvent: {}
+          - connectionCreatedEvent: {}
+          - poolClearedEvent: {}
+          - connectionClosedEvent: {}
+

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.yml
@@ -18,9 +18,7 @@ tests:
   - description: Pool is cleared on authentication error during minPoolSize population
     runOnRequirements:
       # failCommand appName requirements
-      - minServerVersion: "4.4"
-        serverless: forbid
-        auth: true
+      - auth: true
     operations:
       - name: failPoint
         object: testRunner

--- a/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/pool-clear-min-pool-size-error.yml
@@ -7,7 +7,7 @@ runOnRequirements:
   # failCommand appName requirements
   - minServerVersion: "4.4"
     serverless: forbid
-    topologies: [ single, replicaset, sharded ]
+    topologies: [ single ]
 
 createEntities:
   - client:
@@ -20,6 +20,7 @@ tests:
       # failCommand appName requirements
       - minServerVersion: "4.4"
         serverless: forbid
+        auth: true
     operations:
       - name: failPoint
         object: testRunner
@@ -70,11 +71,6 @@ tests:
           - connectionClosedEvent: {}
 
   - description: Pool is cleared on handshake error during minPoolSize population
-    runOnRequirements:
-      # failCommand appName requirements
-      - minServerVersion: "4.4"
-        serverless: forbid
-        topologies: [ single ]
     operations:
       - name: createEntities
         object: testRunner


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Node POC: https://github.com/mongodb/node-mongodb-native/pull/4296

This PR adds tests ensuring that drivers always clear the pool before checking a connection back in / emitting close events, regardless of if the pool cleared error occurs on establishment during minPoolSize population, connection checkout or during operation execution on a checked out connection.

---

This PR originally intended to just add a test that demonstrated that, when we encounter a pool clear error on an application connection, we clear the pool before checking the connection back into the pool.  This avoids a small race condition between SDAM and connection checkout for subsequent requests in the pool - the subsequent requests might check out the errored connection before the pool is cleared.

As I was looking into this, I did realize we do have this coverage already.  But as Matt pointed out on the drivers ticket, the ordering of events seemed to be specified differently in one CMAP minPoolSize test than in other CMAP and SDAM tests.  The race condition isn't present for minPoolSize population, but Matt pointed out that if we expect a different ordering of events for minPoolSize population and connection checkout, we can't share connection establishment logic in both code paths.  So I also updated the ordering of events for the incorrect CMAP test (pool clear must happen before connectionClosed events).

I also realized some tests only tested that handshakes clear the pool, while others test that authentication clears the pool.  I added tests for both errors during the handshake and auth during minPoolSize population and connection checkout, and assert on the expected ordering of events.


Please complete the following before merging:

- [x] Update changelog.
- [x] Make sure there are generated JSON files from the YAML test files.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
