### PR TITLE
DRIVERS-3446 - Add prose tests to verify correct retry behavior when a mix of overload and non-overload errors are encountered

### DIFF
--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -159,9 +159,9 @@ The retry policy in this specification is separate from the other retry policies
 specifications. Drivers MUST ensure:
 
 - When a failed attempt is retried, backoff MUST be applied if and only if the error is an overload error.
-- If an overload error is encountered:
+- If an overload error is encountered at any point during an operation's retry loop:
     - Regardless of whether CSOT is enabled or not, the maximum number of retries for any retry policy becomes
-        `MAX_RETRIES`.
+        `MAX_RETRIES`. This includes retryable non-overload errors following the encountered overload error.
     - If CSOT is enabled and a command has been retried at least `MAX_RETRIES` times, it MUST NOT be retried further.
 
 #### Pseudocode
@@ -307,7 +307,7 @@ The Node and Python drivers will provide the reference implementations. See
 The client backpressure retry loop is primarily concerned with spreading out retries to avoid retry storms. The exact
 sleep duration is not critical to the intended behavior, so long as we sleep at least as long as we say we will.
 
-### Why override existing maximum number of retry attempt defaults for retryable reads and writes if an overload error is received?
+### Why override existing maximum number of retry attempt defaults for retryable reads and writes if an overload error is received at any point during an operation's retry loop?
 
 Load-shedded errors indicate that the request was rejected by the server to minimize load, not that the command failed
 for logical reasons. So, when determining the number of retries an operation should attempt:
@@ -325,8 +325,8 @@ specifications with load-shedding behavior:
     [retryable writes](../retryable-writes/retryable-writes.md) and
     [CSOT](../client-side-operations-timeout/client-side-operations-timeout.md) specifications when no overload errors are
     encountered.
-- Adjusting the maximum number of retry attempts to 5 if an overload error is returned from the server gives requests
-    more opportunities to succeed and helps reduce application errors.
+- Adjusting the maximum number of retry attempts to MAX_RETRIES if an overload error is returned from the server gives
+    requests more opportunities to succeed and helps reduce application errors.
 - An alternative approach would be to retry once if we don't receive an overload error, in which case we'd retry 5
     times. The approach chosen allows for additional retries in scenarios where a non-overload error fails on a retry
     with an overload error.

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -159,9 +159,10 @@ The retry policy in this specification is separate from the other retry policies
 specifications. Drivers MUST ensure:
 
 - When a failed attempt is retried, backoff MUST be applied if and only if the error is an overload error.
-- If an overload error is encountered at any point during an operation's retry loop:
+- If an overload error is encountered:
     - Regardless of whether CSOT is enabled or not, the maximum number of retries for any retry policy becomes
-        `MAX_RETRIES`. This includes retryable non-overload errors following or preceding the encountered overload error.
+        `MAX_RETRIES`. This limiting applies to all retry attempts, including retries for errors that are not overload
+        errors.
     - If CSOT is enabled and a command has been retried at least `MAX_RETRIES` times, it MUST NOT be retried further.
 
 #### Pseudocode

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -161,7 +161,7 @@ specifications. Drivers MUST ensure:
 - When a failed attempt is retried, backoff MUST be applied if and only if the error is an overload error.
 - If an overload error is encountered at any point during an operation's retry loop:
     - Regardless of whether CSOT is enabled or not, the maximum number of retries for any retry policy becomes
-        `MAX_RETRIES`. This includes retryable non-overload errors following the encountered overload error.
+        `MAX_RETRIES`. This includes retryable non-overload errors following or preceding the encountered overload error.
     - If CSOT is enabled and a command has been retried at least `MAX_RETRIES` times, it MUST NOT be retried further.
 
 #### Pseudocode
@@ -431,6 +431,8 @@ another dimension to read preference selection that users need to reason about. 
 to understand and configure.
 
 ## Changelog
+
+- 2026-04-14: Clarify correct retry behavior when a mix of overload and non-overload errors are encountered.
 
 - 2026-03-30: Introduce phase 1 support without token buckets.
 

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -59,7 +59,7 @@ executed against a MongoDB 4.4+ server that has enabled the `configureFailPoint`
         The sum of 2 backoffs is 0.3 seconds. There is a 0.3-second window to account for potential variance between the
         two runs.
 
-#### Test 3: Overload Errors are Retried a Maximum of MAX_RETRIES times
+#### Test 2: Overload Errors are Retried a Maximum of MAX_RETRIES times
 
 Drivers should test that overload errors are retried a maximum of MAX_RETRIES times. This test MUST be executed against
 a MongoDB 4.4+ server that has enabled the `configureFailPoint` command with the `errorLabels` option.
