### PR TITLE
DRIVERS-3279 clarify expected server errors in CSE prose test 4

### DIFF
--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -619,7 +619,8 @@ Using `client_encrypted` perform the following operations:
     `{ "_id": "encryption_exceeds_16mib", "unencrypted": < the string "a" repeated (16777216 - 2000) times > }` into
     `coll`.
 
-    Expect this to fail since encryption results in a document exceeding the `maxBsonObjectSize` limit.
+    Expect this to fail indicating the document exceeded the `maxBsonObjectSize` limit. If the write is sent to the
+    server, expect a server error with code 2 or 10334.
 
 7. If using MongoDB 8.0+, use MongoClient.bulkWrite to insert the following into `coll2`:
 

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -620,7 +620,7 @@ Using `client_encrypted` perform the following operations:
     `coll`.
 
     Expect this to fail indicating the document exceeded the `maxBsonObjectSize` limit. If the write is sent to the
-    server, expect a server error with code 2 or 10334.
+    server (i.e. does not fail due to a driver-side check), expect a server error with code 2 or 10334.
 
 7. If using MongoDB 8.0+, use MongoClient.bulkWrite to insert the following into `coll2`:
 


### PR DESCRIPTION
# Summary

Document expected server error codes in prose test for CSFLE/QE bulkWrite prose test expecting a "too-large document" error.

# Motivation

[SERVER-104405](https://jira.mongodb.org/browse/SERVER-104405) recently changed the expected error code. This broke some drivers testing of [BSON Size Limits and Batch Splitting](https://github.com/mongodb/specifications/blob/49ade88e52ddfa6cee7fa0de286e5f8b0d62dcd0/source/client-side-encryption/tests/README.md#4-bson-size-limits-and-batch-splitting). Document the expected server errors in the specification.

Checking server error codes is not made into a requirement. `MongoCollection.bulkWrite` does not prohibit client-side checks after auto-encryption. The expected error might be a driver-side or server-side error.

---

<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- [x] Test changes in at least one language driver. (See: https://github.com/mongodb/mongo-c-driver/pull/2106)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
