### PR TITLE
DRIVERS-3130 Test wait queue timeout errors do not clear the pool

### DIFF
--- a/source/client-side-operations-timeout/tests/waitQueueTimeout.json
+++ b/source/client-side-operations-timeout/tests/waitQueueTimeout.json
@@ -1,0 +1,173 @@
+{
+  "description": "WaitQueueTimeoutError does not clear the pool",
+  "schemaVersion": "1.9",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.4",
+      "topologies": [
+        "replicaset",
+        "sharded"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "failPointClient",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "client": {
+        "id": "client",
+        "uriOptions": {
+          "maxPoolSize": 1
+        },
+        "useMultipleMongoses": false,
+        "observeEvents": [
+          "commandStartedEvent",
+          "poolClearedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "WaitQueueTimeoutError does not clear the pool",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "failPointClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": {
+                "times": 10
+              },
+              "data": {
+                "failCommands": [
+                  "ping"
+                ],
+                "blockConnection": true,
+                "blockTimeMS": 500
+              }
+            }
+          }
+        },
+        {
+          "name": "createEntities",
+          "object": "testRunner",
+          "arguments": {
+            "entities": [
+              {
+                "thread": {
+                  "id": "thread0"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "runOnThread",
+          "object": "testRunner",
+          "arguments": {
+            "thread": "thread0",
+            "operation": {
+              "name": "runCommand",
+              "object": "database",
+              "arguments": {
+                "command": {
+                  "ping": 1
+                },
+                "commandName": "ping"
+              }
+            }
+          }
+        },
+        {
+          "name": "waitForEvent",
+          "object": "testRunner",
+          "arguments": {
+            "client": "client",
+            "event": {
+              "commandStartedEvent": {
+                "commandName": "ping"
+              }
+            },
+            "count": 1
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "timeoutMS": 200,
+            "command": {
+              "hello": 1
+            },
+            "commandName": "hello"
+          },
+          "expectError": {
+            "isTimeoutError": true
+          }
+        },
+        {
+          "name": "waitForThread",
+          "object": "testRunner",
+          "arguments": {
+            "thread": "thread0"
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "command": {
+              "hello": 1
+            },
+            "commandName": "hello"
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "eventType": "command",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "ping",
+                "databaseName": "test",
+                "command": {
+                  "ping": 1
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "commandName": "hello",
+                "databaseName": "test",
+                "command": {
+                  "hello": 1
+                }
+              }
+            }
+          ]
+        },
+        {
+          "client": "client",
+          "eventType": "cmap",
+          "events": []
+        }
+      ]
+    }
+  ]
+}

