### PR TITLE
DRIVERS-3181 fix timeouts in CSE custom endpoint test

### DIFF
--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -811,7 +811,7 @@ Configure with KMS providers as follows:
          "endpoint": "doesnotexist.invalid:443"
       },
       "kmip": {
-         "endpoint": "doesnotexist.local:5698"
+         "endpoint": "doesnotexist.invalid:5698"
       }
 }
 ```
@@ -960,7 +960,7 @@ The method of passing TLS options for KMIP TLS connections is driver dependent.
     validate it works.
 
     Call `client_encryption_invalid.createDataKey()` with the same masterKey. Expect this to fail with a network
-    exception indicating failure to resolve "doesnotexist.local".
+    exception indicating failure to resolve "doesnotexist.invalid".
 
 11. Call `client_encryption.createDataKey()` with "kmip" as the provider and the following masterKey:
 
@@ -979,11 +979,11 @@ The method of passing TLS options for KMIP TLS connections is driver dependent.
     ```javascript
     {
       "keyId": "1",
-      "endpoint": "doesnotexist.local:5698"
+      "endpoint": "doesnotexist.invalid:5698"
     }
     ```
 
-    Expect this to fail with a network exception indicating failure to resolve "doesnotexist.local".
+    Expect this to fail with a network exception indicating failure to resolve "doesnotexist.invalid".
 
 ### 8. Bypass Spawning mongocryptd
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -866,13 +866,12 @@ The method of passing TLS options for KMIP TLS connections is driver dependent.
     Expect this to succeed. Use the returned UUID of the key to explicitly encrypt and decrypt the string "test" to
     validate it works.
 
-4. Call `client_encryption.createDataKey()` with "aws" as the provider and the following masterKey:
+4. Call `client_encryption.createDataKey()` with "kmip" as the provider and the following masterKey:
 
     ```javascript
     {
-      region: "us-east-1",
-      key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0",
-      endpoint: "kms.us-east-1.amazonaws.com:12345"
+      "keyId": "1",
+      "endpoint": "localhost:12345"
     }
     ```
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -1745,7 +1745,7 @@ Expect an error indicating TLS handshake failed due to an invalid hostname.
 Call `client_encryption_no_client_cert.createDataKey()` with "azure" as the provider and the following masterKey:
 
 ```javascript
-{ 'keyVaultEndpoint': 'doesnotexist.local', 'keyName': 'foo' }
+{ 'keyVaultEndpoint': 'doesnotexist.invalid', 'keyName': 'foo' }
 ```
 
 Expect an error indicating TLS handshake failed.
@@ -1857,7 +1857,7 @@ Call `client_encryption_with_names.createDataKey()` with "azure:no_client_cert" 
 masterKey:
 
 ```javascript
-{ 'keyVaultEndpoint': 'doesnotexist.local', 'keyName': 'foo' }
+{ 'keyVaultEndpoint': 'doesnotexist.invalid', 'keyName': 'foo' }
 ```
 
 Expect an error indicating TLS handshake failed.


### PR DESCRIPTION
# Summary

Update Client-Side Encryption prose test `7. Custom Endpoint Test` to fix recently seen timeout failures:

- Update case 4 to use `localhost` instead of AWS.
- Use `.invalid` instead of `.local` for test URIs intended to be invalid.

Tested in C driver: https://github.com/mongodb/mongo-c-driver/pull/2001

# Background & Motivation

Drivers have seen recent test failures due to timeout. [Node](https://spruce.mongodb.com/task/mongo_node_driver_next_rhel80_large_Node22_test_rapid_sharded_cluster_82303f3de52ac623bd558ec78f72d7180182e793_25_04_23_18_56_15/tests?execution=0&sortBy=STATUS&sortDir=ASC) indicates failure in Client-Side Encryption prose test: `7. Custom Endpoint Test` case 4. Drivers are expected to connect to a KMS using the endpoint string from [mongocrypt_kms_ctx_endpoint](https://github.com/mongodb/libmongocrypt/blob/ca0790dbb2dc8baf5500e8fab23c6b8520b43026/src/mongocrypt.h#L1132-L1147), so this test seemed meaningful to ensure drivers are handling a custom port. To avoid the timeout to AWS, the test is updated to use the "kmip" provider (expected succeed with `localhost:5698`) with `localhost:12345`.


[Java](https://parsley.mongodb.com/test/mongo_java_driver_tests_jdk_secure__version~5.0_os~linux_topology~sharded_cluster_auth~auth_ssl~ssl_jdk~jdk17_test_sync_58b51e3cb7f1551ad66c1e81185a780bd82ce779_25_04_28_15_43_35/0/b04043a868485bf3a8487dff6adcf400?bookmarks=0,73&shareLine=0) logs before a timeout:
```
Connecting to KMS server at doesnotexist.local:5698
```

`doesnotexist.local` is replaced with `doesnotexist.invalid`. Quoting [RFC 2606](https://www.rfc-editor.org/rfc/rfc2606.html#section-2):

> ".invalid" is intended for use in online construction of domain names that are sure to be invalid and which it is obvious at a glance are invalid.

Tests were run in the C driver. Though tests were not previously failing, logs indicate the test was very slow. On a prior [commit](https://spruce.mongodb.com/task/mongo_c_driver_sanitizers_matrix_asan_asan_cse_sasl_cyrus_openssl_ubuntu2004_clang_test_5.0_server_auth_970589376bba991ce1a3a8336ca1410022349f67_25_04_23_18_21_36/logs?execution=0):
```
[...] "/client_side_encryption/custom_endpoint" [...] "elapsed": 143.074858
```

With [this PR](https://spruce.mongodb.com/task/mongo_c_driver_sanitizers_matrix_asan_asan_cse_sasl_cyrus_openssl_ubuntu2004_clang_test_5.0_server_auth_patch_970589376bba991ce1a3a8336ca1410022349f67_680fd22a2f809900074b249c_25_04_28_19_08_27/logs?execution=0):
```
[...] "/client_side_encryption/custom_endpoint" [...] "elapsed": 3.092288
```


---
<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- [x] Test changes in at least one language driver.
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).~~ (N/A. Only changing KMS endpoint).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
