### PR TITLE
DRIVERS-2807 Update GridFS spec to add `delete_by_name` and `rename_by_name`

### DIFF
--- a/source/gridfs/gridfs-spec.md
+++ b/source/gridfs/gridfs-spec.md
@@ -671,7 +671,7 @@ This method is an optimisation over deleting each revision of a stored file indi
 
 Drivers MUST first find the `_id` field of all files collection documents with the given filename. Drivers MUST then
 delete all files collection documents with the found ids. Drivers MUST then delete all chunks with `files_id` in the
-found ids that was just deleted.
+found ids that were just deleted.
 
 If there are no files collection documents with the given filename, drivers MUST raise an error.
 

--- a/source/gridfs/gridfs-spec.md
+++ b/source/gridfs/gridfs-spec.md
@@ -670,8 +670,8 @@ This method is an optimisation over deleting each revision of a stored file indi
 **Implementation details:**
 
 Drivers MUST first find the `_id` field of all files collection documents with the given filename. Drivers MUST then
-delete all chunks with `files_id` in the found ids that was just deleted. Drivers MUST then delete all files collection
-documents with the found ids.
+delete all files collection documents with the found ids. Drivers MUST then delete all chunks with `files_id` in the
+found ids that was just deleted.
 
 If there are no files collection documents with the given filename, drivers MUST raise an error.
 

