### PR TITLE
feat(DRIVERS-2903): use custom aws configuration

### DIFF
--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -1325,7 +1325,9 @@ in the MONGODB-OIDC specification, including sections or blocks that specificall
 
     - AWS_CREDENTIAL_PROVIDER
 
-        A function or object from the AWS SDK that can be used to return AWS credentials.
+        A function or object from the AWS SDK that can be used to return AWS credentials. Drivers MAY allow the user to
+        specify the callback using a `MongoClient` configuration instead of a mechanism property, depending on what is
+        idiomatic for the driver.
 
 <span id="built-in-provider-integrations"/>
 

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -995,7 +995,7 @@ and drivers MUST consult AWS SDK documentation to determine that format when imp
 be `AWS_CREDENTIAL_PROVIDER` and be part of the authentication mechanism properties options that can be provided to the
 client.
 
-Drivers that implement this MAY choose to implement the following scenarios when applicable in their labguage's SDK:
+Drivers that implement this MAY choose to implement the following scenarios when applicable in their language's SDK:
 
 1. The default SDK credential provider.
 2. A custom credential provider chain.

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -1007,6 +1007,7 @@ The order in which Drivers MUST search for credentials is:
 
 1. The URI
 2. Environment variables
+3. A custom AWS credential provider if the driver supports it.
 3. Using `AssumeRoleWithWebIdentity` if `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` are set.
 4. The ECS endpoint if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is set. Otherwise, the EC2 endpoint.
 

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -1008,8 +1008,8 @@ The order in which Drivers MUST search for credentials is:
 1. The URI
 2. Environment variables
 3. A custom AWS credential provider if the driver supports it.
