### PR TITLE
DRIVERS-2573: Reference test for $$matchAsDocument and $$matchAsRoot

### DIFF
--- a/source/unified-test-format/tests/valid-fail/operator-matchAsDocument.json
+++ b/source/unified-test-format/tests/valid-fail/operator-matchAsDocument.json
@@ -1,0 +1,147 @@
+{
+  "description": "operator-matchAsDocument",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "json": "{ \"x\": 1, \"y\": 2 }"
+        },
+        {
+          "_id": 2,
+          "json": "{ \"x\" }"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsDocument with non-matching filter",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": "two"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument evaluates special operators",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument does not permit extra fields",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument fails to decode Extended JSON",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/valid-fail/operator-matchAsDocument.json
+++ b/source/unified-test-format/tests/valid-fail/operator-matchAsDocument.json
@@ -33,6 +33,14 @@
         },
         {
           "_id": 2,
+          "json": "1"
+        },
+        {
+          "_id": 3,
+          "json": "[ \"foo\" ]"
+        },
+        {
+          "_id": 4,
           "json": "{ \"x\" }"
         }
       ]
@@ -119,7 +127,7 @@
       ]
     },
     {
-      "description": "matchAsDocument fails to decode Extended JSON",
+      "description": "matchAsDocument expects JSON object but given scalar",
       "operations": [
         {
           "name": "find",
@@ -135,7 +143,57 @@
               "_id": 2,
               "json": {
                 "$$matchAsDocument": {
-                  "x": 1
+                  "$$matchAsRoot": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument expects JSON object but given array",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 3
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 3,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {}
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument fails to decode Extended JSON",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 4
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 4,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {}
                 }
               }
             }

--- a/source/unified-test-format/tests/valid-fail/operator-matchAsDocument.yml
+++ b/source/unified-test-format/tests/valid-fail/operator-matchAsDocument.yml
@@ -1,0 +1,63 @@
+description: operator-matchAsDocument
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, json: '{ "x": 1, "y": 2 }' }
+      - { _id: 2, json: '{ "x" }' }
+
+tests:
+  - description: matchAsDocument with non-matching filter
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1, y: "two" } } }
+  -
+    description: matchAsDocument evaluates special operators
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1, y: { $$exists: false } } } }
+  -
+    description: matchAsDocument does not permit extra fields
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1 } } }
+  -
+    description: matchAsDocument fails to decode Extended JSON
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 2 }
+          limit: 1
+        expectResult:
+          - { _id: 2, json: { $$matchAsDocument: { x: 1 } } }

--- a/source/unified-test-format/tests/valid-fail/operator-matchAsDocument.yml
+++ b/source/unified-test-format/tests/valid-fail/operator-matchAsDocument.yml
@@ -19,7 +19,10 @@ initialData:
     databaseName: *database0Name
     documents:
       - { _id: 1, json: '{ "x": 1, "y": 2 }' }
-      - { _id: 2, json: '{ "x" }' }
+      # Documents with non-objects or invalid JSON
+      - { _id: 2, json: '1' }
+      - { _id: 3, json: '[ "foo" ]' }
+      - { _id: 4, json: '{ "x" }' }
 
 tests:
   - description: matchAsDocument with non-matching filter
@@ -52,7 +55,7 @@ tests:
         expectResult:
           - { _id: 1, json: { $$matchAsDocument: { x: 1 } } }
   -
-    description: matchAsDocument fails to decode Extended JSON
+    description: matchAsDocument expects JSON object but given scalar
     operations:
       - name: find
         object: *collection0
@@ -60,4 +63,26 @@ tests:
           filter: { _id : 2 }
           limit: 1
         expectResult:
-          - { _id: 2, json: { $$matchAsDocument: { x: 1 } } }
+          # The following $$matchAsRoot expression would match any document, so
+          # this ensures the failure is due to the actual value.
+          - { _id: 2, json: &match_any_document { $$matchAsDocument: { $$matchAsRoot: { } } } }
+  -
+    description: matchAsDocument expects JSON object but given array
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 3 }
+          limit: 1
+        expectResult:
+          - { _id: 3, json: *match_any_document }
+  -
+    description: matchAsDocument fails to decode Extended JSON
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 4 }
+          limit: 1
+        expectResult:
+          - { _id: 4, json: *match_any_document }

