### PR TITLE
Document timeoutMS in collectionOrDatabaseOptions

### DIFF
--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -1320,6 +1320,8 @@ The structure of this object is as follows:
 
 - `readConcern`: Optional object. See [commonOptions_readConcern](#commonOptions_readConcern).
 - `readPreference`: Optional object. See [commonOptions_readPreference](#commonOptions_readPreference).
+- `timeoutMS`: Optional integer. See
+  [Client Side Operations Timeout spec](../client-side-operations-timeout/client-side-operations-timeout.md#timeoutms).
 - `writeConcern`: Optional object. See [commonOptions_writeConcern](#commonOptions_writeConcern).
 
 ### Common Options

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -1321,7 +1321,7 @@ The structure of this object is as follows:
 - `readConcern`: Optional object. See [commonOptions_readConcern](#commonOptions_readConcern).
 - `readPreference`: Optional object. See [commonOptions_readPreference](#commonOptions_readPreference).
 - `timeoutMS`: Optional integer. See
-  [Client Side Operations Timeout spec](../client-side-operations-timeout/client-side-operations-timeout.md#timeoutms).
+  [Client Side Operations Timeout](../client-side-operations-timeout/client-side-operations-timeout.md#timeoutms).
 - `writeConcern`: Optional object. See [commonOptions_writeConcern](#commonOptions_writeConcern).
 
 ### Common Options

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -1321,7 +1321,7 @@ The structure of this object is as follows:
 - `readConcern`: Optional object. See [commonOptions_readConcern](#commonOptions_readConcern).
 - `readPreference`: Optional object. See [commonOptions_readPreference](#commonOptions_readPreference).
 - `timeoutMS`: Optional integer. See
-   [Client Side Operations Timeout](../client-side-operations-timeout/client-side-operations-timeout.md#timeoutms).
+    [Client Side Operations Timeout](../client-side-operations-timeout/client-side-operations-timeout.md#timeoutms).
 - `writeConcern`: Optional object. See [commonOptions_writeConcern](#commonOptions_writeConcern).
 
 ### Common Options

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -1321,7 +1321,7 @@ The structure of this object is as follows:
 - `readConcern`: Optional object. See [commonOptions_readConcern](#commonOptions_readConcern).
 - `readPreference`: Optional object. See [commonOptions_readPreference](#commonOptions_readPreference).
 - `timeoutMS`: Optional integer. See
-  [Client Side Operations Timeout](../client-side-operations-timeout/client-side-operations-timeout.md#timeoutms).
+   [Client Side Operations Timeout](../client-side-operations-timeout/client-side-operations-timeout.md#timeoutms).
 - `writeConcern`: Optional object. See [commonOptions_writeConcern](#commonOptions_writeConcern).
 
 ### Common Options


### PR DESCRIPTION
This was missed in a8a7d01036615dc6122ad16a854834453b25e6f8.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

Intentionally omitting the changelog entry, as the option was already documented in the entry for schema version 1.9.