### PR TITLE
Bump python version for setup-python action

### DIFF
--- a/.github/workflows/json-regenerate-check.yml
+++ b/.github/workflows/json-regenerate-check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Set up npm
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
The `Check if all JSON test files are up-to-date` job runs on `ubuntu-latest` and Github has [announced](https://github.com/actions/runner-images/issues/10636) that Ubuntu 24.04 is being rolled out as the default version for the "ubuntu-latest" label in GitHub Actions. Now the latest python version supported on Ubuntu 24.04 is 3.9.* but we are using 3.7 which currently breaks the setup-python action. This PR bumps the version to the lowest supported version on Ubuntu 24.04