### PR TITLE
OpenTelemetry 

### DIFF
--- a/source/tracing/tests/cursor/cursor.json
+++ b/source/tracing/tests/cursor/cursor.json
@@ -1,0 +1,321 @@
+{
+  "description": "cursor retrieval",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeTracingMessages": {
+          "enableCommandPayload": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "cursor"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "cursor",
+      "documents": [
+        {
+          "_id": 1
+        },
+        {
+          "_id": 2
+        },
+        {
+          "_id": 3
+        },
+        {
+          "_id": 4
+        },
+        {
+          "_id": 5
+        },
+        {
+          "_id": 6
+        }
+      ]
+    }
+  ],
+  "tests": [
+    {
+      "description": "find with a cursor",
+      "operations": [
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": {
+                "$gt": 1
+              }
+            },
+            "batchSize": 2
+          },
+          "expectResult": [
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            },
+            {
+              "_id": 4
+            },
+            {
+              "_id": 5
+            },
+            {
+              "_id": 6
+            }
+          ]
+        }
+      ],
+      "expectTracingMessages": {
+        "client": "client0",
+        "ignoreExtraSpans": false,
+        "spans": [
+          {
+            "name": "find cursor.test",
+            "tags": {
+              "db.system": "mongodb",
+              "db.namespace": "cursor",
+              "db.collection.name": "test",
+              "db.operation.name": "find",
+              "db.operation.summary": "find cursor.test"
+            },
+            "nested": [
+              {
+                "name": "command find",
+                "tags": {
+                  "db.system": "mongodb",
+                  "db.namespace": "cursor",
+                  "db.collection.name": "cursor.$cmd",
+                  "db.command.name": "find",
+                  "network.transport": "tcp",
+                  "db.mongodb.cursor_id": {
+                    "$$exists": false
+                  },
+                  "db.response.status_code": {
+                    "$$exists": false
+                  },
+                  "error.message": {
+                    "$$exists": false
+                  },
+                  "error.type": {
+                    "$$exists": false
+                  },
+                  "error.stacktrace": {
+                    "$$exists": false
+                  },
+                  "server.address": {
+                    "$$type": "string"
+                  },
+                  "server.port": {
+                    "$$type": [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "server.type": {
+                    "$$type": "string"
+                  },
+                  "db.query.summary": "find",
+                  "db.query.text": {
+                    "$$matchAsDocument": {
+                      "$$matchAsRoot": {
+                        "find": "test",
+                        "filter": {
+                          "_id": {
+                            "$gt": 1
+                          }
+                        },
+                        "batchSize": 2,
+                        "$db": "cursor"
+                      }
+                    }
+                  },
+                  "db.mongodb.server_connection_id": {
+                    "$$type": [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "db.mongodb.driver_connection_id": {
+                    "$$type": [
+                      "string"
+                    ]
+                  },
+                  "exception.message": {
+                    "$$exists": false
+                  },
+                  "exception.type": {
+                    "$$exists": false
+                  },
+                  "exception.stacktrace": {
+                    "$$exists": false
+                  }
+                }
+              },
+              {
+                "name": "command getMore",
+                "tags": {
+                  "db.system": "mongodb",
+                  "db.namespace": "cursor",
+                  "db.collection.name": "cursor.$cmd",
+                  "db.command.name": "getMore",
+                  "network.transport": "tcp",
+                  "db.mongodb.cursor_id": {
+                    "$$type": "string"
+                  },
+                  "db.response.status_code": {
+                    "$$exists": false
+                  },
+                  "error.message": {
+                    "$$exists": false
+                  },
+                  "error.type": {
+                    "$$exists": false
+                  },
+                  "error.stacktrace": {
+                    "$$exists": false
+                  },
+                  "server.address": {
+                    "$$type": "string"
+                  },
+                  "server.port": {
+                    "$$type": [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "server.type": {
+                    "$$type": "string"
+                  },
+                  "db.query.summary": "getMore",
+                  "db.query.text": {
+                    "$$matchAsDocument": {
+                      "$$matchAsRoot": {
+                        "getMore": {
+                          "$$type": "long"
+                        },
+                        "collection": "test",
+                        "batchSize": 2,
+                        "$db": "cursor"
+                      }
+                    }
+                  },
+                  "db.mongodb.server_connection_id": {
+                    "$$type": [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "db.mongodb.driver_connection_id": {
+                    "$$type": [
+                      "string"
+                    ]
+                  },
+                  "exception.message": {
+                    "$$exists": false
+                  },
+                  "exception.type": {
+                    "$$exists": false
+                  },
+                  "exception.stacktrace": {
+                    "$$exists": false
+                  }
+                }
+              },
+              {
+                "name": "command getMore",
+                "tags": {
+                  "db.system": "mongodb",
+                  "db.namespace": "cursor",
+                  "db.collection.name": "cursor.$cmd",
+                  "db.command.name": "getMore",
+                  "network.transport": "tcp",
+                  "db.mongodb.cursor_id": {
+                    "$$type": "string"
+                  },
+                  "db.response.status_code": {
+                    "$$exists": false
+                  },
+                  "error.message": {
+                    "$$exists": false
+                  },
+                  "error.type": {
+                    "$$exists": false
+                  },
+                  "error.stacktrace": {
+                    "$$exists": false
+                  },
+                  "server.address": {
+                    "$$type": "string"
+                  },
+                  "server.port": {
+                    "$$type": [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "server.type": {
+                    "$$type": "string"
+                  },
+                  "db.query.summary": "getMore",
+                  "db.query.text": {
+                    "$$matchAsDocument": {
+                      "$$matchAsRoot": {
+                        "getMore": {
+                          "$$type": "long"
+                        },
+                        "collection": "test",
+                        "batchSize": 2,
+                        "$db": "cursor"
+                      }
+                    }
+                  },
+                  "db.mongodb.server_connection_id": {
+                    "$$type": [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "db.mongodb.driver_connection_id": {
+                    "$$type": [
+                      "string"
+                    ]
+                  },
+                  "exception.message": {
+                    "$$exists": false
+                  },
+                  "exception.type": {
+                    "$$exists": false
+                  },
+                  "exception.stacktrace": {
+                    "$$exists": false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/tracing/tests/cursor/cursor.yml
+++ b/source/tracing/tests/cursor/cursor.yml
@@ -1,0 +1,144 @@
+description: cursor retrieval
+schemaVersion: '1.26'
+createEntities:
+  - client:
+      id: client0
+      useMultipleMongoses: false
+      observeTracingMessages:
+        enableCommandPayload: true
+  - database:
+      id: database0
+      client: client0
+      databaseName: cursor
+  - collection:
+      id: collection0
+      database: database0
+      collectionName: test
+initialData:
+  - collectionName: test
+    databaseName: cursor
+    documents:
+      - { _id: 1 }
+      - { _id: 2 }
+      - { _id: 3 }
+      - { _id: 4 }
+      - { _id: 5 }
+      - { _id: 6 }
+tests:
+  - description: find with a cursor
+    operations:
+      - name: find
+        object: collection0
+        arguments:
+          filter: { _id: { $gt: 1 } }
+          batchSize: 2
+        expectResult:
+          - { _id: 2 }
+          - { _id: 3 }
+          - { _id: 4 }
+          - { _id: 5 }
+          - { _id: 6 }
+    expectTracingMessages:
+      client: client0
+      ignoreExtraSpans: false
+      spans:
+        - name: find cursor.test
+          tags:
+            db.system: mongodb
+            db.namespace: cursor
+            db.collection.name: test
+            db.operation.name: find
+            db.operation.summary: find cursor.test
+          nested:
+            - name: command find
+              tags:
+                db.system: mongodb
+                db.namespace: cursor
+                db.collection.name: cursor.$cmd
+                db.command.name: find
+                network.transport: tcp
+                db.mongodb.cursor_id: { $$exists: false }
+                db.response.status_code: { $$exists: false }
+                error.message: { $$exists: false }
+                error.type: { $$exists: false }
+                error.stacktrace: { $$exists: false }
+                server.address: { $$type: string }
+                server.port: { $$type: [ 'long', 'string' ] }
+                server.type: { $$type: string }
+                db.query.summary: find
+                db.query.text:
+                  $$matchAsDocument:
+                    $$matchAsRoot:
+                      find: test
+                      filter: { _id: { $gt: 1 } }
+                      batchSize: 2
+                      $db: cursor
+                db.mongodb.server_connection_id:
+                  $$type: [ 'long', 'string' ]
+                db.mongodb.driver_connection_id:
+                  $$type: [ 'string' ]
+                exception.message: { $$exists: false }
+                exception.type: { $$exists: false }
+                exception.stacktrace: { $$exists: false }
+
+            - name: command getMore
+              tags:
+                db.system: mongodb
+                db.namespace: cursor
+                db.collection.name: cursor.$cmd
+                db.command.name: getMore
+                network.transport: tcp
+                db.mongodb.cursor_id: { $$type: string }
+                db.response.status_code: { $$exists: false }
+                error.message: { $$exists: false }
+                error.type: { $$exists: false }
+                error.stacktrace: { $$exists: false }
+                server.address: { $$type: string }
+                server.port: { $$type: [ 'long', 'string' ] }
+                server.type: { $$type: string }
+                db.query.summary: getMore
+                db.query.text:
+                  $$matchAsDocument:
+                    $$matchAsRoot:
+                      getMore: { $$type: long }
+                      collection: test
+                      batchSize: 2
+                      $db: cursor
+                db.mongodb.server_connection_id:
+                  $$type: [ 'long', 'string' ]
+                db.mongodb.driver_connection_id:
+                  $$type: [ 'string' ]
+                exception.message: { $$exists: false }
+                exception.type: { $$exists: false }
+                exception.stacktrace: { $$exists: false }
+            - name: command getMore
+              tags:
+                db.system: mongodb
+                db.namespace: cursor
+                db.collection.name: cursor.$cmd
+                db.command.name: getMore
+                network.transport: tcp
+                db.mongodb.cursor_id: { $$type: string }
+                db.response.status_code: { $$exists: false }
+                error.message: { $$exists: false }
+                error.type: { $$exists: false }
+                error.stacktrace: { $$exists: false }
+                server.address: { $$type: string }
+                server.port: { $$type: [ 'long', 'string' ] }
+                server.type: { $$type: string }
+                db.query.summary: getMore
+                db.query.text:
+                  $$matchAsDocument:
+                    $$matchAsRoot:
+                      getMore: { $$type: long }
+                      collection: test
+                      batchSize: 2
+                      $db: cursor
+                db.mongodb.server_connection_id:
+                  $$type: [ 'long', 'string' ]
+                db.mongodb.driver_connection_id:
+                  $$type: [ 'string' ]
+                exception.message: { $$exists: false }
+                exception.type: { $$exists: false }
+                exception.stacktrace: { $$exists: false }
+

--- a/source/tracing/tests/operation/find.json
+++ b/source/tracing/tests/operation/find.json
@@ -1,0 +1,136 @@
+{
+  "description" : "operation find",
+  "schemaVersion" : "1.26",
+  "createEntities" : [
+    {
+      "client" : {
+        "id" : "client0",
+        "useMultipleMongoses" : false,
+        "observeTracingMessages" : {
+          "enableCommandPayload" : true
+        }
+      }
+    },
+    {
+      "database" : {
+        "id" : "database0",
+        "client" : "client0",
+        "databaseName" : "operation-find"
+      }
+    },
+    {
+      "collection" : {
+        "id" : "collection0",
+        "database" : "database0",
+        "collectionName" : "test"
+      }
+    }
+  ],
+  "initialData" : [
+    {
+      "collectionName" : "test",
+      "databaseName" : "operation-find",
+      "documents" : []
+    }
+  ],
+  "tests" : [
+    {
+      "description" : "find an element",
+      "operations" : [
+        {
+          "name" : "find",
+          "object" : "collection0",
+          "arguments" : {
+            "filter" : {
+              "x" : 1
+            }
+          }
+        }
+      ],
+      "expectTracingMessages" : {
+        "client" : "client0",
+        "ignoreExtraSpans" : false,
+        "spans" : [
+          {
+            "name" : "find operation-find.test",
+            "tags" : {
+              "db.system" : "mongodb",
+              "db.namespace": "operation-find",
+              "db.collection.name": "test",
+              "db.operation.name": "find",
+              "db.operation.summary": "find operation-find.test"
+            },
+            "nested" : [
+              {
+                "name" : "command find",
+                "tags" : {
+                  "db.system" : "mongodb",
+                  "db.namespace" : "operation-find",
+                  "db.collection.name" : "operation-find.$cmd",
+                  "db.command.name": "find",
+                  "network.transport": "tcp",
+                  "db.mongodb.cursor_id": { "$$exists": false },
+                  "db.response.status_code": { "$$exists": false },
+                  "error.message": { "$$exists": false },
+                  "error.type": { "$$exists": false },
+                  "error.stacktrace": { "$$exists": false },
+                  "server.address" : {
+                    "$$type" : "string"
+                  },
+                  "server.port" : {
+                    "$$type" : [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "server.type" : {
+                    "$$type" : "string"
+                  },
+                  "db.query.summary" : "find",
+                  "db.query.text" : {
+                    "$$matchAsDocument" : {
+                      "$$matchAsRoot" : {
+                        "find" : "test",
+                        "filter" : {
+                          "x" : 1
+                        },
+                        "$db" : "operation-find"
+                      }
+                    }
+                  },
+                  "db.mongodb.server_connection_id" : {
+                    "$$type" : [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "db.mongodb.driver_connection_id" : {
+                    "$$type" : [
+                      "string"
+                    ]
+                  },
+                  "exception.message" : {
+                    "$$exists" : false
+                  },
+                  "exception.type" : {
+                    "$$exists" : false
+                  },
+                  "exception.stacktrace": {
+                    "$$exists" : false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "outcome" : [
+        {
+          "collectionName" : "test",
+          "databaseName" : "operation-find",
+          "documents" : []
+        }
+      ]
+    }
+  ]
+}

--- a/source/tracing/tests/operation/find.yml
+++ b/source/tracing/tests/operation/find.yml
@@ -1,0 +1,74 @@
+description: operation find
+schemaVersion: '1.9'
+createEntities:
+  - client:
+      id: client0
+      useMultipleMongoses: false
+      observeTracingMessages:
+        enableCommandPayload: true
+  - database:
+      id: database0
+      client: client0
+      databaseName: operation-find
+  - collection:
+      id: collection0
+      database: database0
+      collectionName: test
+initialData:
+  - collectionName: test
+    databaseName: operation-find
+    documents: []
+tests:
+  - description: find an element
+    operations:
+      - name: find
+        object: collection0
+        arguments:
+          filter:
+            x: 1
+    expectTracingMessages:
+      client: client0
+      ignoreExtraSpans: false
+      spans:
+        - name: find operation-find.test
+          tags:
+            db.system: mongodb
+            db.namespace: operation-find
+            db.collection.name: test
+            db.operation.name: find
+            db.operation.summary: find operation-find.test
+          nested:
+            - name: command find
+              tags:
+                db.system: mongodb
+                db.namespace: operation-find
+                db.collection.name: operation-find.$cmd
+                db.command.name: find
+                network.transport: tcp
+                db.mongodb.cursor_id: { $$exists: false }
+                db.response.status_code: { $$exists: false }
+                error.message: { $$exists: false }
+                error.type: { $$exists: false }
+                error.stacktrace: { $$exists: false }
+                server.address: { $$type: string }
+                server.port: { $$type: ['long', 'string'] }
+                server.type: { $$type: string }
+                db.query.summary: find
+                db.query.text:
+                  $$matchAsDocument:
+                    $$matchAsRoot:
+                      find: test
+                      filter:
+                        x: 1
+                      $db: operation-find
+                db.mongodb.server_connection_id: 
+                  $$type: ['long', 'string']
+                db.mongodb.driver_connection_id: 
+                  $$type: ['string']
+                exception.message: { $$exists: false }
+                exception.type: { $$exists: false }
+                exception.stacktrace: { $$exists: false }
+    outcome:
+      - collectionName: test
+        databaseName: operation-find
+        documents: []

--- a/source/tracing/tests/operation/insert.json
+++ b/source/tracing/tests/operation/insert.json
@@ -1,0 +1,118 @@
+{
+  "description": "operation insert",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeTracingMessages": {
+          "enableCommandPayload": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "operation-insert"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "operation-insert",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "insert one element",
+      "operations": [
+        {
+          "object": "collection0",
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            }
+          }
+        }
+      ],
+      "expectTracingMessages": {
+        "client": "client0",
+        "ignoreExtraSpans": false,
+        "spans": [
+          {
+            "name": "insert operation-insert.test",
+            "tags": {
+              "db.system": "mongodb",
+              "db.namespace": "operation-insert",
+              "db.collection.name": "test",
+              "db.operation.name": "insert",
+              "db.operation.summary": "insert operation-insert.test"
+            },
+            "nested": [
+              {
+                "name": "command insert",
+                "tags": {
+                  "db.system": "mongodb",
+                  "db.namespace": "operation-insert",
+                  "server.address": {
+                    "$$type": "string"
+                  },
+                  "server.port": {
+                    "$$type": [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "server.type": {
+                    "$$type": "string"
+                  },
+                  "db.query.summary": "insert",
+                  "db.query.text": {
+                    "$$matchAsDocument": {
+                      "$$matchAsRoot": {
+                        "insert": "test",
+                        "ordered": true,
+                        "txnNumber": {
+                          "$$unsetOrMatches": 1
+                        },
+                        "$db": "operation-insert",
+                        "documents": [
+                          {
+                            "_id": 1
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "operation-insert",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/tracing/tests/operation/insert.yml
+++ b/source/tracing/tests/operation/insert.yml
@@ -1,0 +1,63 @@
+description: operation insert
+schemaVersion: '1.26'
+createEntities:
+  - client:
+      id: client0
+      useMultipleMongoses: false
+      observeTracingMessages:
+        enableCommandPayload: true
+  - database:
+      id: database0
+      client: client0
+      databaseName: operation-insert
+  - collection:
+      id: collection0
+      database: database0
+      collectionName: test
+initialData:
+  - collectionName: test
+    databaseName: operation-insert
+    documents: []
+tests:
+  - description: insert one element
+    operations:
+      - object: collection0
+        name: insertOne
+        arguments:
+          document:
+            _id: 1
+    expectTracingMessages:
+      client: client0
+      ignoreExtraSpans: false
+      spans:
+        - name: insert operation-insert.test
+          tags:
+            db.system: mongodb
+            db.namespace: operation-insert
+            db.collection.name: test
+            db.operation.name: insert
+            db.operation.summary: insert operation-insert.test
+          nested:
+            - name: command insert
+              tags:
+                db.system: mongodb
+                db.namespace: operation-insert
+                server.address: { $$type: string }
+                server.port: { $$type: [ 'long', 'string' ] }
+                server.type: { $$type: string }
+                db.query.summary: insert
+                db.query.text:
+                  $$matchAsDocument:
+                    $$matchAsRoot:
+                      insert: test
+                      ordered: true
+                      txnNumber: { $$unsetOrMatches: 1 }
+                      $db: operation-insert
+                      documents:
+                        - _id: 1
+
+    outcome:
+      - collectionName: test
+        databaseName: operation-insert
+        documents:
+          - _id: 1

--- a/source/tracing/tests/transaction/transaction.json
+++ b/source/tracing/tests/transaction/transaction.json
@@ -1,0 +1,223 @@
+{
+  "description": "transaction spans",
+  "schemaVersion": "1.26",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.0",
+      "topologies": [
+        "replicaset"
+      ]
+    },
+    {
+      "minServerVersion": "4.1.8",
+      "topologies": [
+        "sharded",
+        "load-balanced"
+      ]
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "useMultipleMongoses": false,
+        "observeTracingMessages": {
+          "enableCommandPayload": true
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database0",
+        "client": "client0",
+        "databaseName": "transaction-tests"
+      }
+    },
+    {
+      "collection": {
+        "id": "collection0",
+        "database": "database0",
+        "collectionName": "test"
+      }
+    },
+    {
+      "session": {
+        "id": "session0",
+        "client": "client0"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "transaction-tests",
+      "documents": []
+    }
+  ],
+  "tests": [
+    {
+      "description": "tracing around transaction",
+      "operations": [
+        {
+          "object": "session0",
+          "name": "startTransaction"
+        },
+        {
+          "object": "collection0",
+          "name": "insertOne",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          }
+        },
+        {
+          "object": "session0",
+          "name": "commitTransaction"
+        },
+        {
+          "name": "find",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "x": 1
+            }
+          }
+        }
+      ],
+      "expectTracingMessages": {
+        "client": "client0",
+        "ignoreExtraSpans": false,
+        "spans": [
+          {
+            "name": "transaction",
+            "tags": {
+              "db.system": "mongodb"
+            },
+            "nested": [
+              {
+                "name": "insert transaction-tests.test",
+                "tags": {
+                  "db.system": "mongodb",
+                  "db.namespace": "transaction-tests",
+                  "db.collection.name": "test",
+                  "db.operation.name": "insert",
+                  "db.operation.summary": "insert transaction-tests.test"
+                },
+                "nested": [
+                  {
+                    "name": "command insert",
+                    "tags": {
+                      "db.system": "mongodb",
+                      "db.namespace": "transaction-tests",
+                      "server.address": {
+                        "$$type": "string"
+                      },
+                      "server.port": {
+                        "$$type": [
+                          "long",
+                          "string"
+                        ]
+                      },
+                      "server.type": {
+                        "$$type": "string"
+                      },
+                      "db.query.summary": "insert",
+                      "db.query.text": {
+                        "$$matchAsDocument": {
+                          "$$matchAsRoot": {
+                            "insert": "test",
+                            "ordered": true,
+                            "$db": "transaction-tests",
+                            "lsid": {
+                              "$$sessionLsid": "session0"
+                            },
+                            "txnNumber": 1,
+                            "startTransaction": true,
+                            "autocommit": false,
+                            "documents": [
+                              {
+                                "_id": 1
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "db.mongodb.lsid": {
+                        "$$sessionLsid": "session0"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "commitTransaction admin.$cmd",
+                "tags": {
+                  "db.system": "mongodb"
+                },
+                "nested": [
+                  {
+                    "name": "command commitTransaction",
+                    "tags": {
+                      "db.system": "mongodb",
+                      "db.query.text": {
+                        "$$matchAsDocument": {
+                          "$$matchAsRoot": {
+                            "commitTransaction": 1,
+                            "$db": "admin",
+                            "lsid": {
+                              "$$sessionLsid": "session0"
+                            },
+                            "txnNumber": 1,
+                            "autocommit": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "find transaction-tests.test",
+            "nested": [
+              {
+                "name": "command find",
+                "tags": {
+                  "db.system": "mongodb",
+                  "db.namespace": "transaction-tests",
+                  "server.address": {
+                    "$$type": "string"
+                  },
+                  "server.port": {
+                    "$$type": [
+                      "long",
+                      "string"
+                    ]
+                  },
+                  "server.type": {
+                    "$$type": "string"
+                  },
+                  "db.query.summary": "find"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "outcome": [
+        {
+          "collectionName": "test",
+          "databaseName": "transaction-tests",
+          "documents": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/source/tracing/tests/transaction/transaction.yml
+++ b/source/tracing/tests/transaction/transaction.yml
@@ -1,0 +1,116 @@
+description: transaction spans
+schemaVersion: '1.26'
+runOnRequirements:
+  - minServerVersion: '4.0'
+    topologies:
+      - replicaset
+  - minServerVersion: '4.1.8'
+    topologies:
+      - sharded
+      - load-balanced
+createEntities:
+  - client:
+      id: client0
+      useMultipleMongoses: false
+      observeTracingMessages:
+        enableCommandPayload: true
+  - database:
+      id: database0
+      client: client0
+      databaseName: transaction-tests
+  - collection:
+      id: collection0
+      database: database0
+      collectionName: test
+  - session:
+      id: session0
+      client: client0
+initialData:
+  - collectionName: test
+    databaseName: transaction-tests
+    documents: []
+tests:
+  - description: observeTracingMessages around transaction
+    operations:
+      - object: session0
+        name: startTransaction
+      - object: collection0
+        name: insertOne
+        arguments:
+          session: session0
+          document:
+            _id: 1
+      - object: session0
+        name: commitTransaction
+      - name: find
+        object: collection0
+        arguments:
+          filter:
+            x: 1
+    expectTracingMessages:
+      client: client0
+      ignoreExtraSpans: false
+      spans:
+        - name: transaction
+          tags:
+            db.system: mongodb
+          nested:
+            - name: insert transaction-tests.test
+              tags:
+                db.system: mongodb
+                db.namespace: transaction-tests
+                db.collection.name: test
+                db.operation.name: insert
+                db.operation.summary: insert transaction-tests.test
+              nested:
+                - name: command insert
+                  tags:
+                    db.system: mongodb
+                    db.namespace: transaction-tests
+                    server.address: { $$type: string }
+                    server.port: { $$type: ['long', 'string'] }
+                    server.type: { $$type: string }
+                    db.query.summary: insert
+                    db.query.text:
+                      $$matchAsDocument:
+                        $$matchAsRoot:
+                          insert: test
+                          ordered: true
+                          $db: transaction-tests
+                          lsid: { $$sessionLsid: session0 }
+                          txnNumber: 1
+                          startTransaction: true
+                          autocommit: false
+                          documents:
+                            - _id: 1
+                    db.mongodb.lsid: { $$sessionLsid: session0 }
+            - name: commitTransaction admin.$cmd
+              tags:
+                db.system: mongodb
+              nested:
+                - name: command commitTransaction
+                  tags:
+                    db.system: mongodb
+                    db.query.text:
+                      $$matchAsDocument:
+                        $$matchAsRoot:
+                            commitTransaction: 1
+                            $db: admin
+                            lsid: { $$sessionLsid: session0 }
+                            txnNumber: 1
+                            autocommit: false
+        - name: find transaction-tests.test
+          nested:
+            - name: command find
+              tags:
+                db.system: mongodb
+                db.namespace: transaction-tests
+                server.address: { $$type: string }
+                server.port: { $$type: ['long', 'string'] }
+                server.type: { $$type: string }
+                db.query.summary: find
+    outcome:
+      - collectionName: test
+        databaseName: transaction-tests
+        documents:
+          - _id: 1

--- a/source/unified-test-format/schema-1.26.json
+++ b/source/unified-test-format/schema-1.26.json
@@ -1,0 +1,1231 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema#",
+  "title": "Unified Test Format",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "description",
+    "schemaVersion",
+    "tests"
+  ],
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "schemaVersion": {
+      "$ref": "#/definitions/version"
+    },
+    "runOnRequirements": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/runOnRequirement"
+      }
+    },
+    "createEntities": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/entity"
+      }
+    },
+    "initialData": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/collectionData"
+      }
+    },
+    "tests": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/test"
+      }
+    },
+    "_yamlAnchors": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "definitions": {
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+(\\.[0-9]+){1,2}$"
+    },
+    "runOnRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "maxServerVersion": {
+          "$ref": "#/definitions/version"
+        },
+        "minServerVersion": {
+          "$ref": "#/definitions/version"
+        },
+        "topologies": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "single",
+              "replicaset",
+              "sharded",
+              "sharded-replicaset",
+              "load-balanced"
+            ]
+          }
+        },
+        "serverless": {
+          "type": "string",
+          "enum": [
+            "require",
+            "forbid",
+            "allow"
+          ]
+        },
+        "serverParameters": {
+          "type": "object",
+          "minProperties": 1
+        },
+        "auth": {
+          "type": "boolean"
+        },
+        "authMechanism": {
+          "type": "string"
+        },
+        "csfle": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "minProperties": 1,
+              "properties": {
+                "minLibmongocryptVersion": {
+                  "$ref": "#/definitions/version"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "entity": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "client": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "uriOptions": {
+              "type": "object"
+            },
+            "useMultipleMongoses": {
+              "type": "boolean"
+            },
+            "observeEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "enum": [
+                  "commandStartedEvent",
+                  "commandSucceededEvent",
+                  "commandFailedEvent",
+                  "poolCreatedEvent",
+                  "poolReadyEvent",
+                  "poolClearedEvent",
+                  "poolClosedEvent",
+                  "connectionCreatedEvent",
+                  "connectionReadyEvent",
+                  "connectionClosedEvent",
+                  "connectionCheckOutStartedEvent",
+                  "connectionCheckOutFailedEvent",
+                  "connectionCheckedOutEvent",
+                  "connectionCheckedInEvent",
+                  "serverDescriptionChangedEvent",
+                  "topologyDescriptionChangedEvent",
+                  "topologyOpeningEvent",
+                  "topologyClosedEvent"
+                ]
+              }
+            },
+            "ignoreCommandMonitoringEvents": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "storeEventsAsEntities": {
+              "deprecated": true,
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/storeEventsAsEntity"
+              }
+            },
+            "observeLogMessages": {
+              "type": "object",
+              "minProperties": 1,
+              "additionalProperties": false,
+              "properties": {
+                "command": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                },
+                "topology": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                },
+                "serverSelection": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                },
+                "connection": {
+                  "$ref": "#/definitions/logSeverityLevel"
+                }
+              }
+            },
+            "observeTracingMessages": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enableCommandPayload": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "serverApi": {
+              "$ref": "#/definitions/serverApi"
+            },
+            "observeSensitiveCommands": {
+              "type": "boolean"
+            },
+            "autoEncryptOpts": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "keyVaultNamespace",
+                "kmsProviders"
+              ],
+              "properties": {
+                "keyVaultNamespace": {
+                  "type": "string"
+                },
+                "bypassAutoEncryption": {
+                  "type": "boolean"
+                },
+                "kmsProviders": {
+                  "$ref": "#/definitions/kmsProviders"
+                },
+                "schemaMap": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
+                },
+                "extraOptions": {
+                  "type": "object"
+                },
+                "encryptedFieldsMap": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object"
+                  }
+                },
+                "bypassQueryAnalysis": {
+                  "type": "boolean"
+                },
+                "keyExpirationMS": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "clientEncryption": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "clientEncryptionOpts"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "clientEncryptionOpts": {
+              "$ref": "#/definitions/clientEncryptionOpts"
+            }
+          }
+        },
+        "database": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "client",
+            "databaseName"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "client": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "databaseOptions": {
+              "$ref": "#/definitions/collectionOrDatabaseOptions"
+            }
+          }
+        },
+        "collection": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "database",
+            "collectionName"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            },
+            "collectionName": {
+              "type": "string"
+            },
+            "collectionOptions": {
+              "$ref": "#/definitions/collectionOrDatabaseOptions"
+            }
+          }
+        },
+        "session": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "client"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "client": {
+              "type": "string"
+            },
+            "sessionOptions": {
+              "type": "object"
+            }
+          }
+        },
+        "bucket": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "database"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "database": {
+              "type": "string"
+            },
+            "bucketOptions": {
+              "type": "object"
+            }
+          }
+        },
+        "thread": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "logComponent": {
+      "type": "string",
+      "enum": [
+        "command",
+        "topology",
+        "serverSelection",
+        "connection"
+      ]
+    },
+    "spanComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "tags"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "object"
+        },
+        "nested": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/spanComponent"
+          }
+        }
+      }
+    },
+    "logSeverityLevel": {
+      "type": "string",
+      "enum": [
+        "emergency",
+        "alert",
+        "critical",
+        "error",
+        "warning",
+        "notice",
+        "info",
+        "debug",
+        "trace"
+      ]
+    },
+    "clientEncryptionOpts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "keyVaultClient",
+        "keyVaultNamespace",
+        "kmsProviders"
+      ],
+      "properties": {
+        "keyVaultClient": {
+          "type": "string"
+        },
+        "keyVaultNamespace": {
+          "type": "string"
+        },
+        "kmsProviders": {
+          "$ref": "#/definitions/kmsProviders"
+        },
+        "keyExpirationMS": {
+          "type": "integer"
+        }
+      }
+    },
+    "kmsProviders": {
+      "$defs": {
+        "stringOrPlaceholder": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "$$placeholder"
+              ],
+              "properties": {
+                "$$placeholder": {}
+              }
+            }
+          ]
+        }
+      },
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^aws(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "accessKeyId": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "secretAccessKey": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "sessionToken": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^azure(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "tenantId": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "clientId": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "clientSecret": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "identityPlatformEndpoint": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^gcp(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "privateKey": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            },
+            "endpoint": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^kmip(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "endpoint": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        },
+        "^local(:[a-zA-Z0-9_]+)?$": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "key": {
+              "$ref": "#/definitions/kmsProviders/$defs/stringOrPlaceholder"
+            }
+          }
+        }
+      }
+    },
+    "storeEventsAsEntity": {
+      "deprecated": true,
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "events"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "PoolCreatedEvent",
+              "PoolReadyEvent",
+              "PoolClearedEvent",
+              "PoolClosedEvent",
+              "ConnectionCreatedEvent",
+              "ConnectionReadyEvent",
+              "ConnectionClosedEvent",
+              "ConnectionCheckOutStartedEvent",
+              "ConnectionCheckOutFailedEvent",
+              "ConnectionCheckedOutEvent",
+              "ConnectionCheckedInEvent",
+              "CommandStartedEvent",
+              "CommandSucceededEvent",
+              "CommandFailedEvent",
+              "ServerDescriptionChangedEvent",
+              "TopologyDescriptionChangedEvent"
+            ]
+          }
+        }
+      }
+    },
+    "collectionData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "collectionName",
+        "databaseName",
+        "documents"
+      ],
+      "properties": {
+        "collectionName": {
+          "type": "string"
+        },
+        "databaseName": {
+          "type": "string"
+        },
+        "createOptions": {
+          "type": "object",
+          "properties": {
+            "writeConcern": false
+          }
+        },
+        "documents": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "expectedEventsForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "client",
+        "events"
+      ],
+      "properties": {
+        "client": {
+          "type": "string"
+        },
+        "eventType": {
+          "type": "string",
+          "enum": [
+            "command",
+            "cmap",
+            "sdam"
+          ]
+        },
+        "events": {
+          "type": "array"
+        },
+        "ignoreExtraEvents": {
+          "type": "boolean"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "eventType"
+          ],
+          "properties": {
+            "eventType": {
+              "const": "command"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedCommandEvent"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "eventType"
+          ],
+          "properties": {
+            "eventType": {
+              "const": "cmap"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedCmapEvent"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "eventType"
+          ],
+          "properties": {
+            "eventType": {
+              "const": "sdam"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedSdamEvent"
+              }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "client": {
+              "type": "string"
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/expectedCommandEvent"
+              }
+            },
+            "ignoreExtraEvents": {
+              "type": "boolean"
+            }
+          }
+        }
+      ]
+    },
+    "expectedCommandEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "commandStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "type": "object"
+            },
+            "commandName": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "hasServerConnectionId": {
+              "type": "boolean"
+            }
+          }
+        },
+        "commandSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reply": {
+              "type": "object"
+            },
+            "commandName": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "hasServerConnectionId": {
+              "type": "boolean"
+            }
+          }
+        },
+        "commandFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "commandName": {
+              "type": "string"
+            },
+            "databaseName": {
+              "type": "string"
+            },
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "hasServerConnectionId": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    },
+    "expectedCmapEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "poolCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "poolClearedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "hasServiceId": {
+              "type": "boolean"
+            },
+            "interruptInUseConnections": {
+              "type": "boolean"
+            }
+          }
+        },
+        "poolClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCreatedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionReadyEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": {
+              "type": "string"
+            }
+          }
+        },
+        "connectionCheckOutStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckOutFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "reason": {
+              "type": "string"
+            }
+          }
+        },
+        "connectionCheckedOutEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "connectionCheckedInEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      }
+    },
+    "expectedSdamEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "maxProperties": 1,
+      "minProperties": 1,
+      "properties": {
+        "serverDescriptionChangedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "previousDescription": {
+              "$ref": "#/definitions/serverDescription"
+            },
+            "newDescription": {
+              "$ref": "#/definitions/serverDescription"
+            }
+          }
+        },
+        "topologyDescriptionChangedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "previousDescription": {
+              "$ref": "#/definitions/topologyDescription"
+            },
+            "newDescription": {
+              "$ref": "#/definitions/topologyDescription"
+            }
+          }
+        },
+        "serverHeartbeatStartedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "awaited": {
+              "type": "boolean"
+            }
+          }
+        },
+        "serverHeartbeatSucceededEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "awaited": {
+              "type": "boolean"
+            }
+          }
+        },
+        "serverHeartbeatFailedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "awaited": {
+              "type": "boolean"
+            }
+          }
+        },
+        "topologyOpeningEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        },
+        "topologyClosedEvent": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {}
+        }
+      }
+    },
+    "serverDescription": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Standalone",
+            "Mongos",
+            "PossiblePrimary",
+            "RSPrimary",
+            "RSSecondary",
+            "RSOther",
+            "RSArbiter",
+            "RSGhost",
+            "LoadBalancer",
+            "Unknown"
+          ]
+        }
+      }
+    },
+    "topologyDescription": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "Single",
+            "Unknown",
+            "ReplicaSetNoPrimary",
+            "ReplicaSetWithPrimary",
+            "Sharded",
+            "LoadBalanced"
+          ]
+        }
+      }
+    },
+    "expectedLogMessagesForClient": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "client",
+        "messages"
+      ],
+      "properties": {
+        "client": {
+          "type": "string"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expectedLogMessage"
+          }
+        },
+        "ignoreExtraMessages": {
+          "type": "boolean"
+        },
+        "ignoreMessages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/expectedLogMessage"
+          }
+        }
+      }
+    },
+    "expectedLogMessage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "level",
+        "component",
+        "data"
+      ],
+      "properties": {
+        "level": {
+          "$ref": "#/definitions/logSeverityLevel"
+        },
+        "component": {
+          "$ref": "#/definitions/logComponent"
+        },
+        "data": {
+          "type": "object"
+        },
+        "failureIsRedacted": {
+          "type": "boolean"
+        }
+      }
+    },
+    "collectionOrDatabaseOptions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "readConcern": {
+          "type": "object"
+        },
+        "readPreference": {
+          "type": "object"
+        },
+        "writeConcern": {
+          "type": "object"
+        },
+        "timeoutMS": {
+          "type": "integer"
+        }
+      }
+    },
+    "serverApi": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version"
+      ],
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "strict": {
+          "type": "boolean"
+        },
+        "deprecationErrors": {
+          "type": "boolean"
+        }
+      }
+    },
+    "operation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "object"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "object": {
+          "type": "string"
+        },
+        "arguments": {
+          "type": "object"
+        },
+        "ignoreResultAndError": {
+          "type": "boolean"
+        },
+        "expectError": {
+          "$ref": "#/definitions/expectedError"
+        },
+        "expectResult": {},
+        "saveResultAsEntity": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "not": {
+            "required": [
+              "expectError",
+              "expectResult"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "expectError",
+              "saveResultAsEntity"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "ignoreResultAndError",
+              "expectResult"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "ignoreResultAndError",
+              "expectError"
+            ]
+          }
+        },
+        {
+          "not": {
+            "required": [
+              "ignoreResultAndError",
+              "saveResultAsEntity"
+            ]
+          }
+        }
+      ]
+    },
+    "expectedError": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "isError": {
+          "type": "boolean",
+          "const": true
+        },
+        "isClientError": {
+          "type": "boolean"
+        },
+        "isTimeoutError": {
+          "type": "boolean"
+        },
+        "errorContains": {
+          "type": "string"
+        },
+        "errorCode": {
+          "type": "integer"
+        },
+        "errorCodeName": {
+          "type": "string"
+        },
+        "errorLabelsContain": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "errorLabelsOmit": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "writeErrors": {
+          "type": "object"
+        },
+        "writeConcernErrors": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "errorResponse": {
+          "type": "object"
+        },
+        "expectResult": {}
+      }
+    },
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "description",
+        "operations"
+      ],
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "runOnRequirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/runOnRequirement"
+          }
+        },
+        "skipReason": {
+          "type": "string"
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/operation"
+          }
+        },
+        "expectEvents": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/expectedEventsForClient"
+          }
+        },
+        "expectLogMessages": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/expectedLogMessagesForClient"
+          }
+        },
+        "expectTracingMessages": {
+          "additionalProperties" : false,
+          "type": "object",
+          "required": [
+            "client",
+            "spans"
+          ],
+          "properties": {
+            "client": {
+              "type": "string"
+            },
+            "ignoreExtraSpans": {
+              "type": "boolean"
+            },
+            "spans": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "$ref": "#/definitions/spanComponent"
+              }
+            }
+          }
+        },
+        "outcome": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/collectionData"
+          }
+        }
+      }
+    }
+  }
+}

