### PR TITLE
DRIVERS-3106: don't run QE unified tests on standalone servers

### DIFF
--- a/source/unified-test-format/tests/valid-pass/poc-queryable-encryption.json
+++ b/source/unified-test-format/tests/valid-pass/poc-queryable-encryption.json
@@ -4,7 +4,12 @@
   "runOnRequirements": [
     {
       "minServerVersion": "7.0",
-      "csfle": true
+      "csfle": true,
+      "topologies": [
+        "replicaset",
+        "load-balanced",
+        "sharded"
+      ]
     }
   ],
   "createEntities": [

--- a/source/unified-test-format/tests/valid-pass/poc-queryable-encryption.yml
+++ b/source/unified-test-format/tests/valid-pass/poc-queryable-encryption.yml
@@ -5,6 +5,8 @@ schemaVersion: "1.23"
 runOnRequirements:
   - minServerVersion: "7.0"
     csfle: true
+    # QE is not supported on standalone servers
+    topologies: [ replicaset, load-balanced, sharded ]
 
 createEntities:
   - client:


### PR DESCRIPTION
This PR updates the poc-queryable-encryption unified tests not to run on standalone servers, because QE is not supported on standalone servers.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
