### PR TITLE
Relax the WaitQueue fairness requirement in the CMAP spec

### DIFF
--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
@@ -1262,9 +1262,9 @@ from occurring.
 
 Additionally, these options have the effect of prioritizing newer requests over older requests, which is not necessarily
 the behavior that users want. For example, consider a situation when a waitQueue is full, and a request for
-[Connection](#connection) gets rejected. Then a spot opens in the waitQueue, and a newer request gets accepted.
-One may say that the newer request was prioritized over the older one, which violates the fairness recommendation that
-the waitQueue normally adheres to.
+[Connection](#connection) gets rejected. Then a spot opens in the waitQueue, and a newer request gets accepted. One may
+say that the newer request was prioritized over the older one, which violates the fairness recommendation that the
+waitQueue normally adheres to.
 
 Because of these issues, it does not make sense to
 [go against driver mantras and provide an additional knob](../driver-mantras.md#). We may eventually pursue an

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
@@ -247,7 +247,7 @@ either receives a [Connection](#connection) or times out. A WaitQueue has the fo
 - **Ordered/fair**: When [Connections](#connection) are made available, they SHOULD be issued out to threads in the
     order that the threads entered the WaitQueue. If this is behavior poses too much of an implementation burden, then
     at the very least threads that have entered the queue more recently MUST NOT be intentionally prioritized over those
-    that entered it earlier. 
+    that entered it earlier.
 - **Timeout aggressively:** Members of a WaitQueue MUST timeout if they are enqueued for longer than the computed
     timeout and MUST leave the WaitQueue immediately in this case.
 

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
@@ -1261,10 +1261,10 @@ these fields would allow for faster diagnosis of issues in the connection pool, 
 from occurring.
 
 Additionally, these options have the effect of prioritizing newer requests over older requests, which is not necessarily
-the behavior that users want. For example, consider a situation when a waitQueue is full, and a request for
-[Connection](#connection) gets rejected. Then a spot opens in the waitQueue, and a newer request gets accepted. One may
+the behavior that users want. For example, consider a situation when a WaitQueue is full, and a request for
+[Connection](#connection) gets rejected. Then a spot opens in the WaitQueue, and a newer request gets accepted. One may
 say that the newer request was prioritized over the older one, which violates the fairness recommendation that the
-waitQueue normally adheres to.
+WaitQueue normally adheres to.
 
 Because of these issues, it does not make sense to
 [go against driver mantras and provide an additional knob](../driver-mantras.md#). We may eventually pursue an

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
@@ -1260,12 +1260,11 @@ These options were originally only implemented in three drivers (Java, C#, and P
 these fields would allow for faster diagnosis of issues in the connection pool, they would not actually prevent an error
 from occurring.
 
-Additionally, these options have the effect of prioritizing older requests over newer requests, which is not necessarily
-the behavior that users want. They can also result in cases where queue access oscillates back and forth between full
-and not full. If a driver has a full waitQueue, then all requests for [Connections](#connection) will be rejected. If
-the client is continually spammed with requests, you could wind up with a scenario where as soon as the waitQueue is no
-longer full, it is immediately filled. It is not a favorable situation to be in, partially b/c it violates the fairness
-recommendation that the waitQueue normally adheres to.
+Additionally, these options have the effect of prioritizing newer requests over older requests, which is not necessarily
+the behavior that users want. For example, consider a situation when a waitQueue is full, and a request for
+[Connection](#connection) gets rejected. Then a spot opens in the waitQueue, and a newer request gets accepted.
+One may say that the newer request was prioritized over the older one, which violates the fairness recommendation that
+the waitQueue normally adheres to.
 
 Because of these issues, it does not make sense to
 [go against driver mantras and provide an additional knob](../driver-mantras.md#). We may eventually pursue an

--- a/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
+++ b/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.md
@@ -244,10 +244,10 @@ A concept that represents pending requests for [Connections](#connection). When 
 either receives a [Connection](#connection) or times out. A WaitQueue has the following traits:
 
 - **Thread-Safe**: When multiple threads attempt to enter or exit a WaitQueue, they do so in a thread-safe manner.
-- **Ordered/fair**: When [Connections](#connection) are made available, they SHOULD be issued out to
-    threads in the order that the threads entered the WaitQueue. If this is behavior poses too much of an implementation
-    burden, then at the very least threads that have entered the queue more recently MUST NOT be intentionally
-    prioritized over those that entered it earlier. 
+- **Ordered/fair**: When [Connections](#connection) are made available, they SHOULD be issued out to threads in the
+    order that the threads entered the WaitQueue. If this is behavior poses too much of an implementation burden, then
+    at the very least threads that have entered the queue more recently MUST NOT be intentionally prioritized over those
+    that entered it earlier. 
 - **Timeout aggressively:** Members of a WaitQueue MUST timeout if they are enqueued for longer than the computed
     timeout and MUST leave the WaitQueue immediately in this case.
 


### PR DESCRIPTION
The relevant Slack discussion: https://mongodb.slack.com/archives/C72LB5RPV/p1732060999166209.

DRIVERS-3056

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
