### PR TITLE
DRIVERS-3278 Revert field presence changes from server 8.2.0

### DIFF
--- a/source/change-streams/change-streams.md
+++ b/source/change-streams/change-streams.md
@@ -139,7 +139,7 @@ class ChangeStreamDocument {
 
   /**
    * Only present for ops of type 'rename', 'create', 'modify', 'createIndexes', 'dropIndexes', 'shardCollection', 'reshardCollection', 'refineCollectionShardKey'.
-   * Prior to server version 8.2.0, only present when the `showExpandedEvents` change stream option is enabled.
+   * Only present when the `showExpandedEvents` change stream option is enabled.
    *
    * A description of the operation.
    * 
@@ -202,7 +202,7 @@ class ChangeStreamDocument {
   /**
    * The `ui` field from the oplog entry corresponding to the change event.
    * 
-   * Only present for the following events:
+   * Only present when the `showExpandedEvents` change stream option is enabled and for the following events:
    *  - 'insert'
    *  - 'update'
    *  - 'delete'
@@ -214,7 +214,6 @@ class ChangeStreamDocument {
    *  - 'shardCollection'
    *  - 'reshardCollection'
    *  - 'refineCollectionShardKey'
-   * Prior to server versions 8.2, only present when the `showExpandedEvents` change stream option is enabled.
    *  
    * This field is a value of binary subtype 4 (UUID).
    *  
@@ -298,6 +297,8 @@ class UpdateDescription {
    *   }
    * 
    * In each array, all elements will be returned as strings with the exception of array indices, which will be returned as 32 bit integers.
+   * 
+   * Only present when the `showExpandedEvents` change stream option is enabled.
    * 
    * @since 6.1.0
    */
@@ -1025,6 +1026,8 @@ There should be no backwards compatibility concerns.
 - RUBY (RUBY-1228)
 
 ## Changelog
+
+- 2025-09-09: Revert expanded field visibility change.
 
 - 2025-09-08: Clarify resume behavior.
 

--- a/source/change-streams/tests/unified/change-streams-disambiguatedPaths.json
+++ b/source/change-streams/tests/unified/change-streams-disambiguatedPaths.json
@@ -43,6 +43,91 @@
   ],
   "tests": [
     {
+      "description": "disambiguatedPaths is not present when showExpandedEvents is false/unset",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "6.1.0",
+          "maxServerVersion": "8.1.99",
+          "topologies": [
+            "replicaset",
+            "load-balanced",
+            "sharded"
+          ],
+          "serverless": "forbid"
+        },
+        {
+          "minServerVersion": "8.2.1",
+          "topologies": [
+            "replicaset",
+            "load-balanced",
+            "sharded"
+          ],
+          "serverless": "forbid"
+        }
+      ],
+      "operations": [
+        {
+          "name": "insertOne",
+          "object": "collection0",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "a": {
+                "1": 1
+              }
+            }
+          }
+        },
+        {
+          "name": "createChangeStream",
+          "object": "collection0",
+          "arguments": {
+            "pipeline": []
+          },
+          "saveResultAsEntity": "changeStream0"
+        },
+        {
+          "name": "updateOne",
+          "object": "collection0",
+          "arguments": {
+            "filter": {
+              "_id": 1
+            },
+            "update": {
+              "$set": {
+                "a.1": 2
+              }
+            }
+          }
+        },
+        {
+          "name": "iterateUntilDocumentOrError",
+          "object": "changeStream0",
+          "expectResult": {
+            "operationType": "update",
+            "ns": {
+              "db": "database0",
+              "coll": "collection0"
+            },
+            "updateDescription": {
+              "updatedFields": {
+                "$$exists": true
+              },
+              "removedFields": {
+                "$$exists": true
+              },
+              "truncatedArrays": {
+                "$$exists": true
+              },
+              "disambiguatedPaths": {
+                "$$exists": false
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
       "description": "disambiguatedPaths is present on updateDescription when an ambiguous path is present",
       "operations": [
         {

--- a/source/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
+++ b/source/change-streams/tests/unified/change-streams-disambiguatedPaths.yml
@@ -24,6 +24,41 @@ initialData:
     documents: []
 
 tests:
+  - description: "disambiguatedPaths is not present when showExpandedEvents is false/unset"
+    # skip server version 8.2.0, which emits disambiguatedPaths unconditionally
+    runOnRequirements:
+      - minServerVersion: "6.1.0"
+        maxServerVersion: "8.1.99"
+        topologies: [ replicaset, load-balanced, sharded ]
+        serverless: forbid
+      - minServerVersion: "8.2.1"
+        topologies: [ replicaset, load-balanced, sharded ]
+        serverless: forbid
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 1, 'a': { '1': 1 } }
+      - name: createChangeStream
+        object: *collection0
+        arguments: { pipeline: [] }
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { 'a.1': 2 } }
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0, coll: *collection0 }
+          updateDescription:
+            updatedFields: { $$exists: true }
+            removedFields: { $$exists: true }
+            truncatedArrays: { $$exists: true }
+            disambiguatedPaths: { $$exists: false }
+
   - description: "disambiguatedPaths is present on updateDescription when an ambiguous path is present"
     operations:
       - name: insertOne


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Update changelog.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
