### PR TITLE
DRIVERS-3128 test secondary with IPv6 literal in SDAM

### DIFF
--- a/source/server-discovery-and-monitoring/tests/rs/secondary_ipv6_literal.json
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_ipv6_literal.json
@@ -1,0 +1,38 @@
+{
+  "description": "Secondary with IPv6 literal",
+  "uri": "mongodb://[::1]/?replicaSet=rs",
+  "phases": [
+    {
+      "responses": [
+        [
+          "[::1]:27017",
+          {
+            "ok": 1,
+            "helloOk": true,
+            "isWritablePrimary": false,
+            "secondary": true,
+            "setName": "rs",
+            "me": "[::1]:27017",
+            "hosts": [
+              "[::1]:27017"
+            ],
+            "minWireVersion": 0,
+            "maxWireVersion": 26
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "[::1]:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetNoPrimary",
+        "setName": "rs",
+        "logicalSessionTimeoutMinutes": null,
+        "compatible": true
+      }
+    }
+  ]
+}

--- a/source/server-discovery-and-monitoring/tests/rs/secondary_ipv6_literal.yml
+++ b/source/server-discovery-and-monitoring/tests/rs/secondary_ipv6_literal.yml
@@ -1,0 +1,25 @@
+# Regression test for bug discovered in HELP-68823.
+description: Secondary with IPv6 literal
+uri: mongodb://[::1]/?replicaSet=rs
+phases:
+- responses:
+  - - "[::1]:27017"
+    - ok: 1
+      helloOk: true
+      isWritablePrimary: false
+      secondary: true
+      setName: rs
+      me: "[::1]:27017"
+      hosts:
+      - "[::1]:27017"
+      minWireVersion: 0
+      maxWireVersion: 26
+  outcome:
+    servers:
+      "[::1]:27017":
+        type: RSSecondary
+        setName: rs
+    topologyType: ReplicaSetNoPrimary
+    setName: rs
+    logicalSessionTimeoutMinutes: null
+    compatible: true


### PR DESCRIPTION
# Summary

Add regression test for the bug identified in [this comment of HELP-68823](https://jira.mongodb.org/browse/HELP-68823?focusedCommentId=7116340&focusedId=7116340&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-7116340).

# Motivation

Test is added to spec repo to validate other drivers handle IPv6 literals correctly. The tested scenario is:

- Connect with: `mongodb://[::1]:27017/?replicaSet=rs`
- Server responds as a secondary (putting the driver's topology state in `ReplicaSetNoPrimary`) and a `"me":"[::1]:27017`.
- Expect the server to be present. The bug from [HELP-68823](https://jira.mongodb.org/browse/HELP-68823) triggered the server to be (unexpectedly) removed from the topology due to the [mismatched `me` check](https://github.com/mongodb/specifications/blob/f04df7d667e20fa7f9ae067e6951662c68da85b6/source/server-discovery-and-monitoring/server-discovery-and-monitoring.md#updaterswithoutprimary).

# Testing

Tested in https://github.com/mongodb/mongo-rust-driver/pull/1327.

Fails on https://github.com/mongodb/mongo-rust-driver/commit/206b99e6b17b1b0ab9cb42ca70fa7a9f7c0f250f (before fix)
```bash
$ cargo nextest run -- sdam::description::topology::test::sdam::rs
[...]
thread 'sdam::description::topology::test::sdam::rs' panicked at src/sdam/description/topology/test/sdam.rs:441:5:
assertion `left == right` failed: Secondary with IPv6 literal: 0
  left: 0
 right: 1
```

Passes on https://github.com/mongodb/mongo-rust-driver/commit/1acffc4f05d519460c9de7116e8d1254e84e6eb5 (after fix).

---

Please complete the following before merging:

- ~~[ ] Update changelog.~~ (Tests only)
- [x] Test changes in at least one language driver. (Tested in Rust)
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).~~ (N/A. Test mocks data to SDAM)

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
