### PR TITLE
Make `nsType` optional in ChangeStreamDocument

### DIFF
--- a/source/change-streams/change-streams.md
+++ b/source/change-streams/change-streams.md
@@ -1016,6 +1016,8 @@ There should be no backwards compatibility concerns.
 
 ## Changelog
 
+- 2025-02-24: Make `nsType` `Optional` to match other optional fields in the change stream spec.
+
 - 2025-01-29: Add `nsType` to `ChangeStreamDocument`.
 
 - 2024-02-09: Migrated from reStructuredText to Markdown.

--- a/source/change-streams/change-streams.md
+++ b/source/change-streams/change-streams.md
@@ -128,7 +128,7 @@ class ChangeStreamDocument {
    * 
    * @since 8.1.0
    */
-  nsType: "collection" | "timeseries" | "view" | null;
+  nsType: Optional<"collection" | "timeseries" | "view">;
 
   /**
    * Only present for ops of type 'rename'.


### PR DESCRIPTION
Specifications typically use `Optional<...>` instead of `| null` to indicate that a field is only present in some circumstances because drivers represent conditionally present values differently.  While some drivers might use `null` to indicate that a value isn't present, other drivers (like Node) omit keys entirely.  

The changes in this PR make `nsInfo` consistent with other optional fields (ex: `to` or `operationDescription`).
Please complete the following before merging:

- [ ] Update changelog.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
