### PR TITLE
fix: markdown link check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     entry: python3 scripts/check_md_html.py
 
 - repo: https://github.com/tcort/markdown-link-check
-  rev: v3.12.2
+  rev: v3.13.7
   hooks:
     - id: markdown-link-check
       args: ["-q", "-c", "markdown_link_config.json"]


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Updates markdown link check to 3.13.7 to fix dead link failures.

- [ ] Update changelog.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
