### PR TITLE
DRIVERS-3458 Remove timeseries change stream test

### DIFF
--- a/source/change-streams/change-streams.md
+++ b/source/change-streams/change-streams.md
@@ -1034,6 +1034,8 @@ There should be no backwards compatibility concerns.
 
 ## Changelog
 
+- 2026-04-28: Remove test for nsType when creating timeseries
+
 - 2026-03-18: Revert expanded field visibility change.
 
 - 2025-09-08: Clarify resume behavior.

--- a/source/change-streams/tests/unified/change-streams-nsType.json
+++ b/source/change-streams/tests/unified/change-streams-nsType.json
@@ -64,47 +64,6 @@
       ]
     },
     {
-      "description": "nsType is present when creating timeseries",
-      "operations": [
-        {
-          "name": "dropCollection",
-          "object": "database0",
-          "arguments": {
-            "collection": "foo"
-          }
-        },
-        {
-          "name": "createChangeStream",
-          "object": "database0",
-          "arguments": {
-            "pipeline": [],
-            "showExpandedEvents": true
-          },
-          "saveResultAsEntity": "changeStream0"
-        },
-        {
-          "name": "createCollection",
-          "object": "database0",
-          "arguments": {
-            "collection": "foo",
-            "timeseries": {
-              "timeField": "time",
-              "metaField": "meta",
-              "granularity": "minutes"
-            }
-          }
-        },
-        {
-          "name": "iterateUntilDocumentOrError",
-          "object": "changeStream0",
-          "expectResult": {
-            "operationType": "create",
-            "nsType": "timeseries"
-          }
-        }
-      ]
-    },
-    {
       "description": "nsType is present when creating views",
       "operations": [
         {

--- a/source/change-streams/tests/unified/change-streams-nsType.yml
+++ b/source/change-streams/tests/unified/change-streams-nsType.yml
@@ -36,32 +36,6 @@ tests:
           operationType: create
           nsType: collection
 
-  - description: "nsType is present when creating timeseries"
-    operations:
-      - name: dropCollection
-        object: *database0
-        arguments:
-          collection: &collection0 foo
-      - name: createChangeStream
-        object: *database0
-        arguments:
-          pipeline: []
-          showExpandedEvents: true
-        saveResultAsEntity: &changeStream0 changeStream0
-      - name: createCollection
-        object: *database0
-        arguments:
-          collection: *collection0
-          timeseries:
-            timeField: "time"
-            metaField: "meta"
-            granularity: "minutes"
-      - name: iterateUntilDocumentOrError
-        object: *changeStream0
-        expectResult:
-          operationType: create
-          nsType: timeseries
-
   - description: "nsType is present when creating views"
     operations:
       - name: dropCollection


### PR DESCRIPTION
- [✔️] Is the relevant DRIVERS ticket in the PR title?
- [✔️] Update changelog.
- [✔️] Test changes in at least one language driver.
- [✔️] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

[Rust driver run](https://spruce.corp.mongodb.com/version/69f0878e6f8a3800074dab2e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).

I opted to remove the test entirely rather than only running it on pre-9.0 servers because it turns out this behavior was never really supported in the first place.