### PR TITLE
Check all unified tests in UTF makefile

### DIFF
--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -59,7 +59,8 @@ all: atlas-data-lake \
 
 # Keep specifications sorted alphabetically
 # When adding a new specification, remember to add it to the all and .PHONY targets above
-# For specifications that contain
+# For specifications that contain multiple test folders, create a target for each folder
+# in addition to a target for the specification itself
 atlas-data-lake: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../atlas-data-lake-testing/tests/unified/*.yml" --valid
 

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -1,8 +1,61 @@
 SCHEMA=../schema-1.23.json
 
-.PHONY: all atlas-data-lake auth change-streams client-side-encryption client-side-operations-timeout collection-management command-logging-and-monitoring command-logging-and-monitoring/logging command-logging-and-monitoring/monitoring connection-monitoring-and-pooling connection-monitoring-and-pooling/logging crud gridfs index-management load-balancers read-write-concern retryable-reads retryable-writes run-command server-discovery-and-monitoring server-selection server-selection/logging sessions transactions-convenient-api transactions unified-test-format unified-test-format/invalid unified-test-format/valid-fail unified-test-format/valid-pass versioned-api HAS_AJV
+.PHONY: all \
+	atlas-data-lake \
+	auth \
+	change-streams \
+	client-side-encryption \
+	client-side-operations-timeout \
+	collection-management \
+	command-logging-and-monitoring \
+	command-logging-and-monitoring/logging \
+	command-logging-and-monitoring/monitoring \
+	connection-monitoring-and-pooling \
+	connection-monitoring-and-pooling/logging \
+	crud \
+	gridfs \
+	index-management \
+	load-balancers \
+	read-write-concern \
+	retryable-reads \
+	retryable-writes \
+	run-command \
+	server-discovery-and-monitoring \
+	server-selection \
+	server-selection/logging \
+	sessions \
+	transactions-convenient-api \
+	transactions \
+	unified-test-format \
+	unified-test-format/invalid \
+	unified-test-format/valid-fail \
+	unified-test-format/valid-pass \
+	versioned-api \
+	HAS_AJV
 
-all: atlas-data-lake auth change-streams client-side-encryption client-side-operations-timeout collection-management command-logging-and-monitoring connection-monitoring-and-pooling crud gridfs index-management load-balancers read-write-concern retryable-reads retryable-writes run-command server-discovery-and-monitoring server-selection sessions transactions-convenient-api transactions unified-test-format versioned-api
+all: atlas-data-lake \
+	auth \
+	change-streams \
+	client-side-encryption \
+	client-side-operations-timeout \
+	collection-management \
+	command-logging-and-monitoring \
+	connection-monitoring-and-pooling \
+	crud \
+	gridfs \
+	index-management \
+	load-balancers \
+	read-write-concern \
+	retryable-reads \
+	retryable-writes \
+	run-command \
+	server-discovery-and-monitoring \
+	server-selection \
+	sessions \
+	transactions-convenient-api \
+	transactions \
+	unified-test-format \
+	versioned-api
 
 # Keep specifications sorted alphabetically
 # When adding a new specification, remember to add it to the all and .PHONY targets above

--- a/source/unified-test-format/tests/Makefile
+++ b/source/unified-test-format/tests/Makefile
@@ -1,48 +1,54 @@
 SCHEMA=../schema-1.23.json
 
-.PHONY: all invalid valid-fail valid-pass atlas-data-lake versioned-api load-balancers gridfs transactions transactions-convenient-api crud collection-management read-write-concern retryable-reads retryable-writes sessions command-logging-and-monitoring client-side-operations-timeout HAS_AJV
+.PHONY: all atlas-data-lake auth change-streams client-side-encryption client-side-operations-timeout collection-management command-logging-and-monitoring command-logging-and-monitoring/logging command-logging-and-monitoring/monitoring connection-monitoring-and-pooling connection-monitoring-and-pooling/logging crud gridfs index-management load-balancers read-write-concern retryable-reads retryable-writes run-command server-discovery-and-monitoring server-selection server-selection/logging sessions transactions-convenient-api transactions unified-test-format unified-test-format/invalid unified-test-format/valid-fail unified-test-format/valid-pass versioned-api HAS_AJV
 
-all: invalid valid-fail valid-pass atlas-data-lake versioned-api load-balancers gridfs transactions transactions-convenient-api change-streams crud collection-management read-write-concern retryable-reads retryable-writes sessions command-logging-and-monitoring client-side-operations-timeout client-side-encryption
+all: atlas-data-lake auth change-streams client-side-encryption client-side-operations-timeout collection-management command-logging-and-monitoring connection-monitoring-and-pooling crud gridfs index-management load-balancers read-write-concern retryable-reads retryable-writes run-command server-discovery-and-monitoring server-selection sessions transactions-convenient-api transactions unified-test-format versioned-api
 
-invalid: HAS_AJV
-	@# Redirect stdout to hide expected validation errors
-	@ajv test -s $(SCHEMA) -d "invalid/*.yml" --invalid > /dev/null && echo "invalid/*.yml passed test"
-
-valid-fail: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "valid-fail/*.yml" --valid
-
-valid-pass: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "valid-pass/*.yml" --valid
-
+# Keep specifications sorted alphabetically
+# When adding a new specification, remember to add it to the all and .PHONY targets above
+# For specifications that contain
 atlas-data-lake: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../atlas-data-lake-testing/tests/unified/*.yml" --valid
 
-versioned-api: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "../../versioned-api/tests/*.yml" --valid
-
-load-balancers: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "../../load-balancers/tests/*.yml" --valid
-
-gridfs: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "../../gridfs/tests/*.yml" --valid
-
-transactions: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "../../transactions/tests/unified/*.yml" --valid
-
-transactions-convenient-api: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "../../transactions-convenient-api/tests/unified/*.yml" --valid
+auth: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../auth/tests/unified/*.yml" --valid
 
 change-streams: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../change-streams/tests/unified/*.yml" --valid
 
+client-side-encryption: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../client-side-encryption/tests/unified/*.yml" --valid
+
 client-side-operations-timeout: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../client-side-operations-timeout/tests/*.yml" --valid
+
+collection-management: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../collection-management/tests/*.yml" --valid
+
+command-logging-and-monitoring: command-logging-and-monitoring/logging command-logging-and-monitoring/monitoring
+
+command-logging-and-monitoring/logging: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../command-logging-and-monitoring/tests/logging/*.yml" --valid
+
+command-logging-and-monitoring/monitoring: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../command-logging-and-monitoring/tests/monitoring/*.yml" --valid
+
+connection-monitoring-and-pooling: connection-monitoring-and-pooling/logging
+
+connection-monitoring-and-pooling/logging: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../connection-monitoring-and-pooling/tests/logging/*.yml" --valid
 
 crud: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../crud/tests/unified/*.yml" --valid
 
-collection-management: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "../../collection-management/tests/*.yml" --valid
+gridfs: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../gridfs/tests/*.yml" --valid
+
+index-management: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../index-management/tests/*.yml" --valid
+
+load-balancers: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../load-balancers/tests/*.yml" --valid
 
 read-write-concern: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../read-write-concern/tests/operation/*.yml" --valid
@@ -53,15 +59,40 @@ retryable-reads: HAS_AJV
 retryable-writes: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../retryable-writes/tests/unified/*.yml" --valid
 
+run-command: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../run-command/tests/unified/*.yml" --valid
+
+server-discovery-and-monitoring: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../server-discovery-and-monitoring/tests/unified/*.yml" --valid
+
+server-selection: server-selection/logging
+
+server-selection/logging: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../server-selection/tests/logging/*.yml" --valid
+
 sessions: HAS_AJV
 	@ajv test -s $(SCHEMA) -d "../../sessions/tests/*.yml" --valid
 
-command-logging-and-monitoring: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "../../command-logging-and-monitoring/tests/logging/*.yml" --valid
-	@ajv test -s $(SCHEMA) -d "../../command-logging-and-monitoring/tests/monitoring/*.yml" --valid
+transactions-convenient-api: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../transactions-convenient-api/tests/unified/*.yml" --valid
 
-client-side-encryption: HAS_AJV
-	@ajv test -s $(SCHEMA) -d "../../client-side-encryption/tests/unified/*.yml" --valid
+transactions: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../transactions/tests/unified/*.yml" --valid
+
+unified-test-format: unified-test-format/invalid unified-test-format/valid-fail unified-test-format/valid-pass
+
+unified-test-format/invalid: HAS_AJV
+	@# Redirect stdout to hide expected validation errors
+	@ajv test -s $(SCHEMA) -d "invalid/*.yml" --invalid > /dev/null && echo "invalid/*.yml passed test"
+
+unified-test-format/valid-fail: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "valid-fail/*.yml" --valid
+
+unified-test-format/valid-pass: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "valid-pass/*.yml" --valid
+
+versioned-api: HAS_AJV
+	@ajv test -s $(SCHEMA) -d "../../versioned-api/tests/*.yml" --valid
 
 HAS_AJV:
 	@if ! command -v ajv > /dev/null; then                \


### PR DESCRIPTION
This PR does not check any specifications or test files, but it completely revamps the makefile used to test specifications. The change was prompted by me realising that not all folders were properly checked. As a result, I changed the following:

- Introduced separate targets for each folder containing test files. This creates multiple targets in specifications like the unified test format, e.g. `unified-test-format/invalid` and `unified-test-format/valid-pass`. In those cases, I also added a compound target, e.g. `unified-test-format`, that runs all individual targets
- Sorted target names alphabetically

The following specifications didn't have their test files checked previously:
- auth
- connection-monitoring-and-pooling
- index-management
- run-command
- server-discovery-and-monitoring
- server-selection