@@ -88,7 +88,7 @@ a MongoDB 4.4+ server that has enabled the `configureFailPoint` command with the
 
 6. Assert that the total number of started commands is MAX_RETRIES + 1 (3).
 
-#### Test 4: Overload Errors are Retried a Maximum of maxAdaptiveRetries times when configured
+#### Test 3: Overload Errors are Retried a Maximum of maxAdaptiveRetries times when configured
 
 Drivers should test that overload errors are retried a maximum of `maxAdaptiveRetries` times, when configured. This test
 MUST be executed against a MongoDB 4.4+ server that has enabled the `configureFailPoint` command with the `errorLabels`

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -59,7 +59,9 @@ executed against a MongoDB 4.4+ server that has enabled the `configureFailPoint`
         The sum of 2 backoffs is 0.3 seconds. There is a 0.3-second window to account for potential variance between the
         two runs.
 
-#### Test 2: Overload Errors are Retried a Maximum of MAX_RETRIES times
+#### Test 2: REMOVED
+
+#### Test 3: Overload Errors are Retried a Maximum of MAX_RETRIES times
 
 Drivers should test that overload errors are retried a maximum of MAX_RETRIES times. This test MUST be executed against
 a MongoDB 4.4+ server that has enabled the `configureFailPoint` command with the `errorLabels` option.
@@ -88,7 +90,7 @@ a MongoDB 4.4+ server that has enabled the `configureFailPoint` command with the
 
 6. Assert that the total number of started commands is MAX_RETRIES + 1 (3).
 
-#### Test 3: Overload Errors are Retried a Maximum of maxAdaptiveRetries times when configured
+#### Test 4: Overload Errors are Retried a Maximum of maxAdaptiveRetries times when configured
 
 Drivers should test that overload errors are retried a maximum of `maxAdaptiveRetries` times, when configured. This test
 MUST be executed against a MongoDB 4.4+ server that has enabled the `configureFailPoint` command with the `errorLabels`
@@ -117,30 +119,3 @@ option.
 5. Assert that the raised error contains both the `RetryableError` and `SystemOverloadedError` error labels.
 
 6. Assert that the total number of started commands is `maxAdaptiveRetries` + 1 (2).
-
-#### Test 4: Backoff is not applied for non-overload retryable errors
-
-Drivers should test that backoff is not applied for non-overload retryable errors. This test MUST be executed against a
-MongoDB 4.4+ server that has enabled the `configureFailPoint` command with the `errorLabels` option.
-
-1. Let `client` be a `MongoClient`.
-
-2. Let `coll` be a collection.
-
-3. Configure the following failpoint:
-
-    ```javascript
-        {
-            configureFailPoint: 'failCommand',
-            mode: { times: 1 },
-            data: {
-                failCommands: ['find'],
-                errorCode: 91,  // ShutdownInProgress
-                errorLabels: ['RetryableError']
-            }
-        }
-    ```
-
-4. Perform a find operation with `coll` that fails on the initial attempt, then succeeds on the first retry attempt.
-
-5. Assert that no backoff was applied for the retry attempt.

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -117,3 +117,30 @@ option.
 5. Assert that the raised error contains both the `RetryableError` and `SystemOverloadedError` error labels.
 
 6. Assert that the total number of started commands is `maxAdaptiveRetries` + 1 (2).
+
+#### Test 4: Backoff is not applied for non-overload retryable errors
+
+Drivers should test that backoff is not applied for non-overload retryable errors. This test MUST be executed against a
+MongoDB 4.4+ server that has enabled the `configureFailPoint` command with the `errorLabels` option.
+
+1. Let `client` be a `MongoClient`.
+
+2. Let `coll` be a collection.
+
+3. Configure the following failpoint:
+
+    ```javascript
+        {
+            configureFailPoint: 'failCommand',
+            mode: { times: 1 },
+            data: {
+                failCommands: ['find'],
+                errorCode: 91,  // ShutdownInProgress
+                errorLabels: ['RetryableError']
+            }
+        }
+    ```
+
+4. Perform a find operation with `coll` that fails on the initial attempt, then succeeds on the first retry attempt.
+
+5. Assert that no backoff was applied for the retry attempt.

