### PR TITLE
DRIVERS-3123 add test skip and clarification

### DIFF
--- a/source/bson-binary-vector/tests/README.md
+++ b/source/bson-binary-vector/tests/README.md
@@ -103,7 +103,7 @@ server does.
 ```python
 b1 = Binary(b'\x10\x07\x80', subtype=9) # 1-bit vector with all 0 ignored bits.
 b2 = Binary(b'\x10\x07\xff', subtype=9) # 1-bit vector with all 1 ignored bits.
-b3 = Binary(b'\x10\x07\x80', subtype=9) # Same data as b1.
+b3 = Binary.from_vector([0b10000000], BinaryVectorDtype.PACKED_BIT, padding=7) # Same data as b1.
 
 v1 = Binary.as_vector(b1)
 v2 = Binary.as_vector(b2)

--- a/source/bson-binary-vector/tests/README.md
+++ b/source/bson-binary-vector/tests/README.md
@@ -101,8 +101,8 @@ means that two single bit vectors in which 7 bits are ignored do not match unles
 server does.
 
 ```python
-b1 = Binary(b'\x10\x07\x80', subtype=9)
-b2 = Binary(b'\x10\x07\xff', subtype=9)
+b1 = Binary(b'\x10\x07\x80', subtype=9) # 1-bit vector with all 0 ignored bits.
+b2 = Binary(b'\x10\x07\xff', subtype=9) # 1-bit vector with all 1 ignored bits.
 
 v1 = Binary.as_vector(b1)
 v2 = Binary.as_vector(b2)

--- a/source/bson-binary-vector/tests/README.md
+++ b/source/bson-binary-vector/tests/README.md
@@ -115,7 +115,8 @@ assert b1 == b3  # Equal at naive Binary level
 assert v1 == v3  # Equal at the BinaryVector level
 ```
 
-Drivers MAY skip this test if they choose not to implement a `Vector` type, or the type does not support comparison.
+Drivers MAY skip this test if they choose not to implement a `Vector` type, or the type does not support comparison, or
+the type cannot be constructed with non-zero ignored bits.
 
 ## FAQ
 

--- a/source/bson-binary-vector/tests/README.md
+++ b/source/bson-binary-vector/tests/README.md
@@ -101,12 +101,10 @@ means that two single bit vectors in which 7 bits are ignored do not match unles
 server does.
 
 ```python
-b1 = Binary.from_vector([0b10000000], BinaryVectorDtype.PACKED_BIT, padding=7)
-assert b1 == Binary(b'\x10\x07\x80', subtype=9) # This is effectively a roundtrip.
-v1 = Binary.as_vector(b1)
+b1 = Binary(b'\x10\x07\x80', subtype=9)
+b2 = Binary(b'\x10\x07\xff', subtype=9)
 
-b2 = Binary.from_vector([0b11111111], BinaryVectorDtype.PACKED_BIT, padding=7)
-assert b2 == Binary(b'\x10\x07\xff', subtype=9)
+v1 = Binary.as_vector(b1)
 v2 = Binary.as_vector(b2)
 
 assert b1 != b2  # Unequal at naive Binary level 

--- a/source/bson-binary-vector/tests/README.md
+++ b/source/bson-binary-vector/tests/README.md
@@ -103,12 +103,16 @@ server does.
 ```python
 b1 = Binary(b'\x10\x07\x80', subtype=9) # 1-bit vector with all 0 ignored bits.
 b2 = Binary(b'\x10\x07\xff', subtype=9) # 1-bit vector with all 1 ignored bits.
+b3 = Binary(b'\x10\x07\x80', subtype=9) # Same data as b1.
 
 v1 = Binary.as_vector(b1)
 v2 = Binary.as_vector(b2)
+v3 = Binary.as_vector(b3)
 
 assert b1 != b2  # Unequal at naive Binary level 
 assert v2 != v1  # Also chosen to be unequal at BinaryVector level as [255] != [128]
+assert b1 == b3  # Equal at naive Binary level
+assert v1 == v3  # Equal at the BinaryVector level
 ```
 
 Drivers MAY skip this test if they choose not to implement a `Vector` type, or the type does not support comparison.

--- a/source/bson-binary-vector/tests/README.md
+++ b/source/bson-binary-vector/tests/README.md
@@ -113,7 +113,7 @@ assert b1 != b2  # Unequal at naive Binary level
 assert v2 != v1  # Also chosen to be unequal at BinaryVector level as [255] != [128]
 ```
 
-Drivers MAY skip this test if they choose not to implement a `Vector` type.
+Drivers MAY skip this test if they choose not to implement a `Vector` type, or the type does not support comparison.
 
 ## FAQ
 


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/specifications/pull/1812. Applies pending suggestions from [review](https://github.com/mongodb/specifications/pull/1812#pullrequestreview-2971930645):

- Allow drivers to skip the comparison test if the `Vector` type does not support comparison. The C driver's [bson_vector_packed_bit_view_t](https://mongoc.org/libbson/current/bson_vector_packed_bit_view_t.html) does not support comparison.

- Do not use `Binary.from_vector` in test example with non-zero ignored bits. PyMongo 4.14.0-dev raises an exception:
```
>>> b2 = Binary.from_vector([0b11111111], BinaryVectorDtype.PACKED_BIT, padding=7)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/kevin.albertson/code/mongo-python-driver/bson/binary.py", line 482, in from_vector
    raise ValueError(
ValueError: Vector has a padding P, but bits in the final byte lower than P are non-zero. They must be zero.
```


<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- ~~[ ] Test changes in at least one language driver.~~
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
