### PR TITLE
add `retryOn429`

### DIFF
--- a/markdown_link_config.json
+++ b/markdown_link_config.json
@@ -12,5 +12,6 @@
       {
         "pattern": "cloudkms.googleapis.com"
       }
-    ]
+    ],
+    "retryOn429": true
 }

--- a/markdown_link_config.json
+++ b/markdown_link_config.json
@@ -13,5 +13,6 @@
         "pattern": "cloudkms.googleapis.com"
       }
     ],
-    "retryOn429": true
+    "retryOn429": true,
+    "fallbackRetryDelay": "5s"
 }


### PR DESCRIPTION
Intended to address observed GitHub actions failures ([example](https://github.com/mongodb/specifications/actions/runs/14840588027)):

```
  ERROR: 1 dead links found in docs/workforce-human-oidc-auth.md !
  [✖] https://github.com/mongodb/specifications/blob/master/source/auth/auth.md#mongodb-oidc → Status: 429
```

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- ~~[ ] Test changes in at least one language driver.~~
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
