### PR TITLE
DRIVERS-1815 Add TransientTransactionError label to PoolClearedError

### DIFF
--- a/source/transactions/tests/README.md
+++ b/source/transactions/tests/README.md
@@ -73,8 +73,12 @@ driver, use command monitoring instead.
         assert len(addresses) > 1
     ```
 
+3. Test that `PoolClearedError` has `TransientTransactionError` label. Since there is no simple way to trigger
+    `PoolClearedError`, this test should be implemented in a way that suites each driver the best.
+
 ## Changelog
 
+- 2024-10-31: Add test for PoolClearedError.
 - 2024-02-15: Migrated from reStructuredText to Markdown.
 - 2024-02-07: Converted legacy transaction tests to unified format and moved the legacy test format docs to a separate
     file.

--- a/source/transactions/transactions.md
+++ b/source/transactions/transactions.md
@@ -64,7 +64,8 @@ string error labels. Drivers may also add error labels to errors that they retur
 
 #### Transient Transaction Error
 
-Any command or network error that includes the "TransientTransactionError" error label in the "errorLabels" field.
+Any command, network, or driver error that includes the "TransientTransactionError" error label in the "errorLabels"
+field.
 
 ### **Naming variations**
 
@@ -673,12 +674,13 @@ string error labels.
 
 ### Transient Transaction Error
 
-Any command error that includes the "TransientTransactionError" error label in the "errorLabels" field. Any network
-error or server selection error encountered running any command besides commitTransaction in a transaction. In the case
-of command errors, the server adds the label; in the case of network errors or server selection errors where the client
-receives no server reply, the client MUST add the label. If a network error occurs while running the commitTransaction
-command then it is not known whether the transaction committed or not, and thus the "TransientTransactionError" label
-MUST NOT be added.
+- Any command error that includes the "TransientTransactionError" error label in the "errorLabels" field. In the case of
+    command errors, the server adds the label.
+- Any network error or server selection error encountered running any command besides commitTransaction in a
+    transaction. In the case of network errors or server selection errors where the client receives no server reply, the
+    client MUST add the label. If a network error occurs while running the commitTransaction command then it is not
+    known whether the transaction committed or not, and thus the "TransientTransactionError" label MUST NOT be added.
+- `PoolClearedError`. Driver MUST add the label to this error.
 
 #### Retrying transactions that fail with TransientTransactionError
 
@@ -1071,7 +1073,7 @@ objective of avoiding duplicate commits.
 
 ## **Changelog**
 
-- 2024-10-28: Clarify when drivers must add TransientTransactionError label.
+- 2024-10-31: Clarify when drivers must add TransientTransactionError label.
 
 - 2024-10-28: Note read preference must always be primary in a transaction.
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

Ruby PoC - https://github.com/mongodb/mongo-ruby-driver/pull/2906