### PR TITLE
DRIVERS-3033 SDAM logging tests should allow durationMS as a float

### DIFF
--- a/source/server-discovery-and-monitoring/tests/unified/logging-replicaset.json
+++ b/source/server-discovery-and-monitoring/tests/unified/logging-replicaset.json
@@ -357,6 +357,7 @@
                 },
                 "durationMS": {
                   "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]
@@ -398,6 +399,7 @@
                 },
                 "durationMS": {
                   "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]
@@ -439,6 +441,7 @@
                 },
                 "durationMS": {
                   "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]
@@ -589,6 +592,7 @@
                 },
                 "durationMS": {
                   "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]

--- a/source/server-discovery-and-monitoring/tests/unified/logging-replicaset.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/logging-replicaset.yml
@@ -176,7 +176,7 @@ tests:
               serverPort: { $$type: [int, long] }
               driverConnectionId: { $$exists: true }
               serverConnectionId: { $$exists: true }
-              durationMS: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
               reply:
                 $$matchAsDocument:
                   "$$matchAsRoot":
@@ -191,7 +191,7 @@ tests:
               serverPort: { $$type: [int, long] }
               driverConnectionId: { $$exists: true }
               serverConnectionId: { $$exists: true }
-              durationMS: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
               reply:
                 $$matchAsDocument:
                   "$$matchAsRoot":
@@ -206,7 +206,7 @@ tests:
               serverPort: { $$type: [int, long] }
               driverConnectionId: { $$exists: true }
               serverConnectionId: { $$exists: true }
-              durationMS: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
               reply:
                 $$matchAsDocument:
                   "$$matchAsRoot":
@@ -285,5 +285,5 @@ tests:
             serverHost: { $$type: string }
             serverPort: { $$type: [int, long] }
             driverConnectionId: { $$exists: true }
-            durationMS: { $$type: [int, long] }
+            durationMS: { $$type: [double, int, long] }
             failure: { $$exists: true }

--- a/source/server-discovery-and-monitoring/tests/unified/logging-sharded.json
+++ b/source/server-discovery-and-monitoring/tests/unified/logging-sharded.json
@@ -324,6 +324,7 @@
                 },
                 "durationMS": {
                   "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]
@@ -475,6 +476,7 @@
                 },
                 "durationMS": {
                   "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]

--- a/source/server-discovery-and-monitoring/tests/unified/logging-sharded.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/logging-sharded.yml
@@ -164,7 +164,7 @@ tests:
               serverPort: { $$type: [int, long] }
               driverConnectionId: { $$exists: true }
               serverConnectionId: { $$exists: true }
-              durationMS: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
               reply:
                 $$matchAsDocument:
                   "$$matchAsRoot":
@@ -244,5 +244,5 @@ tests:
             serverHost: { $$type: string }
             serverPort: { $$type: [int, long] }
             driverConnectionId: { $$exists: true }
-            durationMS: { $$type: [int, long] }
+            durationMS: { $$type: [double, int, long] }
             failure: { $$exists: true }

--- a/source/server-discovery-and-monitoring/tests/unified/logging-standalone.json
+++ b/source/server-discovery-and-monitoring/tests/unified/logging-standalone.json
@@ -339,6 +339,7 @@
                 },
                 "durationMS": {
                   "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]
@@ -500,6 +501,7 @@
                 },
                 "durationMS": {
                   "$$type": [
+                    "double",
                     "int",
                     "long"
                   ]

--- a/source/server-discovery-and-monitoring/tests/unified/logging-standalone.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/logging-standalone.yml
@@ -169,7 +169,7 @@ tests:
               serverPort: { $$type: [int, long] }
               driverConnectionId: { $$exists: true }
               serverConnectionId: { $$exists: true }
-              durationMS: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
               reply:
                 $$matchAsDocument:
                   "$$matchAsRoot":
@@ -254,5 +254,5 @@ tests:
               serverHost: { $$type: string }
               serverPort: { $$type: [int, long] }
               driverConnectionId: { $$exists: true }
-              durationMS: { $$type: [int, long] }
+              durationMS: { $$type: [double, int, long] }
               failure: { $$exists: true }


### PR DESCRIPTION
DRIVERS-3033 SDAM logging tests should allow durationMS as a float

See details in the ticket. 

- [X] Tested in python here: https://github.com/mongodb/mongo-python-driver/pull/1988
