### PR TITLE
DRIVERS-3022 Unskip tests with `errorCodeName` on Serverless

### DIFF
--- a/source/transactions-convenient-api/tests/unified/commit-retry.json
+++ b/source/transactions-convenient-api/tests/unified/commit-retry.json
@@ -422,11 +422,6 @@
     },
     {
       "description": "commit is not retried after MaxTimeMSExpired error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/transactions-convenient-api/tests/unified/commit-retry.yml
+++ b/source/transactions-convenient-api/tests/unified/commit-retry.yml
@@ -212,9 +212,6 @@ tests:
           - { _id: 1 }
   -
     description: commit is not retried after MaxTimeMSExpired error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/source/transactions-convenient-api/tests/unified/commit-writeconcernerror.json
+++ b/source/transactions-convenient-api/tests/unified/commit-writeconcernerror.json
@@ -1,6 +1,6 @@
 {
   "description": "commit-writeconcernerror",
-  "schemaVersion": "1.4",
+  "schemaVersion": "1.3",
   "runOnRequirements": [
     {
       "minServerVersion": "4.0",
@@ -414,11 +414,6 @@
     },
     {
       "description": "commitTransaction is not retried after UnknownReplWriteConcern error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",
@@ -551,11 +546,6 @@
     },
     {
       "description": "commitTransaction is not retried after UnsatisfiableWriteConcern error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",
@@ -688,11 +678,6 @@
     },
     {
       "description": "commitTransaction is not retried after MaxTimeMSExpired error",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/transactions-convenient-api/tests/unified/commit-writeconcernerror.yml
+++ b/source/transactions-convenient-api/tests/unified/commit-writeconcernerror.yml
@@ -1,6 +1,6 @@
 description: commit-writeconcernerror
 
-schemaVersion: '1.4' # For `serverless` in `runOnRequirements`
+schemaVersion: '1.3'
 
 runOnRequirements:
   - minServerVersion: '4.0'
@@ -151,9 +151,6 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after UnknownReplWriteConcern error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -206,9 +203,6 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after UnsatisfiableWriteConcern error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner
@@ -232,9 +226,6 @@ tests:
     outcome: *outcome
   -
     description: commitTransaction is not retried after MaxTimeMSExpired error
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       - name: failPoint
         object: testRunner

--- a/source/transactions/tests/unified/retryable-commit.json
+++ b/source/transactions/tests/unified/retryable-commit.json
@@ -89,11 +89,6 @@
   "tests": [
     {
       "description": "commitTransaction fails after Interrupted",
-      "runOnRequirements": [
-        {
-          "serverless": "forbid"
-        }
-      ],
       "operations": [
         {
           "object": "testRunner",

--- a/source/transactions/tests/unified/retryable-commit.yml
+++ b/source/transactions/tests/unified/retryable-commit.yml
@@ -67,9 +67,6 @@ initialData:
 tests:
   -
     description: 'commitTransaction fails after Interrupted'
-    runOnRequirements:
-      # Serverless sets empty `codeName` on failpoint errors. Remove once CLOUDP-280424 is fixed.
-      - serverless: forbid
     operations:
       -
         object: testRunner


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/specifications/pull/1680. Reverts 5f6fd2830847e5f311e7e56ba74db7aa87810fa6.

[CLOUDP-280424](https://jira.mongodb.org/browse/CLOUDP-280424) fixes Atlas Proxy to set an error `codeName` when a failpoint is triggered.

Verified with Rust driver in [this patch](https://spruce.mongodb.com/version/673e45c6b58c46000702bc03).


<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ N/A.
- [x] Test changes in at least one language driver.
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).~~ N/A. Only impacts serverless.

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
