### PR TITLE
DRIVERS-3081: Relax requirement for optional fields and introducing appName for failPoints for transactions unified tests

### DIFF
--- a/source/transactions/tests/unified/findOneAndReplace.json
+++ b/source/transactions/tests/unified/findOneAndReplace.json
@@ -127,7 +127,9 @@
                   "update": {
                     "x": 1
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },
@@ -299,7 +301,9 @@
                   "update": {
                     "x": 1
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },

--- a/source/transactions/tests/unified/findOneAndReplace.yml
+++ b/source/transactions/tests/unified/findOneAndReplace.yml
@@ -88,7 +88,7 @@ tests:
                 findAndModify: *collection_name
                 query: { _id: 3 }
                 update: { x: 1 }
-                new: false
+                new: { $$unsetOrMatches: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '1' }
                 startTransaction: true
@@ -178,7 +178,7 @@ tests:
                 findAndModify: *collection_name
                 query: { _id: 3 }
                 update: { x: 1 }
-                new: false
+                new: { $$unsetOrMatches: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '1' }
                 startTransaction: true

--- a/source/transactions/tests/unified/findOneAndUpdate.json
+++ b/source/transactions/tests/unified/findOneAndUpdate.json
@@ -491,7 +491,9 @@
                       "x": 1
                     }
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },

--- a/source/transactions/tests/unified/findOneAndUpdate.json
+++ b/source/transactions/tests/unified/findOneAndUpdate.json
@@ -189,7 +189,9 @@
                       "x": 1
                     }
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },
@@ -281,7 +283,9 @@
                       "x": 1
                     }
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },
@@ -340,7 +344,9 @@
                       "x": 1
                     }
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },

--- a/source/transactions/tests/unified/findOneAndUpdate.yml
+++ b/source/transactions/tests/unified/findOneAndUpdate.yml
@@ -130,7 +130,7 @@ tests:
                 findAndModify: *collection_name
                 query: { _id: 3 }
                 update: { $inc: { x: 1 } }
-                new: false
+                new: { $$unsetOrMatches: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '1' }
                 startTransaction: true
@@ -173,7 +173,7 @@ tests:
                 findAndModify: *collection_name
                 query: { _id: 3 }
                 update: { $inc: { x: 1 } }
-                new: false
+                new: { $$unsetOrMatches: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '2' }
                 startTransaction: true
@@ -201,7 +201,7 @@ tests:
                 findAndModify: *collection_name
                 query: { _id: 3 }
                 update: { $inc: { x: 1 } }
-                new: false
+                new: { $$unsetOrMatches: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '3' }
                 startTransaction: true

--- a/source/transactions/tests/unified/findOneAndUpdate.yml
+++ b/source/transactions/tests/unified/findOneAndUpdate.yml
@@ -277,7 +277,7 @@ tests:
                 findAndModify: *collection_name
                 query: { _id: 3 }
                 update: { $inc: { x: 1 } }
-                new: false
+                new: { $$unsetOrMatches: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '1' }
                 startTransaction: true

--- a/source/transactions/tests/unified/mongos-recovery-token.json
+++ b/source/transactions/tests/unified/mongos-recovery-token.json
@@ -232,7 +232,8 @@
                   "id": "client1",
                   "useMultipleMongoses": true,
                   "uriOptions": {
-                    "heartbeatFrequencyMS": 30000
+                    "heartbeatFrequencyMS": 30000,
+                    "appName": "transactionsClient"
                   },
                   "observeEvents": [
                     "commandStartedEvent"
@@ -299,7 +300,8 @@
                   "isMaster",
                   "hello"
                 ],
-                "closeConnection": true
+                "closeConnection": true,
+                "appName": "transactionsClient"
               }
             }
           }

--- a/source/transactions/tests/unified/mongos-recovery-token.yml
+++ b/source/transactions/tests/unified/mongos-recovery-token.yml
@@ -150,6 +150,7 @@ tests:
                   # flight heartbeat refreshes the first mongoes' SDAM state in between
                   # the initial commitTransaction and the retry attempt.
                   heartbeatFrequencyMS: 30000
+                  appName: &appName transactionsClient
                 observeEvents:
                   - commandStartedEvent
             - database:
@@ -195,6 +196,7 @@ tests:
                 - isMaster
                 - hello
               closeConnection: true
+              appName: *appName
       # The first commitTransaction sees a retryable connection error due to
       # the fail point and also fails on the server. The retry attempt on a
       # new mongos will wait for the transaction to timeout and will fail

--- a/source/transactions/tests/unified/pin-mongos.json
+++ b/source/transactions/tests/unified/pin-mongos.json
@@ -1249,7 +1249,8 @@
                   "id": "client1",
                   "useMultipleMongoses": true,
                   "uriOptions": {
-                    "heartbeatFrequencyMS": 30000
+                    "heartbeatFrequencyMS": 30000,
+                    "appName": "transactionsClient"
                   },
                   "observeEvents": [
                     "commandStartedEvent"
@@ -1316,7 +1317,8 @@
                   "isMaster",
                   "hello"
                 ],
-                "closeConnection": true
+                "closeConnection": true,
+                "appName": "transactionsClient"
               }
             }
           }

--- a/source/transactions/tests/unified/pin-mongos.yml
+++ b/source/transactions/tests/unified/pin-mongos.yml
@@ -527,6 +527,7 @@ tests:
                   # flight heartbeat refreshes the first mongoes' SDAM state in between
                   # the insert connection error and the single commit attempt.
                   heartbeatFrequencyMS: 30000
+                  appName: &appName transactionsClient
                 observeEvents:
                   - commandStartedEvent
             - database:
@@ -572,6 +573,7 @@ tests:
                 - isMaster
                 - hello
               closeConnection: true
+              appName: *appName
       -
         object: *collection1
         name: insertOne

--- a/source/transactions/tests/unified/write-concern.json
+++ b/source/transactions/tests/unified/write-concern.json
@@ -1417,7 +1417,9 @@
                   "update": {
                     "x": 1
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },
@@ -1522,7 +1524,9 @@
                       "x": 1
                     }
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },

--- a/source/transactions/tests/unified/write-concern.yml
+++ b/source/transactions/tests/unified/write-concern.yml
@@ -606,7 +606,7 @@ tests:
                 findAndModify: *collection_name
                 query: { _id: 0 }
                 update: { x: 1 }
-                new: false
+                new: { $$unsetOrMatches: false }
                 <<: *transactionCommandArgs
               commandName: findAndModify
               databaseName: *database_name
@@ -642,7 +642,7 @@ tests:
                 findAndModify: *collection_name
                 query: { _id: 0 }
                 update: { $inc: { x: 1 } }
-                new: false
+                new: { $$unsetOrMatches: false }
                 <<: *transactionCommandArgs
               commandName: findAndModify
               databaseName: *database_name


### PR DESCRIPTION
While migrating to unified spec format for transactions tests in CSHARP Driver I've run into 2 minor problems which I suggest to fix by this PR (please let me know if the changes makes sense and I'll create an appropriate ticket):
1) CSharp Driver does not write default values for optional fields, that's why we should make 'new' field of `findOneAndModify` command optional (`{ $$unsetOrMatches: false }`)
2) When there is a failPoint set on `hello` command, I suggest to use appName to let other connection work (we use additional client to setup and tire down the failpoints).