### PR TITLE
DRIVERS-2781 increase `wait` time.

### DIFF
--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -376,7 +376,7 @@ class AutoEncryptionOpts {
    // Set bypassQueryAnalysis to true to use explicit encryption on indexed fields
    // without the MongoDB Enterprise Advanced licensed crypt_shared library.
    bypassQueryAnalysis: Optional<Boolean>; // Default false.
-   keyExpirationMS: Optional<Uint64>; // Default 60000.
+   keyExpirationMS: Optional<Uint64>; // Default 60000. 0 means "never expire".
 }
 ```
 
@@ -1049,7 +1049,7 @@ interface ClientEncryptionOpts {
    keyVaultNamespace: String;
    kmsProviders: KMSProviders;
    tlsOptions?: KMSProvidersTLSOptions; // Maps KMS provider to TLS options.
-   keyExpirationMS: Optional<Uint64>; // Default 60000.
+   keyExpirationMS: Optional<Uint64>; // Default 60000. 0 means "never expire".
 };
 
 interface KMSProvidersTLSOptions {

--- a/source/client-side-encryption/etc/test-templates/keyCache.yml.template
+++ b/source/client-side-encryption/etc/test-templates/keyCache.yml.template
@@ -21,7 +21,7 @@ tests:
       - name: wait
         object: testRunner
         arguments:
-          ms: 2
+          ms: 50 # Wait long enough to account for coarse time resolution on Windows (CDRIVER-4526).
       - name: find
         arguments:
           filter: { _id: 1 }

--- a/source/client-side-encryption/tests/legacy/keyCache.json
+++ b/source/client-side-encryption/tests/legacy/keyCache.json
@@ -122,7 +122,7 @@
           "name": "wait",
           "object": "testRunner",
           "arguments": {
-            "ms": 2
+            "ms": 50
           }
         },
         {

--- a/source/client-side-encryption/tests/legacy/keyCache.yml
+++ b/source/client-side-encryption/tests/legacy/keyCache.yml
@@ -21,7 +21,7 @@ tests:
       - name: wait
         object: testRunner
         arguments:
-          ms: 2
+          ms: 50 # Wait long enough to account for coarse time resolution on Windows (CDRIVER-4526).
       - name: find
         arguments:
           filter: { _id: 1 }

--- a/source/client-side-encryption/tests/unified/keyCache.json
+++ b/source/client-side-encryption/tests/unified/keyCache.json
@@ -105,7 +105,7 @@
           "name": "wait",
           "object": "testRunner",
           "arguments": {
-            "ms": 2
+            "ms": 50
           }
         },
         {

--- a/source/client-side-encryption/tests/unified/keyCache.yml
+++ b/source/client-side-encryption/tests/unified/keyCache.yml
@@ -62,7 +62,7 @@ tests:
       - name: wait
         object: testRunner
         arguments:
-          ms: 2
+          ms: 50 # Wait long enough to account for coarse time resolution on Windows (CDRIVER-4526).
       - name: decrypt
         object: *clientEncryption0
         arguments:


### PR DESCRIPTION
# Summary

Follow-up to https://github.com/mongodb/specifications/pull/1730

- Increase `wait` time in `keyCache.json` tests to fix failures on Windows.
- Document `keyExpirationMS=0` means "never expire".

See https://github.com/mongodb/mongo-c-driver/pull/1804 for motivation.

---

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- [x] Test changes in at least one language driver.
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and ~~serverless~~).~~ **Verified by this [patch build](https://spruce.mongodb.com/version/675066dec4dc3c0006a3e9b3). But C does not test serverless.**

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