--- a/source/retryable-reads/tests/README.md
+++ b/source/retryable-reads/tests/README.md
@@ -257,7 +257,7 @@ This test MUST be executed against a MongoDB 4.4+ server that supports `retryRea
     Configure the second fail point command only if the failed event is for the first error configured in step 2.
 
 4. Attempt a `findOne` operation on any record for any database and collection. Expect the `findOne` to fail with a
-    server error. Assert that `MAX_ADAPTIVE_RETRIES + 1` attempts were made.
+    server error. Assert that `MAX_RETRIES + 1` attempts were made.
 
 5. Disable the fail point:
 

--- a/source/retryable-reads/tests/README.md
+++ b/source/retryable-reads/tests/README.md
@@ -217,7 +217,7 @@ This test MUST be executed against a MongoDB 4.4+ replica set that has at least 
 
 6. Assert that both events occurred on the same server.
 
-### 1: Test that drivers set the maximum number of retries for all retryable read errors when an overload error is encountered
+### 4: Test that drivers set the maximum number of retries for all retryable read errors when an overload error is encountered
 
 This test MUST be executed against a MongoDB 4.4+ server that supports `retryReads=true` and has enabled the
 `configureFailPoint` command with the `errorLabels` option.
@@ -268,9 +268,61 @@ This test MUST be executed against a MongoDB 4.4+ server that supports `retryRea
     }
     ```
 
+### 5: Test that drivers do not apply backoff to non-overload errors
+
+This test MUST be executed against a MongoDB 4.4+ server that supports `retryReads=true` and has enabled the
+`configureFailPoint` command with the `errorLabels` option.
+
+1. Create a client.
+
+2. Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
+    `SystemOverloadedError` error labels:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: {times: 1},
+        data: {
+            failCommands: ["find"],
+            errorLabels: ["RetryableError", "SystemOverloadedError"],
+            errorCode: 91
+        }
+    }
+    ```
+
+3. Via the command monitoring CommandFailedEvent, configure a fail point with error code `91` (ShutdownInProgress) and
+    the `RetryableError` label:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: "alwaysOn",
+        data: {
+            failCommands: ["find"],
+            errorLabels: ["RetryableError"],
+            errorCode: 91
+        }
+    }
+    ```
+
+    Configure the second fail point command only if the failed event is for the first error configured in step 2.
+
+4. Attempt a `findOne` operation on any record for any database and collection. Expect the `findOne` to fail with a
+    server error. Assert that backoff was applied only once for the initial overload error and not for the subsequent
+    non-overload retryable errors.
+
+5. Disable the fail point:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: "off"
+    }
+    ```
+
 ## Changelog
 
-- 2026-04-14: Add prose test for retry behavior when a mix of overload and non-overload errors are encountered.
+- 2026-04-14: Add prose tests for retry behavior when a mix of overload and non-overload errors are encountered.
 
 - 2026-03-31: Add additional prose test for overload retargeting.
 

--- a/source/retryable-reads/tests/README.md
+++ b/source/retryable-reads/tests/README.md
@@ -270,6 +270,8 @@ This test MUST be executed against a MongoDB 4.4+ server that supports `retryRea
 
 ## Changelog
 
+- 2026-04-14: Add prose test for retry behavior when a mix of overload and non-overload errors are encountered.
+
 - 2026-03-31: Add additional prose test for overload retargeting.
 
 - 2026-02-19: Add prose tests for retrying against a replica set.

--- a/source/retryable-reads/tests/README.md
+++ b/source/retryable-reads/tests/README.md
@@ -217,6 +217,57 @@ This test MUST be executed against a MongoDB 4.4+ replica set that has at least 
 
 6. Assert that both events occurred on the same server.
 
+### 1: Test that drivers set the maximum number of retries for all retryable read errors when an overload error is encountered
+
+This test MUST be executed against a MongoDB 4.4+ server that supports `retryReads=true` and has enabled the
+`configureFailPoint` command with the `errorLabels` option.
+
+1. Create a client.
+
+2. Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
+    `SystemOverloadedError` error labels:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: {times: 1},
+        data: {
+            failCommands: ["find"],
+            errorLabels: ["RetryableError", "SystemOverloadedError"],
+            errorCode: 91
+        }
+    }
+    ```
+
+3. Via the command monitoring CommandFailedEvent, configure a fail point with error code `91` (ShutdownInProgress) and
+    the `RetryableError` label:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: "alwaysOn",
+        data: {
+            failCommands: ["find"],
+            errorLabels: ["RetryableError"],
+            errorCode: 91
+        }
+    }
+    ```
+
+    Configure the second fail point command only if the failed event is for the first error configured in step 2.
+
+4. Attempt a `findOne` operation on any record for any database and collection. Expect the `findOne` to fail with a
+    server error. Assert that `MAX_ADAPTIVE_RETRIES + 1` attempts were made.
+
+5. Disable the fail point:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: "off"
+    }
+    ```
+
 ## Changelog
 
 - 2026-03-31: Add additional prose test for overload retargeting.

