### PR TITLE
DRIVERS-3023 Add spec tests for GridFS rename and require client errors

### DIFF
--- a/source/gridfs/gridfs-spec.md
+++ b/source/gridfs/gridfs-spec.md
@@ -1042,6 +1042,7 @@ system?") it is a potential area of growth for the future.
 
 ## Changelog
 
+- 2024-10-30: Add spec tests for `rename` method
 - 2024-10-28: Removed deprecated fields from tests: `md5`, `contentType`, `aliases`
 - 2024-02-27: Migrated from reStructuredText to Markdown.
 - 2016-05-10: Support custom file ids

--- a/source/gridfs/gridfs-spec.md
+++ b/source/gridfs/gridfs-spec.md
@@ -1042,7 +1042,6 @@ system?") it is a potential area of growth for the future.
 
 ## Changelog
 
-- 2024-10-30: Add spec tests for `rename` method
 - 2024-10-28: Removed deprecated fields from tests: `md5`, `contentType`, `aliases`
 - 2024-02-27: Migrated from reStructuredText to Markdown.
 - 2016-05-10: Support custom file ids

--- a/source/gridfs/tests/delete.json
+++ b/source/gridfs/tests/delete.json
@@ -497,7 +497,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],
@@ -650,7 +650,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ],

--- a/source/gridfs/tests/delete.yml
+++ b/source/gridfs/tests/delete.yml
@@ -141,7 +141,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000000" }
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound
     outcome:
       - collectionName: *bucket0_files_collectionName
         databaseName: *database0Name
@@ -170,7 +170,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000004" }
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound
     outcome:
       - collectionName: *bucket0_files_collectionName
         databaseName: *database0Name

--- a/source/gridfs/tests/download.json
+++ b/source/gridfs/tests/download.json
@@ -338,7 +338,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -370,7 +370,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -402,7 +402,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -471,7 +471,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -514,7 +514,7 @@
             }
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]

--- a/source/gridfs/tests/download.yml
+++ b/source/gridfs/tests/download.yml
@@ -139,7 +139,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000000" }
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound
   - description: "download when an intermediate chunk is missing"
     operations:
       - name: deleteOne
@@ -154,7 +154,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000005" }
-        expectError: { isError: true } # ChunkIsMissing
+        expectError: { isClientError: true } # ChunkIsMissing
   - description: "download when final chunk is missing"
     operations:
       - name: deleteOne
@@ -169,7 +169,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000005" }
-        expectError: { isError: true } # ChunkIsMissing
+        expectError: { isClientError: true } # ChunkIsMissing
   - description: "download when an intermediate chunk is the wrong size"
     operations:
       - name: bulkWrite
@@ -195,7 +195,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000005" }
-        expectError: { isError: true } # ChunkIsWrongSize
+        expectError: { isClientError: true } # ChunkIsWrongSize
   - description: "download when final chunk is the wrong size"
     operations:
       - name: updateOne
@@ -213,7 +213,7 @@ tests:
         object: *bucket0
         arguments:
           id: { $oid: "000000000000000000000005" }
-        expectError: { isError: true } # ChunkIsWrongSize
+        expectError: { isClientError: true } # ChunkIsWrongSize
   - description: "download legacy file with no name"
     operations:
       - name: download

--- a/source/gridfs/tests/downloadByName.json
+++ b/source/gridfs/tests/downloadByName.json
@@ -290,7 +290,7 @@
             "filename": "xyz"
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]
@@ -306,7 +306,7 @@
             "revision": 999
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]

--- a/source/gridfs/tests/downloadByName.yml
+++ b/source/gridfs/tests/downloadByName.yml
@@ -133,7 +133,7 @@ tests:
         object: *bucket0
         arguments:
           filename: "xyz"
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound
   - description: "downloadByName when revision does not exist"
     operations:
       - name: downloadByName
@@ -141,4 +141,4 @@ tests:
         arguments:
           filename: "abc"
           revision: 999
-        expectError: { isError: true } # RevisionNotFound
+        expectError: { isClientError: true } # RevisionNotFound

--- a/source/gridfs/tests/rename.json
+++ b/source/gridfs/tests/rename.json
@@ -170,7 +170,7 @@
             "newFilename": "newfilename"
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]

--- a/source/gridfs/tests/rename.json
+++ b/source/gridfs/tests/rename.json
@@ -1,0 +1,179 @@
+{
+  "description": "gridfs-rename",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "gridfs-tests"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_files_collection",
+        "database": "database0",
+        "collectionName": "fs.files"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_chunks_collection",
+        "database": "database0",
+        "collectionName": "fs.chunks"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "fs.files",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "collectionName": "fs.chunks",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "rename by id",
+      "operations": [
+        {
+          "name": "rename",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000001"
+            },
+            "newFilename": "newfilename"
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "fs.files",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000001"
+              },
+              "length": 0,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "newfilename",
+              "metadata": {}
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "length": 0,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "filename",
+              "metadata": {}
+            }
+          ]
+        },
+        {
+          "collectionName": "fs.chunks",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000001"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rename when file id does not exist",
+      "operations": [
+        {
+          "name": "rename",
+          "object": "bucket0",
+          "arguments": {
+            "id": {
+              "$oid": "000000000000000000000003"
+            },
+            "newFilename": "newfilename"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/gridfs/tests/rename.yml
+++ b/source/gridfs/tests/rename.yml
@@ -75,4 +75,4 @@ tests:
         arguments:
           id: { "$oid": "000000000000000000000003" }
           newFilename: newfilename
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound

--- a/source/gridfs/tests/rename.yml
+++ b/source/gridfs/tests/rename.yml
@@ -1,0 +1,78 @@
+description: "gridfs-rename"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name gridfs-tests
+  - bucket:
+      id: &bucket0 bucket0
+      database: *database0
+  - collection:
+      id: &bucket0_files_collection bucket0_files_collection
+      database: *database0
+      collectionName: &bucket0_files_collectionName fs.files
+  - collection:
+      id: &bucket0_chunks_collection bucket0_chunks_collection
+      database: *database0
+      collectionName: &bucket0_chunks_collectionName fs.chunks
+
+initialData:
+  - collectionName: *bucket0_files_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file1
+        _id: { "$oid": "000000000000000000000001" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file2
+        _id: { "$oid": "000000000000000000000002" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+  - collectionName: *bucket0_chunks_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file2_chunk0
+        _id: { "$oid": "000000000000000000000001" }
+        files_id: { "$oid": "000000000000000000000002" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+
+tests:
+  - description: "rename by id"
+    operations:
+      - name: rename
+        object: *bucket0
+        arguments:
+          id: { "$oid": "000000000000000000000001" }
+          newFilename: newfilename
+    outcome:
+      - collectionName: *bucket0_files_collectionName
+        databaseName: *database0Name
+        documents:
+          - <<: *file1
+            filename: newfilename
+          - <<: *file2
+            filename: filename
+      - collectionName: *bucket0_chunks_collectionName
+        databaseName: *database0Name
+        documents:
+          - *file2_chunk0
+  - description: "rename when file id does not exist"
+    operations:
+      - name: rename
+        object: *bucket0
+        arguments:
+          id: { "$oid": "000000000000000000000003" }
+          newFilename: newfilename
+        expectError: { isError: true } # FileNotFound


### PR DESCRIPTION
Fix [DRIVERS-3023](https://jira.mongodb.org/browse/DRIVERS-3023)

Please complete the following before merging:

- [x] Update changelog.
- [x] Test changes in at least one language driver https://github.com/mongodb/mongo-php-library/pull/1507
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
