### PR TITLE
DRIVERS-3106: Replace empty UUIDs in localSchema.json spec test

### DIFF
--- a/source/client-side-encryption/tests/unified/localSchema.json
+++ b/source/client-side-encryption/tests/unified/localSchema.json
@@ -27,7 +27,7 @@
                     "keyId": [
                       {
                         "$binary": {
-                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "base64": "OyQRAeK7QlWMr0E2xWapYg==",
                           "subType": "04"
                         }
                       }
@@ -41,7 +41,7 @@
                     "keyId": [
                       {
                         "$binary": {
-                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "base64": "OyQRAeK7QlWMr0E2xWapYg==",
                           "subType": "04"
                         }
                       }
@@ -55,7 +55,7 @@
                     "keyId": [
                       {
                         "$binary": {
-                          "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                          "base64": "OyQRAeK7QlWMr0E2xWapYg==",
                           "subType": "04"
                         }
                       }
@@ -163,7 +163,7 @@
           "status": 1,
           "_id": {
             "$binary": {
-              "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+              "base64": "OyQRAeK7QlWMr0E2xWapYg==",
               "subType": "04"
             }
           },
@@ -248,7 +248,7 @@
                           "$in": [
                             {
                               "$binary": {
-                                "base64": "AAAAAAAAAAAAAAAAAAAAAA==",
+                                "base64": "OyQRAeK7QlWMr0E2xWapYg==",
                                 "subType": "04"
                               }
                             }
@@ -278,7 +278,7 @@
                       "_id": 1,
                       "encrypted_string": {
                         "$binary": {
-                          "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                          "base64": "ATskEQHiu0JVjK9BNsVmqWIClDjVEWlpmVRN76InSQuFW2piVbYFkh0QhZCKyx9DdvFBUG+FWluh0kXyhdq3b2Vt/nqNWjXn2y0+JPhrc4W+wQ==",
                           "subType": "06"
                         }
                       }
@@ -311,7 +311,7 @@
               "_id": 1,
               "encrypted_string": {
                 "$binary": {
-                  "base64": "AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==",
+                  "base64": "ATskEQHiu0JVjK9BNsVmqWIClDjVEWlpmVRN76InSQuFW2piVbYFkh0QhZCKyx9DdvFBUG+FWluh0kXyhdq3b2Vt/nqNWjXn2y0+JPhrc4W+wQ==",
                   "subType": "06"
                 }
               }

--- a/source/client-side-encryption/tests/unified/localSchema.yml
+++ b/source/client-side-encryption/tests/unified/localSchema.yml
@@ -11,7 +11,7 @@ createEntities:
       id: &client0 client0
       autoEncryptOpts:
         schemaMap:
-          "default.default": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
+          "default.default": {'properties': {'encrypted_w_altname': {'encrypt': {'keyId': '/altname', 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string': {'encrypt': {'keyId': [{'$binary': {'base64': 'OyQRAeK7QlWMr0E2xWapYg==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}, 'random': {'encrypt': {'keyId': [{'$binary': {'base64': 'OyQRAeK7QlWMr0E2xWapYg==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'}}, 'encrypted_string_equivalent': {'encrypt': {'keyId': [{'$binary': {'base64': 'OyQRAeK7QlWMr0E2xWapYg==', 'subType': '04'}}], 'bsonType': 'string', 'algorithm': 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'}}}, 'bsonType': 'object'}
         keyVaultNamespace: keyvault.datakeys
         kmsProviders:
           aws: { accessKeyId: { $$placeholder: 1 }, secretAccessKey: { $$placeholder: 1 }, sessionToken: { $$placeholder: 1 } }
@@ -47,7 +47,7 @@ initialData:
   - databaseName: &keyvaultDBName keyvault
     collectionName: &datakeysCollName datakeys
     documents:
-      - {'status': 1, '_id': {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}}, 'masterKey': {'provider': 'aws', 'key': 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0', 'region': 'us-east-1'}, 'updateDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyMaterial': {'$binary': {'base64': 'AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO', 'subType': '00'}}, 'creationDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyAltNames': ['altname', 'another_altname']}
+      - {'status': 1, '_id': {'$binary': {'base64': 'OyQRAeK7QlWMr0E2xWapYg==', 'subType': '04'}}, 'masterKey': {'provider': 'aws', 'key': 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0', 'region': 'us-east-1'}, 'updateDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyMaterial': {'$binary': {'base64': 'AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gEqnsxXlR51T5EbEVezUqqKAAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDHa4jo6yp0Z18KgbUgIBEIB74sKxWtV8/YHje5lv5THTl0HIbhSwM6EqRlmBiFFatmEWaeMk4tO4xBX65eq670I5TWPSLMzpp8ncGHMmvHqRajNBnmFtbYxN3E3/WjxmdbOOe+OXpnGJPcGsftc7cB2shRfA4lICPnE26+oVNXT6p0Lo20nY5XC7jyCO', 'subType': '00'}}, 'creationDate': {'$date': {'$numberLong': '1552949630483'}}, 'keyAltNames': ['altname', 'another_altname']}
   - databaseName: *encryptedDBName
     collectionName: *encryptedCollName
     documents: []
@@ -73,14 +73,14 @@ tests:
               commandName: find
               command:
                 find: *datakeysCollName
-                filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'AAAAAAAAAAAAAAAAAAAAAA==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
+                filter: {"$or": [{"_id": {"$in": [ {'$binary': {'base64': 'OyQRAeK7QlWMr0E2xWapYg==', 'subType': '04'}} ] }}, {"keyAltNames": {"$in": []}}]}
                 readConcern: { level: "majority" }
           - commandStartedEvent:
               commandName: insert
               command:
                 insert: *encryptedCollName
                 documents:
-                  - &doc0_encrypted { _id: 1, encrypted_string: {'$binary': {'base64': 'AQAAAAAAAAAAAAAAAAAAAAACwj+3zkv2VM+aTfk60RqhXq6a/77WlLwu/BxXFkL7EppGsju/m8f0x5kBDD3EZTtGALGXlym5jnpZAoSIkswHoA==', 'subType': '06'}} }
+                  - &doc0_encrypted { _id: 1, encrypted_string: {'$binary': {'base64': 'ATskEQHiu0JVjK9BNsVmqWIClDjVEWlpmVRN76InSQuFW2piVbYFkh0QhZCKyx9DdvFBUG+FWluh0kXyhdq3b2Vt/nqNWjXn2y0+JPhrc4W+wQ==', 'subType': '06'}} }
                 ordered: true
           - commandStartedEvent:
               commandName: find


### PR DESCRIPTION
The current localSchema.json spec test uses empty UUIDs which causes test failures for the C# driver. This PR updates the test data to use non-empty UUIDs.

In C#, UUIDs are represented as GUIDs (value types/structs) with a default value of an empty UUID (00000000-0000-0000-0000-000000000000). Following standard C# conventions, an empty UUID indicates an uninitialized GUID. Therefore, the C# driver correctly treats empty UUID IDs as "not-set" and automatically generates new IDs during insert operations, which is the expected behavior for the language.

After evaluation, we've decided to maintain the C# driver's current behavior as it aligns with C# language conventions. This behavior will be documented in our driver documentation to ensure users are aware of this UUID handling.

We could workaround the issue in our test runner but updating the spec test data is a lot easier. 

Tested in this [patch](https://spruce.mongodb.com/version/68ae263f10c35300077bad9f/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
