### PR TITLE
DRIVERS-3082 add prose tests for `$lookup`

### DIFF
--- a/source/client-side-encryption/etc/data/lookup/key-doc.json
+++ b/source/client-side-encryption/etc/data/lookup/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "sHe0kz57YW7v8g9VP9sf/+K1ex4JqKc5rf/URX3n3p8XdZ6+15uXPaSayC6adWbNxkFskuMCOifDoTT+rkqMtFkDclOy884RuGGtUysq3X7zkAWYTKi8QAfKkajvVbZl2y23UqgVasdQu3OVBQCrH/xY00nNAs/52e958nVjBuzQkSb1T8pKJAyjZsHJ60+FtnfafDZSTAIBJYn7UWBCwQ==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/source/client-side-encryption/etc/data/lookup/schema-csfle.json
+++ b/source/client-side-encryption/etc/data/lookup/schema-csfle.json
@@ -1,0 +1,19 @@
+{
+    "properties": {
+        "csfle": {
+            "encrypt": {
+                "keyId": [
+                    {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    }
+                ],
+                "bsonType": "string",
+                "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+        }
+    },
+    "bsonType": "object"
+}

--- a/source/client-side-encryption/etc/data/lookup/schema-csfle2.json
+++ b/source/client-side-encryption/etc/data/lookup/schema-csfle2.json
@@ -1,0 +1,19 @@
+{
+    "properties": {
+        "csfle2": {
+            "encrypt": {
+                "keyId": [
+                    {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    }
+                ],
+                "bsonType": "string",
+                "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+        }
+    },
+    "bsonType": "object"
+}

--- a/source/client-side-encryption/etc/data/lookup/schema-qe.json
+++ b/source/client-side-encryption/etc/data/lookup/schema-qe.json
@@ -1,0 +1,20 @@
+{
+    "escCollection": "enxcol_.qe.esc",
+    "ecocCollection": "enxcol_.qe.ecoc",
+    "fields": [
+        {
+            "keyId": {
+                "$binary": {
+                    "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                    "subType": "04"
+                }
+            },
+            "path": "qe",
+            "bsonType": "string",
+            "queries": {
+                "queryType": "equality",
+                "contention": 0
+            }
+        }
+    ]
+}

--- a/source/client-side-encryption/etc/data/lookup/schema-qe2.json
+++ b/source/client-side-encryption/etc/data/lookup/schema-qe2.json
@@ -1,0 +1,20 @@
+{
+    "escCollection": "enxcol_.qe2.esc",
+    "ecocCollection": "enxcol_.qe2.ecoc",
+    "fields": [
+        {
+            "keyId": {
+                "$binary": {
+                    "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                    "subType": "04"
+                }
+            },
+            "path": "qe2",
+            "bsonType": "string",
+            "queries": {
+                "queryType": "equality",
+                "contention": 0
+            }
+        }
+    ]
+}

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3659,9 +3659,9 @@ Run an aggregate operation on `db.csfle` with the following pipeline:
 
 Expect an exception to be thrown with a message containing the substring `not supported`.
 
-#### Case 9: test error with pre-8.1
+#### Case 9: test error with \<8.1
 
-This case requires mongocryptd/crypt_shared pre-8.1.
+This case requires mongocryptd/crypt_shared \<8.1.
 
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3416,7 +3416,8 @@ Repeat this test with the `azure` and `gcp` masterKeys.
 
 ### 25. Test $lookup
 
-Unless otherwise noted, these tests require: libmongocrypt 1.13.0, mongocryptd/crypt_shared 8.1+, and server 8.1+. Skip on standalone.
+Unless otherwise noted, these tests require: libmongocrypt 1.13.0, mongocryptd/crypt_shared 8.1+, and server 8.1+. Skip
+on standalone.
 
 The syntax `<filename.json>` is used to refer to the content of the corresponding file in `../etc/data/lookup`.
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3420,8 +3420,7 @@ This test requires libmongocrypt 1.13.0. Unless otherwise noted, tests require m
 
 Tests require server support of QE: Require MongoDB server 7.0+. Skip on standalone.
 
-The syntax `<filename.json>` is used to refer to files in
-[source/client-side-encryption/etc/data/lookup](../etc/data/lookup/).
+The syntax `<filename.json>` is used to refer to files in `../etc/data/lookup`.
 
 #### Setup
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3424,19 +3424,6 @@ The syntax `<filename.json>` is used to refer to the content of the correspondin
 
 #### Setup
 
-Create an unencrypted MongoClient named `unencryptedClient`. Drop database `db`.
-
-Insert `<key-doc.json>` into `db.keyvault` with majority write concern.
-
-Create the following collections:
-
-- `db.csfle` with options: `{ "validator": { "$jsonSchema": "<schema-csfle.json>"}}`.
-- `db.csfle2` with options: `{ "validator": { "$jsonSchema": "<schema-csfle2.json>"}}`.
-- `db.qe` with options: `{ "encryptedFields": "<schema-qe.json>"}`.
-- `db.qe2` with options: `{ "encryptedFields": "<schema-qe2.json>"}`.
-- `db.no_schema` with no options.
-- `db.no_schema2` with no options.
-
 Create an encrypted MongoClient named `encryptedClient` configured with:
 
 ```python
@@ -3445,6 +3432,19 @@ AutoEncryptionOpts(
     kmsProviders={"local": { "key": "<base64 decoding of LOCAL_MASTERKEY>" }}
 )
 ```
+
+Use `encryptedClient` to drop `db.keyvault`. Insert `<key-doc.json>` into `db.keyvault` with majority write concern.
+
+Use `encryptedClient` to drop and create the following collections:
+
+- `db.csfle` with options: `{ "validator": { "$jsonSchema": "<schema-csfle.json>"}}`.
+- `db.csfle2` with options: `{ "validator": { "$jsonSchema": "<schema-csfle2.json>"}}`.
+- `db.qe` with options: `{ "encryptedFields": "<schema-qe.json>"}`.
+- `db.qe2` with options: `{ "encryptedFields": "<schema-qe2.json>"}`.
+- `db.no_schema` with no options.
+- `db.no_schema2` with no options.
+
+Create an unencrypted MongoClient named `unencryptedClient`.
 
 Insert documents with `encryptedClient`:
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3419,7 +3419,7 @@ Repeat this test with the `azure` and `gcp` masterKeys.
 This test requires libmongocrypt 1.13.0. Unless otherwise noted, tests require mongocryptd/crypt_shared 8.1+.
 
 The syntax `<filename.json>` is used to refer to files in
-[source/client-side-encryption/etc/data/lookup](/source/client-side-encryption/etc/data/lookup/).
+[source/client-side-encryption/etc/data/lookup](../etc/data/lookup/).
 
 #### Setup
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3424,7 +3424,7 @@ The syntax `<filename.json>` is used to refer to the content of the correspondin
 
 #### Setup
 
-Create an unencrypted MongoClient. Drop database `db`.
+Create an unencrypted MongoClient named `unencryptedClient`. Drop database `db`.
 
 Insert `<key-doc.json>` into `db.keyvault` with majority write concern.
 
@@ -3437,7 +3437,7 @@ Create the following collections:
 - `db.no_schema` with no options.
 - `db.no_schema2` with no options.
 
-Create an encrypted MongoClient configured with:
+Create an encrypted MongoClient named `encryptedClient` configured with:
 
 ```python
 AutoEncryptionOpts(
@@ -3446,23 +3446,23 @@ AutoEncryptionOpts(
 )
 ```
 
-Insert documents with the encrypted MongoClient:
+Insert documents with `encryptedClient`:
 
 - `{"csfle": "csfle"}` into `db.csfle`
-    - Use the unencrypted client to retrieve it. Assert the `csfle` field is BSON binary.
+    - Use `unencryptedClient` to retrieve it. Assert the `csfle` field is BSON binary.
 - `{"csfle2": "csfle2"}` into `db.csfle2`
-    - Use the unencrypted client to retrieve it. Assert the `csfle2` field is BSON binary.
+    - Use `unencryptedClient` to retrieve it. Assert the `csfle2` field is BSON binary.
 - `{"qe": "qe"}` into `db.qe`
-    - Use the unencrypted client to retrieve it. Assert the `qe` field is BSON binary.
+    - Use `unencryptedClient` to retrieve it. Assert the `qe` field is BSON binary.
 - `{"qe2": "qe2"}` into `db.qe2`
-    - Use the unencrypted client to retrieve it. Assert the `qe2` field is BSON binary.
+    - Use `unencryptedClient` to retrieve it. Assert the `qe2` field is BSON binary.
 - `{"no_schema": "no_schema"}` into `db.no_schema`
 - `{"no_schema2": "no_schema2"}` into `db.no_schema2`
 
 #### Case 1: `db.csfle` joins `db.no_schema`
 
-Create a new encrypted MongoClient with the same `AutoEncryptionOpts` as the setup. (Creating a new client prevents
-schema caching from impacting the test).
+Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
+impacting the test).
 
 Run an aggregate operation on `db.csfle` with the following pipeline:
 
@@ -3484,8 +3484,8 @@ Expect one document to be returned matching: `{"csfle" : "csfle", "matched" : [ 
 
 #### Case 2: `db.qe` joins `db.no_schema`
 
-Create a new encrypted MongoClient with the same `AutoEncryptionOpts` as the setup. (Creating a new client prevents
-schema caching from impacting the test).
+Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
+impacting the test).
 
 Run an aggregate operation on `db.qe` with the following pipeline:
 
@@ -3508,8 +3508,8 @@ Expect one document to be returned matching: `{"qe" : "qe", "matched" : [ {"no_s
 
 #### Case 3: `db.no_schema` joins `db.csfle`
 
-Create a new encrypted MongoClient with the same `AutoEncryptionOpts` as the setup. (Creating a new client prevents
-schema caching from impacting the test).
+Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
+impacting the test).
 
 Run an aggregate operation on `db.no_schema` with the following pipeline:
 
@@ -3531,8 +3531,8 @@ Expect one document to be returned matching: `{"no_schema" : "no_schema", "match
 
 #### Case 4: `db.no_schema` joins `db.qe`
 
-Create a new encrypted MongoClient with the same `AutoEncryptionOpts` as the setup. (Creating a new client prevents
-schema caching from impacting the test).
+Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
+impacting the test).
 
 Run an aggregate operation on `db.no_schema` with the following pipeline:
 
@@ -3554,8 +3554,8 @@ Expect one document to be returned matching: `{"no_schema" : "no_schema", "match
 
 #### Case 5: `db.csfle` joins `db.csfle2`
 
-Create a new encrypted MongoClient with the same `AutoEncryptionOpts` as the setup. (Creating a new client prevents
-schema caching from impacting the test).
+Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
+impacting the test).
 
 Run an aggregate operation on `db.csfle` with the following pipeline:
 
@@ -3577,8 +3577,8 @@ Expect one document to be returned matching: `{"csfle" : "csfle", "matched" : [ 
 
 #### Case 6: `db.qe` joins `db.qe2`
 
-Create a new encrypted MongoClient with the same `AutoEncryptionOpts` as the setup. (Creating a new client prevents
-schema caching from impacting the test).
+Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
+impacting the test).
 
 Run an aggregate operation on `db.qe` with the following pipeline:
 
@@ -3600,8 +3600,8 @@ Expect one document to be returned matching: `{"qe" : "qe", "matched" : [ {"qe2"
 
 #### Case 7: `db.no_schema` joins `db.no_schema2`
 
-Create a new encrypted MongoClient with the same `AutoEncryptionOpts` as the setup. (Creating a new client prevents
-schema caching from impacting the test).
+Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
+impacting the test).
 
 Run an aggregate operation on `db.no_schema` with the following pipeline:
 
@@ -3624,8 +3624,8 @@ Expect one document to be returned matching:
 
 #### Case 8: `db.csfle` joins `db.qe`
 
-Create a new encrypted MongoClient with the same `AutoEncryptionOpts` as the setup. (Creating a new client prevents
-schema caching from impacting the test).
+Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
+impacting the test).
 
 Run an aggregate operation on `db.csfle` with the following pipeline:
 
@@ -3649,8 +3649,8 @@ Expect an exception to be thrown with a message containing the substring `not su
 
 This case requires mongocryptd/crypt_shared \<8.1.
 
-Create a new encrypted MongoClient with the same `AutoEncryptionOpts` as the setup. (Creating a new client prevents
-schema caching from impacting the test).
+Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
+impacting the test).
 
 Run an aggregate operation on `db.csfle` with the following pipeline:
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3420,7 +3420,7 @@ Unless otherwise noted, these tests require: libmongocrypt 1.13.0, mongocryptd/c
 
 Tests require server support of QE: Require MongoDB server 7.0+. Skip on standalone.
 
-The syntax `<filename.json>` is used to refer to files in `../etc/data/lookup`.
+The syntax `<filename.json>` is used to refer to the content of the corresponding file in `../etc/data/lookup`.
 
 #### Setup
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3416,9 +3416,7 @@ Repeat this test with the `azure` and `gcp` masterKeys.
 
 ### 25. Test $lookup
 
-Unless otherwise noted, these tests require: libmongocrypt 1.13.0, mongocryptd/crypt_shared 8.1+, and server 8.1+.
-
-Tests require server support of QE: Require MongoDB server 7.0+. Skip on standalone.
+Unless otherwise noted, these tests require: libmongocrypt 1.13.0, mongocryptd/crypt_shared 8.1+, and server 8.1+. Skip on standalone.
 
 The syntax `<filename.json>` is used to refer to the content of the corresponding file in `../etc/data/lookup`.
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3416,7 +3416,7 @@ Repeat this test with the `azure` and `gcp` masterKeys.
 
 ### 25. Test $lookup
 
-This test requires libmongocrypt 1.13.0. Unless otherwise noted, tests require mongocryptd/crypt_shared 8.1+.
+Unless otherwise noted, these tests require: libmongocrypt 1.13.0, mongocryptd/crypt_shared 8.1+.
 
 Tests require server support of QE: Require MongoDB server 7.0+. Skip on standalone.
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3416,8 +3416,7 @@ Repeat this test with the `azure` and `gcp` masterKeys.
 
 ### 25. Test $lookup
 
-Unless otherwise noted, these tests require: libmongocrypt 1.13.0, mongocryptd/crypt_shared 8.1+, and server 8.1+. Skip
-on standalone.
+All tests require libmongocrypt 1.13.0, server 7.0+, and must be skipped on standalone. Tests define more constraints.
 
 The syntax `<filename.json>` is used to refer to the content of the corresponding file in `../etc/data/lookup`.
 
@@ -3460,6 +3459,8 @@ Insert documents with `encryptedClient`:
 
 #### Case 1: `db.csfle` joins `db.no_schema`
 
+Test requires server 8.1+ and mongocryptd/crypt_shared 8.1+.
+
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).
 
@@ -3482,6 +3483,8 @@ Run an aggregate operation on `db.csfle` with the following pipeline:
 Expect one document to be returned matching: `{"csfle" : "csfle", "matched" : [ {"no_schema" : "no_schema"} ]}`.
 
 #### Case 2: `db.qe` joins `db.no_schema`
+
+Test requires server 8.1+ and mongocryptd/crypt_shared 8.1+.
 
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).
@@ -3507,6 +3510,8 @@ Expect one document to be returned matching: `{"qe" : "qe", "matched" : [ {"no_s
 
 #### Case 3: `db.no_schema` joins `db.csfle`
 
+Test requires server 8.1+ and mongocryptd/crypt_shared 8.1+.
+
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).
 
@@ -3529,6 +3534,8 @@ Run an aggregate operation on `db.no_schema` with the following pipeline:
 Expect one document to be returned matching: `{"no_schema" : "no_schema", "matched" : [ {"csfle" : "csfle"} ]}`.
 
 #### Case 4: `db.no_schema` joins `db.qe`
+
+Test requires server 8.1+ and mongocryptd/crypt_shared 8.1+.
 
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).
@@ -3553,6 +3560,8 @@ Expect one document to be returned matching: `{"no_schema" : "no_schema", "match
 
 #### Case 5: `db.csfle` joins `db.csfle2`
 
+Test requires server 8.1+ and mongocryptd/crypt_shared 8.1+.
+
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).
 
@@ -3576,6 +3585,8 @@ Expect one document to be returned matching: `{"csfle" : "csfle", "matched" : [ 
 
 #### Case 6: `db.qe` joins `db.qe2`
 
+Test requires server 8.1+ and mongocryptd/crypt_shared 8.1+.
+
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).
 
@@ -3598,6 +3609,8 @@ Run an aggregate operation on `db.qe` with the following pipeline:
 Expect one document to be returned matching: `{"qe" : "qe", "matched" : [ {"qe2" : "qe2"} ]}`.
 
 #### Case 7: `db.no_schema` joins `db.no_schema2`
+
+Test requires server 8.1+ and mongocryptd/crypt_shared 8.1+.
 
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).
@@ -3623,6 +3636,8 @@ Expect one document to be returned matching:
 
 #### Case 8: `db.csfle` joins `db.qe`
 
+Test requires server 8.1+ and mongocryptd/crypt_shared 8.1+.
+
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).
 
@@ -3644,9 +3659,9 @@ Run an aggregate operation on `db.csfle` with the following pipeline:
 
 Expect an exception to be thrown with a message containing the substring `not supported`.
 
-#### Case 9: test error with \<8.1
+#### Case 9: test error with pre-8.1
 
-This case requires mongocryptd/crypt_shared \<8.1.
+This case requires mongocryptd/crypt_shared pre-8.1.
 
 Recreate `encryptedClient` with the same `AutoEncryptionOpts` as the setup. (Recreating prevents schema caching from
 impacting the test).

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3418,6 +3418,8 @@ Repeat this test with the `azure` and `gcp` masterKeys.
 
 This test requires libmongocrypt 1.13.0. Unless otherwise noted, tests require mongocryptd/crypt_shared 8.1+.
 
+Tests require server support of QE: Require MongoDB server 7.0+. Skip on standalone.
+
 The syntax `<filename.json>` is used to refer to files in
 [source/client-side-encryption/etc/data/lookup](../etc/data/lookup/).
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3416,7 +3416,7 @@ Repeat this test with the `azure` and `gcp` masterKeys.
 
 ### 25. Test $lookup
 
-Unless otherwise noted, these tests require: libmongocrypt 1.13.0, mongocryptd/crypt_shared 8.1+.
+Unless otherwise noted, these tests require: libmongocrypt 1.13.0, mongocryptd/crypt_shared 8.1+, and server 8.1+.
 
 Tests require server support of QE: Require MongoDB server 7.0+. Skip on standalone.
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3426,7 +3426,7 @@ The syntax `<filename.json>` is used to refer to the content of the correspondin
 
 Create an unencrypted MongoClient. Drop database `db`.
 
-Insert `<key-doc.json>` into `db.keyvault`.
+Insert `<key-doc.json>` into `db.keyvault` with majority write concern.
 
 Create the following collections:
 


### PR DESCRIPTION
# Summary

Add prose test for `$lookup` support in QE/CSFLE.

Tests were run in the C driver in [this patch](https://spruce.mongodb.com/version/67b1feac78623900074b9ef8). Note: `latest` tasks were updated to use `latest-build` to use unreleased 8.1 builds (see [slack](https://mongodb.slack.com/archives/C72LB5RPV/p1739884710850709) for background).

Testing requires a unreleased version of libmongocrypt to include changes from [MONGOCRYPT-723](https://jira.mongodb.org/browse/MONGOCRYPT-723). Binaries are available on [this patch build](https://spruce.mongodb.com/task/libmongocrypt_publish_upload_all_patch_c3dff011c9c0dc326c31414471a4b613e0d91365_67af62d2eff4dc0007490c8f_25_02_14_15_35_47/files?execution=0) or by building from source at https://github.com/mongodb/libmongocrypt/commit/33fdf65cce5a0c0cdd293c64ed40e4a8205c3ce0.

The failed `Markdown Link Check` on the [GitHub action](https://github.com/mongodb/specifications/actions/runs/13551263630/job/37875175396?pr=1757) appears unrelated (and is failing on master).

# libmongocrypt protocol change

libmongocrypt's protocol previously assumed auto encrypting a command only required at most one schema. With `$lookup` there can be multiple schemas on an `aggregate` command. As a result, a small driver change is needed: feed all listCollections results to libmongocrypt in the `MONGOCRYPT_CTX_NEED_MONGO_COLLINFO(_WITH_DB)` states. The previous protocol only required returning the first. Call `mongocrypt_setopt_enable_multiple_collinfo` to indicate the new behavior is implemented (otherwise libmongocrypt returns an error if a command requires multiple schemas).

The libmongocrypt documentation includes a change to the protocol [in integrating.md](https://github.com/mongodb/libmongocrypt/commit/33fdf65cce5a0c0cdd293c64ed40e4a8205c3ce0#diff-831b7c30649e24ea657915e29deba4aec0b05937c9d96a76cf22e89dca32d042R143).

See the small protocol change implemented in the C driver [here](https://github.com/kevinAlbs/mongo-c-driver/commit/eb18fc82e822424a4a84c7754debd707ba3b1e9a).


<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ **Test changes only**
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
