### PR TITLE
DRIVERS-3106 revise expected error

### DIFF
--- a/source/client-side-encryption/tests/unified/localSchema.json
+++ b/source/client-side-encryption/tests/unified/localSchema.json
@@ -333,7 +333,8 @@
             }
           },
           "expectError": {
-            "isClientError": true
+            "isError": true,
+            "errorContains": "JSON schema keyword 'required' is only allowed with a remote schema"
           }
         }
       ]

--- a/source/client-side-encryption/tests/unified/localSchema.yml
+++ b/source/client-side-encryption/tests/unified/localSchema.yml
@@ -99,4 +99,5 @@ tests:
         arguments:
           document: &doc0 { _id: 1, encrypted_string: "string0" }
         expectError:
-          isClientError: true
+          isError: true
+          errorContains: "JSON schema keyword 'required' is only allowed with a remote schema"


### PR DESCRIPTION
# Summary

Use `errorContains` for assertion in test: `A local schema with no encryption is an error`.

# Background & Motivation

https://github.com/mongodb/specifications/issues/1756 migrated `errorContains` (in [legacy](https://github.com/mongodb/specifications/blob/668992950d975d3163e538849dd20383a214fc37/source/client-side-encryption/tests/legacy/localSchema.yml#L64-L65)) to `isClientError` (in [unified](https://github.com/mongodb/specifications/blob/668992950d975d3163e538849dd20383a214fc37/source/client-side-encryption/tests/unified/localSchema.yml#L102)). I expect this may have been copied from other unified tests. `isClientError` triggered a [test failure in Node](https://mongodb.slack.com/archives/C0668RJBA0J/p1752600616931609?thread_ts=1752528282.188439&cid=C0668RJBA0J).

`A local schema with no encryption is an error` expects an error from mongocryptd or crypt_shared. An error from a mongocryptd may reasonably be considered a non-client error. Quoting the [Unified Test Format](https://github.com/mongodb/specifications/blob/668992950d975d3163e538849dd20383a214fc37/source/unified-test-format/unified-test-format.md#expectederror):

> the test runner MUST assert that the error originates from the client (i.e. it is not derived from a server response).
The legacy test `errorContains` was changed to `isClientError` in unified format.



<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- [x] Test changes in at least one language driver. (Tested in https://github.com/mongodb/mongo-c-driver/pull/2061)
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).~~ C does not test sharded with In-Use Encryption.

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
