### PR TITLE
DRIVERS-3115: Remove serverless testing requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Please complete the following before merging:
 
 - [ ] Update changelog.
 - [ ] Test changes in at least one language driver.
-- [ ] Test these changes against all server versions and topologies (including standalone, replica set, sharded
-    clusters, and serverless).
+- [ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
+    clusters).
 
 <!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

--- a/source/serverless-testing/README.md
+++ b/source/serverless-testing/README.md
@@ -1,9 +1,14 @@
 # Atlas Serverless Tests
 
-- Status: Accepted
+- Status: Obsolete
 - Minimum Server Version: N/A
 
 ______________________________________________________________________
+
+## Obsolescence Notice
+
+This document is obsolete and there is no longer a requirement for drivers to test against Atlas Serverless. The
+specification is preserved for historical purposes only.
 
 ## Introduction
 

--- a/source/unified-test-format/unified-test-format.md
+++ b/source/unified-test-format/unified-test-format.md
@@ -337,9 +337,10 @@ The structure of this object is as follows:
     Note: load balancers were introduced in MongoDB 5.0. Therefore, any sharded cluster behind a load balancer implicitly
     uses replica sets for its shards.
 
-- `serverless`: Optional string. Whether or not the test should be run on Atlas Serverless instances. Valid values are
-    "require", "forbid", and "allow". If "require", the test MUST only be run on Atlas Serverless instances. If
-    "forbid", the test MUST NOT be run on Atlas Serverless instances. If omitted or "allow", this option has no effect.
+- `serverless` (deprecated): Optional string. Whether or not the test should be run on Atlas Serverless instances. Valid
+    values are "require", "forbid", and "allow". If "require", the test MUST only be run on Atlas Serverless instances.
+    If "forbid", the test MUST NOT be run on Atlas Serverless instances. If omitted or "allow", this option has no
+    effect.
 
     The test runner MUST be informed whether or not Atlas Serverless is being used in order to determine if this
     requirement is met (e.g. through an environment variable or configuration option).
@@ -347,6 +348,9 @@ The structure of this object is as follows:
     Note: the Atlas Serverless proxy imitates mongos, so the test runner is not capable of determining if Atlas Serverless
     is in use by issuing commands such as `buildInfo` or `hello`. Furthermore, connections to Atlas Serverless use a
     load balancer, so the topology will appear as "load-balanced".
+
+    Note: serverless testing is no longer required, and drivers that no longer support serverless testing MAY omit
+    implementation of this requirement and instantly skip all tests that use `serverless: require`.
 
 - `serverParameters`: Optional object of server parameters to check against. To check server parameters, drivers send a
     `{ getParameter: 1, <parameter>: 1 }` command to the server using an internal MongoClient. Drivers MAY also choose
@@ -3578,6 +3582,8 @@ operations and arguments. This is a concession until such time that better proce
 other specs *and* collating spec changes developed in parallel or during the same release cycle.
 
 ## Changelog
+
+- 2025-06-04: Deprecate the `serverless` runOnRequirement
 
 - 2025-04-25: Drop `_enxcol` collections.
 


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Update changelog.
- [ ] N/A Test changes in at least one language driver.
- [ ] N/A Test these changes against all server versions and topologies (including standalone, replica set, sharded
    clusters, and serverless).

This PR marks the serverless testing spec as obsolete and deprecates the `serverless` runOnRequirement in the unified test format. No tests have been modified as part of this PR as we want to preserve existing test behaviour until all drivers have disabled serverless testing.
