### PR TITLE
DRIVERS-3064 Add support for the rawData command option

### DIFF
--- a/source/collection-management/tests/listCollections-rawdata.json
+++ b/source/collection-management/tests/listCollections-rawdata.json
@@ -1,0 +1,91 @@
+{
+  "description": "listCollections-rawData",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "listCollections with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database0",
+          "arguments": {
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "filter": {},
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "listCollections with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "listCollections",
+          "object": "database0",
+          "arguments": {
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "filter": {},
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/collection-management/tests/listCollections-rawdata.json
+++ b/source/collection-management/tests/listCollections-rawdata.json
@@ -23,7 +23,8 @@
       "description": "listCollections with rawData option",
       "runOnRequirements": [
         {
-          "minServerVersion": "8.2.0"
+          "minServerVersion": "8.2.0",
+          "auth": false
         }
       ],
       "operations": [
@@ -56,7 +57,8 @@
       "description": "listCollections with rawData option on less than 8.2.0 - ignore argument",
       "runOnRequirements": [
         {
-          "maxServerVersion": "8.1.99"
+          "maxServerVersion": "8.1.99",
+          "auth": false
         }
       ],
       "operations": [

--- a/source/collection-management/tests/listCollections-rawdata.yml
+++ b/source/collection-management/tests/listCollections-rawdata.yml
@@ -1,0 +1,49 @@
+description: "listCollections-rawData"
+
+schemaVersion: "1.4"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0
+
+tests:
+  - description: "listCollections with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+        auth: false
+    operations:
+      - name: listCollections
+        object: *database0
+        arguments:
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                listCollections: 1
+                filter: {}
+                rawData: *rawdata
+  - description: "listCollections with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+        auth: false
+    operations:
+      - name: listCollections
+        object: *database0
+        arguments:
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                listCollections: 1
+                filter: {}
+                rawData:
+                  $$exists: false

--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -310,6 +310,15 @@ class BulkWriteOptions {
     comment: Optional<BSON value>;
 
     /**
+     * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+     *
+     * @note This option will not be sent when connected to pre-9.0 servers.
+     *
+     * @since MongoDB 8.2
+     */
+    rawData: Optional<Boolean>;
+
+    /**
      * Whether detailed results for each successful operation should be included in the returned
      * BulkWriteResult.
      *
@@ -538,6 +547,7 @@ The `bulkWrite` server command has the following format:
     "bypassDocumentValidation": Optional<Boolean>,
     "comment": Optional<BSON value>,
     "let": Optional<Document>,
+    "rawData": Optional<Boolean>,
     ...additional operation-agnostic fields
 }
 ```
@@ -916,6 +926,8 @@ The requirement has since been removed. Checking size limits complicates some dr
 error in this specific situation does not seem helpful enough to require size checks.
 
 ## **Changelog**
+
+- 2025-06-27: Added `rawData` option.
 
 - 2024-11-05: Updated the requirements regarding the size validation.
 

--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -319,6 +319,15 @@ class AggregateOptions {
    * @see https://www.mongodb.com/docs/manual/reference/command/aggregate/
    */
   let: Optional<Document>;
+
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class CountOptions {
@@ -371,6 +380,15 @@ class CountOptions {
    * and providing one will result in a server-side error.
    */
   comment: Optional<any>;
+
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class EstimatedDocumentCountOptions {
@@ -395,6 +413,15 @@ class EstimatedDocumentCountOptions {
    * comment may result in a server-side error.
    */
   comment: Optional<any>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class DistinctOptions {
@@ -439,6 +466,15 @@ class DistinctOptions {
    * @see https://www.mongodb.com/docs/manual/reference/command/find/
    */
   hint: Optional<(String | Document)>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 enum CursorType {
@@ -713,6 +749,15 @@ class FindOptions {
    * @see https://www.mongodb.com/docs/manual/reference/command/find/
    */
   let: Optional<Document>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 type FindOneOptions = Omit<FindOptions, 'batchSize' | 'cursorType' | 'limit' | 'noCursorTimeout'>;
@@ -985,6 +1030,15 @@ class BulkWriteOptions {
    * The value of let will be passed to all update and delete, but not insert, commands.
    */
   let: Optional<Document>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class InsertOneOptions {
@@ -1007,6 +1061,15 @@ class InsertOneOptions {
    * and providing one will result in a server-side error.
    */
   comment: Optional<any>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class InsertManyOptions {
@@ -1036,6 +1099,15 @@ class InsertManyOptions {
    * and providing one will result in a server-side error.
    */
   comment: Optional<any>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class UpdateOptions {
@@ -1127,6 +1199,15 @@ class UpdateOptions {
    * @see https://www.mongodb.com/docs/manual/reference/command/update/
    */
   sort: Optional<Document>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class ReplaceOptions {
@@ -1206,6 +1287,15 @@ class ReplaceOptions {
    * @see https://www.mongodb.com/docs/manual/reference/command/update/
    */
   sort: Optional<Document>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class DeleteOptions {
@@ -1256,6 +1346,15 @@ class DeleteOptions {
    * and providing one will result in a server-side error.
    */
   comment: Optional<any>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 ```
 
@@ -2009,6 +2108,15 @@ class FindOneAndDeleteOptions {
    * and providing one will result in a server-side error.
    */
   comment: Optional<any>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class FindOneAndReplaceOptions {
@@ -2117,6 +2225,15 @@ class FindOneAndReplaceOptions {
    * and providing one will result in a server-side error.
    */
   comment: Optional<any>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 
 class FindOneAndUpdateOptions {
@@ -2234,6 +2351,15 @@ class FindOneAndUpdateOptions {
    * and providing one will result in a server-side error.
    */
   comment: Optional<any>;
+  
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 ```
 
@@ -2511,6 +2637,8 @@ the Stable API, it was decided that this change was acceptable to make in minor 
 aforementioned allowance in the SemVer spec.
 
 ## Changelog
+
+- 2025-06-27: Added `rawData` options.
 
 - 2024-11-13: Define `findOne` operation as optional, and add guidance on `limit` and `batchSize` for `find` operations.
 

--- a/source/crud/tests/unified/aggregate-rawdata.json
+++ b/source/crud/tests/unified/aggregate-rawdata.json
@@ -1,0 +1,116 @@
+{
+  "description": "aggregate-rawData",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Aggregate with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Aggregate with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "aggregate",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": [
+              {
+                "$match": {}
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/aggregate-rawdata.yml
+++ b/source/crud/tests/unified/aggregate-rawdata.yml
@@ -1,0 +1,55 @@
+description: "aggregate-rawData"
+
+schemaVersion: "1.4"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "Aggregate with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: aggregate
+        object: *collection0
+        arguments:
+          pipeline: &pipeline0
+            - $match: {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline0
+                rawData: *rawdata
+  - description: "Aggregate with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: aggregate
+        object: *collection0
+        arguments:
+          pipeline: &pipeline0
+            - $match: {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline: *pipeline0
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/bulkWrite-deleteMany-rawdata.json
+++ b/source/crud/tests/unified/bulkWrite-deleteMany-rawdata.json
@@ -1,0 +1,122 @@
+{
+  "description": "BulkWrite deleteMany-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite deleteMany with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "deleteMany": {
+                  "filter": {}
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 0
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite deleteMany with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "deleteMany": {
+                  "filter": {}
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 0
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/bulkWrite-deleteMany-rawdata.yml
+++ b/source/crud/tests/unified/bulkWrite-deleteMany-rawdata.yml
@@ -1,0 +1,61 @@
+description: "BulkWrite deleteMany-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "BulkWrite deleteMany with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - deleteMany:
+                filter: &filter {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 0
+                rawData: *rawdata
+  - description: "BulkWrite deleteMany with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - deleteMany:
+                filter: &filter {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 0
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/bulkWrite-deleteOne-rawdata.json
+++ b/source/crud/tests/unified/bulkWrite-deleteOne-rawdata.json
@@ -1,0 +1,122 @@
+{
+  "description": "BulkWrite deleteOne-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite deleteOne with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "deleteOne": {
+                  "filter": {}
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 1
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite deleteOne with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "deleteOne": {
+                  "filter": {}
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 1
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/bulkWrite-deleteOne-rawdata.yml
+++ b/source/crud/tests/unified/bulkWrite-deleteOne-rawdata.yml
@@ -1,0 +1,61 @@
+description: "BulkWrite deleteOne-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "BulkWrite deleteOne with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - deleteOne:
+                filter: &filter {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 1
+                rawData: *rawdata
+  - description: "BulkWrite deleteOne with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - deleteOne:
+                filter: &filter {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: *filter
+                    limit: 1
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/bulkWrite-replaceOne-rawdata.json
+++ b/source/crud/tests/unified/bulkWrite-replaceOne-rawdata.json
@@ -1,0 +1,136 @@
+{
+  "description": "BulkWrite replaceOne-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite replaceOne with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {},
+                  "replacement": {}
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": {},
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite replaceOne with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "replaceOne": {
+                  "filter": {},
+                  "replacement": {}
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": {},
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/bulkWrite-replaceOne-rawdata.yml
+++ b/source/crud/tests/unified/bulkWrite-replaceOne-rawdata.yml
@@ -1,0 +1,71 @@
+description: "BulkWrite replaceOne-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "BulkWrite replaceOne with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - replaceOne:
+                filter: &filter {}
+                replacement: &replacement {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *replacement
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData: *rawdata
+  - description: "BulkWrite replaceOne with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - replaceOne:
+                filter: &filter {}
+                replacement: &replacement {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *replacement
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/bulkWrite-updateMany-rawdata.json
+++ b/source/crud/tests/unified/bulkWrite-updateMany-rawdata.json
@@ -1,0 +1,157 @@
+{
+  "description": "BulkWrite updateMany-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite updateMany with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {},
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 1
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite updateMany with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2.0",
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateMany": {
+                  "filter": {},
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 1
+                          }
+                        }
+                      ],
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/bulkWrite-updateMany-rawdata.yml
+++ b/source/crud/tests/unified/bulkWrite-updateMany-rawdata.yml
@@ -1,0 +1,72 @@
+description: "BulkWrite updateMany-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "BulkWrite updateMany with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateMany:
+                filter: &filter {}
+                update: &update
+                  - $set:
+                      x: 1
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *update
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+                rawData: *rawdata
+  - description: "BulkWrite updateMany with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - minServerVersion: "4.2.0"
+        maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateMany:
+                filter: &filter {}
+                update: &update
+                  - $set:
+                      x: 1
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *update
+                    multi: true
+                    upsert: { $$unsetOrMatches: false }
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/bulkWrite-updateOne-rawdata.json
+++ b/source/crud/tests/unified/bulkWrite-updateOne-rawdata.json
@@ -1,0 +1,161 @@
+{
+  "description": "BulkWrite updateOne-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "BulkWrite updateOne with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {},
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 1
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "BulkWrite updateOne with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2.0",
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "bulkWrite",
+          "arguments": {
+            "requests": [
+              {
+                "updateOne": {
+                  "filter": {},
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 1
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": [
+                        {
+                          "$set": {
+                            "x": 1
+                          }
+                        }
+                      ],
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/bulkWrite-updateOne-rawdata.yml
+++ b/source/crud/tests/unified/bulkWrite-updateOne-rawdata.yml
@@ -1,0 +1,76 @@
+description: "BulkWrite updateOne-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "BulkWrite updateOne with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateOne:
+                filter: &filter {}
+                update: &update
+                  - $set:
+                      x: 1
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *update
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData: *rawdata
+  - description: "BulkWrite updateOne with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - minServerVersion: "4.2.0"
+        maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: bulkWrite
+        arguments:
+          requests:
+            - updateOne:
+                filter: &filter {}
+                update: &update
+                  - $set:
+                      x: 1
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: *filter
+                    u: *update
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/client-bulkWrite-delete-rawdata.json
+++ b/source/crud/tests/unified/client-bulkWrite-delete-rawdata.json
@@ -44,7 +44,7 @@
                 "deleteOne": {
                   "namespace": "crud-tests.coll0",
                   "filter": {}
-               }
+                }
               },
               {
                 "deleteMany": {

--- a/source/crud/tests/unified/client-bulkWrite-delete-rawdata.json
+++ b/source/crud/tests/unified/client-bulkWrite-delete-rawdata.json
@@ -147,15 +147,15 @@
                       "filter": {},
                       "multi": true
                     }
-                  ]
-                },
-                "nsInfo": [
-                  {
-                    "ns": "crud-tests.coll0"
+                  ],
+                  "nsInfo": [
+                    {
+                      "ns": "crud-tests.coll0"
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
                   }
-                ],
-                "rawData": {
-                  "$$exists": false
                 }
               }
             }

--- a/source/crud/tests/unified/client-bulkWrite-delete-rawdata.json
+++ b/source/crud/tests/unified/client-bulkWrite-delete-rawdata.json
@@ -1,0 +1,167 @@
+{
+  "description": "client bulkWrite delete-rawData",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "client bulk write delete with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "deleteOne": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {}
+               }
+              },
+              {
+                "deleteMany": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {}
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "bulkWrite",
+                "databaseName": "admin",
+                "command": {
+                  "bulkWrite": 1,
+                  "ordered": true,
+                  "ops": [
+                    {
+                      "delete": 0,
+                      "filter": {},
+                      "multi": false
+                    },
+                    {
+                      "delete": 0,
+                      "filter": {},
+                      "multi": true
+                    }
+                  ],
+                  "nsInfo": [
+                    {
+                      "ns": "crud-tests.coll0"
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "client bulk write delete with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0",
+          "maxServerVersion": "8.1.99",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "deleteOne": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {}
+                }
+              },
+              {
+                "deleteMany": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {}
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "bulkWrite",
+                "databaseName": "admin",
+                "command": {
+                  "bulkWrite": 1,
+                  "ordered": true,
+                  "ops": [
+                    {
+                      "delete": 0,
+                      "filter": {},
+                      "multi": false
+                    },
+                    {
+                      "delete": 0,
+                      "filter": {},
+                      "multi": true
+                    }
+                  ]
+                },
+                "nsInfo": [
+                  {
+                    "ns": "crud-tests.coll0"
+                  }
+                ],
+                "rawData": {
+                  "$$exists": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/client-bulkWrite-delete-rawdata.yml
+++ b/source/crud/tests/unified/client-bulkWrite-delete-rawdata.yml
@@ -1,0 +1,94 @@
+description: "client bulkWrite delete-rawData"
+
+schemaVersion: "1.4"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+_yamlAnchors:
+  namespace: &namespace "crud-tests.coll0"
+  filter: &filter {}
+
+tests:
+  - description: "client bulk write delete with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+        serverless: forbid
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - deleteOne:
+                namespace: *namespace
+                filter: *filter
+            - deleteMany:
+                namespace: *namespace
+                filter: *filter
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: bulkWrite
+              databaseName: admin
+              command:
+                bulkWrite: 1
+                ordered: true
+                ops:
+                  - delete: 0
+                    filter: *filter
+                    multi: false
+                  - delete: 0
+                    filter: *filter
+                    multi: true
+                nsInfo:
+                  - ns: *namespace
+                rawData: *rawdata
+  - description: "client bulk write delete with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - minServerVersion: "8.0"
+        maxServerVersion: "8.1.99"
+        serverless: forbid
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - deleteOne:
+                namespace: *namespace
+                filter: *filter
+            - deleteMany:
+                namespace: *namespace
+                filter: *filter
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: bulkWrite
+              databaseName: admin
+              command:
+                bulkWrite: 1
+                ordered: true
+                ops:
+                  - delete: 0
+                    filter: *filter
+                    multi: false
+                  - delete: 0
+                    filter: *filter
+                    multi: true
+              nsInfo:
+                - ns: *namespace
+              rawData:
+                $$exists: false

--- a/source/crud/tests/unified/client-bulkWrite-delete-rawdata.yml
+++ b/source/crud/tests/unified/client-bulkWrite-delete-rawdata.yml
@@ -88,7 +88,7 @@ tests:
                   - delete: 0
                     filter: *filter
                     multi: true
-              nsInfo:
-                - ns: *namespace
-              rawData:
-                $$exists: false
+                nsInfo:
+                  - ns: *namespace
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.json
+++ b/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.json
@@ -146,7 +146,7 @@
                         "$$unsetOrMatches": false
                       }
                     }
-                 ]
+                  ]
                 },
                 "nsInfo": [
                   {

--- a/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.json
+++ b/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.json
@@ -146,15 +146,15 @@
                         "$$unsetOrMatches": false
                       }
                     }
-                  ]
-                },
-                "nsInfo": [
-                  {
-                    "ns": "crud-tests.coll0"
+                  ],
+                  "nsInfo": [
+                    {
+                      "ns": "crud-tests.coll0"
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
                   }
-                ],
-                "rawData": {
-                  "$$exists": false
                 }
               }
             }

--- a/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.json
+++ b/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.json
@@ -1,0 +1,166 @@
+{
+  "description": "client bulkWrite replaceOne-rawData",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "client bulkWrite replaceOne with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "replaceOne": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {},
+                  "replacement": {
+                    "x": 1
+                  }
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "bulkWrite",
+                "databaseName": "admin",
+                "command": {
+                  "bulkWrite": 1,
+                  "ops": [
+                    {
+                      "update": 0,
+                      "filter": {},
+                      "updateMods": {
+                        "x": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "nsInfo": [
+                    {
+                      "ns": "crud-tests.coll0"
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "client bulk write replaceOne with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0",
+          "maxServerVersion": "8.1.99",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "replaceOne": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {},
+                  "replacement": {
+                    "x": 1
+                  }
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "bulkWrite",
+                "databaseName": "admin",
+                "command": {
+                  "bulkWrite": 1,
+                  "ordered": true,
+                  "ops": [
+                    {
+                      "update": 0,
+                      "filter": {},
+                      "updateMods": {
+                        "x": 1
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                 ]
+                },
+                "nsInfo": [
+                  {
+                    "ns": "crud-tests.coll0"
+                  }
+                ],
+                "rawData": {
+                  "$$exists": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.yml
+++ b/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.yml
@@ -1,0 +1,92 @@
+description: "client bulkWrite replaceOne-rawData"
+
+schemaVersion: "1.4"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+_yamlAnchors:
+  namespace: &namespace "crud-tests.coll0"
+
+tests:
+  - description: "client bulkWrite replaceOne with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+        serverless: forbid
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - replaceOne:
+                namespace: *namespace
+                filter: &filter {}
+                replacement: &replacement
+                  x: 1
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: bulkWrite
+              databaseName: admin
+              command:
+                bulkWrite: 1
+                ops:
+                  - update: 0
+                    filter: *filter
+                    updateMods: *replacement
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+                nsInfo:
+                  - ns: *namespace
+                rawData: *rawdata
+  - description: "client bulk write replaceOne with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - minServerVersion: "8.0"
+        maxServerVersion: "8.1.99"
+        serverless: forbid
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - replaceOne:
+                namespace: *namespace
+                filter: &filter {}
+                replacement: &replacement
+                  x: 1
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: bulkWrite
+              databaseName: admin
+              command:
+                bulkWrite: 1
+                ordered: true
+                ops:
+                  - update: 0
+                    filter: *filter
+                    updateMods: *replacement
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+              nsInfo:
+                - ns: *namespace
+              rawData:
+                $$exists: false

--- a/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.yml
+++ b/source/crud/tests/unified/client-bulkWrite-replaceOne-rawdata.yml
@@ -86,7 +86,7 @@ tests:
                       $$unsetOrMatches: false
                     upsert:
                       $$unsetOrMatches: false
-              nsInfo:
-                - ns: *namespace
-              rawData:
-                $$exists: false
+                nsInfo:
+                  - ns: *namespace
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/client-bulkWrite-update-rawdata.json
+++ b/source/crud/tests/unified/client-bulkWrite-update-rawdata.json
@@ -1,0 +1,191 @@
+{
+  "description": "client bulkWrite update-rawData",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "client bulk write update with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "updateOne": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {},
+                  "update": {
+                    "$set": {}
+                  }
+                }
+              },
+              {
+                "updateMany": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {},
+                  "update": {
+                    "$set": {}
+                  }
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "bulkWrite",
+                "databaseName": "admin",
+                "command": {
+                  "bulkWrite": 1,
+                  "ordered": true,
+                  "ops": [
+                    {
+                      "update": 0,
+                      "filter": {},
+                      "updateMods": {
+                        "$set": {}
+                      },
+                      "multi": false
+                    },
+                    {
+                      "update": 0,
+                      "filter": {},
+                      "updateMods": {
+                        "$set": {}
+                      },
+                      "multi": true
+                    }
+                  ],
+                  "nsInfo": [
+                    {
+                      "ns": "crud-tests.coll0"
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "client bulk write update with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.0",
+          "maxServerVersion": "8.1.99",
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "object": "client0",
+          "name": "clientBulkWrite",
+          "arguments": {
+            "models": [
+              {
+                "updateOne": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {},
+                  "update": {
+                    "$set": {}
+                  }
+                }
+              },
+              {
+                "updateMany": {
+                  "namespace": "crud-tests.coll0",
+                  "filter": {},
+                  "update": {
+                    "$set": {}
+                  }
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "commandName": "bulkWrite",
+                "databaseName": "admin",
+                "command": {
+                  "bulkWrite": 1,
+                  "ordered": true,
+                  "ops": [
+                    {
+                      "update": 0,
+                      "filter": {},
+                      "updateMods": {
+                        "$set": {}
+                      },
+                      "multi": false
+                    },
+                    {
+                      "update": 0,
+                      "filter": {},
+                      "updateMods": {
+                        "$set": {}
+                      },
+                      "multi": true
+                    }
+                 ]
+                },
+                "nsInfo": [
+                  {
+                    "ns": "crud-tests.coll0"
+                  }
+                ],
+                "rawData": {
+                  "$$exists": false
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/client-bulkWrite-update-rawdata.json
+++ b/source/crud/tests/unified/client-bulkWrite-update-rawdata.json
@@ -171,7 +171,7 @@
                       },
                       "multi": true
                     }
-                 ]
+                  ]
                 },
                 "nsInfo": [
                   {

--- a/source/crud/tests/unified/client-bulkWrite-update-rawdata.json
+++ b/source/crud/tests/unified/client-bulkWrite-update-rawdata.json
@@ -171,15 +171,15 @@
                       },
                       "multi": true
                     }
-                  ]
-                },
-                "nsInfo": [
-                  {
-                    "ns": "crud-tests.coll0"
+                  ],
+                  "nsInfo": [
+                    {
+                      "ns": "crud-tests.coll0"
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
                   }
-                ],
-                "rawData": {
-                  "$$exists": false
                 }
               }
             }

--- a/source/crud/tests/unified/client-bulkWrite-update-rawdata.yml
+++ b/source/crud/tests/unified/client-bulkWrite-update-rawdata.yml
@@ -97,7 +97,7 @@ tests:
                     filter: *filter
                     updateMods: *update
                     multi: true
-              nsInfo:
-                - ns: *namespace
-              rawData:
-                $$exists: false
+                nsInfo:
+                  - ns: *namespace
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/client-bulkWrite-update-rawdata.yml
+++ b/source/crud/tests/unified/client-bulkWrite-update-rawdata.yml
@@ -1,0 +1,103 @@
+description: "client bulkWrite update-rawData"
+schemaVersion: "1.4"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+_yamlAnchors:
+  namespace: &namespace "crud-tests.coll0"
+  filter: &filter {}
+  update: &update
+    $set: {}
+
+tests:
+  - description: "client bulk write update with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+        serverless: forbid
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - updateOne:
+                namespace: *namespace
+                filter: *filter
+                update: *update
+            - updateMany:
+                namespace: *namespace
+                filter: *filter
+                update: *update
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: bulkWrite
+              databaseName: admin
+              command:
+                bulkWrite: 1
+                ordered: true
+                ops:
+                  - update: 0
+                    filter: *filter
+                    updateMods: *update
+                    multi: false
+                  - update: 0
+                    filter: *filter
+                    updateMods: *update
+                    multi: true
+                nsInfo:
+                  - ns: *namespace
+                rawData: *rawdata
+  - description: "client bulk write update with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - minServerVersion: "8.0"
+        maxServerVersion: "8.1.99"
+        serverless: forbid
+    operations:
+      - object: *client0
+        name: clientBulkWrite
+        arguments:
+          models:
+            - updateOne:
+                namespace: *namespace
+                filter: *filter
+                update: *update
+            - updateMany:
+                namespace: *namespace
+                filter: *filter
+                update: *update
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: bulkWrite
+              databaseName: admin
+              command:
+                bulkWrite: 1
+                ordered: true
+                ops:
+                  - update: 0
+                    filter: *filter
+                    updateMods: *update
+                    multi: false
+                  - update: 0
+                    filter: *filter
+                    updateMods: *update
+                    multi: true
+              nsInfo:
+                - ns: *namespace
+              rawData:
+                $$exists: false

--- a/source/crud/tests/unified/count-rawdata.json
+++ b/source/crud/tests/unified/count-rawdata.json
@@ -1,0 +1,100 @@
+{
+  "description": "count-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Deprecated count with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "count",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0",
+                  "rawData": true
+                },
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Deprecated count with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "count",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0",
+                  "rawData": {
+                    "$$exists": false
+                  }
+                },
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/count-rawdata.yml
+++ b/source/crud/tests/unified/count-rawdata.yml
@@ -1,0 +1,53 @@
+description: "count-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "Deprecated count with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: count
+        arguments:
+          filter: {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+                rawData: *rawdata
+              databaseName: *database0Name
+  - description: "Deprecated count with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: count
+        arguments:
+          filter: {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+                rawData:
+                  $$exists: false
+              databaseName: *database0Name

--- a/source/crud/tests/unified/countDocuments-rawdata.json
+++ b/source/crud/tests/unified/countDocuments-rawdata.json
@@ -1,0 +1,128 @@
+{
+  "description": "countDocuments-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Count documents with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "countDocuments",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    },
+                    {
+                      "$group": {
+                        "_id": 1,
+                        "n": {
+                          "$sum": 1
+                        }
+                      }
+                    }
+                  ],
+                  "rawData": true
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Count documents with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "countDocuments",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "aggregate": "coll0",
+                  "pipeline": [
+                    {
+                      "$match": {}
+                    },
+                    {
+                      "$group": {
+                        "_id": 1,
+                        "n": {
+                          "$sum": 1
+                        }
+                      }
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "aggregate",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/countDocuments-rawdata.yml
+++ b/source/crud/tests/unified/countDocuments-rawdata.yml
@@ -1,0 +1,61 @@
+description: "countDocuments-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "Count documents with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: countDocuments
+        arguments:
+          filter: {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $match: {}
+                  - $group: { _id: 1, n: { $sum: 1 } }
+                rawData: *rawdata
+              commandName: aggregate
+              databaseName: *database0Name
+  - description: "Count documents with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: countDocuments
+        arguments:
+          filter: {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $match: {}
+                  - $group: { _id: 1, n: { $sum: 1 } }
+                rawData:
+                  $$exists: false
+              commandName: aggregate
+              databaseName: *database0Name

--- a/source/crud/tests/unified/deleteMany-rawdata.json
+++ b/source/crud/tests/unified/deleteMany-rawdata.json
@@ -1,0 +1,110 @@
+{
+  "description": "deleteMany-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "deleteMany with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 0
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "deleteMany with with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 0
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/deleteMany-rawdata.yml
+++ b/source/crud/tests/unified/deleteMany-rawdata.yml
@@ -1,0 +1,57 @@
+description: "deleteMany-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "deleteMany with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: deleteMany
+        object: *collection0
+        arguments:
+          filter: {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: {}
+                    limit: 0
+                rawData: *rawdata
+  - description: "deleteMany with with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: deleteMany
+        object: *collection0
+        arguments:
+          filter: {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: {}
+                    limit: 0
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/deleteOne-rawdata.json
+++ b/source/crud/tests/unified/deleteOne-rawdata.json
@@ -1,0 +1,110 @@
+{
+  "description": "deleteOne-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "deleteOne with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 1
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "deleteOne with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "deleteOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "delete": "coll0",
+                  "deletes": [
+                    {
+                      "q": {},
+                      "limit": 1
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/deleteOne-rawdata.yml
+++ b/source/crud/tests/unified/deleteOne-rawdata.yml
@@ -1,0 +1,57 @@
+description: "deleteOne-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "deleteOne with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: deleteOne
+        object: *collection0
+        arguments:
+          filter: {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: {}
+                    limit: 1
+                rawData: *rawdata
+  - description: "deleteOne with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: deleteOne
+        object: *collection0
+        arguments:
+          filter: {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                delete: *collection0Name
+                deletes:
+                  - q: {}
+                    limit: 1
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/distinct-rawdata.json
+++ b/source/crud/tests/unified/distinct-rawdata.json
@@ -1,0 +1,104 @@
+{
+  "description": "distinct-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "distinct with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection0",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "distinct": "coll0",
+                  "key": "x",
+                  "query": {},
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "distinct with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "distinct",
+          "object": "collection0",
+          "arguments": {
+            "fieldName": "x",
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "distinct": "coll0",
+                  "key": "x",
+                  "query": {},
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/distinct-rawdata.yml
+++ b/source/crud/tests/unified/distinct-rawdata.yml
@@ -1,0 +1,57 @@
+description: "distinct-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "distinct with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: distinct
+        object: *collection0
+        arguments:
+          fieldName: &fieldName x
+          filter: &filter {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                distinct: *collection0Name
+                key: *fieldName
+                query: *filter
+                rawData: *rawdata
+  - description: "distinct with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: distinct
+        object: *collection0
+        arguments:
+          fieldName: &fieldName x
+          filter: &filter {}
+          rawData: true
+    expectEvents:
+      - client: client0
+        events:
+          - commandStartedEvent:
+              command:
+                distinct: *collection0Name
+                key: *fieldName
+                query: *filter
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/estimatedDocumentCount-rawdata.json
+++ b/source/crud/tests/unified/estimatedDocumentCount-rawdata.json
@@ -1,0 +1,100 @@
+{
+  "description": "estimatedDocumentCount-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Estimated document count with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "estimatedDocumentCount",
+          "arguments": {
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0",
+                  "rawData": true
+                },
+                "commandName": "count",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Estimated document count with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "estimatedDocumentCount",
+          "arguments": {
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "count": "coll0",
+                  "rawData": {
+                    "$$exists": false
+                  }
+                },
+                "commandName": "count",
+                "databaseName": "crud-tests"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/estimatedDocumentCount-rawdata.yml
+++ b/source/crud/tests/unified/estimatedDocumentCount-rawdata.yml
@@ -1,0 +1,53 @@
+description: "estimatedDocumentCount-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "Estimated document count with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: estimatedDocumentCount
+        arguments:
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+                rawData: *rawdata
+              commandName: count
+              databaseName: *database0Name
+  - description: "Estimated document count with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: estimatedDocumentCount
+        arguments:
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                count: *collection0Name
+                rawData:
+                  $$exists: false
+              commandName: count
+              databaseName: *database0Name

--- a/source/crud/tests/unified/find-rawdata.json
+++ b/source/crud/tests/unified/find-rawdata.json
@@ -1,0 +1,100 @@
+{
+  "description": "find-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Find with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Find with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "coll0",
+                  "filter": {},
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/find-rawdata.yml
+++ b/source/crud/tests/unified/find-rawdata.yml
@@ -1,0 +1,53 @@
+description: "find-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "Find with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: {}
+                rawData: *rawdata
+  - description: "Find with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          filter: {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: {}
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/findOneAndDelete-rawdata.json
+++ b/source/crud/tests/unified/findOneAndDelete-rawdata.json
@@ -1,0 +1,102 @@
+{
+  "description": "findOneAndDelete-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "findOneAndDelete with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndDelete",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {},
+                  "remove": true,
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndDelete with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndDelete",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {},
+                  "remove": true,
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/findOneAndDelete-rawdata.yml
+++ b/source/crud/tests/unified/findOneAndDelete-rawdata.yml
@@ -1,0 +1,55 @@
+description: "findOneAndDelete-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "findOneAndDelete with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: findOneAndDelete
+        object: *collection0
+        arguments:
+          filter: {}
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: {}
+                remove: true
+                rawData: *rawdata
+  - description: "findOneAndDelete with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: findOneAndDelete
+        object: *collection0
+        arguments:
+          filter: {}
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: {}
+                remove: true
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/findOneAndReplace-rawdata.json
+++ b/source/crud/tests/unified/findOneAndReplace-rawdata.json
@@ -1,0 +1,112 @@
+{
+  "description": "findOneAndReplace-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "findOneAndReplace with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "replacement": {
+              "x": "x"
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {},
+                  "update": {
+                    "x": "x"
+                  },
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndReplace with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndReplace",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "replacement": {
+              "x": "x"
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {},
+                  "update": {
+                    "x": "x"
+                  },
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/findOneAndReplace-rawdata.yml
+++ b/source/crud/tests/unified/findOneAndReplace-rawdata.yml
@@ -1,0 +1,57 @@
+description: "findOneAndReplace-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "findOneAndReplace with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: {}
+          replacement: &replacement { x: x }
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: {}
+                update: *replacement
+                rawData: *rawdata
+  - description: "findOneAndReplace with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          filter: {}
+          replacement: &replacement { x: x }
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: {}
+                update: *replacement
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/findOneAndUpdate-rawdata.json
+++ b/source/crud/tests/unified/findOneAndUpdate-rawdata.json
@@ -1,0 +1,129 @@
+{
+  "description": "findOneAndUpdate-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "findOneAndUpdate with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "update": [
+              {
+                "$set": {
+                  "x": 1
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {},
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 1
+                      }
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "findOneAndUpdate with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.2.0",
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "findOneAndUpdate",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "update": [
+              {
+                "$set": {
+                  "x": 1
+                }
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "findAndModify": "coll0",
+                  "query": {},
+                  "update": [
+                    {
+                      "$set": {
+                        "x": 1
+                      }
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/findOneAndUpdate-rawdata.yml
+++ b/source/crud/tests/unified/findOneAndUpdate-rawdata.yml
@@ -1,0 +1,57 @@
+description: "findOneAndUpdate-rawData"
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "findOneAndUpdate with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: {}
+          update: &update [ $set: { x: 1 } ]
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: {}
+                update: *update
+                rawData: *rawdata
+  - description: "findOneAndUpdate with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - minServerVersion: "4.2.0"
+        maxServerVersion: "8.1.99"
+    operations:
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          filter: {}
+          update: &update [ $set: { x: 1 } ]
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                findAndModify: *collection0Name
+                query: {}
+                update: *update
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/insertMany-rawdata.json
+++ b/source/crud/tests/unified/insertMany-rawdata.json
@@ -1,0 +1,120 @@
+{
+  "description": "insertMany-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "insertMany with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 2,
+                "x": 22
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "insertMany with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertMany",
+          "object": "collection0",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 2,
+                "x": 22
+              }
+            ],
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/insertMany-rawdata.yml
+++ b/source/crud/tests/unified/insertMany-rawdata.yml
@@ -1,0 +1,53 @@
+description: "insertMany-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "insertMany with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents: &documents [ { _id: 2, x: 22 } ]
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: *documents
+                rawData: *rawdata
+  - description: "insertMany with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: insertMany
+        object: *collection0
+        arguments:
+          documents: &documents [ { _id: 2, x: 22 } ]
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: *documents
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/insertOne-rawdata.json
+++ b/source/crud/tests/unified/insertOne-rawdata.json
@@ -1,0 +1,116 @@
+{
+  "description": "insertOne-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "insertOne with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 2,
+              "x": 22
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "insertOne with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 2,
+              "x": 22
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll0",
+                  "documents": [
+                    {
+                      "_id": 2,
+                      "x": 22
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/insertOne-rawdata.yml
+++ b/source/crud/tests/unified/insertOne-rawdata.yml
@@ -1,0 +1,53 @@
+description: "insertOne-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "insertOne with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &document { _id: 2, x: 22 }
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: [ *document ]
+                rawData: *rawdata
+  - description: "insertOne with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: &document { _id: 2, x: 22 }
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: [ *document ]
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/replaceOne-rawdata.json
+++ b/source/crud/tests/unified/replaceOne-rawdata.json
@@ -1,0 +1,132 @@
+{
+  "description": "replaceOne-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "ReplaceOne with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {},
+            "replacement": {
+              "x": 22
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": {
+                        "x": 22
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "ReplaceOne with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "replaceOne",
+          "arguments": {
+            "filter": {},
+            "replacement": {
+              "x": 22
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": {
+                        "x": 22
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/replaceOne-rawdata.yml
+++ b/source/crud/tests/unified/replaceOne-rawdata.yml
@@ -1,0 +1,67 @@
+description: "replaceOne-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "ReplaceOne with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: replaceOne
+        arguments:
+          filter: {}
+          replacement: &replacement { x: 22 }
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: {}
+                    u: *replacement
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData: *rawdata
+  - description: "ReplaceOne with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: replaceOne
+        arguments:
+          filter: {}
+          replacement: &replacement { x: 22 }
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: {}
+                    u: *replacement
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/updateMany-rawdata.json
+++ b/source/crud/tests/unified/updateMany-rawdata.json
@@ -1,0 +1,136 @@
+{
+  "description": "updateMany-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "updateMany with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": {
+                        "$set": {
+                          "x": 1
+                        }
+                      },
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "updateMany with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateMany",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": {
+                        "$set": {
+                          "x": 1
+                        }
+                      },
+                      "multi": true,
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/updateMany-rawdata.yml
+++ b/source/crud/tests/unified/updateMany-rawdata.yml
@@ -1,0 +1,65 @@
+description: "updateMany-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "updateMany with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: {}
+          update: &update { $set: {x: 1} }
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: {}
+                    u: *update
+                    multi: true
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData: *rawdata
+  - description: "updateMany with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: updateMany
+        object: *collection0
+        arguments:
+          filter: {}
+          update: &update { $set: {x: 1} }
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: {}
+                    u: *update
+                    multi: true
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData:
+                  $$exists: false

--- a/source/crud/tests/unified/updateOne-rawdata.json
+++ b/source/crud/tests/unified/updateOne-rawdata.json
@@ -1,0 +1,140 @@
+{
+  "description": "updateOne-rawData",
+  "schemaVersion": "1.0",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "crud-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "coll0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "UpdateOne with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": {
+                        "$set": {
+                          "x": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "UpdateOne with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {},
+            "update": {
+              "$set": {
+                "x": 1
+              }
+            },
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "update": "coll0",
+                  "updates": [
+                    {
+                      "q": {},
+                      "u": {
+                        "$set": {
+                          "x": 1
+                        }
+                      },
+                      "multi": {
+                        "$$unsetOrMatches": false
+                      },
+                      "upsert": {
+                        "$$unsetOrMatches": false
+                      }
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/crud/tests/unified/updateOne-rawdata.yml
+++ b/source/crud/tests/unified/updateOne-rawdata.yml
@@ -1,0 +1,67 @@
+description: "updateOne-rawData"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name crud-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+tests:
+  - description: "UpdateOne with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: {}
+          update: &update { $set: { x: 1 } }
+          rawData: &rawdata true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: {}
+                    u: *update
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData: *rawdata
+  - description: "UpdateOne with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: {}
+          update: &update { $set: { x: 1 } }
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                update: *collection0Name
+                updates:
+                  - q: {}
+                    u: *update
+                    multi:
+                      $$unsetOrMatches: false
+                    upsert:
+                      $$unsetOrMatches: false
+                rawData:
+                  $$exists: false

--- a/source/index-management/index-management.md
+++ b/source/index-management/index-management.md
@@ -215,6 +215,15 @@ interface CreateIndexOptions {
   maxTimeMS: Optional<Int64>;
 
   /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
+ 
+  /**
    * Enables users to specify an arbitrary comment to help trace the operation through
    * the database profiler, currentOp and logs. The default is to not send a value.
    *
@@ -238,6 +247,15 @@ interface DropIndexOptions {
   maxTimeMS: Optional<Int64>;
 
   /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
+
+/**
    * Enables users to specify an arbitrary comment to help trace the operation through
    * the database profiler, currentOp and logs. The default is to not send a value.
    *
@@ -803,6 +821,15 @@ interface ListIndexesOptions {
    * @note drivers MAY chose to support batchSize on the ListIndexesOptions.
    */
   batchSize: Optional<Int32>;
+
+  /**
+   * This option allows operations to function on the bucket-level data while accessing the primary namespace (not system.buckets).
+   *
+   * @note This option will not be sent when connected to pre-9.0 servers.
+   *
+   * @since MongoDB 8.2
+   */
+  rawData: Optional<Boolean>;
 }
 ```
 
@@ -1146,6 +1173,8 @@ internally by the server on those versions, and its value could have adverse eff
 from mistakenly specifying this option, drivers manually verify it is only sent to 4.4+ servers.
 
 #### Changelog
+
+- 2025-06-27: Added `rawData` option to CreateIndexOptions, DropIndexOptions and ListIndexesOptions.
 
 - 2024-09-05: Moved options in SearchIndexModel to SearchIndexOptions for consistency with IndexModel and IndexOptions.
 

--- a/source/index-management/tests/index-rawdata.json
+++ b/source/index-management/tests/index-rawdata.json
@@ -1,0 +1,186 @@
+{
+  "description": "index management-rawData",
+  "schemaVersion": "1.4",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "database0"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "collection0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "index management with rawData option",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "8.2.0"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "createIndex",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "rawData": true
+          }
+        },
+        {
+          "object": "collection0",
+          "name": "listIndexes",
+          "arguments": {
+            "rawData": true
+          }
+        },
+        {
+          "object": "collection0",
+          "name": "dropIndex",
+          "arguments": {
+            "name": "x_1",
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "name": "x_1",
+                      "key": {
+                        "x": 1
+                      }
+                    }
+                  ],
+                  "rawData": true
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listIndexes": "collection0",
+                  "rawData": true
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "dropIndexes": "collection0",
+                  "index": "x_1",
+                  "rawData": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "index management with rawData option on less than 8.2.0 - ignore argument",
+      "runOnRequirements": [
+        {
+          "maxServerVersion": "8.1.99"
+        }
+      ],
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "createIndex",
+          "arguments": {
+            "keys": {
+              "x": 1
+            },
+            "rawData": true
+          }
+        },
+        {
+          "object": "collection0",
+          "name": "listIndexes",
+          "arguments": {
+            "rawData": true
+          }
+        },
+        {
+          "object": "collection0",
+          "name": "dropIndex",
+          "arguments": {
+            "name": "x_1",
+            "rawData": true
+          }
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client0",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "createIndexes": "collection0",
+                  "indexes": [
+                    {
+                      "name": "x_1",
+                      "key": {
+                        "x": 1
+                      }
+                    }
+                  ],
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listIndexes": "collection0",
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "dropIndexes": "collection0",
+                  "index": "x_1",
+                  "rawData": {
+                    "$$exists": false
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/index-management/tests/index-rawdata.yml
+++ b/source/index-management/tests/index-rawdata.yml
@@ -1,0 +1,95 @@
+description: "index management-rawData"
+
+schemaVersion: "1.4"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name database0
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name collection0
+
+tests:
+  - description: "index management with rawData option"
+    runOnRequirements:
+      - minServerVersion: "8.2.0"
+    operations:
+      - object: *collection0
+        name: createIndex
+        arguments:
+          keys: &key { x: 1 }
+          rawData: true
+      - object: *collection0
+        name: listIndexes
+        arguments:
+          rawData: true
+      - object: *collection0
+        name: dropIndex
+        arguments:
+          name: &name x_1
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createIndexes: *collection0
+                indexes:
+                  - name: x_1
+                    key: *key
+                rawData: true
+          - commandStartedEvent:
+              command:
+                listIndexes: *collection0
+                rawData: true
+          - commandStartedEvent:
+              command:
+                dropIndexes: *collection0
+                index: *name
+                rawData: true
+  - description: "index management with rawData option on less than 8.2.0 - ignore argument"
+    runOnRequirements:
+      - maxServerVersion: "8.1.99"
+    operations:
+      - object: *collection0
+        name: createIndex
+        arguments:
+          keys: &key { x: 1 }
+          rawData: true
+      - object: *collection0
+        name: listIndexes
+        arguments:
+          rawData: true
+      - object: *collection0
+        name: dropIndex
+        arguments:
+          name: &name x_1
+          rawData: true
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                createIndexes: *collection0
+                indexes:
+                  - name: x_1
+                    key: *key
+                rawData:
+                  $$exists: false
+          - commandStartedEvent:
+              command:
+                listIndexes: *collection0
+                rawData:
+                  $$exists: false
+          - commandStartedEvent:
+              command:
+                dropIndexes: *collection0
+                index: *name
+                rawData:
+                  $$exists: false


### PR DESCRIPTION
Add support for the new rawData command option for the following CRUD operations:
- aggregate
- bulkWrite (collection and client)
- count
- countDocuments
- deleteMany
- deleteOne
- distinct
- estimatedDocumentCount
- find
- findOne
- findAndModify
- insertMany
- insertOne
- replaceOne
- updateMany
- updateOne
- listIndexes
- dropIndexes
- createIndexes
- listCollections

Please complete the following before merging:

- [x] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