-3. Using `AssumeRoleWithWebIdentity` if `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` are set.
-4. The ECS endpoint if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is set. Otherwise, the EC2 endpoint.
+4. Using `AssumeRoleWithWebIdentity` if `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` are set.
+5. The ECS endpoint if `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` is set. Otherwise, the EC2 endpoint.
 
 > [!NOTE]
 > See *Should drivers support accessing Amazon EC2 instance metadata in Amazon ECS* in [Q & A](#q-and-a)

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -989,10 +989,10 @@ application. Alternatively, you can create an AWS profile specifically for your 
 
 ##### Custom Credential Providers
 
-Drivers that choose to use the AWS SDK to fetch credentials MAY also allow users to provide a custom credential
-provider as an option to the `MongoClient`. The interface for the option provided depends on the individual language SDK
-and drivers MUST consult AWS SDK documentation to determine that format when implementing. The name of the option MUST
-be `AWS_CREDENTIAL_PROVIDER` and be part of the authentication mechanism properties options that can be provided to the
+Drivers that choose to use the AWS SDK to fetch credentials MAY also allow users to provide a custom credential provider
+as an option to the `MongoClient`. The interface for the option provided depends on the individual language SDK and
+drivers MUST consult AWS SDK documentation to determine that format when implementing. The name of the option MUST be
+`AWS_CREDENTIAL_PROVIDER` and be part of the authentication mechanism properties options that can be provided to the
 client.
 
 Drivers that implement this MAY choose to implement the following scenarios when applicable in their language's SDK:

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -987,6 +987,22 @@ those credentials will be used by default if AWS auth environment variables are 
 application. Alternatively, you can create an AWS profile specifically for your MongoDB credentials and set the
 `AWS_PROFILE` environment variable to that profile name."
 
+##### Custom Credential Providers
+
+Drivers that choose you use the AWS SDK to fetch credentials MAY also allow users to provide a custom credential
+provider as an option to the `MongoClient`. The interface for the option provided depends on the individual language SDK
+and drivers MUST consult AWS SDK documentation to determine that format when implementing. The name of the option MUST
+be `AWS_CREDENTIAL_PROVIDER` and be part of the authentication mechanism properties options that can be provided to the
+client.
+
+Drivers that implement this MAY choose to implement the following scenarios when applicable in their labguage's SDK:
+
+1. The default SDK credential provider.
+2. A custom credential provider chain.
+3. A single credential provider of any available SDK options provided by the SDK.
+
+##### Credential Fetching Order
+
 The order in which Drivers MUST search for credentials is:
 
 1. The URI
@@ -1305,6 +1321,10 @@ in the MONGODB-OIDC specification, including sections or blocks that specificall
         invoking any user-provided callbacks. This value MUST NOT be allowed in the URI connection string. The hostname
         check MUST be performed after SRV record resolution, if applicable. This property is only required for drivers
         that support the [Human Authentication Flow](#human-authentication-flow).
+
+    - AWS_CREDENTIAL_PROVIDER
+
+        A function or object from the AWS SDK that can be used to return AWS credentials.
 
 <span id="built-in-provider-integrations"/>
 
@@ -2133,6 +2153,8 @@ practice to avoid this. (See
 [IAM Roles for Tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html))
 
 ## Changelog
+
+- 2025-01-29: Add support for custom AWS credential providers.
 
 - 2024-10-02: Add Kubernetes built-in OIDC provider integration.
 

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -995,7 +995,7 @@ drivers MUST consult AWS SDK documentation to determine that format when impleme
 `AWS_CREDENTIAL_PROVIDER` and be part of the authentication mechanism properties options that can be provided to the
 client.
 
-Drivers that implement this MAY choose to implement the following scenarios when applicable in their language's SDK:
+Drivers MAY expose API for default providers for the following scenarios when applicable in their language's SDK:
 
 1. The default SDK credential provider.
 2. A custom credential provider chain.

--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -989,7 +989,7 @@ application. Alternatively, you can create an AWS profile specifically for your 
 
 ##### Custom Credential Providers
 
-Drivers that choose you use the AWS SDK to fetch credentials MAY also allow users to provide a custom credential
+Drivers that choose to use the AWS SDK to fetch credentials MAY also allow users to provide a custom credential
 provider as an option to the `MongoClient`. The interface for the option provided depends on the individual language SDK
 and drivers MUST consult AWS SDK documentation to determine that format when implementing. The name of the option MUST
 be `AWS_CREDENTIAL_PROVIDER` and be part of the authentication mechanism properties options that can be provided to the

--- a/source/auth/tests/mongodb-aws.md
+++ b/source/auth/tests/mongodb-aws.md
@@ -24,6 +24,8 @@ Token=AQoDYXdzEJr...<remainder of security token>
 If the driver supports user provided custom AWS credential providers, then the driver MUST also test the above scenarios
 2-6 with a user provided `AWS_CREDENTIAL_PROVIDER` auth mechanism property. This value MUST be the default credential
 provider from the AWS SDK. If the default provider does not cover all scenarios above, those not covered MAY be skipped.
+In these tests the driver MUST also assert that the user provided credential provider was called at least once in each
+test.
 
 If the driver supports a custom AWS credential provider, it MUST verify the custom provider was used when testing. This
 may be via a custom function or object that wraps the calls to the custom provider and asserts that it was called at

--- a/source/auth/tests/mongodb-aws.md
+++ b/source/auth/tests/mongodb-aws.md
@@ -25,6 +25,10 @@ If the driver supports user provided custom AWS credential providers, then the d
 2-6 with a user provided `AWS_CREDENTIAL_PROVIDER` auth mechanism property. This value MUST be the default credential
 provider from the AWS SDK. If the default provider does not cover all scenarios above, those not covered MAY be skipped.
 
+If the driver supports a custom AWS credential provider, it MUST verify the custom provider was used when testing. This
+may be via a custom function or object that wraps the calls to the custom provider and asserts that it was called at
+least once.
+
 ## Regular credentials
 
 Drivers MUST be able to authenticate by providing a valid access key id and secret access key pair as the username and

--- a/source/auth/tests/mongodb-aws.md
+++ b/source/auth/tests/mongodb-aws.md
@@ -21,6 +21,10 @@ SecretAccessKey=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 Token=AQoDYXdzEJr...<remainder of security token>
 ```
 
+If the driver supports user provided custom AWS credential providers, then the driver MUST also test the above scenarios
+2-6 with a user provided `AWS_CREDENTIAL_PROVIDER` auth mechanism property. This value MUST be the default credential
+provider from the AWS SDK. If the default provider does not cover all scenarios above, those not covered MAY be skipped.
+
 ## Regular credentials
 
 Drivers MUST be able to authenticate by providing a valid access key id and secret access key pair as the username and

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -480,8 +480,8 @@ See
 
 The `credentialProviders` property may be specified on [ClientEncryptionOpts](#ClientEncryptionOpts) or
 [AutoEncryptionOpts](#AutoEncryptionOpts). Current support is for AWS only, but is designed to be able to accomodate
-additional providers in the future. If a custom credential provider is present, it MUST be used instead of the
-default flow for fetching automatic credentials.
+additional providers in the future. If a custom credential provider is present, it MUST be used instead of the default
+flow for fetching automatic credentials.
 
 ```typescript
 interface CredentialProviders {
@@ -498,10 +498,10 @@ The following shows an example object of `CredentialProviders` for Node.js:
 ```typescript
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 
-{
-   // Acquire credentials for AWS:
-   aws: fromNodeProviderChain()
-}
+const creentialProviders = {
+  // Acquire credentials for AWS:
+  aws: fromNodeProviderChain()
+};
 ```
 
 #### kmsProviders

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -481,7 +481,8 @@ See
 The `credentialProviders` property may be specified on [ClientEncryptionOpts](#ClientEncryptionOpts) or
 [AutoEncryptionOpts](#AutoEncryptionOpts). Current support is for AWS only, but is designed to be able to accommodate
 additional providers in the future. If a custom credential provider is present, it MUST be used instead of the default
-flow for fetching automatic credentials.
+flow for fetching automatic credentials and if the `kmsProviders` are not configured for automatic credential fetching
+an error MUST be thrown.
 
 ```typescript
 interface CredentialProviders {

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -479,7 +479,7 @@ See
 #### credentialProviders
 
 The `credentialProviders` property may be specified on [ClientEncryptionOpts](#ClientEncryptionOpts) or
-[AutoEncryptionOpts](#AutoEncryptionOpts). Current support is for AWS only, but is designed to be able to accomodate
+[AutoEncryptionOpts](#AutoEncryptionOpts). Current support is for AWS only, but is designed to be able to accommodate
 additional providers in the future. If a custom credential provider is present, it MUST be used instead of the default
 flow for fetching automatic credentials.
 

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -499,10 +499,19 @@ The following shows an example object of `CredentialProviders` for Node.js:
 ```typescript
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 
-const credentialProviders = {
-  // Acquire credentials for AWS:
-  aws: fromNodeProviderChain()
-};
+const client = new MongoClient(process.env.MONGODB_URI, {
+  autoEncryption: {
+    keyVaultNamespace: 'keyvault.datakeys',
+    kmsProviders: {
+      // Set to empty map to use `credentialProviders`.
+      aws: {}
+   },
+    credentialProviders: {
+      // Acquire credentials for AWS:
+      aws: fromNodeProviderChain()
+    }
+  }
+}
 ```
 
 #### kmsProviders

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -489,7 +489,7 @@ interface CredentialProviders {
 }
 
 // The type of the AWS credential provider is dictated by the AWS SDK's credential provider for the specific
-// lamguage.
+// language.
 type AWSCredentialProvider = Function | Object;
 ```
 
@@ -498,7 +498,7 @@ The following shows an example object of `CredentialProviders` for Node.js:
 ```typescript
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 
-const creentialProviders = {
+const credentialProviders = {
   // Acquire credentials for AWS:
   aws: fromNodeProviderChain()
 };

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -486,7 +486,7 @@ an error MUST be thrown.
 
 ```typescript
 interface CredentialProviders {
-   aws? AWSCredentialProvider
+   aws?: AWSCredentialProvider
 }
 
 // The type of the AWS credential provider is dictated by the AWS SDK's credential provider for the specific

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -596,14 +596,14 @@ Once requested, drivers MUST create a new [KMSProviders](#kmsproviders) $P$ acco
     [ClientEncryptionOpts](#ClientEncryptionOpts) or [AutoEncryptionOpts](#AutoEncryptionOpts).
 2. Initialize $P$ to an empty [KMSProviders](#kmsproviders) object.
 3. If $K$ contains an `aws` property, and that property is an empty map:
-    1. If a custom credential provider is supplied via the `awsCredentialProvider` auto encryption option, use that to fetch the
-        credentials from AWS.
+    1. If a custom credential provider is supplied via the `awsCredentialProvider` auto encryption option, use that to
+        fetch the credentials from AWS.
     2. Otherwise:
         1. Attempt to obtain credentials $C$ from the environment using similar logic as is detailed in
-           [the obtaining-AWS-credentials section from the Driver Authentication specification](../auth/auth.md#obtaining-credentials),
-           but ignoring the case of loading the credentials from a URI
+            [the obtaining-AWS-credentials section from the Driver Authentication specification](../auth/auth.md#obtaining-credentials),
+            but ignoring the case of loading the credentials from a URI
         2. If credentials $C$ were successfully loaded, create a new [AWSKMSOptions](#AWSKMSOptions) map from $C$ and insert
-           that map onto $P$ as the `aws` property.
+            that map onto $P$ as the `aws` property.
 4. If $K$ contains an `gcp` property, and that property is an empty map:
     1. Attempt to obtain credentials $C$ from the environment logic as is detailed in
         [Obtaining GCP Credentials](#obtaining-gcp-credentials).
@@ -1285,6 +1285,11 @@ non-applicable queryType.
 
 rangeOpts only applies when algorithm is "Range". libmongocrypt returns an error if rangeOpts is set for a
 non-applicable algorithm.
+
+### Custom AWS Credential Provider
+
+When using a `ClientEncryption` object directly and a custom AWS credential provider is specified as an auth mechanism
+property on the `MongoClient`, that provider must be used to fetch the credentials for the KMS requests.
 
 ## User facing API: When Auto Encryption Fails
 
@@ -2425,6 +2430,8 @@ on. To support concurrent access of the key vault collection, the key management
 explicit session parameter as described in the [Drivers Sessions Specification](../sessions/driver-sessions.md).
 
 ## Changelog
+
+- 2024-02-19: Add custom options AWS credential provider.
 
 - 2024-10-09: Add retry prose test.
 

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -602,8 +602,8 @@ Once requested, drivers MUST create a new [KMSProviders](#kmsproviders) $P$ acco
         1. Attempt to obtain credentials $C$ from the environment using similar logic as is detailed in
             [the obtaining-AWS-credentials section from the Driver Authentication specification](../auth/auth.md#obtaining-credentials),
             but ignoring the case of loading the credentials from a URI
-        2. If credentials $C$ were successfully loaded, create a new [AWSKMSOptions](#AWSKMSOptions) map from $C$ and insert
-            that map onto $P$ as the `aws` property.
+        2. If credentials $C$ were successfully loaded, create a new [AWSKMSOptions](#AWSKMSOptions) map from $C$ and
+            insert that map onto $P$ as the `aws` property.
 4. If $K$ contains an `gcp` property, and that property is an empty map:
     1. Attempt to obtain credentials $C$ from the environment logic as is detailed in
         [Obtaining GCP Credentials](#obtaining-gcp-credentials).

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -622,8 +622,8 @@ Once requested, drivers MUST create a new [KMSProviders](#kmsproviders) $P$ acco
     [ClientEncryptionOpts](#ClientEncryptionOpts) or [AutoEncryptionOpts](#AutoEncryptionOpts).
 2. Initialize $P$ to an empty [KMSProviders](#kmsproviders) object.
 3. If $K$ contains an `aws` property, and that property is an empty map:
-    1. If a custom credential provider is supplied via the `credentialProviders.aws` applicable encryption option, use that to
-        fetch the credentials from AWS.
+    1. If a custom credential provider is supplied via the `credentialProviders.aws` applicable encryption option, use
+        that to fetch the credentials from AWS.
     2. Otherwise:
         1. Attempt to obtain credentials $C$ from the environment using similar logic as is detailed in
             [the obtaining-AWS-credentials section from the Driver Authentication specification](../auth/auth.md#obtaining-credentials),

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -380,6 +380,9 @@ class AutoEncryptionOpts {
    // without the MongoDB Enterprise Advanced licensed crypt_shared library.
    bypassQueryAnalysis: Optional<Boolean>; // Default false.
    keyExpirationMS: Optional<Uint64>; // Default 60000. 0 means "never expire".
+   // Depending on the language's AWS SDK, this is a function or object used to fetch
+   // credentials from the environment or identity provider.
+   awsCredentialProvider: Optional<Function> | Optional<Object>;
 }
 ```
 
@@ -593,11 +596,14 @@ Once requested, drivers MUST create a new [KMSProviders](#kmsproviders) $P$ acco
     [ClientEncryptionOpts](#ClientEncryptionOpts) or [AutoEncryptionOpts](#AutoEncryptionOpts).
 2. Initialize $P$ to an empty [KMSProviders](#kmsproviders) object.
 3. If $K$ contains an `aws` property, and that property is an empty map:
-    1. Attempt to obtain credentials $C$ from the environment using similar logic as is detailed in
-        [the obtaining-AWS-credentials section from the Driver Authentication specification](../auth/auth.md#obtaining-credentials),
-        but ignoring the case of loading the credentials from a URI
-    2. If credentials $C$ were successfully loaded, create a new [AWSKMSOptions](#AWSKMSOptions) map from $C$ and insert
-        that map onto $P$ as the `aws` property.
+    1. If a custom credential provider is supplied via the `awsCredentialProvider` auto encryption option, use that to fetch the
+        credentials from AWS.
+    2. Otherwise:
+        1. Attempt to obtain credentials $C$ from the environment using similar logic as is detailed in
+           [the obtaining-AWS-credentials section from the Driver Authentication specification](../auth/auth.md#obtaining-credentials),
+           but ignoring the case of loading the credentials from a URI
+        2. If credentials $C$ were successfully loaded, create a new [AWSKMSOptions](#AWSKMSOptions) map from $C$ and insert
+           that map onto $P$ as the `aws` property.
 4. If $K$ contains an `gcp` property, and that property is an empty map:
     1. Attempt to obtain credentials $C$ from the environment logic as is detailed in
         [Obtaining GCP Credentials](#obtaining-gcp-credentials).

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3756,7 +3756,7 @@ expect(dk).to.be.a(Binary);
 expect(calledCount).to.be.greaterThan(0);
 ```
 
-#### Case 3: Auto encryption with credentials and custom credential provider
+#### Case 3: `AutoEncryptionOpts` with `credentialProviders` and incorrect `kmsProviders`
 
 Create a `MongoClient` object with the following options:
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3707,7 +3707,7 @@ class ClientEncryptionOpts {
 
 Assert that an error is thrown.
 
-#### Case 2: Explicit encryption with custom credential provider
+#### Case 2: ClientEncryption with `credentialProviders` works
 
 Create a MongoClient named `setupClient`.
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3723,13 +3723,15 @@ class ClientEncryptionOpts {
 ```
 
 Use the client encryption to create a datakey using the "aws" KMS provider. This should successfully load and use the
-AWS credentials that were provided by the secrets manager for the remote provider. Assert the datakey was created.
+AWS credentials that were provided by the secrets manager for the remote provider. Assert the datakey was created and
+that the custom credential provider was called at least once.
 
 An example of this in Node.js:
 
 ```typescript
 import { ClientEncryption, MongoClient } from 'mongodb';
 
+let calledCount = 0;
 const masterKey = {
   region: '<aws region>',
   key: '<key for arn>'
@@ -3740,6 +3742,7 @@ const options = {
   kmsProviders: { aws: {} },
   credentialProviders: {
     aws: async () => {
+      calledCount++;
       return {
         accessKeyId: process.env.FLE_AWS_KEY,
         secretAccessKey: process.env.FLE_AWS_SECRET
@@ -3749,6 +3752,8 @@ const options = {
 };
 const clientEncryption = new ClientEncryption(keyVaultClient, options);
 const dk = await clientEncryption.createDataKey('aws', { masterKey });
+expect(dk).to.be.a(Binary);
+expect(calledCount).to.be.greaterThan(0);
 ```
 
 #### Case 3: Auto encryption with credentials and custom credential provider

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3683,3 +3683,43 @@ Run an aggregate operation on `db.csfle` with the following pipeline:
 ```
 
 Expect an exception to be thrown with a message containing the substring `Upgrade`.
+
+### 26. Custom AWS Credentials
+
+These tests require valid AWS credentials. Refer:
+[Automatic AWS Credentials](../client-side-encryption.md#automatic-credentials).
+
+#### Case 1: Explicit encryption with credentials and custom credential provider
+
+Create a MongoClient named `setupClient`.
+
+Create a [ClientEncryption](../client-side-encryption.md#clientencryption) object with the following options:
+
+```typescript
+class ClientEncryptionOpts {
+   keyVaultClient: <setupClient>,
+   keyVaultNamespace: "keyvault.datakeys",
+   kmsProviders: { "aws": { "accessKeyId": <set from environment>, "secretAccessKey": <set from environment> } },
+   credentialProviders: { "aws": <default provider from AWS SDK> }
+}
+```
+
+Assert that an error is thrown.
+
+#### Case 2: Explicit encryption with custom credential provider
+
+Create a MongoClient named `setupClient`.
+
+Create a [ClientEncryption](../client-side-encryption.md#clientencryption) object with the following options:
+
+```typescript
+class ClientEncryptionOpts {
+   keyVaultClient: <setupClient>,
+   keyVaultNamespace: "keyvault.datakeys",
+   kmsProviders: { "aws": {} },
+   credentialProviders: { "aws": <default provider from AWS SDK> }
+}
+```
+
+Use the client encryption to create a datakey using the "aws" KMS provider. This should successfully load and use
+the AWS credentials that were defined in the environment.

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3686,9 +3686,9 @@ Expect an exception to be thrown with a message containing the substring `Upgrad
 
 ### 26. Custom AWS Credentials
 
-These tests require valid AWS credentials for the remote KMS provider via the secrets manager. These tests MUST NOT
-run inside an AWS environment that has the same credentials set in order to properly ensure the tests would fail
-using on-demand credentials.
+These tests require valid AWS credentials for the remote KMS provider via the secrets manager. These tests MUST NOT run
+inside an AWS environment that has the same credentials set in order to properly ensure the tests would fail using
+on-demand credentials.
 
 #### Case 1: Explicit encryption with credentials and custom credential provider
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3725,6 +3725,32 @@ class ClientEncryptionOpts {
 Use the client encryption to create a datakey using the "aws" KMS provider. This should successfully load and use the
 AWS credentials that were provided by the secrets manager for the remote provider. Assert the datakey was created.
 
+An example of this in Node.js:
+
+```typescript
+import { ClientEncryption, MongoClient } from 'mongodb';
+
+const masterKey = {
+  region: '<aws region>',
+  key: '<key for arn>'
+};
+const keyVaultClient = new MongoClient(process.env.MONGODB_URI);
+const options = {
+  keyVaultNamespace: 'keyvault.datakeys',
+  kmsProviders: { aws: {} },
+  credentialProviders: {
+    aws: async () => {
+      return {
+        accessKeyId: process.env.FLE_AWS_KEY,
+        secretAccessKey: process.env.FLE_AWS_SECRET
+      };
+    }
+  }
+};
+const clientEncryption = new ClientEncryption(keyVaultClient, options);
+const dk = await clientEncryption.createDataKey('aws', { masterKey });
+```
+
 #### Case 3: Auto encryption with credentials and custom credential provider
 
 Create a `MongoClient` object with the following options:

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3686,9 +3686,9 @@ Expect an exception to be thrown with a message containing the substring `Upgrad
 
 ### 26. Custom AWS Credentials
 
-These tests require valid AWS credentials for the remote KMS provider via the secrets manager. These tests MUST NOT run
-inside an AWS environment that has the same credentials set in order to properly ensure the tests would fail using
-on-demand credentials.
+These tests require valid AWS credentials for the remote KMS provider via the secrets manager (FLE_AWS_KEY and
+FLE_AWS_SECRET). These tests MUST NOT run inside an AWS environment that has the same credentials set in order to
+properly ensure the tests would fail using on-demand credentials.
 
 #### Case 1: Explicit encryption with credentials and custom credential provider
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3721,5 +3721,5 @@ class ClientEncryptionOpts {
 }
 ```
 
-Use the client encryption to create a datakey using the "aws" KMS provider. This should successfully load and use
-the AWS credentials that were defined in the environment.
+Use the client encryption to create a datakey using the "aws" KMS provider. This should successfully load and use the
+AWS credentials that were defined in the environment.

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3690,7 +3690,7 @@ These tests require valid AWS credentials for the remote KMS provider via the se
 FLE_AWS_SECRET). These tests MUST NOT run inside an AWS environment that has the same credentials set in order to
 properly ensure the tests would fail using on-demand credentials.
 
-#### Case 1: Explicit encryption with credentials and custom credential provider
+#### Case 1: ClientEncryption with `credentialProviders` and incorrect `kmsProviders`
 
 Create a MongoClient named `setupClient`.
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3717,9 +3717,9 @@ class ClientEncryptionOpts {
    keyVaultClient: <setupClient>,
    keyVaultNamespace: "keyvault.datakeys",
    kmsProviders: { "aws": {} },
-   credentialProviders: { "aws": <default provider from AWS SDK> }
+   credentialProviders: { "aws": <object/function that returns valid credentials from the environment> }
 }
 ```
 
 Use the client encryption to create a datakey using the "aws" KMS provider. This should successfully load and use the
-AWS credentials that were defined in the environment.
+AWS credentials that were defined in the environment. Assert the datakey was created.


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Adds section to auth spec and CSFLE spec on allowing user provided custom credential providers for AWS and notes on testing.

Node implementation: https://github.com/mongodb/node-mongodb-native/pull/4373

- [x] Update changelog.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
