### PR TITLE
DRIVERS-3426: Use documented 'auth_database' field instead 'db' for initial-dns-seedlist-discovery tests

### DIFF
--- a/source/initial-dns-seedlist-discovery/tests/replica-set/dbname-with-commas-escaped.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/dbname-with-commas-escaped.json
@@ -14,6 +14,6 @@
     "ssl": true
   },
   "parsed_options": {
-    "defaultDatabase": "some,db"
+    "auth_database": "some,db"
   }
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/dbname-with-commas-escaped.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/dbname-with-commas-escaped.yml
@@ -10,4 +10,4 @@ options:
   replicaSet: repl0
   ssl: true
 parsed_options:
-  defaultDatabase: some,db
+  auth_database: some,db

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/dbname-with-commas.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/dbname-with-commas.json
@@ -14,6 +14,6 @@
     "ssl": true
   },
   "parsed_options": {
-    "defaultDatabase": "some,db"
+    "auth_database": "some,db"
   }
 }

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/dbname-with-commas.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/dbname-with-commas.yml
@@ -10,4 +10,4 @@ options:
   replicaSet: repl0
   ssl: true
 parsed_options:
-  defaultDatabase: some,db
+  auth_database: some,db

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.json
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.json
@@ -15,7 +15,7 @@
   "parsed_options": {
     "user": "b*b@f3tt=",
     "password": "$4to@L8=MC",
-    "db": "mydb?"
+    "auth_database": "mydb?"
   },
   "ping": false,
   "comment": "Encoded user, pass, and DB parse correctly"

--- a/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.yml
+++ b/source/initial-dns-seedlist-discovery/tests/replica-set/encoded-userinfo-and-db.yml
@@ -11,7 +11,7 @@ options:
 parsed_options:
     user: "b*b@f3tt="
     password: "$4to@L8=MC"
-    db: "mydb?"
+    auth_database: "mydb?"
 # Don't run a ping for URIs that include userinfo. Ping doesn't require authentication, so missing
 # userinfo isn't a problem, but some drivers will fail handshake on a connection if userinfo is
 # provided but incorrect.


### PR DESCRIPTION
Please complete the following before merging:

- [X] Is the relevant DRIVERS ticket in the PR title?
- [ ] Update changelog.
- [X] Test changes in at least one language driver ([Custom patch](https://spruce.corp.mongodb.com/version/69bc553d6acf86000798ef49/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) for CSharp Driver).
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).
