### PR TITLE
DRIVERS-3109 Revert skip to non-lb-connection-establishment

### DIFF
--- a/source/load-balancers/tests/non-lb-connection-establishment.json
+++ b/source/load-balancers/tests/non-lb-connection-establishment.json
@@ -57,19 +57,6 @@
   "tests": [
     {
       "description": "operations against non-load balanced clusters fail if URI contains loadBalanced=true",
-      "runOnRequirements": [
-        {
-          "maxServerVersion": "8.0.99",
-          "topologies": [
-            "single"
-          ]
-        },
-        {
-          "topologies": [
-            "sharded"
-          ]
-        }
-      ],
       "operations": [
         {
           "name": "runCommand",

--- a/source/load-balancers/tests/non-lb-connection-establishment.yml
+++ b/source/load-balancers/tests/non-lb-connection-establishment.yml
@@ -42,11 +42,6 @@ tests:
   # If the server is not configured to be behind a load balancer and the URI contains loadBalanced=true, the driver
   # should error during the connection handshake because the server's hello response does not contain a serviceId field.
   - description: operations against non-load balanced clusters fail if URI contains loadBalanced=true
-    runOnRequirements:
-      - maxServerVersion: 8.0.99 # DRIVERS-3108: Skip test on >=8.1 mongod. SERVER-85804 changes a non-LB mongod to close connection.
-        topologies: [ single ]
-      - topologies: [ sharded ]
-
     operations:
       - name: runCommand
         object: *lbTrueDatabase


### PR DESCRIPTION
# Summary

Revert test skip from https://github.com/mongodb/specifications/pull/1758

Verified with [this C driver patch build](https://spruce.mongodb.com/version/67c890930593660007b45fe7) testing latest server builds. The macOS failure is likely caused by [SERVER-101020](https://jira.mongodb.org/browse/SERVER-101020)

# Background & Motivation

https://github.com/mongodb/specifications/commit/d05c33e0a6124ee7d1a9de665084d540b2ff06c5 added a temporary test skip to workaround SERVER-101078. With SERVER-101078 fixed, this skip is removed.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~ (N/A).
- [x] Test changes in at least one language driver. (Tested in C)
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).~~ (C does not test serverless)

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
