### PR TITLE
DRIVERS-3153 Fix incorrect batchSize assertion in ADL getMore test.

### DIFF
--- a/source/atlas-data-lake-testing/tests/README.md
+++ b/source/atlas-data-lake-testing/tests/README.md
@@ -62,6 +62,8 @@ configuration and execute a ping command. Repeat this test using SCRAM-SHA-256.
 
 ## Changelog
 
+- 2025-03-31: Fix incorrect batchSize assertion in "A successful find event with getMore" test.
+
 - 2024-03-08: Convert legacy ADL tests to unified format. Convert test README from reStructuredText to Markdown.
 
 - 2022-10-05: Add spec front matter

--- a/source/atlas-data-lake-testing/tests/unified/getMore.json
+++ b/source/atlas-data-lake-testing/tests/unified/getMore.json
@@ -81,7 +81,7 @@
                   "collection": {
                     "$$type": "string"
                   },
-                  "batchSize": 1
+                  "batchSize": 3
                 },
                 "commandName": "getMore",
                 "databaseName": "cursors"

--- a/source/atlas-data-lake-testing/tests/unified/getMore.yml
+++ b/source/atlas-data-lake-testing/tests/unified/getMore.yml
@@ -42,7 +42,7 @@ tests:
                 getMore: { $$type: [ int, long ] }
                 # collection name will be an internal identifier
                 collection: { $$type: string }
-                batchSize: 1
+                batchSize: 3
               commandName: getMore
               # mongohoused always expects getMores on the "cursors" database
               databaseName: cursors


### PR DESCRIPTION
[DRIVERS-3153](https://jira.mongodb.org/browse/DRIVERS-3153)

The ADL test case "A successful find event with getMore" in [getMore.json](https://github.com/mongodb/specifications/blob/f3549601e6bdfe4f18568985dfe706ca500dc679/source/atlas-data-lake-testing/tests/unified/getMore.json#L84) sets a "batchSize" of 3, then asserts that the `getMore` sends a "batchSize" of 1 (see [here](https://github.com/mongodb/specifications/blob/f3549601e6bdfe4f18568985dfe706ca500dc679/source/atlas-data-lake-testing/tests/unified/getMore.json#L84)). It seems like it's based on an [existing bug](https://github.com/mongodb/specifications/blob/68da5c5c9af9d87677ed90d30f8ad9ca3ea7e798/source/atlas-data-lake-testing/tests/getMore.yml#L32) that was previously ignored by the spec test runner, but then was persisted when the spec test was converted to a unified spec test.

Please complete the following before merging:

- [x] Update changelog.
- [x] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
