### PR TITLE
DRIVERS-2915 Add ENVIRONMENT auth mechanism property to test URIs

### DIFF
--- a/source/connection-string/tests/valid-options.json
+++ b/source/connection-string/tests/valid-options.json
@@ -40,7 +40,7 @@
     },
     {
       "description": "Colon in a key value pair",
-      "uri": "mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster",
+      "uri": "mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster,ENVIRONMENT:azure",
       "valid": true,
       "warning": false,
       "hosts": [
@@ -53,7 +53,8 @@
       "auth": null,
       "options": {
         "authmechanismProperties": {
-          "TOKEN_RESOURCE": "mongodb://test-cluster"
+          "TOKEN_RESOURCE": "mongodb://test-cluster",
+          "ENVIRONMENT": "azure"
         }
       }
     }

--- a/source/connection-string/tests/valid-options.yml
+++ b/source/connection-string/tests/valid-options.yml
@@ -30,11 +30,11 @@ tests:
               tls: true
     -
         description: Colon in a key value pair
-        uri: mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster
+        uri: mongodb://example.com/?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster,ENVIRONMENT:azure
         valid: true
         warning: false
         hosts:
-            - 
+            -
                 type: hostname
                 host: example.com
                 port: ~
@@ -42,3 +42,4 @@ tests:
         options:
             authmechanismProperties:
                 TOKEN_RESOURCE: 'mongodb://test-cluster'
+                ENVIRONMENT: azure

--- a/source/connection-string/tests/valid-warnings.json
+++ b/source/connection-string/tests/valid-warnings.json
@@ -108,11 +108,7 @@
       ],
       "auth": null,
       "options": {
-        "authMechanism": "MONGODB-OIDC",
-        "authmechanismProperties": {
-          "TOKEN_RESOURCE": "mongodb://test-cluster",
-          "ENVIRONMENT": "azure"
-        }
+        "authMechanism": "MONGODB-OIDC"
       }
     }
   ]

--- a/source/connection-string/tests/valid-warnings.json
+++ b/source/connection-string/tests/valid-warnings.json
@@ -96,7 +96,7 @@
     },
     {
       "description": "Comma in a key value pair causes a warning",
-      "uri": "mongodb://localhost?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2",
+      "uri": "mongodb://localhost?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2,ENVIRONMENT:azure",
       "valid": true,
       "warning": true,
       "hosts": [
@@ -108,7 +108,11 @@
       ],
       "auth": null,
       "options": {
-        "authMechanism": "MONGODB-OIDC"
+        "authMechanism": "MONGODB-OIDC",
+        "authmechanismProperties": {
+          "TOKEN_RESOURCE": "mongodb://test-cluster",
+          "ENVIRONMENT": "azure"
+        }
       }
     }
   ]

--- a/source/connection-string/tests/valid-warnings.yml
+++ b/source/connection-string/tests/valid-warnings.yml
@@ -86,6 +86,3 @@ tests:
         auth: ~
         options:
             authMechanism: MONGODB-OIDC
-            authmechanismProperties:
-                TOKEN_RESOURCE: 'mongodb://test-cluster'
-                ENVIRONMENT: azure

--- a/source/connection-string/tests/valid-warnings.yml
+++ b/source/connection-string/tests/valid-warnings.yml
@@ -75,7 +75,7 @@ tests:
         options: ~
     -
         description: Comma in a key value pair causes a warning
-        uri: mongodb://localhost?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2
+        uri: mongodb://localhost?authMechanism=MONGODB-OIDC&authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2,ENVIRONMENT:azure
         valid: true
         warning: true
         hosts:
@@ -86,3 +86,6 @@ tests:
         auth: ~
         options:
             authMechanism: MONGODB-OIDC
+            authmechanismProperties:
+                TOKEN_RESOURCE: 'mongodb://test-cluster'
+                ENVIRONMENT: azure


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Tested in https://github.com/mongodb/mongo-rust-driver/pull/1315.

I didn't file a separate ticket for this as I don't expect other drivers will need to sync these tests. Added an "ENVIRONMENT" entry to a few tests that were failing in the Rust driver due to enforcement of the rule listed [here](https://github.com/mongodb/specifications/blob/master/source/auth/auth.md#mongocredential-properties-6) regarding the combination of "ENVIRONMENT" and "TOKEN_RESOURCE".

Please complete the following before merging:

- [ ] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
