### PR TITLE
DRIVERS-2295 fix typo in `commandName`

### DIFF
--- a/source/client-side-encryption/tests/unified/validatorAndPartialFieldExpression.json
+++ b/source/client-side-encryption/tests/unified/validatorAndPartialFieldExpression.json
@@ -248,7 +248,7 @@
           "name": "runCommand",
           "object": "db",
           "arguments": {
-            "commandName": "collMod",
+            "commandName": "createIndexes",
             "command": {
               "createIndexes": "encryptedCollection",
               "indexes": [

--- a/source/client-side-encryption/tests/unified/validatorAndPartialFieldExpression.yml
+++ b/source/client-side-encryption/tests/unified/validatorAndPartialFieldExpression.yml
@@ -160,7 +160,7 @@ tests:
       - name: runCommand
         object: "db"
         arguments:
-          commandName: collMod
+          commandName: createIndexes
           command:
             createIndexes: "encryptedCollection"
             indexes:


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/specifications/issues/1784. Replace `collMod` with `createIndexes` so `commandName` and `command` match.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [x] Test changes in at least one language driver. (Tested locally in C driver)
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