--- a/source/retryable-writes/tests/README.md
+++ b/source/retryable-writes/tests/README.md
@@ -419,6 +419,54 @@ to cover the same sequence of events.
     }
     ```
 
+#### Case 4: Test that drivers set the maximum number of retries for all retryable write errors when an overload error is encountered
+
+1. Create a client with `retryWrites=true`.
+
+2. Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
+    `SystemOverloadedError` error labels:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: {times: 1},
+        data: {
+            failCommands: ["insert"],
+            errorLabels: ["RetryableError", "SystemOverloadedError"],
+            errorCode: 91
+        }
+    }
+    ```
+
+3. Via the command monitoring CommandFailedEvent, configure a fail point with error code `91` (ShutdownInProgress) and
+    the `RetryableWriteError` and `RetryableError` labels:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: "alwaysOn",
+        data: {
+            failCommands: ["insert"],
+            errorLabels: ["RetryableError", "RetryableWriteError"],
+            errorCode: 91
+        }
+    }
+    ```
+
+    Configure the second fail point command only if the failed event is for the first error configured in step 2.
+
+4. Attempt an `insertOne` operation on any record for any database and collection. Expect the `insertOne` to fail with a
+    server error. Assert that `MAX_ADAPTIVE_RETRIES + 1` attempts were made.
+
+5. Disable the fail point:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: "off"
+    }
+    ```
+
 ## Changelog
 
 - 2026-04-02: Fix test for error propagation behavior when multiple errors are encountered.

--- a/source/retryable-writes/tests/README.md
+++ b/source/retryable-writes/tests/README.md
@@ -467,9 +467,58 @@ to cover the same sequence of events.
     }
     ```
 
+#### Case 5: Test that drivers do not apply backoff to non-overload errors
+
+1. Create a client with `retryWrites=true`.
+
+2. Configure a fail point with error code `91` (ShutdownInProgress) with the `RetryableError` and
+    `SystemOverloadedError` error labels:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: {times: 1},
+        data: {
+            failCommands: ["insert"],
+            errorLabels: ["RetryableError", "SystemOverloadedError"],
+            errorCode: 91
+        }
+    }
+    ```
+
+3. Via the command monitoring CommandFailedEvent, configure a fail point with error code `91` (ShutdownInProgress) and
+    the `RetryableWriteError` and `RetryableError` labels:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: "alwaysOn",
+        data: {
+            failCommands: ["insert"],
+            errorLabels: ["RetryableError", "RetryableWriteError"],
+            errorCode: 91
+        }
+    }
+    ```
+
+    Configure the second fail point command only if the failed event is for the first error configured in step 2.
+
+4. Attempt an `insertOne` operation on any record for any database and collection. Expect the `insertOne` to fail with a
+    server error. Assert that backoff was applied only once for the initial overload error and not for the subsequent
+    non-overload retryable errors.
+
+5. Disable the fail point:
+
+    ```javascript
+    {
+        configureFailPoint: "failCommand",
+        mode: "off"
+    }
+    ```
+
 ## Changelog
 
-- 2026-04-14: Add prose test for retry behavior when a mix of overload and non-overload errors are encountered.
+- 2026-04-14: Add prose tests for retry behavior when a mix of overload and non-overload errors are encountered.
 
 - 2026-04-02: Fix test for error propagation behavior when multiple errors are encountered.
 

--- a/source/retryable-writes/tests/README.md
+++ b/source/retryable-writes/tests/README.md
@@ -469,6 +469,8 @@ to cover the same sequence of events.
 
 ## Changelog
 
+- 2026-04-14: Add prose test for retry behavior when a mix of overload and non-overload errors are encountered.
+
 - 2026-04-02: Fix test for error propagation behavior when multiple errors are encountered.
 
 - 2026-02-17: Fix test for error propagation behavior when multiple errors are encountered.

--- a/source/retryable-writes/tests/README.md
+++ b/source/retryable-writes/tests/README.md
@@ -456,7 +456,7 @@ to cover the same sequence of events.
     Configure the second fail point command only if the failed event is for the first error configured in step 2.
 
 4. Attempt an `insertOne` operation on any record for any database and collection. Expect the `insertOne` to fail with a
-    server error. Assert that `MAX_ADAPTIVE_RETRIES + 1` attempts were made.
+    server error. Assert that `MAX_RETRIES + 1` attempts were made.
 
 5. Disable the fail point:
 


### PR DESCRIPTION
DRIVERS-3446

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [X] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

- [X] Update changelog.
- [X] Test changes in at least one language driver. [Python](https://github.com/mongodb/mongo-python-driver/pull/2755).
- [X] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->

Ruby PoC: https://github.com/mongodb/mongo-ruby-driver/pull/3021
