### PR TITLE
DRIVERS-3007: Rename WriteConcernFailed to WriteConcernTimeout

### DIFF
--- a/source/read-write-concern/read-write-concern.md
+++ b/source/read-write-concern/read-write-concern.md
@@ -427,8 +427,8 @@ writeConcernError but may not be exhaustive. Note that some errors have been abb
 - `{ok:1, writeConcernError: {code: 11600, codeName: "InterruptedAtShutdown"}}`
 - `{ok:1, writeConcernError: {code: 11601, codeName: "Interrupted"}}`
 - `{ok:1, writeConcernError: {code: 11602, codeName: "InterruptedDueToReplStateChange"}}`
-- `{ok:1, writeConcernError: {code: 64, codeName: "WriteConcernFailed", errmsg: "waiting for replication timed out", errInfo: {wtimeout: True}}}`
-- `{ok:1, writeConcernError: {code: 64, codeName: "WriteConcernFailed", errmsg: "multiple errors reported : {...} at shardName1 :: and :: {...} at shardName2"}}`[^1]
+- `{ok:1, writeConcernError: {code: 64, codeName: "WriteConcernTimeout", errmsg: "waiting for replication timed out", errInfo: {wtimeout: True}}}`
+- `{ok:1, writeConcernError: {code: 64, codeName: "WriteConcernTimeout", errmsg: "multiple errors reported : {...} at shardName1 :: and :: {...} at shardName2"}}`[^1]
 - `{ok:1, writeConcernError: {code: 50, codeName: "MaxTimeMSExpired"}}`
 - `{ok:1, writeConcernError: {code: 100, codeName: "UnsatisfiableWriteConcern", errmsg: "Not enough data-bearing nodes"}}`
 - `{ok:1, writeConcernError: {code: 79, codeName: "UnknownReplWriteConcern"}}`
@@ -532,6 +532,7 @@ don't send one and if a user does specify a `ReadConcern`, we do send one. If th
 instance, we send it.
 
 ## Changelog
+- 2025-02-25: Rename WriteConcernFailed to WriteConcernTimeout
 
 - 2015-10-16: ReadConcern of local is no longer allowed to be used when talking with MaxWireVersion \< 4.
 

