### PR TITLE
DRIVERS-3143: Relax requirement for optional fields for sessions unified tests

### DIFF
--- a/source/sessions/tests/driver-sessions-dirty-session-errors.json
+++ b/source/sessions/tests/driver-sessions-dirty-session-errors.json
@@ -347,7 +347,9 @@
                       "x": 1
                     }
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },
@@ -375,7 +377,9 @@
                       "x": 1
                     }
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$sessionLsid": "session0"
                   },
@@ -627,7 +631,9 @@
                       "x": 1
                     }
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$type": "object"
                   },
@@ -655,7 +661,9 @@
                       "x": 1
                     }
                   },
-                  "new": false,
+                  "new": {
+                    "$$unsetOrMatches": false
+                  },
                   "lsid": {
                     "$$type": "object"
                   },

--- a/source/sessions/tests/driver-sessions-dirty-session-errors.yml
+++ b/source/sessions/tests/driver-sessions-dirty-session-errors.yml
@@ -164,7 +164,7 @@ tests:
                 findAndModify: *collection0Name
                 query: { _id: 1 }
                 update: { $inc: { x: 1 } }
-                new: false
+                new: { $$unsetOrMatches: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: 1
                 readConcern: { $$exists: false }
@@ -255,7 +255,7 @@ tests:
                 findAndModify: *collection0Name
                 query: { _id: 1 }
                 update: { $inc: { x: 1 } }
-                new: false
+                new: { $$unsetOrMatches: false }
                 lsid: { $$type: object }
                 txnNumber: 1
                 readConcern: { $$exists: false }


### PR DESCRIPTION
Please complete the following before merging:

- [ ] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).