--- a/source/client-side-operations-timeout/tests/waitQueueTimeout.json
+++ b/source/client-side-operations-timeout/tests/waitQueueTimeout.json
@@ -5,6 +5,7 @@
     {
       "minServerVersion": "4.4",
       "topologies": [
+        "single",
         "replicaset",
         "sharded"
       ]
@@ -21,7 +22,8 @@
       "client": {
         "id": "client",
         "uriOptions": {
-          "maxPoolSize": 1
+          "maxPoolSize": 1,
+          "appname": "waitQueueTimeoutErrorTest"
         },
         "useMultipleMongoses": false,
         "observeEvents": [
@@ -50,14 +52,15 @@
             "failPoint": {
               "configureFailPoint": "failCommand",
               "mode": {
-                "times": 10
+                "times": 1
               },
               "data": {
                 "failCommands": [
                   "ping"
                 ],
                 "blockConnection": true,
-                "blockTimeMS": 500
+                "blockTimeMS": 500,
+                "appName": "waitQueueTimeoutErrorTest"
               }
             }
           }
@@ -109,7 +112,7 @@
           "name": "runCommand",
           "object": "database",
           "arguments": {
-            "timeoutMS": 200,
+            "timeoutMS": 100,
             "command": {
               "hello": 1
             },

--- a/source/client-side-operations-timeout/tests/waitQueueTimeout.yml
+++ b/source/client-side-operations-timeout/tests/waitQueueTimeout.yml
@@ -4,7 +4,7 @@ schemaVersion: "1.9"
 
 runOnRequirements:
   - minServerVersion: "4.4"
-    topologies: ["replicaset", "sharded"]
+    topologies: ["single", "replicaset", "sharded"]
 
 createEntities:
   - client:
@@ -14,6 +14,7 @@ createEntities:
       id: &client client
       uriOptions:
         maxPoolSize: 1
+        appname: &appname waitQueueTimeoutErrorTest
       useMultipleMongoses: false
       observeEvents:
         - commandStartedEvent
@@ -32,11 +33,12 @@ tests:
           client: *failPointClient
           failPoint:
             configureFailPoint: failCommand
-            mode: { times: 10 }
+            mode: { times: 1 }
             data:
               failCommands: ["ping"]
               blockConnection: true
               blockTimeMS: 500
+              appName: *appname
       # Start thread.
       - name: createEntities
         object: testRunner
@@ -67,7 +69,7 @@ tests:
       - name: runCommand
         object: *database
         arguments:
-          timeoutMS: 200
+          timeoutMS: 100
           command: { hello: 1 }
           commandName: hello
         expectError:
@@ -76,7 +78,7 @@ tests:
         object: testRunner
         arguments:
           thread: *thread0
-      # Run another command with no timeout ensure the pool is not cleared.
+      # Run another command with no timeout to ensure the pool is not cleared.
       - name: runCommand
         object: *database
         arguments:

--- a/source/client-side-operations-timeout/tests/waitQueueTimeout.yml
+++ b/source/client-side-operations-timeout/tests/waitQueueTimeout.yml
@@ -1,0 +1,103 @@
+description: "WaitQueueTimeoutError does not clear the pool"
+
+schemaVersion: "1.9"
+
+runOnRequirements:
+  - minServerVersion: "4.4"
+    topologies: ["replicaset", "sharded"]
+
+createEntities:
+  - client:
+      id: &failPointClient failPointClient
+      useMultipleMongoses: false
+  - client:
+      id: &client client
+      uriOptions:
+        maxPoolSize: 1
+      useMultipleMongoses: false
+      observeEvents:
+        - commandStartedEvent
+        - poolClearedEvent
+  - database:
+      id: &database database
+      client: *client
+      databaseName: &databaseName test
+
+tests:
+  - description: "WaitQueueTimeoutError does not clear the pool"
+    operations:
+      - name: failPoint
+        object: testRunner
+        arguments:
+          client: *failPointClient
+          failPoint:
+            configureFailPoint: failCommand
+            mode: { times: 10 }
+            data:
+              failCommands: ["ping"]
+              blockConnection: true
+              blockTimeMS: 500
+      # Start thread.
+      - name: createEntities
+        object: testRunner
+        arguments:
+          entities:
+            - thread:
+                id: &thread0 thread0
+      - name: runOnThread
+        object: testRunner
+        arguments:
+          thread: *thread0
+          operation:
+            name: runCommand
+            object: *database
+            arguments:
+              command: { ping: 1 }
+              commandName: ping
+      # Wait for the thread to checkout the only connection (maxPoolSize=1).
+      - name: waitForEvent
+        object: testRunner
+        arguments:
+          client: *client
+          event:
+            commandStartedEvent:
+              commandName: ping
+          count: 1
+      # Run another command with a short timeout to make it likely to get a WaitQueueTimeoutError.
+      - name: runCommand
+        object: *database
+        arguments:
+          timeoutMS: 200
+          command: { hello: 1 }
+          commandName: hello
+        expectError:
+          isTimeoutError: true
+      - name: waitForThread
+        object: testRunner
+        arguments:
+          thread: *thread0
+      # Run another command with no timeout ensure the pool is not cleared.
+      - name: runCommand
+        object: *database
+        arguments:
+          command: { hello: 1 }
+          commandName: hello
+
+    expectEvents:
+      - client: *client
+        eventType: command
+        events:
+          - commandStartedEvent:
+              commandName: ping
+              databaseName: *databaseName
+              command:
+                ping: 1
+          - commandStartedEvent:
+              commandName: hello
+              databaseName: *databaseName
+              command:
+                hello: 1
+      # No poolClearedEvent.
+      - client: *client
+        eventType: cmap
+        events: []


### PR DESCRIPTION
DRIVERS-3130 Test wait queue timeout errors do not clear the pool

- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).
- [x] Should we bother adding a similar test that uses waitQueueTimeoutMS and not CSOT?
   - Answer: There's already a test for waitQueueTimeoutMS here: https://github.com/mongodb/specifications/blob/fe86082/source/connection-monitoring-and-pooling/tests/cmap-format/wait-queue-timeout.yml
