### PR TITLE
DRIVERS-2953 getMore should not have maxTimeMS for non-tailable cursor

### DIFF
--- a/source/client-side-operations-timeout/tests/runCursorCommand.json
+++ b/source/client-side-operations-timeout/tests/runCursorCommand.json
@@ -200,7 +200,7 @@
                   },
                   "collection": "collection",
                   "maxTimeMS": {
-                    "$$exists": true
+                    "$$exists": false
                   }
                 }
               }
@@ -210,7 +210,7 @@
       ]
     },
     {
-      "description": "Non=tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure",
+      "description": "Non-tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure",
       "runOnRequirements": [
         {
           "serverless": "forbid"

--- a/source/client-side-operations-timeout/tests/runCursorCommand.yml
+++ b/source/client-side-operations-timeout/tests/runCursorCommand.yml
@@ -70,7 +70,7 @@ tests:
     runOnRequirements:
       - serverless: forbid
     operations:
-      # Block find/getMore for 15ms.
+      # Block find/getMore for 60ms.
       - name: failPoint
         object: testRunner
         arguments:
@@ -83,8 +83,9 @@ tests:
               blockConnection: true
               blockTimeMS: 60
       # Run a find with timeoutMS less than double our failPoint blockTimeMS and
-      # batchSize less than the total document count will cause a find and a getMore to be sent.
-      # Both will block for 60ms so together they will go over the timeout.
+      # batchSize less than the total document count will cause a find and a 
+      # getMore to be sent. Both will block for 60ms so together they will go 
+      # over the timeout.
       - name: runCursorCommand
         object: *db
         arguments:
@@ -106,12 +107,12 @@ tests:
               command:
                 getMore: { $$type: [int, long] }
                 collection: *collection
-                maxTimeMS: { $$exists: true }
+                maxTimeMS: { $$exists: false }
 
   # If timeoutMode=ITERATION, timeoutMS applies separately to the initial find and the getMore on the cursor. Neither
   # command should have a maxTimeMS field. This is a failure test. The "find" inherits timeoutMS=100 and "getMore"
   # commands are blocked for 60ms, causing iteration to fail with a timeout error.
-  - description: Non=tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure
+  - description: Non-tailable cursor iteration timeoutMS is refreshed for getMore if timeoutMode is iteration - failure
     runOnRequirements:
       - serverless: forbid
     operations:


### PR DESCRIPTION
<!-- Thanks for contributing! -->

DRIVERS-2953

> The only time a "getMore" can include "maxTimeMS" is for a tailable awaitData cursor. The test bug is masked because the test case expects a timeout on "getMore", preventing the driver from receiving the server error.

Please complete the following before merging:

- [ ] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
