### PR TITLE
DRIVERS-3123 Require ignored bits in BSON binary vector PACKED_BITS to be zero.

### DIFF
--- a/source/bson-binary-vector/bson-binary-vector.md
+++ b/source/bson-binary-vector/bson-binary-vector.md
@@ -184,6 +184,7 @@ Drivers MUST validate vector metadata and raise an error if any invariant is vio
 
 - Padding MUST be 0 for all dtypes where padding doesn’t apply, and MUST be within \[0, 7\] for PACKED_BIT.
 - A PACKED_BIT vector MUST NOT be empty if padding is in the range \[1, 7\].
+- For a PACKED_BIT vector, bits lower the given padding (those ignored) must be zero.
 - When unpacking binary data into a FLOAT32 Vector structure, the length of the binary data following the dtype and
     padding MUST be a multiple of 4 bytes.
 

--- a/source/bson-binary-vector/tests/packed_bit.json
+++ b/source/bson-binary-vector/tests/packed_bit.json
@@ -14,11 +14,29 @@
     {
       "description": "Simple Vector PACKED_BIT",
       "valid": true,
-      "vector": [127, 7],
+      "vector": [127, 8],
       "dtype_hex": "0x10",
       "dtype_alias": "PACKED_BIT",
       "padding": 0,
-      "canonical_bson": "1600000005766563746F7200040000000910007F0700"
+      "canonical_bson": "1600000005766563746F7200040000000910007F0800"
+    },
+    {
+      "description": "PACKED_BIT with padding",
+      "valid": true,
+      "vector": [127, 8],
+      "dtype_hex": "0x10",
+      "dtype_alias": "PACKED_BIT",
+      "padding": 3,
+      "canonical_bson": "1600000005766563746F7200040000000910037F0800"
+    },
+    {
+      "description": "PACKED_BIT with inconsistent padding",
+      "valid": false,
+      "vector": [127, 7],
+      "dtype_hex": "0x10",
+      "dtype_alias": "PACKED_BIT",
+      "padding": 3,
+      "canonical_bson": "1600000005766563746F7200040000000910037F0700"
     },
     {
       "description": "Empty Vector PACKED_BIT",
@@ -28,15 +46,6 @@
       "dtype_alias": "PACKED_BIT",
       "padding": 0,
       "canonical_bson": "1400000005766563746F72000200000009100000"
-    },
-    {
-      "description": "PACKED_BIT with padding",
-      "valid": true,
-      "vector": [127, 7],
-      "dtype_hex": "0x10",
-      "dtype_alias": "PACKED_BIT",
-      "padding": 3,
-      "canonical_bson": "1600000005766563746F7200040000000910037F0700"
     },
     {
       "description": "Overflow Vector PACKED_BIT",


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [X] Test changes in at least one language driver.
- [X] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
