### PR TITLE
DRIVERS-2223 Fix race condition in pool-checkout-returned-connection-maxConnecting.yml

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
@@ -1374,6 +1374,8 @@ to close and remove from its pool a [Connection](#connection) which has unread e
 
 ## Changelog
 
+- 2024-11-01: Fixed race condition in pool-checkout-returned-connection-maxConnecting.yml test.
+
 - 2024-01-23: Migrated from reStructuredText to Markdown.
 
 - 2019-06-06: Add "connectionError" as a valid reason for ConnectionCheckOutFailedEvent

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.json
@@ -23,6 +23,7 @@
     }
   },
   "poolOptions": {
+    "maxConnecting": 2,
     "maxPoolSize": 10,
     "waitQueueTimeoutMS": 5000
   },
@@ -70,11 +71,6 @@
     {
       "name": "checkIn",
       "connection": "conn0"
-    },
-    {
-      "name": "waitForEvent",
-      "event": "ConnectionCheckedOut",
-      "count": 4
     }
   ],
   "events": [
@@ -103,14 +99,6 @@
     {
       "type": "ConnectionCheckedOut",
       "connectionId": 1,
-      "address": 42
-    },
-    {
-      "type": "ConnectionCheckedOut",
-      "address": 42
-    },
-    {
-      "type": "ConnectionCheckedOut",
       "address": 42
     }
   ],

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.json
@@ -71,6 +71,10 @@
     {
       "name": "checkIn",
       "connection": "conn0"
+    },
+    {
+      "name": "wait",
+      "ms": 100
     }
   ],
   "events": [

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
@@ -50,6 +50,9 @@ operations:
   # out the idle connection before the two new connections are ready.
   - name: checkIn
     connection: conn0
+  # Wait for 100ms to let one of the blocked checkOut operations complete.
+  - name: wait
+    ms: 100
 events:
   # main thread checking out a Connection and holding it
   - type: ConnectionCreated

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
@@ -15,6 +15,7 @@ failPoint:
     blockConnection: true
     blockTimeMS: 750
 poolOptions:
+  maxConnecting: 2
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
 operations:
@@ -45,14 +46,10 @@ operations:
     count: 4
   - name: wait
     ms: 100
-  # check original connection back in, so the thread that isn't
-  # currently establishing will become unblocked. Then wait for
-  # all threads to complete.
+  # Check original connection back in, so one of the waiting threads can check
+  # out the idle connection before the two new connections are ready.
   - name: checkIn
     connection: conn0
-  - name: waitForEvent
-    event: ConnectionCheckedOut
-    count: 4
 events:
   # main thread checking out a Connection and holding it
   - type: ConnectionCreated
@@ -69,15 +66,13 @@ events:
   - type: ConnectionCheckedIn
     connectionId: 1
     address: 42
-  # remaining thread checking out the returned Connection
+  # Another thread checks out the returned Connection before the two new
+  # connections are checked out.
   - type: ConnectionCheckedOut
     connectionId: 1
     address: 42
-  # first two threads finishing Connection establishment
-  - type: ConnectionCheckedOut
-    address: 42
-  - type: ConnectionCheckedOut
-    address: 42
+  # Events after this can come in different orders but still be valid.
+  # See DRIVERS-2223 for details.
 ignore:
   - ConnectionPoolReady
   - ConnectionClosed


### PR DESCRIPTION
[DRIVERS-2223](https://jira.mongodb.org/browse/DRIVERS-2223)

Don't wait on the remaining checkOut events to resolve a race condition in the "threads blocked by maxConnecting check out returned connections" test caused by different connection pool implementations.

Based on a helpful [comment](https://github.com/mongodb/specifications/pull/1152#issuecomment-1057088946) by @stIncMale from https://github.com/mongodb/specifications/pull/1152.

Please complete the following before merging:

- [x] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
