### PR TITLE
DRIVERS-3155 Add topologyClosedEvent and topologyOpeningEvent

### DIFF
--- a/source/server-discovery-and-monitoring/tests/unified/replicaset-emit-topology-changed-before-close.json
+++ b/source/server-discovery-and-monitoring/tests/unified/replicaset-emit-topology-changed-before-close.json
@@ -1,6 +1,6 @@
 {
   "description": "replicaset-emit-topology-description-changed-before-close",
-  "schemaVersion": "1.20",
+  "schemaVersion": "1.24",
   "runOnRequirements": [
     {
       "topologies": [

--- a/source/server-discovery-and-monitoring/tests/unified/replicaset-emit-topology-changed-before-close.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/replicaset-emit-topology-changed-before-close.yml
@@ -1,6 +1,6 @@
 description: "replicaset-emit-topology-description-changed-before-close"
 
-schemaVersion: "1.20"
+schemaVersion: "1.24"
 
 runOnRequirements:
   - topologies:

--- a/source/server-discovery-and-monitoring/tests/unified/sharded-emit-topology-changed-before-close.json
+++ b/source/server-discovery-and-monitoring/tests/unified/sharded-emit-topology-changed-before-close.json
@@ -1,6 +1,6 @@
 {
   "description": "sharded-emit-topology-description-changed-before-close",
-  "schemaVersion": "1.20",
+  "schemaVersion": "1.24",
   "runOnRequirements": [
     {
       "topologies": [

--- a/source/server-discovery-and-monitoring/tests/unified/sharded-emit-topology-changed-before-close.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/sharded-emit-topology-changed-before-close.yml
@@ -1,6 +1,6 @@
 description: "sharded-emit-topology-description-changed-before-close"
 
-schemaVersion: "1.20"
+schemaVersion: "1.24"
 
 runOnRequirements:
   - topologies:

--- a/source/server-discovery-and-monitoring/tests/unified/standalone-emit-topology-changed-before-close.json
+++ b/source/server-discovery-and-monitoring/tests/unified/standalone-emit-topology-changed-before-close.json
@@ -1,6 +1,6 @@
 {
   "description": "standalone-emit-topology-description-changed-before-close",
-  "schemaVersion": "1.20",
+  "schemaVersion": "1.24",
   "runOnRequirements": [
     {
       "topologies": [

--- a/source/server-discovery-and-monitoring/tests/unified/standalone-emit-topology-changed-before-close.yml
+++ b/source/server-discovery-and-monitoring/tests/unified/standalone-emit-topology-changed-before-close.yml
@@ -1,6 +1,6 @@
 description: "standalone-emit-topology-description-changed-before-close"
 
-schemaVersion: "1.20"
+schemaVersion: "1.24"
 
 runOnRequirements:
   - topologies:

--- a/source/unified-test-format/schema-1.24.json
+++ b/source/unified-test-format/schema-1.24.json
@@ -1,0 +1,1171 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Unified Test Format",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "description",
+    "schemaVersion",
+    "tests"
+  ],
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "$ref": "#/definitions/version"
+    },
+    "runOnRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/runOnRequirement"
+      }
+    },
+    "createEntities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/entity"
+      }
+    },
+    "initialData": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/collectionData"
+      }
+    },
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/test"
+      }
+    },
+    "_yamlAnchors": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "definitions": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+    },
+    "runOnRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "maxServerVersion": {
+          "$ref": "#/definitions/version"
+        },
+        "minServerVersion": {
+          "$ref": "#/definitions/version"
+        },
+        "topologies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "single",
+              "replicaset",
+              "sharded",
+              "sharded-replicaset",
+              "load-balanced"
+            ]
+          }
+        },
+        "serverless": {
+          "type": "string",
+          "enum": [
+            "require",
+            "forbid",
+            "allow"
+          ]
+        },
+        "serverParameters": {
+          "type": "object",
+          "minProperties": 1
+        },
+        "auth": {
+          "type": "boolean"
+        },
+        "authMechanism": {
+          "type": "string"
+        },
+        "csfle": {
+          "type": "boolean"
+        }
+      }
+    },
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "client": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "uriOptions": {
+              "type": "object"
+            },
+            "useMultipleMongoses": {
+              "type": "boolean"
+            },
+            "observeEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "commandStartedEvent",
+                  "commandSucceededEvent",
+                  "commandFailedEvent",
+                  "poolCreatedEvent",
+                  "poolReadyEvent",
+                  "poolClearedEvent",
+                  "poolClosedEvent",
+                  "connectionCreatedEvent",
+                  "connectionReadyEvent",
+                  "connectionClosedEvent",
+                  "connectionCheckOutStartedEvent",
+                  "connectionCheckOutFailedEvent",
+                  "connectionCheckedOutEvent",
+                  "connectionCheckedInEvent",
+                  "serverDescriptionChangedEvent",
+                  "topologyDescriptionChangedEvent",
+                  "topologyOpeningEvent",
+                  "topologyClosedEvent"
+                ]
+              }
+            },
+            "ignoreCommandMonitoringEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "storeEventsAsEntities": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/storeEventsAsEntity"
+              }
+            },
+            "observeLogMessages": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": false,
+              "properties": {
+                "command": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                },
+                "topology": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                },
+                "serverSelection": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                },
+                "connection": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                }
+              }
+            },
+            "serverApi": {
+              "$ref": "#/definitions/serverApi"
+            },
+            "observeSensitiveCommands": {
+              "type": "boolean"
+            },
+            "autoEncryptOpts": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "keyVaultNamespace",
+                "kmsProviders"
+              ],
+              "properties": {
+                "keyVaultNamespace": {
+                  "type": "string"
+                },
+                "bypassAutoEncryption": {
+                  "type": "boolean"
+                },
+                "kmsProviders": {
+                  "$ref": "#/definitions/kmsProviders"
+                },
+                "schemaMap": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
+                },
+                "extraOptions": {
+                  "type": "object"
+                },
+                "encryptedFieldsMap": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
+                },
+                "bypassQueryAnalysis": {
+                  "type": "boolean"
+                },
+                "keyExpirationMS": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "clientEncryption": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "clientEncryptionOpts"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "clientEncryptionOpts": {
+              "$ref": "#/definitions/clientEncryptionOpts"
+            }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "client",
+            "databaseName"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "client": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "databaseOptions": {
+              "$ref": "#/definitions/collectionOrDatabaseOptions"
+            }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "database",
+            "collectionName"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            },
+            "collectionName": {
+              "type": "string"
+            },
+            "collectionOptions": {
+              "$ref": "#/definitions/collectionOrDatabaseOptions"
+            }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "client"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "client": {
+              "type": "string"
+            },
+            "sessionOptions": {
+              "type": "object"
+            }
+          }
+        },
+        "bucket": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "database"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            },
+            "bucketOptions": {
+              "type": "object"
+            }
+          }
+        },
+        "thread": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "logComponent": {
+      "type": "string",
+      "enum": [
+        "command",
+        "topology",
+        "serverSelection",
+        "connection"
+      ]
+    },
+    "logSeverityLevel": {
+      "type": "string",
+      "enum": [
+        "emergency",
+        "alert",
+        "critical",
+        "error",
+        "warning",
+        "notice",
+        "info",
+        "debug",
+        "trace"
+      ]
+    },
+    "clientEncryptionOpts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keyVaultClient",
+        "keyVaultNamespace",
+        "kmsProviders"
+      ],
+      "properties": {
+        "keyVaultClient": {
+          "type": "string"
+        },
+        "keyVaultNamespace": {
+          "type": "string"
+        },
+        "kmsProviders": {
+          "$ref": "#/definitions/kmsProviders"
+        },
+        "keyExpirationMS": {
+          "type": "integer"
+        }
+      }
+    },
+    "kmsProviders": {
+      "$defs": {
+        "stringOrPlaceholder": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "$$placeholder"
+              ],
+              "properties": {
+                "$$placeholder": {}
+              }
+            }
+          ]
+        }
+      },
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^aws(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "accessKeyId": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "secretAccessKey": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "sessionToken": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^azure(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "tenantId": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "clientId": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "clientSecret": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "identityPlatformEndpoint": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^gcp(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "privateKey": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "endpoint": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^kmip(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "endpoint": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^local(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        }
+      }
+    },
+    "storeEventsAsEntity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "events"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "PoolCreatedEvent",
+              "PoolReadyEvent",
+              "PoolClearedEvent",
+              "PoolClosedEvent",
+              "ConnectionCreatedEvent",
+              "ConnectionReadyEvent",
+              "ConnectionClosedEvent",
+              "ConnectionCheckOutStartedEvent",
+              "ConnectionCheckOutFailedEvent",
+              "ConnectionCheckedOutEvent",
+              "ConnectionCheckedInEvent",
+              "CommandStartedEvent",
+              "CommandSucceededEvent",
+              "CommandFailedEvent",
+              "ServerDescriptionChangedEvent",
+              "TopologyDescriptionChangedEvent"
+            ]
+          }
+        }
+      }
+    },
+    "collectionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "collectionName",
+        "databaseName",
+        "documents"
+      ],
+      "properties": {
+        "collectionName": {
+          "type": "string"
+        },
+        "databaseName": {
+          "type": "string"
+        },
+        "createOptions": {
+          "type": "object",
+          "properties": {
+            "writeConcern": false
+          }
+        },
+        "documents": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "expectedEventsForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "client",
+        "events"
+      ],
+      "properties": {
+        "client": {
+          "type": "string"
+        },
+        "eventType": {
+          "type": "string",
+          "enum": [
+            "command",
+            "cmap",
+            "sdam"
+          ]
+        },
+        "events": {
+          "type": "array"
+        },
+        "ignoreExtraEvents": {
+          "type": "boolean"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "eventType"
+          ],
+          "properties": {
+            "eventType": {
+              "const": "command"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedCommandEvent"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "eventType"
+          ],
+          "properties": {
+            "eventType": {
+              "const": "cmap"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedCmapEvent"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "eventType"
+          ],
+          "properties": {
+            "eventType": {
+              "const": "sdam"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedSdamEvent"
+              }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "client": {
+              "type": "string"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedCommandEvent"
+              }
+            },
+            "ignoreExtraEvents": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "expectedCommandEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "commandStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "object"
+            },
+            "commandName": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "hasServerConnectionId": {
+              "type": "boolean"
+            }
+          }
+        },
+        "commandSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reply": {
+              "type": "object"
+            },
+            "commandName": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "hasServerConnectionId": {
+              "type": "boolean"
+            }
+          }
+        },
+        "commandFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "commandName": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "hasServerConnectionId": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "expectedCmapEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "poolCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolClearedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "interruptInUseConnections": {
+              "type": "boolean"
+            }
+          }
+        },
+        "poolClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": {
+              "type": "string"
+            }
+          }
+        },
+        "connectionCheckOutStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckOutFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": {
+              "type": "string"
+            }
+          }
+        },
+        "connectionCheckedOutEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckedInEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      }
+    },
+    "expectedSdamEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "serverDescriptionChangedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "previousDescription": {
+              "$ref": "#/definitions/serverDescription"
+            },
+            "newDescription": {
+              "$ref": "#/definitions/serverDescription"
+            }
+          }
+        },
+        "topologyDescriptionChangedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "previousDescription": {
+              "$ref": "#/definitions/topologyDescription"
+            },
+            "newDescription": {
+              "$ref": "#/definitions/topologyDescription"
+            }
+          }
+        },
+        "topologyOpeningEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "topologyClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "serverHeartbeatStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "awaited": {
+              "type": "boolean"
+            }
+          }
+        },
+        "serverHeartbeatSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "awaited": {
+              "type": "boolean"
+            }
+          }
+        },
+        "serverHeartbeatFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "awaited": {
+              "type": "boolean"
+            }
+          }
+        },
+        "topologyOpeningEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "topologyClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      }
+    },
+    "serverDescription": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Standalone",
+            "Mongos",
+            "PossiblePrimary",
+            "RSPrimary",
+            "RSSecondary",
+            "RSOther",
+            "RSArbiter",
+            "RSGhost",
+            "LoadBalancer",
+            "Unknown"
+          ]
+        }
+      }
+    },
+    "topologyDescription": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Single",
+            "Unknown",
+            "ReplicaSetNoPrimary",
+            "ReplicaSetWithPrimary",
+            "Sharded",
+            "LoadBalanced"
+          ]
+        }
+      }
+    },
+    "expectedLogMessagesForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "client",
+        "messages"
+      ],
+      "properties": {
+        "client": {
+          "type": "string"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expectedLogMessage"
+          }
+        },
+        "ignoreExtraMessages": {
+          "type": "boolean"
+        },
+        "ignoreMessages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expectedLogMessage"
+          }
+        }
+      }
+    },
+    "expectedLogMessage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "level",
+        "component",
+        "data"
+      ],
+      "properties": {
+        "level": {
+          "$ref": "#/definitions/logSeverityLevel"
+        },
+        "component": {
+          "$ref": "#/definitions/logComponent"
+        },
+        "data": {
+          "type": "object"
+        },
+        "failureIsRedacted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "collectionOrDatabaseOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readConcern": {
+          "type": "object"
+        },
+        "readPreference": {
+          "type": "object"
+        },
+        "writeConcern": {
+          "type": "object"
+        },
+        "timeoutMS": {
+          "type": "integer"
+        }
+      }
+    },
+    "serverApi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "strict": {
+          "type": "boolean"
+        },
+        "deprecationErrors": {
+          "type": "boolean"
+        }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "object"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "arguments": {
+          "type": "object"
+        },
+        "ignoreResultAndError": {
+          "type": "boolean"
+        },
+        "expectError": {
+          "$ref": "#/definitions/expectedError"
+        },
+        "expectResult": {},
+        "saveResultAsEntity": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "not": {
+            "required": [
+              "expectError",
+              "expectResult"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "expectError",
+              "saveResultAsEntity"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "ignoreResultAndError",
+              "expectResult"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "ignoreResultAndError",
+              "expectError"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "ignoreResultAndError",
+              "saveResultAsEntity"
+            ]
+          }
+        }
+      ]
+    },
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "isError": {
+          "type": "boolean",
+          "const": true
+        },
+        "isClientError": {
+          "type": "boolean"
+        },
+        "isTimeoutError": {
+          "type": "boolean"
+        },
+        "errorContains": {
+          "type": "string"
+        },
+        "errorCode": {
+          "type": "integer"
+        },
+        "errorCodeName": {
+          "type": "string"
+        },
+        "errorLabelsContain": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "errorLabelsOmit": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "writeErrors": {
+          "type": "object"
+        },
+        "writeConcernErrors": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "errorResponse": {
+          "type": "object"
+        },
+        "expectResult": {}
+      }
+    },
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "description",
+        "operations"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "runOnRequirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/runOnRequirement"
+          }
+        },
+        "skipReason": {
+          "type": "string"
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/operation"
+          }
+        },
+        "expectEvents": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/expectedEventsForClient"
+          }
+        },
+        "expectLogMessages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/expectedLogMessagesForClient"
+          }
+        },
+        "outcome": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/collectionData"
+          }
+        }
+      }
+    }
+  }
+}

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -1,4 +1,4 @@
-SCHEMA=../schema-1.23.json
+SCHEMA=../schema-1.24.json
 
 .PHONY: all invalid valid-fail valid-pass atlas-data-lake versioned-api load-balancers gridfs transactions transactions-convenient-api crud collection-management read-write-concern retryable-reads retryable-writes sessions command-logging-and-monitoring client-side-operations-timeout HAS_AJV
 

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -485,6 +485,8 @@ The structure of this object is as follows:
         - [serverHeartbeatSucceededEvent](#expectedEvent_serverHeartbeatSucceededEvent)
         - [serverHeartbeatFailedEvent](#expectedEvent_serverHeartbeatFailedEvent)
         - [topologyDescriptionChangedEvent](#expectedEvent_topologyDescriptionChangedEvent)
+        - [topologyOpeningEvent](#expectedEvent_topologyOpeningEvent)
+        - [topologyClosedEvent](#expectedEvent_topologyOpeningEvent)
 
     <span id="entity_client_ignoreCommandMonitoringEvents"></span>
 
@@ -1230,6 +1232,19 @@ The structure of this object is as follows:
 
         Test runners SHOULD ignore any other fields present on the `previousDescription` and `newDescription` fields of the
         captured `topologyDescriptionChangedEvent`.
+
+<span id="expectedEvent_topologyOpeningEvent"></span>
+
+- `topologyOpeningEvent`: Optional object. Assertions for one
+    [topologyOpeningEvent](../server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring.md#events-api)
+    object.
+
+<span id="expectedEvent_topologyClosedEvent"></span>
+
+- `topologyClosedEvent`: Optional object. Assertions for one
+    [topologyClosedEvent](../server-discovery-and-monitoring/server-discovery-and-monitoring-logging-and-monitoring.md#events-api)
+    object.
+
 
 ##### hasServiceId
 
@@ -3554,6 +3569,10 @@ operations and arguments. This is a concession until such time that better proce
 other specs *and* collating spec changes developed in parallel or during the same release cycle.
 
 ## Changelog
+
+- 2025-04-07: **Schema version 1.24.**
+
+    Add `topologyOpeningEvent` and `topologyClosedEvent` to "observeEvents" and "expectedSdamEvent".
 
 - 2025-01-21: **Schema version 1.23.**
 


### PR DESCRIPTION
DRIVERS-3155

<!-- Thanks for contributing! -->

DRIVERS-2711 added test to extend topologyClosedEvent and topologyOpeningEvent to observeEvents and SDAM expected events. This should be reflected in the unified spec tests and the subsequent tests should be updated to include the new schema version.

- [x] Update changelog.
- [x] Test changes in at least one language driver. (https://github.com/mongodb/mongo-go-driver/pull/2002)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