--- a/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-additionalProperties.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-additionalProperties.yml
@@ -1,0 +1,14 @@
+description: "entity-client-observeTracingMessages-additionalProperties"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      observeTracingMessages: {
+        foo: "bar"
+      }
+
+tests:
+  - description: "observeTracingMessages must not have additional properties'"
+    operations: [ ]

--- a/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-additionalPropertyType.json
+++ b/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-additionalPropertyType.json
@@ -1,0 +1,20 @@
+{
+  "description": "entity-client-observeTracingMessages-additionalPropertyType",
+  "schemaVersion": "1.25",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeTracingMessages": {
+          "enableCommandPayload": 0
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "observeTracingMessages enableCommandPayload must be boolean",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-additionalPropertyType.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-additionalPropertyType.yml
@@ -1,0 +1,14 @@
+description: "entity-client-observeTracingMessages-additionalPropertyType"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      observeTracingMessages: {
+        enableCommandPayload: 0
+      }
+
+tests:
+  - description: "observeTracingMessages enableCommandPayload must be boolean"
+    operations: [ ]

--- a/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-type.json
+++ b/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-type.json
@@ -1,0 +1,18 @@
+{
+  "description": "entity-client-expectTracingMessages-type",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0",
+        "observeTracingMessages": "foo"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "expectTracingMessages must be an object",
+      "operations": []
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-type.yml
+++ b/source/unified-test-format/tests/invalid/entity-client-observeTracingMessages-type.yml
@@ -1,0 +1,12 @@
+description: "entity-client-observeTracingMessages-type"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+      observeTracingMessages: "foo"
+
+tests:
+  - description: "observeTracingMessages must be an object"
+    operations: [ ]

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-additionalProperties.json
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-additionalProperties.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedTracingSpans-additionalProperties",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "additional property foo not allowed in expectTracingMessages",
+      "operations": [],
+      "expectTracingMessages": {
+        "client": "client0",
+        "ignoreExtraSpans": false,
+        "spans": [
+          {}
+        ],
+        "foo": 0
+      }
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-additionalProperties.yml
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-additionalProperties.yml
@@ -1,0 +1,16 @@
+description: "expectedTracingSpans-additionalProperties"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "additional property foo not allowed in expectTracingMessages"
+    operations: []
+    expectTracingMessages:
+      client: *client0
+      ignoreExtraSpans: false
+      spans: [{}]
+      foo: 0

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-clientType.json
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-clientType.json
@@ -1,0 +1,23 @@
+{
+  "description": "expectedTracingSpans-clientType",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "client type must be string",
+      "operations": [],
+      "expectTracingMessages": {
+        "client": 0,
+        "spans": [
+          {}
+        ]
+      }
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-clientType.yml
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-clientType.yml
@@ -1,0 +1,14 @@
+description: "expectedTracingSpans-clientType"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "client type must be string"
+    operations: []
+    expectTracingMessages:
+      client: 0
+      spans: [{}]

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-missingPropertyClient.json
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-missingPropertyClient.json
@@ -1,0 +1,22 @@
+{
+  "description": "expectedTracingSpans-missingPropertyClient",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "missing required property client",
+      "operations": [],
+      "expectTracingMessages": {
+        "spans": [
+          {}
+        ]
+      }
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-missingPropertyClient.yml
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-missingPropertyClient.yml
@@ -1,0 +1,13 @@
+description: "expectedTracingSpans-missingPropertyClient"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "missing required property client"
+    operations: []
+    expectTracingMessages:
+      spans: [{}]

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-missingPropertySpans.json
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-missingPropertySpans.json
@@ -1,0 +1,20 @@
+{
+  "description": "expectedTracingSpans-missingPropertySpans",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "missing required property spans",
+      "operations": [],
+      "expectTracingMessages": {
+        "client": "client0"
+      }
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-missingPropertySpans.yml
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-missingPropertySpans.yml
@@ -1,0 +1,13 @@
+description: "expectedTracingSpans-missingPropertySpans"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "missing required property spans"
+    operations: []
+    expectTracingMessages:
+      client: client0

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedAdditionalProperties.json
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedAdditionalProperties.json
@@ -1,0 +1,28 @@
+{
+  "description": "expectedTracingSpans-spanMalformedAdditionalProperties",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Span must not have additional properties",
+      "operations": [],
+      "expectTracingMessages": {
+        "client": "client0",
+        "spans": [
+          {
+            "name": "foo",
+            "tags": {},
+            "nested": [],
+            "foo": "bar"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedAdditionalProperties.yml
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedAdditionalProperties.yml
@@ -1,0 +1,19 @@
+description: "expectedTracingSpans-spanMalformedAdditionalProperties"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "Span must not have additional properties"
+    operations: []
+    expectTracingMessages:
+      client: client0
+      spans:
+        - name: "foo"
+          tags: {}
+          nested: []
+          foo: "bar"
+

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedMissingName.json
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedMissingName.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedTracingSpans-spanMalformedMissingName",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "missing required span name",
+      "operations": [],
+      "expectTracingMessages": {
+        "client": "client0",
+        "spans": [
+          {
+            "tags": {
+              "db.system": "mongodb"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedMissingName.yml
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedMissingName.yml
@@ -1,0 +1,16 @@
+description: "expectedTracingSpans-spanMalformedMissingName"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "missing required span name"
+    operations: []
+    expectTracingMessages:
+      client: client0
+      spans:
+        - tags:
+            db.system: mongodb

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedMissingTags.json
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedMissingTags.json
@@ -1,0 +1,25 @@
+{
+  "description": "expectedTracingSpans-spanMalformedMissingTags",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "missing required span tags",
+      "operations": [],
+      "expectTracingMessages": {
+        "client": "client0",
+        "spans": [
+          {
+            "name": "foo"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedMissingTags.yml
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedMissingTags.yml
@@ -1,0 +1,15 @@
+description: "expectedTracingSpans-spanMalformedMissingTags"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "missing required span tags"
+    operations: []
+    expectTracingMessages:
+      client: client0
+      spans:
+        - name: "foo"

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedNestedMustBeArray.json
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedNestedMustBeArray.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedTracingSpans-spanMalformedNestedMustBeArray",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "nested spans must be an array",
+      "operations": [],
+      "expectTracingMessages": {
+        "client": "client0",
+        "spans": [
+          {
+            "name": "foo",
+            "tags": {},
+            "nested": {}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedNestedMustBeArray.yml
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedNestedMustBeArray.yml
@@ -1,0 +1,18 @@
+description: "expectedTracingSpans-spanMalformedNestedMustBeArray"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "nested spans must be an array"
+    operations: []
+    expectTracingMessages:
+      client: client0
+      spans:
+        - name: "foo"
+          tags: {}
+          nested: {}
+

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedTagsMustBeObject.json
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedTagsMustBeObject.json
@@ -1,0 +1,27 @@
+{
+  "description": "expectedTracingSpans-spanMalformedNestedMustBeObject",
+  "schemaVersion": "1.26",
+  "createEntities": [
+    {
+      "client": {
+        "id": "client0"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "span tags must be an object",
+      "operations": [],
+      "expectTracingMessages": {
+        "client": "client0",
+        "spans": [
+          {
+            "name": "foo",
+            "tags": [],
+            "nested": []
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedTagsMustBeObject.yml
+++ b/source/unified-test-format/tests/invalid/expectedTracingSpans-spanMalformedTagsMustBeObject.yml
@@ -1,0 +1,18 @@
+description: "expectedTracingSpans-spanMalformedNestedMustBeObject"
+
+schemaVersion: "1.26"
+
+createEntities:
+  - client:
+      id: &client0 "client0"
+
+tests:
+  - description: "span tags must be an object"
+    operations: []
+    expectTracingMessages:
+      client: client0
+      spans:
+        - name: "foo"
+          tags: []
+          nested: []
+


### PR DESCRIPTION
DRIVERS-719
- [x] Update schema to 1.26
- [x] Added invalid test to unified test runner
- [x] Added nominal valid tests for the 3 tracing grouping (Operation, Cursor and Transaction)
- [ ] Update description of the new field `observeTracingMessages` and `expectTracingMessages`
- [ ] Merge back the draft [spec](https://github.com/mongodb/specifications/pull/1821)  into this 
