### PR TITLE
DRIVERS-3023 rename test operation to avoid clash with existing op

### DIFF
--- a/source/gridfs/tests/rename.json
+++ b/source/gridfs/tests/rename.json
@@ -93,7 +93,7 @@
       "description": "rename by id",
       "operations": [
         {
-          "name": "rename",
+          "name": "renameById",
           "object": "bucket0",
           "arguments": {
             "id": {
@@ -161,7 +161,7 @@
       "description": "rename when file id does not exist",
       "operations": [
         {
-          "name": "rename",
+          "name": "renameById",
           "object": "bucket0",
           "arguments": {
             "id": {

--- a/source/gridfs/tests/rename.yml
+++ b/source/gridfs/tests/rename.yml
@@ -51,7 +51,7 @@ initialData:
 tests:
   - description: "rename by id"
     operations:
-      - name: rename
+      - name: renameById
         object: *bucket0
         arguments:
           id: { "$oid": "000000000000000000000001" }
@@ -70,7 +70,7 @@ tests:
           - *file2_chunk0
   - description: "rename when file id does not exist"
     operations:
-      - name: rename
+      - name: renameById
         object: *bucket0
         arguments:
           id: { "$oid": "000000000000000000000003" }


### PR DESCRIPTION
- [✅] Update changelog.
- [✅] Test changes in at least one language driver. (https://github.com/mongodb/mongo-rust-driver/pull/1366)
- [✅] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

This renames the gridfs rename operation from "rename" to "renameById" (consistent with the existing "renameByName") to avoid conflicting with the existing change streams "rename" test operation.  AFAICT the only driver that picked up the tests with the original name is PHP so churn should be minimal.