### PR TITLE
DRIVERS-3108 skip non-LB test on >=8.1 server

### DIFF
--- a/source/load-balancers/tests/non-lb-connection-establishment.json
+++ b/source/load-balancers/tests/non-lb-connection-establishment.json
@@ -57,6 +57,19 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.0.99",
+          "topologies": [
+            "single"
+          ]
+        },
+        {
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "runCommand",

--- a/source/load-balancers/tests/non-lb-connection-establishment.yml
+++ b/source/load-balancers/tests/non-lb-connection-establishment.yml
@@ -42,6 +42,11 @@ tests:
   # If the server is not configured to be behind a load balancer and the URI contains loadBalanced=true, the driver
   # should error during the connection handshake because the server's hello response does not contain a serviceId field.
   - description: operations against non-load balanced clusters fail if URI contains loadBalanced=true
+    runOnRequirements:
+      - maxServerVersion: 8.0.99 # DRIVERS-3108: Skip test on >=8.1 mongod. SERVER-85804 changes a non-LB mongod to close connection.
+        topologies: [ single ]
+      - topologies: [ sharded ]
+
     operations:
       - name: runCommand
         object: *lbTrueDatabase


### PR DESCRIPTION
Skip the test `operations against non-load balanced clusters fail if URI contains loadBalanced=true` on >= 8.1. See DRIVERS-3108 for motivation.

Tested in the C driver in [this patch](https://spruce.mongodb.com/version/67b4ad051cd3dc00077ea2ab). Patch also applies https://github.com/mongodb-labs/drivers-evergreen-tools/pull/607 to test unreleased 8.1 servers. The failure on macOS appears to be a separate issue.

---
<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ **Test changes only**
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
