### PR TITLE
DRIVERS-1016 clarify decryption does not need the key ID or algorithm.

### DIFF
--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -143,19 +143,19 @@ See also:
 One of the data formats of [BSON binary encrypted](../bson-binary-encrypted/binary-encrypted.md), representing an
 encoded BSON document containing encrypted ciphertext and metadata.
 
-**FLE**
+**Client-Side Field Level Encryption (CSFLE)**
 
-FLE is the first version of Client-Side Field Level Encryption. FLE is almost entirely client-side with the exception of
-server-side JSON schema.
+CSFLE is the first version of In-Use Encryption. CSFLE is almost entirely client-side with the
+exception of server-side JSON schema.
 
-**Queryable Encryption**
+**Queryable Encryption (QE)**
 
-Queryable Encryption the second version of Client-Side Field Level Encryption. Data is encrypted client-side. Queryable
+Queryable Encryption the second version of In-Use Encryption. Data is encrypted client-side. Queryable
 Encryption supports indexed encrypted fields, which are further processed server-side.
 
 **In-Use Encryption**
 
-Is an umbrella term describing the both FLE and Queryable Encryption.
+Is an umbrella term describing the both CSFLE and Queryable Encryption.
 
 **encryptedFields**
 
@@ -2224,17 +2224,17 @@ KMIP support in the MongoDB server is a precedent. The server supports `--kmipSe
 TLS options may be useful for the AWS, Azure, and GCP KMS providers in a case where the default trust store does not
 include the needed CA certificates.
 
-### Why is it an error to have an FLE 1 and Queryable Encryption field in the same collection?
+### Why is it an error to have an CSFLE and Queryable Encryption field in the same collection?
 
-There is no technical limitation to having a separate FLE field and Queryable Encryption field in the same collection.
-Prohibiting FLE and Queryable Encryption in the same collection reduces complexity. From the product perspective, a
-random FLE field and a non-queryable Queryable Encryption field have the same behavior and similar security guarantees.
-A deterministic FLE field leaks more information then a deterministic Queryable Encryption field. There is not a
-compelling use case to use both FLE and Queryable Encryption in the same collection.
+There is no technical limitation to having a separate CSFLE field and Queryable Encryption field in the same collection.
+Prohibiting CSFLE and Queryable Encryption in the same collection reduces complexity. From the product perspective, a
+random CSFLE field and a non-queryable Queryable Encryption field have the same behavior and similar security guarantees.
+A deterministic CSFLE field leaks more information then a deterministic Queryable Encryption field. There is not a
+compelling use case to use both CSFLE and Queryable Encryption in the same collection.
 
 ### Is it an error to set schemaMap and encryptedFieldsMap?
 
-No. FLE and Queryable Encryption fields can coexist in different collections. The same collection cannot be in the
+No. CSFLE and Queryable Encryption fields can coexist in different collections. The same collection cannot be in the
 `encryptedFieldsMap` and `schemaMap`. [libmongocrypt](#libmongocrypt) will error if the same collection is specified in
 a `schemaMap` and `encryptedFieldsMap`.
 

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -145,13 +145,13 @@ encoded BSON document containing encrypted ciphertext and metadata.
 
 **Client-Side Field Level Encryption (CSFLE)**
 
-CSFLE is the first version of In-Use Encryption. CSFLE is almost entirely client-side with the
-exception of server-side JSON schema.
+CSFLE is the first version of In-Use Encryption. CSFLE is almost entirely client-side with the exception of server-side
+JSON schema.
 
 **Queryable Encryption (QE)**
 
-Queryable Encryption the second version of In-Use Encryption. Data is encrypted client-side. Queryable
-Encryption supports indexed encrypted fields, which are further processed server-side.
+Queryable Encryption the second version of In-Use Encryption. Data is encrypted client-side. Queryable Encryption
+supports indexed encrypted fields, which are further processed server-side.
 
 **In-Use Encryption**
 
@@ -2228,9 +2228,9 @@ include the needed CA certificates.
 
 There is no technical limitation to having a separate CSFLE field and Queryable Encryption field in the same collection.
 Prohibiting CSFLE and Queryable Encryption in the same collection reduces complexity. From the product perspective, a
-random CSFLE field and a non-queryable Queryable Encryption field have the same behavior and similar security guarantees.
-A deterministic CSFLE field leaks more information then a deterministic Queryable Encryption field. There is not a
-compelling use case to use both CSFLE and Queryable Encryption in the same collection.
+random CSFLE field and a non-queryable Queryable Encryption field have the same behavior and similar security
+guarantees. A deterministic CSFLE field leaks more information then a deterministic Queryable Encryption field. There is
+not a compelling use case to use both CSFLE and Queryable Encryption in the same collection.
 
 ### Is it an error to set schemaMap and encryptedFieldsMap?
 

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -237,6 +237,7 @@ created_key_id = clientencryption.create_data_key("aws", opts)
 opts = EncryptOpts(key_id=created_key_id,
     algorithm="AEAD_AES_256_CBC_HMAC_SHA_512-Random")
 encrypted = clientencryption.encrypt("secret text", opts)
+# Decryption does not require the key ID or algorithm. The ciphertext indicates the key ID and algorithm used.
 decrypted = clientencryption.decrypt(encrypted)
 ```
 


### PR DESCRIPTION
# Summary

Clarify decryption does not need the key ID or algorithm.

As a drive-by fix, the terms "In-Use Encryption" (the umbrella term) "CSFLE" (the first version) and "QE" (the second version) are applied.

# Background & Motivation

Using "In-Use Encryption", "CSFLE", and "QE" is intended to more closely agree with public documentation. See [Naming](https://github.com/mongodb/specifications/blob/e26b8cdff55ec33c28cc0fbb2b4eeba004093c1e/source/client-side-encryption/client-side-encryption.md#naming).

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- ~~[ ] Test changes in at least one language driver.~~
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