--- a/source/retryable-writes/tests/unified/insertOne-serverErrors.json
+++ b/source/retryable-writes/tests/unified/insertOne-serverErrors.json
@@ -739,7 +739,7 @@
       ]
     },
     {
-      "description": "InsertOne fails after WriteConcernError WriteConcernFailed",
+      "description": "InsertOne fails after WriteConcernError WriteConcernTimeout",
       "operations": [
         {
           "name": "failPoint",
@@ -757,7 +757,6 @@
                 ],
                 "writeConcernError": {
                   "code": 64,
-                  "codeName": "WriteConcernFailed",
                   "errmsg": "waiting for replication timed out",
                   "errInfo": {
                     "wtimeout": true

--- a/source/retryable-writes/tests/unified/insertOne-serverErrors.yml
+++ b/source/retryable-writes/tests/unified/insertOne-serverErrors.yml
@@ -339,7 +339,7 @@ tests:
           - { _id: 2, x: 22 }
           - { _id: 3, x: 33 } # The write was still applied.
   -
-    description: 'InsertOne fails after WriteConcernError WriteConcernFailed'
+    description: 'InsertOne fails after WriteConcernError WriteConcernTimeout'
     operations:
       -
         name: failPoint
@@ -353,7 +353,6 @@ tests:
               failCommands: [ insert ]
               writeConcernError:
                 code: 64
-                codeName: WriteConcernFailed
                 errmsg: 'waiting for replication timed out'
                 errInfo:
                   wtimeout: true

--- a/source/transactions-convenient-api/tests/unified/commit-writeconcernerror.json
+++ b/source/transactions-convenient-api/tests/unified/commit-writeconcernerror.json
@@ -56,7 +56,7 @@
   ],
   "tests": [
     {
-      "description": "commitTransaction is retried after WriteConcernFailed timeout error",
+      "description": "commitTransaction is retried after WriteConcernTimeout timeout error",
       "operations": [
         {
           "name": "failPoint",
@@ -74,7 +74,6 @@
                 ],
                 "writeConcernError": {
                   "code": 64,
-                  "codeName": "WriteConcernFailed",
                   "errmsg": "waiting for replication timed out",
                   "errInfo": {
                     "wtimeout": true
@@ -236,7 +235,7 @@
       ]
     },
     {
-      "description": "commitTransaction is retried after WriteConcernFailed non-timeout error",
+      "description": "commitTransaction is retried after WriteConcernTimeout non-timeout error",
       "operations": [
         {
           "name": "failPoint",
@@ -254,7 +253,6 @@
                 ],
                 "writeConcernError": {
                   "code": 64,
-                  "codeName": "WriteConcernFailed",
                   "errmsg": "multiple errors reported"
                 }
               }

--- a/source/transactions-convenient-api/tests/unified/commit-writeconcernerror.yml
+++ b/source/transactions-convenient-api/tests/unified/commit-writeconcernerror.yml
@@ -32,7 +32,7 @@ initialData:
 
 tests:
   -
-    description: commitTransaction is retried after WriteConcernFailed timeout error
+    description: commitTransaction is retried after WriteConcernTimeout timeout error
     operations:
       - name: failPoint
         object: testRunner
@@ -47,7 +47,6 @@ tests:
               # with writeConcernError (see: SERVER-39292)
               writeConcernError:
                 code: 64
-                codeName: WriteConcernFailed
                 errmsg: "waiting for replication timed out"
                 errInfo: { wtimeout: true }
       - &operation
@@ -126,10 +125,10 @@ tests:
           - { _id: 1 }
   -
     # This test configures the fail point to return an error with the
-    # WriteConcernFailed code but without errInfo that would identify it as a
+    # WriteConcernTimeout code but without errInfo that would identify it as a
     # wtimeout error. This tests that drivers do not assume that all
-    # WriteConcernFailed errors are due to a replication timeout.
-    description: commitTransaction is retried after WriteConcernFailed non-timeout error
+    # WriteConcernTimeout errors are due to a replication timeout.
+    description: commitTransaction is retried after WriteConcernTimeout non-timeout error
     operations:
       - name: failPoint
         object: testRunner
@@ -144,7 +143,6 @@ tests:
               # with writeConcernError (see: SERVER-39292)
               writeConcernError:
                 code: 64
-                codeName: WriteConcernFailed
                 errmsg: "multiple errors reported"
       - *operation
     expectEvents: *expectEvents_with_retries

--- a/source/transactions/tests/unified/error-labels.json
+++ b/source/transactions/tests/unified/error-labels.json
@@ -1176,7 +1176,7 @@
       ]
     },
     {
-      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernTimeout",
       "operations": [
         {
           "object": "testRunner",
@@ -1338,7 +1338,7 @@
       ]
     },
     {
-      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed with wtimeout",
+      "description": "add UnknownTransactionCommitResult label to writeConcernError WriteConcernTimeout with wtimeout",
       "operations": [
         {
           "object": "testRunner",
@@ -1356,7 +1356,6 @@
                 ],
                 "writeConcernError": {
                   "code": 64,
-                  "codeName": "WriteConcernFailed",
                   "errmsg": "waiting for replication timed out",
                   "errInfo": {
                     "wtimeout": true

--- a/source/transactions/tests/unified/error-labels.yml
+++ b/source/transactions/tests/unified/error-labels.yml
@@ -688,7 +688,7 @@ tests:
         databaseName: *database_name
         documents: []
   -
-    description: 'add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed'
+    description: 'add UnknownTransactionCommitResult label to writeConcernError WriteConcernTimeout'
     operations:
       -
         object: testRunner
@@ -702,7 +702,7 @@ tests:
               failCommands:
                 - commitTransaction
               writeConcernError:
-                code: 64 # WriteConcernFailed without wtimeout
+                code: 64 # WriteConcernTimeout without wtimeout
                 errmsg: 'multiple errors reported'
       -
         object: *session0
@@ -782,7 +782,7 @@ tests:
         documents:
           - { _id: 1 }
   -
-    description: 'add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed with wtimeout'
+    description: 'add UnknownTransactionCommitResult label to writeConcernError WriteConcernTimeout with wtimeout'
     operations:
       -
         object: testRunner
@@ -797,7 +797,6 @@ tests:
                 - commitTransaction
               writeConcernError:
                 code: 64
-                codeName: WriteConcernFailed
                 errmsg: 'waiting for replication timed out'
                 errInfo:
                   wtimeout: true


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Renames the WriteConcernError WriteConcernFailed to WriteConcernTimeout. WriteConcernFailed was mainly specified when setting up failpoints but we found out that there is no need to specify the codeName when setting up the failpoint with a writeConcernError, ideally we should be working the error codes and not the codeNames which are more likely to change than the error codes. 

Please complete the following before merging:

- [x] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
