### PR TITLE
DRIVERS-2124: test that inserts and upserts respect null _id values

### DIFF
--- a/source/crud/tests/unified/create-null-ids.json
+++ b/source/crud/tests/unified/create-null-ids.json
@@ -1,5 +1,5 @@
 {
-  "description": "CRUD ID Type Tests",
+  "description": "create-null-ids",
   "schemaVersion": "1.0",
   "createEntities": [
     {
@@ -25,40 +25,37 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "type_tests",
+      "databaseName": "crud_id",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "inserting _id with type undefined via insertOne",
       "operations": [
         {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
-        {
           "name": "insertOne",
           "object": "collection",
           "arguments": {
             "document": {
-              "_id": {
-                "$undefined": true
-              }
+              "_id": null
             }
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
               "_id": {
-                "$undefined": true
+                "$type": "undefined"
               }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
@@ -66,37 +63,27 @@
       "description": "inserting _id with type undefined via insertMany",
       "operations": [
         {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
-        {
           "name": "insertMany",
           "object": "collection",
           "arguments": {
             "documents": [
               {
-                "_id": {
-                  "$undefined": true
-                }
+                "_id": null
               }
             ]
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
               "_id": {
-                "$undefined": true
+                "$type": "undefined"
               }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
@@ -104,20 +91,11 @@
       "description": "inserting _id with type undefined via updateOne",
       "operations": [
         {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
-        {
           "name": "updateOne",
           "object": "collection",
           "arguments": {
             "filter": {
-              "_id": {
-                "$undefined": true
-              }
+              "_id": null
             },
             "update": {
               "$unset": {
@@ -126,19 +104,18 @@
             },
             "upsert": true
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
               "_id": {
-                "$undefined": true
+                "$type": "undefined"
               }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
@@ -146,20 +123,11 @@
       "description": "inserting _id with type undefined via updateMany",
       "operations": [
         {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
-        {
           "name": "updateMany",
           "object": "collection",
           "arguments": {
             "filter": {
-              "_id": {
-                "$undefined": true
-              }
+              "_id": null
             },
             "update": {
               "$unset": {
@@ -168,19 +136,18 @@
             },
             "upsert": true
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
               "_id": {
-                "$undefined": true
+                "$type": "undefined"
               }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
@@ -188,50 +155,33 @@
       "description": "inserting _id with type undefined via replaceOne",
       "operations": [
         {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
-        {
           "name": "replaceOne",
           "object": "collection",
           "arguments": {
             "filter": {},
             "replacement": {
-              "_id": {
-                "$undefined": true
-              }
+              "_id": null
             },
             "upsert": true
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
               "_id": {
-                "$undefined": true
+                "$type": "undefined"
               }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
     {
       "description": "inserting _id with type undefined via bulkWrite",
       "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
         {
           "name": "bulkWrite",
           "object": "collection",
@@ -240,27 +190,24 @@
               {
                 "insertOne": {
                   "document": {
-                    "_id": {
-                      "$undefined": true
-                    }
+                    "_id": null
                   }
                 }
               }
             ]
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
               "_id": {
-                "$undefined": true
+                "$type": "undefined"
               }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
@@ -273,13 +220,6 @@
       ],
       "operations": [
         {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
-        {
           "name": "clientBulkWrite",
           "object": "client",
           "arguments": {
@@ -288,40 +228,30 @@
                 "insertOne": {
                   "namespace": "crud_id.type_tests",
                   "document": {
-                    "_id": {
-                      "$undefined": true
-                    }
+                    "_id": null
                   }
                 }
               }
             ]
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
               "_id": {
-                "$undefined": true
+                "$type": "undefined"
               }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
     {
       "description": "inserting _id with type null via insertOne",
       "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
         {
           "name": "insertOne",
           "object": "collection",
@@ -330,30 +260,24 @@
               "_id": null
             }
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
-              "_id": null
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
     {
       "description": "inserting _id with type null via insertMany",
       "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
         {
           "name": "insertMany",
           "object": "collection",
@@ -364,30 +288,24 @@
               }
             ]
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
-              "_id": null
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
     {
       "description": "inserting _id with type null via updateOne",
       "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
         {
           "name": "updateOne",
           "object": "collection",
@@ -402,30 +320,24 @@
             },
             "upsert": true
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
-              "_id": null
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
     {
       "description": "inserting _id with type null via updateMany",
       "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
         {
           "name": "updateMany",
           "object": "collection",
@@ -440,30 +352,24 @@
             },
             "upsert": true
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
-              "_id": null
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
     {
       "description": "inserting _id with type null via replaceOne",
       "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
         {
           "name": "replaceOne",
           "object": "collection",
@@ -474,30 +380,24 @@
             },
             "upsert": true
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
-              "_id": null
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
     {
       "description": "inserting _id with type null via bulkWrite",
       "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
         {
           "name": "bulkWrite",
           "object": "collection",
@@ -512,17 +412,18 @@
               }
             ]
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
-              "_id": null
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     },
@@ -534,13 +435,6 @@
         }
       ],
       "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database",
-          "arguments": {
-            "collection": "type_tests"
-          }
-        },
         {
           "name": "clientBulkWrite",
           "object": "client",
@@ -556,17 +450,18 @@
               }
             ]
           }
-        }
-      ],
-      "outcome": [
+        },
         {
-          "databaseName": "crud_id",
-          "collectionName": "type_tests",
-          "documents": [
-            {
-              "_id": null
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "null"
+              }
             }
-          ]
+          },
+          "expectResult": 1
         }
       ]
     }

--- a/source/crud/tests/unified/create-null-ids.json
+++ b/source/crud/tests/unified/create-null-ids.json
@@ -1,0 +1,574 @@
+{
+  "description": "CRUD ID Type Tests",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "crud_id"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection",
+        "database": "database",
+        "collectionName": "type_tests"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "inserting _id with type undefined via insertOne",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": {
+                "$undefined": true
+              }
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": {
+                "$undefined": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via insertMany",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": {
+                  "$undefined": true
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": {
+                "$undefined": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via updateOne",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$undefined": true
+              }
+            },
+            "update": {
+              "$unset": {
+                "a": ""
+              }
+            },
+            "upsert": true
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": {
+                "$undefined": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via updateMany",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$undefined": true
+              }
+            },
+            "update": {
+              "$unset": {
+                "a": ""
+              }
+            },
+            "upsert": true
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": {
+                "$undefined": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via replaceOne",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "replacement": {
+              "_id": {
+                "$undefined": true
+              }
+            },
+            "upsert": true
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": {
+                "$undefined": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via bulkWrite",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": {
+                      "$undefined": true
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": {
+                "$undefined": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via clientBulkWrite",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "clientBulkWrite",
+          "object": "client",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud_id.type_tests",
+                  "document": {
+                    "_id": {
+                      "$undefined": true
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": {
+                "$undefined": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via insertOne",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": null
+            }
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via insertMany",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": null
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via updateOne",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": null
+            },
+            "update": {
+              "$unset": {
+                "a": ""
+              }
+            },
+            "upsert": true
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via updateMany",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": null
+            },
+            "update": {
+              "$unset": {
+                "a": ""
+              }
+            },
+            "upsert": true
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via replaceOne",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "replacement": {
+              "_id": null
+            },
+            "upsert": true
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via bulkWrite",
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": null
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type null via clientBulkWrite",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "dropCollection",
+          "object": "database",
+          "arguments": {
+            "collection": "type_tests"
+          }
+        },
+        {
+          "name": "clientBulkWrite",
+          "object": "client",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud_id.type_tests",
+                  "document": {
+                    "_id": null
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "databaseName": "crud_id",
+          "collectionName": "type_tests",
+          "documents": [
+            {
+              "_id": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/create-null-ids.json
+++ b/source/crud/tests/unified/create-null-ids.json
@@ -34,222 +34,6 @@
   ],
   "tests": [
     {
-      "description": "inserting _id with type undefined via insertOne",
-      "operations": [
-        {
-          "name": "insertOne",
-          "object": "collection",
-          "arguments": {
-            "document": {
-              "_id": null
-            }
-          }
-        },
-        {
-          "name": "countDocuments",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": {
-                "$type": "undefined"
-              }
-            }
-          },
-          "expectResult": 1
-        }
-      ]
-    },
-    {
-      "description": "inserting _id with type undefined via insertMany",
-      "operations": [
-        {
-          "name": "insertMany",
-          "object": "collection",
-          "arguments": {
-            "documents": [
-              {
-                "_id": null
-              }
-            ]
-          }
-        },
-        {
-          "name": "countDocuments",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": {
-                "$type": "undefined"
-              }
-            }
-          },
-          "expectResult": 1
-        }
-      ]
-    },
-    {
-      "description": "inserting _id with type undefined via updateOne",
-      "operations": [
-        {
-          "name": "updateOne",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": null
-            },
-            "update": {
-              "$unset": {
-                "a": ""
-              }
-            },
-            "upsert": true
-          }
-        },
-        {
-          "name": "countDocuments",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": {
-                "$type": "undefined"
-              }
-            }
-          },
-          "expectResult": 1
-        }
-      ]
-    },
-    {
-      "description": "inserting _id with type undefined via updateMany",
-      "operations": [
-        {
-          "name": "updateMany",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": null
-            },
-            "update": {
-              "$unset": {
-                "a": ""
-              }
-            },
-            "upsert": true
-          }
-        },
-        {
-          "name": "countDocuments",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": {
-                "$type": "undefined"
-              }
-            }
-          },
-          "expectResult": 1
-        }
-      ]
-    },
-    {
-      "description": "inserting _id with type undefined via replaceOne",
-      "operations": [
-        {
-          "name": "replaceOne",
-          "object": "collection",
-          "arguments": {
-            "filter": {},
-            "replacement": {
-              "_id": null
-            },
-            "upsert": true
-          }
-        },
-        {
-          "name": "countDocuments",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": {
-                "$type": "undefined"
-              }
-            }
-          },
-          "expectResult": 1
-        }
-      ]
-    },
-    {
-      "description": "inserting _id with type undefined via bulkWrite",
-      "operations": [
-        {
-          "name": "bulkWrite",
-          "object": "collection",
-          "arguments": {
-            "requests": [
-              {
-                "insertOne": {
-                  "document": {
-                    "_id": null
-                  }
-                }
-              }
-            ]
-          }
-        },
-        {
-          "name": "countDocuments",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": {
-                "$type": "undefined"
-              }
-            }
-          },
-          "expectResult": 1
-        }
-      ]
-    },
-    {
-      "description": "inserting _id with type undefined via clientBulkWrite",
-      "runOnRequirements": [
-        {
-          "minServerVersion": "8.0"
-        }
-      ],
-      "operations": [
-        {
-          "name": "clientBulkWrite",
-          "object": "client",
-          "arguments": {
-            "models": [
-              {
-                "insertOne": {
-                  "namespace": "crud_id.type_tests",
-                  "document": {
-                    "_id": null
-                  }
-                }
-              }
-            ]
-          }
-        },
-        {
-          "name": "countDocuments",
-          "object": "collection",
-          "arguments": {
-            "filter": {
-              "_id": {
-                "$type": "undefined"
-              }
-            }
-          },
-          "expectResult": 1
-        }
-      ]
-    },
-    {
       "description": "inserting _id with type null via insertOne",
       "operations": [
         {
@@ -458,6 +242,236 @@
             "filter": {
               "_id": {
                 "$type": "null"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via insertOne",
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "document": {
+              "_id": {
+                "$undefined": true
+              }
+            }
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "undefined"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via insertMany",
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": {
+                  "$undefined": true
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "undefined"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via updateOne",
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$undefined": true
+              }
+            },
+            "update": {
+              "$unset": {
+                "a": ""
+              }
+            },
+            "upsert": true
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "undefined"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via updateMany",
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$undefined": true
+              }
+            },
+            "update": {
+              "$unset": {
+                "a": ""
+              }
+            },
+            "upsert": true
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "undefined"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via replaceOne",
+      "operations": [
+        {
+          "name": "replaceOne",
+          "object": "collection",
+          "arguments": {
+            "filter": {},
+            "replacement": {
+              "_id": {
+                "$undefined": true
+              }
+            },
+            "upsert": true
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "undefined"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via bulkWrite",
+      "operations": [
+        {
+          "name": "bulkWrite",
+          "object": "collection",
+          "arguments": {
+            "requests": [
+              {
+                "insertOne": {
+                  "document": {
+                    "_id": {
+                      "$undefined": true
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "undefined"
+              }
+            }
+          },
+          "expectResult": 1
+        }
+      ]
+    },
+    {
+      "description": "inserting _id with type undefined via clientBulkWrite",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "clientBulkWrite",
+          "object": "client",
+          "arguments": {
+            "models": [
+              {
+                "insertOne": {
+                  "namespace": "crud_id.type_tests",
+                  "document": {
+                    "_id": {
+                      "$undefined": true
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "countDocuments",
+          "object": "collection",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$type": "undefined"
               }
             }
           },

--- a/source/crud/tests/unified/create-null-ids.yml
+++ b/source/crud/tests/unified/create-null-ids.yml
@@ -1,0 +1,288 @@
+description: CRUD ID Type Tests
+schemaVersion: '1.0'
+createEntities:
+  - client:
+      id: client
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: database
+      client: client
+      databaseName: crud_id
+  - collection:
+      id: collection
+      database: database
+      collectionName: type_tests
+tests:
+  - description: inserting _id with type undefined via insertOne
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id:
+              $undefined: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id:
+              $undefined: true
+  - description: inserting _id with type undefined via insertMany
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: insertMany
+        object: collection
+        arguments:
+          documents:
+            - _id:
+                $undefined: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id:
+              $undefined: true
+  - description: inserting _id with type undefined via updateOne
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: updateOne
+        object: collection
+        arguments:
+          filter:
+            _id:
+              $undefined: true
+          update:
+            $unset:
+              a: ''
+          upsert: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id:
+              $undefined: true
+  - description: inserting _id with type undefined via updateMany
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: updateMany
+        object: collection
+        arguments:
+          filter:
+            _id:
+              $undefined: true
+          update:
+            $unset:
+              a: ''
+          upsert: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id:
+              $undefined: true
+  - description: inserting _id with type undefined via replaceOne
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: replaceOne
+        object: collection
+        arguments:
+          filter: {}
+          replacement:
+            _id:
+              $undefined: true
+          upsert: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id:
+              $undefined: true
+  - description: inserting _id with type undefined via bulkWrite
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: bulkWrite
+        object: collection
+        arguments:
+          requests:
+            - insertOne:
+                document:
+                  _id:
+                    $undefined: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id:
+              $undefined: true
+  - description: inserting _id with type undefined via clientBulkWrite
+    runOnRequirements:
+      - minServerVersion: '8.0'
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: clientBulkWrite
+        object: client
+        arguments:
+          models:
+            - insertOne:
+                namespace: crud_id.type_tests
+                document:
+                  _id:
+                    $undefined: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id:
+              $undefined: true
+  - description: inserting _id with type null via insertOne
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: insertOne
+        object: collection
+        arguments:
+          document:
+            _id: null
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id: null
+  - description: inserting _id with type null via insertMany
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: insertMany
+        object: collection
+        arguments:
+          documents:
+            - _id: null
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id: null
+  - description: inserting _id with type null via updateOne
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: updateOne
+        object: collection
+        arguments:
+          filter:
+            _id: null
+          update:
+            $unset:
+              a: ''
+          upsert: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id: null
+  - description: inserting _id with type null via updateMany
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: updateMany
+        object: collection
+        arguments:
+          filter:
+            _id: null
+          update:
+            $unset:
+              a: ''
+          upsert: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id: null
+  - description: inserting _id with type null via replaceOne
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: replaceOne
+        object: collection
+        arguments:
+          filter: {}
+          replacement:
+            _id: null
+          upsert: true
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id: null
+  - description: inserting _id with type null via bulkWrite
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: bulkWrite
+        object: collection
+        arguments:
+          requests:
+            - insertOne:
+                document:
+                  _id: null
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id: null
+  - description: inserting _id with type null via clientBulkWrite
+    runOnRequirements:
+      - minServerVersion: '8.0'
+    operations:
+      - name: dropCollection
+        object: database
+        arguments:
+          collection: type_tests
+      - name: clientBulkWrite
+        object: client
+        arguments:
+          models:
+            - insertOne:
+                namespace: crud_id.type_tests
+                document:
+                  _id: null
+    outcome:
+      - databaseName: crud_id
+        collectionName: type_tests
+        documents:
+          - _id: null

--- a/source/crud/tests/unified/create-null-ids.yml
+++ b/source/crud/tests/unified/create-null-ids.yml
@@ -22,7 +22,7 @@ initialData:
 
 tests:
 
-  - description: inserting _id with type undefined via insertOne
+  - description: inserting _id with type null via insertOne
     operations:
       - name: insertOne
         object: *collection
@@ -31,129 +31,57 @@ tests:
       # this is to avoid client side type conversions (potentially common: undefined -> null)
       - name: countDocuments
         object: *collection
-        arguments: {filter: {_id: {$type: undefined}}}
-        expectResult: 1
-
-  - description: inserting _id with type undefined via insertMany
-    operations:
-      - name: insertMany
-        object: *collection
-        arguments: {documents: [*null_id]}
-      - name: countDocuments
-        object: *collection
-        arguments: {filter: {_id: {$type: undefined}}}
-        expectResult: 1
-
-  - description: inserting _id with type undefined via updateOne
-    operations:
-      - name: updateOne
-        object: *collection
-        arguments: {filter: *null_id, update: {$unset: {a: ''}}, upsert: true}
-      - name: countDocuments
-        object: *collection
-        arguments: {filter: {_id: {$type: undefined}}}
-        expectResult: 1
-
-  - description: inserting _id with type undefined via updateMany
-    operations:
-      - name: updateMany
-        object: *collection
-        arguments: {filter: *null_id, update: {$unset: {a: ''}}, upsert: true}
-      - name: countDocuments
-        object: *collection
-        arguments: {filter: {_id: {$type: undefined}}}
-        expectResult: 1
-
-  - description: inserting _id with type undefined via replaceOne
-    operations:
-      - name: replaceOne
-        object: *collection
-        arguments: {filter: {}, replacement: *null_id, upsert: true}
-      - name: countDocuments
-        object: *collection
-        arguments: {filter: {_id: {$type: undefined}}}
-        expectResult: 1
-
-  - description: inserting _id with type undefined via bulkWrite
-    operations:
-      - name: bulkWrite
-        object: *collection
-        arguments: {requests: [{insertOne: {document: *null_id}}]}
-      - name: countDocuments
-        object: *collection
-        arguments: {filter: {_id: {$type: undefined}}}
-        expectResult: 1
-
-  - description: inserting _id with type undefined via clientBulkWrite
-    runOnRequirements:
-      - minServerVersion: '8.0'
-    operations:
-      - name: clientBulkWrite
-        object: client
-        arguments: {models: [{insertOne: {namespace: crud_id.type_tests, document: *null_id}}]}
-      - name: countDocuments
-        object: *collection
-        arguments: {filter: {_id: {$type: undefined}}}
-        expectResult: 1
-
-  - description: inserting _id with type null via insertOne
-    operations:
-      - name: insertOne
-        object: *collection
-        arguments: {document: &undefined_id {_id: null}}
-      - name: countDocuments
-        object: *collection
-        arguments: {filter: {_id: {$type: 'null'}}}
+        arguments: {filter: &null_id_filter {_id: {$type: 'null'}}}
         expectResult: 1
 
   - description: inserting _id with type null via insertMany
     operations:
       - name: insertMany
         object: *collection
-        arguments: {documents: [*undefined_id]}
+        arguments: {documents: [*null_id]}
       - name: countDocuments
         object: *collection
-        arguments: {filter: {_id: {$type: 'null'}}}
+        arguments: {filter: *null_id_filter}
         expectResult: 1
 
   - description: inserting _id with type null via updateOne
     operations:
       - name: updateOne
         object: *collection
-        arguments: {filter: *undefined_id, update: {$unset: {a: ''}}, upsert: true}
+        arguments: {filter: *null_id, update: {$unset: {a: ''}}, upsert: true}
       - name: countDocuments
         object: *collection
-        arguments: {filter: {_id: {$type: 'null'}}}
+        arguments: {filter: *null_id_filter}
         expectResult: 1
 
   - description: inserting _id with type null via updateMany
     operations:
       - name: updateMany
         object: *collection
-        arguments: {filter: *undefined_id, update: {$unset: {a: ''}}, upsert: true}
+        arguments: {filter: *null_id, update: {$unset: {a: ''}}, upsert: true}
       - name: countDocuments
         object: *collection
-        arguments: {filter: {_id: {$type: 'null'}}}
+        arguments: {filter: *null_id_filter}
         expectResult: 1
 
   - description: inserting _id with type null via replaceOne
     operations:
       - name: replaceOne
         object: *collection
-        arguments: {filter: {}, replacement: *undefined_id, upsert: true}
+        arguments: {filter: {}, replacement: *null_id, upsert: true}
       - name: countDocuments
         object: *collection
-        arguments: {filter: {_id: {$type: 'null'}}}
+        arguments: {filter: *null_id_filter}
         expectResult: 1
 
   - description: inserting _id with type null via bulkWrite
     operations:
       - name: bulkWrite
         object: *collection
-        arguments: {requests: [{insertOne: {document: *undefined_id}}]}
+        arguments: {requests: [{insertOne: {document: *null_id}}]}
       - name: countDocuments
         object: *collection
-        arguments: {filter: {_id: {$type: 'null'}}}
+        arguments: {filter: *null_id_filter}
         expectResult: 1
 
   - description: inserting _id with type null via clientBulkWrite
@@ -162,8 +90,80 @@ tests:
     operations:
       - name: clientBulkWrite
         object: client
+        arguments: {models: [{insertOne: {namespace: crud_id.type_tests, document: *null_id}}]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *null_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type undefined via insertOne
+    operations:
+      - name: insertOne
+        object: *collection
+        arguments: {document: &undefined_id {_id: { $undefined: true }}}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: &undefined_id_filter {_id: {$type: 'undefined'}}}
+        expectResult: 1
+
+  - description: inserting _id with type undefined via insertMany
+    operations:
+      - name: insertMany
+        object: *collection
+        arguments: {documents: [*undefined_id]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *undefined_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type undefined via updateOne
+    operations:
+      - name: updateOne
+        object: *collection
+        arguments: {filter: *undefined_id, update: {$unset: {a: ''}}, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *undefined_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type undefined via updateMany
+    operations:
+      - name: updateMany
+        object: *collection
+        arguments: {filter: *undefined_id, update: {$unset: {a: ''}}, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *undefined_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type undefined via replaceOne
+    operations:
+      - name: replaceOne
+        object: *collection
+        arguments: {filter: {}, replacement: *undefined_id, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *undefined_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type undefined via bulkWrite
+    operations:
+      - name: bulkWrite
+        object: *collection
+        arguments: {requests: [{insertOne: {document: *undefined_id}}]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: *undefined_id_filter}
+        expectResult: 1
+
+  - description: inserting _id with type undefined via clientBulkWrite
+    runOnRequirements:
+      - minServerVersion: '8.0'
+    operations:
+      - name: clientBulkWrite
+        object: client
         arguments: {models: [{insertOne: {namespace: crud_id.type_tests, document: *undefined_id}}]}
       - name: countDocuments
         object: *collection
-        arguments: {filter: {_id: {$type: 'null'}}}
+        arguments: {filter: *undefined_id_filter}
         expectResult: 1

--- a/source/crud/tests/unified/create-null-ids.yml
+++ b/source/crud/tests/unified/create-null-ids.yml
@@ -1,288 +1,169 @@
-description: CRUD ID Type Tests
+description: create-null-ids
 schemaVersion: '1.0'
+
 createEntities:
   - client:
       id: client
       observeEvents:
         - commandStartedEvent
   - database:
-      id: database
+      id: &database database
       client: client
       databaseName: crud_id
   - collection:
-      id: collection
-      database: database
+      id: &collection collection
+      database: *database
       collectionName: type_tests
+
+initialData:
+  - collectionName: type_tests
+    databaseName: crud_id
+    documents: []
+
 tests:
+
   - description: inserting _id with type undefined via insertOne
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: insertOne
-        object: collection
-        arguments:
-          document:
-            _id:
-              $undefined: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id:
-              $undefined: true
+        object: *collection
+        arguments: {document: &null_id {_id: null}}
+      # We use countDocuments with a $type query to verify the insert of the correct BSON type
+      # this is to avoid client side type conversions (potentially common: undefined -> null)
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: undefined}}}
+        expectResult: 1
+
   - description: inserting _id with type undefined via insertMany
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: insertMany
-        object: collection
-        arguments:
-          documents:
-            - _id:
-                $undefined: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id:
-              $undefined: true
+        object: *collection
+        arguments: {documents: [*null_id]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: undefined}}}
+        expectResult: 1
+
   - description: inserting _id with type undefined via updateOne
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: updateOne
-        object: collection
-        arguments:
-          filter:
-            _id:
-              $undefined: true
-          update:
-            $unset:
-              a: ''
-          upsert: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id:
-              $undefined: true
+        object: *collection
+        arguments: {filter: *null_id, update: {$unset: {a: ''}}, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: undefined}}}
+        expectResult: 1
+
   - description: inserting _id with type undefined via updateMany
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: updateMany
-        object: collection
-        arguments:
-          filter:
-            _id:
-              $undefined: true
-          update:
-            $unset:
-              a: ''
-          upsert: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id:
-              $undefined: true
+        object: *collection
+        arguments: {filter: *null_id, update: {$unset: {a: ''}}, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: undefined}}}
+        expectResult: 1
+
   - description: inserting _id with type undefined via replaceOne
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: replaceOne
-        object: collection
-        arguments:
-          filter: {}
-          replacement:
-            _id:
-              $undefined: true
-          upsert: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id:
-              $undefined: true
+        object: *collection
+        arguments: {filter: {}, replacement: *null_id, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: undefined}}}
+        expectResult: 1
+
   - description: inserting _id with type undefined via bulkWrite
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: bulkWrite
-        object: collection
-        arguments:
-          requests:
-            - insertOne:
-                document:
-                  _id:
-                    $undefined: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id:
-              $undefined: true
+        object: *collection
+        arguments: {requests: [{insertOne: {document: *null_id}}]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: undefined}}}
+        expectResult: 1
+
   - description: inserting _id with type undefined via clientBulkWrite
     runOnRequirements:
       - minServerVersion: '8.0'
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: clientBulkWrite
         object: client
-        arguments:
-          models:
-            - insertOne:
-                namespace: crud_id.type_tests
-                document:
-                  _id:
-                    $undefined: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id:
-              $undefined: true
+        arguments: {models: [{insertOne: {namespace: crud_id.type_tests, document: *null_id}}]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: undefined}}}
+        expectResult: 1
+
   - description: inserting _id with type null via insertOne
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: insertOne
-        object: collection
-        arguments:
-          document:
-            _id: null
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id: null
+        object: *collection
+        arguments: {document: &undefined_id {_id: null}}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: 'null'}}}
+        expectResult: 1
+
   - description: inserting _id with type null via insertMany
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: insertMany
-        object: collection
-        arguments:
-          documents:
-            - _id: null
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id: null
+        object: *collection
+        arguments: {documents: [*undefined_id]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: 'null'}}}
+        expectResult: 1
+
   - description: inserting _id with type null via updateOne
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: updateOne
-        object: collection
-        arguments:
-          filter:
-            _id: null
-          update:
-            $unset:
-              a: ''
-          upsert: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id: null
+        object: *collection
+        arguments: {filter: *undefined_id, update: {$unset: {a: ''}}, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: 'null'}}}
+        expectResult: 1
+
   - description: inserting _id with type null via updateMany
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: updateMany
-        object: collection
-        arguments:
-          filter:
-            _id: null
-          update:
-            $unset:
-              a: ''
-          upsert: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id: null
+        object: *collection
+        arguments: {filter: *undefined_id, update: {$unset: {a: ''}}, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: 'null'}}}
+        expectResult: 1
+
   - description: inserting _id with type null via replaceOne
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: replaceOne
-        object: collection
-        arguments:
-          filter: {}
-          replacement:
-            _id: null
-          upsert: true
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id: null
+        object: *collection
+        arguments: {filter: {}, replacement: *undefined_id, upsert: true}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: 'null'}}}
+        expectResult: 1
+
   - description: inserting _id with type null via bulkWrite
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: bulkWrite
-        object: collection
-        arguments:
-          requests:
-            - insertOne:
-                document:
-                  _id: null
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id: null
+        object: *collection
+        arguments: {requests: [{insertOne: {document: *undefined_id}}]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: 'null'}}}
+        expectResult: 1
+
   - description: inserting _id with type null via clientBulkWrite
     runOnRequirements:
       - minServerVersion: '8.0'
     operations:
-      - name: dropCollection
-        object: database
-        arguments:
-          collection: type_tests
       - name: clientBulkWrite
         object: client
-        arguments:
-          models:
-            - insertOne:
-                namespace: crud_id.type_tests
-                document:
-                  _id: null
-    outcome:
-      - databaseName: crud_id
-        collectionName: type_tests
-        documents:
-          - _id: null
+        arguments: {models: [{insertOne: {namespace: crud_id.type_tests, document: *undefined_id}}]}
+      - name: countDocuments
+        object: *collection
+        arguments: {filter: {_id: {$type: 'null'}}}
+        expectResult: 1


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~[ ] Update changelog.~ N/A
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

## Description

Adds tests for null and undefined as `_id` values to check that drivers do not interpret these types as "unset" and generate an ObjectId and overwrite the value.