### PR TITLE
DRIVERS-3139: Revise assertion for unacknowledged client bulkWrite result

### DIFF
--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.json
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.json
@@ -95,29 +95,34 @@
             "ordered": false
           },
           "expectResult": {
-            "insertedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "upsertedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "matchedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "modifiedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "deletedCount": {
-              "$$unsetOrMatches": 0
-            },
-            "insertResults": {
-              "$$unsetOrMatches": {}
-            },
-            "updateResults": {
-              "$$unsetOrMatches": {}
-            },
-            "deleteResults": {
-              "$$unsetOrMatches": {}
+            "$$unsetOrMatches": {
+              "acknowledged": {
+                "$$unsetOrMatches": false
+              },
+              "insertedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "upsertedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "matchedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "modifiedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "deletedCount": {
+                "$$unsetOrMatches": 0
+              },
+              "insertResults": {
+                "$$unsetOrMatches": {}
+              },
+              "updateResults": {
+                "$$unsetOrMatches": {}
+              },
+              "deleteResults": {
+                "$$unsetOrMatches": {}
+              }
             }
           }
         },

--- a/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.yml
+++ b/source/command-logging-and-monitoring/tests/monitoring/unacknowledged-client-bulkWrite.yml
@@ -52,22 +52,16 @@ tests:
                 update: { $set: { x: 333 } }
           ordered: false
         expectResult:
-          insertedCount:
-            $$unsetOrMatches: 0
-          upsertedCount:
-            $$unsetOrMatches: 0
-          matchedCount:
-            $$unsetOrMatches: 0
-          modifiedCount:
-            $$unsetOrMatches: 0
-          deletedCount:
-            $$unsetOrMatches: 0
-          insertResults:
-            $$unsetOrMatches: {}
-          updateResults:
-            $$unsetOrMatches: {}
-          deleteResults:
-            $$unsetOrMatches: {}
+          $$unsetOrMatches:
+            acknowledged: { $$unsetOrMatches: false }
+            insertedCount: { $$unsetOrMatches: 0 }
+            upsertedCount: { $$unsetOrMatches: 0 }
+            matchedCount: { $$unsetOrMatches: 0 }
+            modifiedCount: { $$unsetOrMatches: 0 }
+            deletedCount: { $$unsetOrMatches: 0 }
+            insertResults: { $$unsetOrMatches: {} }
+            updateResults: { $$unsetOrMatches: {} }
+            deleteResults: { $$unsetOrMatches: {} }
       # Force completion of the w:0 write by executing a find on the same connection
       - object: *collection
         name: find


### PR DESCRIPTION
https://jira.mongodb.org/browse/DRIVERS-3139

This makes the assertion consistent with collection bulkWrites by allowing for an entirely optional result and conditionally checking acknowledged=false.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
