### PR TITLE
fix missing space before inline math

### DIFF
--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -854,7 +854,7 @@ Assume an exposition-only function $GetEncryptedFields(opts, collName, dbName, a
 options, $collName$ is the name of the collection, $dbName$ is the name of the database associated with that collection,
 and $askDb$ is a boolean value. The resulting `encryptedFields` $EF$ is found by:
 
-1. Let $QualName$ be the string formed by joining$dbName$ and $collName$ with an ASCII dot `"."`.
+1. Let $QualName$ be the string formed by joining $dbName$ and $collName$ with an ASCII dot `"."`.
 2. If $opts$ contains an `"encryptedFields"` property, then $EF$ is the value of that property.
 3. Otherwise, if `AutoEncryptionOptions.encryptedFieldsMap` contains an element named by $QualName$, then $EF$ is the
     value of that element.


### PR DESCRIPTION
This fixes a Markdown rendering error in the client-side-encryption spec due to a typo. The problem was much more noticeable on GitHub than on mkdocs (readthedocs):
* on GitHub, the word was no longer interpreted as math, and it rendered in plain text as "joining$dbName$"
* on mkdocs the math markup rendered normally still, so it appeared as "joiningdbName" with "dbName" in math italics, making the missing space somewhat hard to see