--- a/source/unified-test-format/tests/valid-fail/operator-matchAsRoot.json
+++ b/source/unified-test-format/tests/valid-fail/operator-matchAsRoot.json
@@ -1,0 +1,98 @@
+{
+  "description": "operator-matchAsRoot",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "x": {
+            "y": 2,
+            "z": 3
+          }
+        },
+        {
+          "_id": 2,
+          "x": "{ \"x\": 1, \"y\": 2.0 }"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsRoot with nested document",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": {
+                "$$matchAsRoot": {
+                  "y": 3
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsRoot with matchAsDocument",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "x": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/valid-fail/operator-matchAsRoot.json
+++ b/source/unified-test-format/tests/valid-fail/operator-matchAsRoot.json
@@ -33,17 +33,13 @@
             "y": 2,
             "z": 3
           }
-        },
-        {
-          "_id": 2,
-          "x": "{ \"x\": 1, \"y\": 2.0 }"
         }
       ]
     }
   ],
   "tests": [
     {
-      "description": "matchAsRoot with nested document",
+      "description": "matchAsRoot with nested document does not match",
       "operations": [
         {
           "name": "find",
@@ -60,33 +56,6 @@
               "x": {
                 "$$matchAsRoot": {
                   "y": 3
-                }
-              }
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "description": "matchAsRoot with matchAsDocument",
-      "operations": [
-        {
-          "name": "find",
-          "object": "collection0",
-          "arguments": {
-            "filter": {
-              "_id": 1
-            },
-            "limit": 1
-          },
-          "expectResult": [
-            {
-              "_id": 2,
-              "x": {
-                "$$matchAsDocument": {
-                  "$$matchAsRoot": {
-                    "x": 1
-                  }
                 }
               }
             }

--- a/source/unified-test-format/tests/valid-fail/operator-matchAsRoot.yml
+++ b/source/unified-test-format/tests/valid-fail/operator-matchAsRoot.yml
@@ -19,11 +19,10 @@ initialData:
     databaseName: *database0Name
     documents:
       - { _id: 1, x: { y: 2, z: 3 } }
-      - { _id: 2, x: '{ "x": 1, "y": 2.0 }' }
 
 tests:
   -
-    description: matchAsRoot with nested document
+    description: matchAsRoot with nested document does not match
     operations:
       - name: find
         object: *collection0
@@ -32,13 +31,3 @@ tests:
           limit: 1
         expectResult:
           - { _id: 1, x: { $$matchAsRoot: { y: 3 } } }
-  -
-    description: matchAsRoot with matchAsDocument
-    operations:
-      - name: find
-        object: *collection0
-        arguments:
-          filter: { _id : 1 }
-          limit: 1
-        expectResult:
-          - { _id: 2, x: { $$matchAsDocument: { $$matchAsRoot: { x: 1 } } } }

--- a/source/unified-test-format/tests/valid-fail/operator-matchAsRoot.yml
+++ b/source/unified-test-format/tests/valid-fail/operator-matchAsRoot.yml
@@ -1,0 +1,44 @@
+description: operator-matchAsRoot
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: { y: 2, z: 3 } }
+      - { _id: 2, x: '{ "x": 1, "y": 2.0 }' }
+
+tests:
+  -
+    description: matchAsRoot with nested document
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, x: { $$matchAsRoot: { y: 3 } } }
+  -
+    description: matchAsRoot with matchAsDocument
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 2, x: { $$matchAsDocument: { $$matchAsRoot: { x: 1 } } } }

--- a/source/unified-test-format/tests/valid-pass/operator-lte.json
+++ b/source/unified-test-format/tests/valid-pass/operator-lte.json
@@ -1,5 +1,5 @@
 {
-  "description": "matches-lte-operator",
+  "description": "operator-lte",
   "schemaVersion": "1.9",
   "createEntities": [
     {

--- a/source/unified-test-format/tests/valid-pass/operator-lte.yml
+++ b/source/unified-test-format/tests/valid-pass/operator-lte.yml
@@ -1,6 +1,6 @@
-description: matches-lte-operator
+description: operator-lte
 
-# Note: $$lte is not technically in the 1.8 schema but was introduced at the same time.
+# Note: $$lte was introduced alongside schema changes for CSOT
 schemaVersion: "1.9"
 
 createEntities:

--- a/source/unified-test-format/tests/valid-pass/operator-matchAsDocument.json
+++ b/source/unified-test-format/tests/valid-pass/operator-matchAsDocument.json
@@ -1,0 +1,124 @@
+{
+  "description": "operator-matchAsDocument",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "json": "{ \"x\": 1, \"y\": 2.0 }"
+        },
+        {
+          "_id": 2,
+          "json": "{ \"x\": { \"$oid\": \"57e193d7a9cc81b4027498b5\" } }"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsDocument performs flexible numeric comparisons",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": 2
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument evaluates special operators",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": 1,
+                  "y": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsDocument decodes Extended JSON",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "json": {
+                "$$matchAsDocument": {
+                  "x": {
+                    "$$type": "objectId"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/valid-pass/operator-matchAsDocument.yml
+++ b/source/unified-test-format/tests/valid-pass/operator-matchAsDocument.yml
@@ -1,0 +1,54 @@
+description: operator-matchAsDocument
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, json: '{ "x": 1, "y": 2.0 }' }
+      - { _id: 2, json: '{ "x": { "$oid": "57e193d7a9cc81b4027498b5" } }' }
+
+tests:
+  -
+    description: matchAsDocument performs flexible numeric comparisons
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1.0, y: 2 } } }
+  -
+    description: matchAsDocument evaluates special operators
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, json: { $$matchAsDocument: { x: 1, y: { $$exists: true } } } }
+  -
+    description: matchAsDocument decodes Extended JSON
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 2 }
+          limit: 1
+        expectResult:
+          - { _id: 2, json: { $$matchAsDocument: { x: { $$type: "objectId" } } } }

--- a/source/unified-test-format/tests/valid-pass/operator-matchAsRoot.json
+++ b/source/unified-test-format/tests/valid-pass/operator-matchAsRoot.json
@@ -1,0 +1,151 @@
+{
+  "description": "operator-matchAsRoot",
+  "schemaVersion": "1.13",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "test"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "coll0",
+      "databaseName": "test",
+      "documents": [
+        {
+          "_id": 1,
+          "x": {
+            "y": 2,
+            "z": 3
+          }
+        },
+        {
+          "_id": 2,
+          "json": "{ \"x\": 1, \"y\": 2 }"
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "matchAsRoot with nested document",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": {
+                "$$matchAsRoot": {
+                  "y": 2
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsRoot performs flexible numeric comparisons",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": {
+                "$$matchAsRoot": {
+                  "y": 2
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsRoot evaluates special operators",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 1,
+              "x": {
+                "$$matchAsRoot": {
+                  "y": 2,
+                  "z": {
+                    "$$exists": true
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "matchAsRoot with matchAsDocument",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 2
+            },
+            "limit": 1
+          },
+          "expectResult": [
+            {
+              "_id": 2,
+              "json": {
+                "$$matchAsDocument": {
+                  "$$matchAsRoot": {
+                    "x": 1
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/unified-test-format/tests/valid-pass/operator-matchAsRoot.yml
+++ b/source/unified-test-format/tests/valid-pass/operator-matchAsRoot.yml
@@ -1,0 +1,64 @@
+description: operator-matchAsRoot
+
+schemaVersion: "1.13"
+
+createEntities:
+  - client:
+      id: &client0 client0
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name test
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1, x: { y: 2, z: 3 } }
+      - { _id: 2, json: '{ "x": 1, "y": 2 }' }
+
+tests:
+  -
+    description: matchAsRoot with nested document
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, x: { $$matchAsRoot: { y: 2 } } }
+  -
+    description: matchAsRoot performs flexible numeric comparisons
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, x: { $$matchAsRoot: { y: 2.0 } } }
+  -
+    description: matchAsRoot evaluates special operators
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 1 }
+          limit: 1
+        expectResult:
+          - { _id: 1, x: { $$matchAsRoot: { y: 2, z: { $$exists: true } } } }
+  -
+    description: matchAsRoot with matchAsDocument
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: { _id : 2 }
+          limit: 1
+        expectResult:
+          - { _id: 2, json: { $$matchAsDocument: { $$matchAsRoot: { x: 1 } } } }


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-2573

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Test changes in at least one language driver: https://github.com/mongodb/mongo-php-library/pull/1508

Note: I implemented `$$matchAsDocument` and `$$matchAsRoot` in PHPLIB in order to POC this, so I'd appreciate it if another language driver could also test this.