--- a/source/gridfs/tests/deleteByName.json
+++ b/source/gridfs/tests/deleteByName.json
@@ -1,0 +1,230 @@
+{
+  "description": "gridfs-deleteByName",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "gridfs-tests"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_files_collection",
+        "database": "database0",
+        "collectionName": "fs.files"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_chunks_collection",
+        "database": "database0",
+        "collectionName": "fs.chunks"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "fs.files",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "length": 2,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "length": 8,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "otherfilename",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "collectionName": "fs.chunks",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "delete when multiple revisions of the file exist",
+      "operations": [
+        {
+          "name": "deleteByName",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "filename"
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "fs.files",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "length": 8,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "otherfilename",
+              "metadata": {}
+            }
+          ]
+        },
+        {
+          "collectionName": "fs.chunks",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "delete when file name does not exist",
+      "operations": [
+        {
+          "name": "deleteByName",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "missing-file"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/gridfs/tests/deleteByName.json
+++ b/source/gridfs/tests/deleteByName.json
@@ -221,7 +221,7 @@
             "filename": "missing-file"
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]

--- a/source/gridfs/tests/deleteByName.yml
+++ b/source/gridfs/tests/deleteByName.yml
@@ -1,0 +1,102 @@
+description: "gridfs-deleteByName"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name gridfs-tests
+  - bucket:
+      id: &bucket0 bucket0
+      database: *database0
+  - collection:
+      id: &bucket0_files_collection bucket0_files_collection
+      database: *database0
+      collectionName: &bucket0_files_collectionName fs.files
+  - collection:
+      id: &bucket0_chunks_collection bucket0_chunks_collection
+      database: *database0
+      collectionName: &bucket0_chunks_collectionName fs.chunks
+
+initialData:
+  - collectionName: *bucket0_files_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file1
+        _id: { "$oid": "000000000000000000000001" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file2
+        _id: { "$oid": "000000000000000000000002" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file3
+        _id: { "$oid": "000000000000000000000003" }
+        length: 2
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file4
+        _id: { "$oid": "000000000000000000000004" }
+        length: 8
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "otherfilename"
+        metadata: {}
+  - collectionName: *bucket0_chunks_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file2_chunk0
+        _id: { "$oid": "000000000000000000000001" }
+        files_id: { "$oid": "000000000000000000000002" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file3_chunk0
+        _id: { "$oid": "000000000000000000000002" }
+        files_id: { "$oid": "000000000000000000000003" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file3_chunk1
+        _id: { "$oid": "000000000000000000000003" }
+        files_id: { "$oid": "000000000000000000000003" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file4_chunk0
+        _id: { "$oid": "000000000000000000000004" }
+        files_id: { "$oid": "000000000000000000000004" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+
+tests:
+  - description: "delete when multiple revisions of the file exist"
+    operations:
+      - name: deleteByName
+        object: *bucket0
+        arguments:
+          filename: filename
+    outcome:
+      - collectionName: *bucket0_files_collectionName
+        databaseName: *database0Name
+        documents:
+          - <<: *file4
+      - collectionName: *bucket0_chunks_collectionName
+        databaseName: *database0Name
+        documents:
+          - *file4_chunk0
+  - description: "delete when file name does not exist"
+    operations:
+      - name: deleteByName
+        object: *bucket0
+        arguments:
+          filename: missing-file
+        expectError: { isError: true } # FileNotFound

--- a/source/gridfs/tests/deleteByName.yml
+++ b/source/gridfs/tests/deleteByName.yml
@@ -99,4 +99,4 @@ tests:
         object: *bucket0
         arguments:
           filename: missing-file
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound

--- a/source/gridfs/tests/renameByName.json
+++ b/source/gridfs/tests/renameByName.json
@@ -1,0 +1,313 @@
+{
+  "description": "gridfs-renameByName",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "gridfs-tests"
+      }
+    },
+    {
+      "bucket": {
+        "id": "bucket0",
+        "database": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_files_collection",
+        "database": "database0",
+        "collectionName": "fs.files"
+      }
+    },
+    {
+      "collection": {
+        "id": "bucket0_chunks_collection",
+        "database": "database0",
+        "collectionName": "fs.chunks"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "fs.files",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "length": 0,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "length": 2,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "filename",
+          "metadata": {}
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "length": 8,
+          "chunkSize": 4,
+          "uploadDate": {
+            "$date": "1970-01-01T00:00:00.000Z"
+          },
+          "filename": "otherfilename",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "collectionName": "fs.chunks",
+      "databaseName": "gridfs-tests",
+      "documents": [
+        {
+          "_id": {
+            "$oid": "000000000000000000000001"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000002"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000003"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "n": 0,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        },
+        {
+          "_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "files_id": {
+            "$oid": "000000000000000000000004"
+          },
+          "n": 1,
+          "data": {
+            "$binary": {
+              "base64": "",
+              "subType": "00"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "rename when multiple revisions of the file exist",
+      "operations": [
+        {
+          "name": "renameByName",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "filename",
+            "newFilename": "newfilename"
+          }
+        }
+      ],
+      "outcome": [
+        {
+          "collectionName": "fs.files",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000001"
+              },
+              "length": 0,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "newfilename",
+              "metadata": {}
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "length": 0,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "newfilename",
+              "metadata": {}
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000003"
+              },
+              "length": 2,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "newfilename",
+              "metadata": {}
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "length": 8,
+              "chunkSize": 4,
+              "uploadDate": {
+                "$date": "1970-01-01T00:00:00.000Z"
+              },
+              "filename": "otherfilename",
+              "metadata": {}
+            }
+          ]
+        },
+        {
+          "collectionName": "fs.chunks",
+          "databaseName": "gridfs-tests",
+          "documents": [
+            {
+              "_id": {
+                "$oid": "000000000000000000000001"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000002"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000003"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000003"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "n": 0,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            },
+            {
+              "_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "files_id": {
+                "$oid": "000000000000000000000004"
+              },
+              "n": 1,
+              "data": {
+                "$binary": {
+                  "base64": "",
+                  "subType": "00"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "rename when file name does not exist",
+      "operations": [
+        {
+          "name": "renameByName",
+          "object": "bucket0",
+          "arguments": {
+            "filename": "missing-file",
+            "newFilename": "newfilename"
+          },
+          "expectError": {
+            "isError": true
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/gridfs/tests/renameByName.json
+++ b/source/gridfs/tests/renameByName.json
@@ -304,7 +304,7 @@
             "newFilename": "newfilename"
           },
           "expectError": {
-            "isError": true
+            "isClientError": true
           }
         }
       ]

--- a/source/gridfs/tests/renameByName.yml
+++ b/source/gridfs/tests/renameByName.yml
@@ -110,4 +110,4 @@ tests:
         arguments:
           filename: missing-file
           newFilename: newfilename
-        expectError: { isError: true } # FileNotFound
+        expectError: { isClientError: true } # FileNotFound

--- a/source/gridfs/tests/renameByName.yml
+++ b/source/gridfs/tests/renameByName.yml
@@ -1,0 +1,113 @@
+description: "gridfs-renameByName"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name gridfs-tests
+  - bucket:
+      id: &bucket0 bucket0
+      database: *database0
+  - collection:
+      id: &bucket0_files_collection bucket0_files_collection
+      database: *database0
+      collectionName: &bucket0_files_collectionName fs.files
+  - collection:
+      id: &bucket0_chunks_collection bucket0_chunks_collection
+      database: *database0
+      collectionName: &bucket0_chunks_collectionName fs.chunks
+
+initialData:
+  - collectionName: *bucket0_files_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file1
+        _id: { "$oid": "000000000000000000000001" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file2
+        _id: { "$oid": "000000000000000000000002" }
+        length: 0
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file3
+        _id: { "$oid": "000000000000000000000003" }
+        length: 2
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "filename"
+        metadata: {}
+      - &file4
+        _id: { "$oid": "000000000000000000000004" }
+        length: 8
+        chunkSize: 4
+        uploadDate: { "$date": "1970-01-01T00:00:00.000Z" }
+        filename: "otherfilename"
+        metadata: {}
+  - collectionName: *bucket0_chunks_collectionName
+    databaseName: *database0Name
+    documents:
+      - &file2_chunk0
+        _id: { "$oid": "000000000000000000000001" }
+        files_id: { "$oid": "000000000000000000000002" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file3_chunk0
+        _id: { "$oid": "000000000000000000000002" }
+        files_id: { "$oid": "000000000000000000000003" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file4_chunk0
+        _id: { "$oid": "000000000000000000000003" }
+        files_id: { "$oid": "000000000000000000000004" }
+        n: 0
+        data: { "$binary": { "base64": "", "subType": "00" } }
+      - &file4_chunk1
+        _id: { "$oid": "000000000000000000000004" }
+        files_id: { "$oid": "000000000000000000000004" }
+        n: 1
+        data: { "$binary": { "base64": "", "subType": "00" } }
+
+tests:
+  - description: "rename when multiple revisions of the file exist"
+    operations:
+      - name: renameByName
+        object: *bucket0
+        arguments:
+          filename: filename
+          newFilename: newfilename
+    outcome:
+      - collectionName: *bucket0_files_collectionName
+        databaseName: *database0Name
+        documents:
+          - <<: *file1
+            filename: newfilename
+          - <<: *file2
+            filename: newfilename
+          - <<: *file3
+            filename: newfilename
+          - <<: *file4
+      - collectionName: *bucket0_chunks_collectionName
+        databaseName: *database0Name
+        documents:
+          - *file2_chunk0
+          - *file3_chunk0
+          - *file4_chunk0
+          - *file4_chunk1
+  - description: "rename when file name does not exist"
+    operations:
+      - name: renameByName
+        object: *bucket0
+        arguments:
+          filename: missing-file
+          newFilename: newfilename
+        expectError: { isError: true } # FileNotFound


### PR DESCRIPTION
Fix [DRIVERS-2808](https://jira.mongodb.org/browse/DRIVERS-2808) and [DRIVERS-2807](https://jira.mongodb.org/browse/DRIVERS-2807)

Please complete the following before merging:

- [x] Update changelog.
- [x] Test changes in at least one language driver https://github.com/mongodb/mongo-php-library/pull/1504
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).
