### PR TITLE
DRIVERS-2415 minor OIDC clarifications

### DIFF
--- a/source/auth/auth.md
+++ b/source/auth/auth.md
@@ -1830,6 +1830,8 @@ def auth(connection):
       if e.code == 18:
         invalidate(access_token)
         access_token, _ = get_access_token()
+      else:
+        raise e # Raise other errors.
 
   connection.oidc_cache.access_token = access_token
   sasl_start(connection, payload={"jwt": access_token})

--- a/source/auth/tests/mongodb-oidc.md
+++ b/source/auth/tests/mongodb-oidc.md
@@ -199,7 +199,7 @@ source the `secrets-export.sh` file and use the associated env variables in your
 }
 ```
 
-- Perform a `find` operation that fails.
+- Perform a `insert` operation that fails.
 - Assert that the callback was called 2 times.
 - Close the client.
 

--- a/source/auth/tests/mongodb-oidc.md
+++ b/source/auth/tests/mongodb-oidc.md
@@ -209,7 +209,7 @@ source the `secrets-export.sh` file and use the associated env variables in your
 - Populate the *Client Cache* with a valid access token to enforce Speculative Authentication.
 - Perform an `insert` operation that succeeds.
 - Assert that the callback was not called.
-- Assert there were no `SaslStart` commands executed.
+- Assert there were no `saslStart` commands executed.
 - Set a fail point for `insert` commands of the form:
 
 ```javascript
@@ -229,7 +229,7 @@ source the `secrets-export.sh` file and use the associated env variables in your
 
 - Perform an `insert` operation that succeeds.
 - Assert that the callback was called once.
-- Assert there were `SaslStart` commands executed.
+- Assert there were `saslStart` commands executed.
 - Close the client.
 
 #### 4.5 Reauthentication Succeeds when a Session is involved


### PR DESCRIPTION
# Summary

This PR includes minor clarifications (e.g. typos) found when implementing in the C driver:

- Fix casing: `SaslStart` => `saslStart`
- Fix OIDC prose test 4.3: `find` => `insert`
    - Test sets a failpoint on `insert` and expects an error after.
- Fix auth code example: re-raise a non-auth error to match the described algorithm.


<!-- Thanks for contributing! -->

Please complete the following before merging:

- ~~[ ] Update changelog.~~
- ~~[ ] Test changes in at least one language driver.~~
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
