### PR TITLE
DRIVERS-3459: Use appName for hello failPoints in CMAP tests

### DIFF
--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-custom-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-custom-maxConnecting-is-enforced.json
@@ -17,13 +17,15 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 500
+      "blockTimeMS": 500,
+      "appName": "cmap-format-tests"
     }
   },
   "poolOptions": {
     "maxConnecting": 1,
     "maxPoolSize": 2,
-    "waitQueueTimeoutMS": 5000
+    "waitQueueTimeoutMS": 5000,
+    "appName": "cmap-format-tests"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-custom-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-custom-maxConnecting-is-enforced.json
@@ -18,14 +18,14 @@
       "closeConnection": false,
       "blockConnection": true,
       "blockTimeMS": 500,
-      "appName": "cmap-format-tests"
+      "appName": "PoolCheckoutCustomMaxConnectingIsEnforced"
     }
   },
   "poolOptions": {
     "maxConnecting": 1,
     "maxPoolSize": 2,
     "waitQueueTimeoutMS": 5000,
-    "appName": "cmap-format-tests"
+    "appName": "PoolCheckoutCustomMaxConnectingIsEnforced"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-custom-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-custom-maxConnecting-is-enforced.yml
@@ -12,11 +12,13 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 500
+    appName: "cmap-format-tests"
 poolOptions:
   maxConnecting: 1
   # gives opportunity for the checkout in thread2 to establish a new connection, which it must not do until thread1 establishes one
   maxPoolSize: 2
   waitQueueTimeoutMS: 5000
+  appName: "cmap-format-tests"
 operations:
   - name: ready
   # thread1 exists to consume the single permit to open a connection,

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-custom-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-custom-maxConnecting-is-enforced.yml
@@ -12,13 +12,13 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 500
-    appName: "cmap-format-tests"
+    appName: "PoolCheckoutCustomMaxConnectingIsEnforced"
 poolOptions:
   maxConnecting: 1
   # gives opportunity for the checkout in thread2 to establish a new connection, which it must not do until thread1 establishes one
   maxPoolSize: 2
   waitQueueTimeoutMS: 5000
-  appName: "cmap-format-tests"
+  appName: "PoolCheckoutCustomMaxConnectingIsEnforced"
 operations:
   - name: ready
   # thread1 exists to consume the single permit to open a connection,

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.json
@@ -19,12 +19,14 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 800
+      "blockTimeMS": 800,
+      "appName": "cmap-format-tests"
     }
   },
   "poolOptions": {
     "maxPoolSize": 10,
-    "waitQueueTimeoutMS": 5000
+    "waitQueueTimeoutMS": 5000,
+    "appName": "cmap-format-tests"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.json
@@ -20,13 +20,13 @@
       "closeConnection": false,
       "blockConnection": true,
       "blockTimeMS": 800,
-      "appName": "cmap-format-tests"
+      "appName": "PoolCheckoutMaxConnectingIsEnforced"
     }
   },
   "poolOptions": {
     "maxPoolSize": 10,
     "waitQueueTimeoutMS": 5000,
-    "appName": "cmap-format-tests"
+    "appName": "PoolCheckoutMaxConnectingIsEnforced"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
@@ -14,9 +14,11 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 800
+    appName: "cmap-format-tests"
 poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
+  appName: "cmap-format-tests"
 operations:
   - name: ready
   # start 3 threads

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-is-enforced.yml
@@ -14,11 +14,11 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 800
-    appName: "cmap-format-tests"
+    appName: "PoolCheckoutMaxConnectingIsEnforced"
 poolOptions:
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
-  appName: "cmap-format-tests"
+  appName: "PoolCheckoutMaxConnectingIsEnforced"
 operations:
   - name: ready
   # start 3 threads

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.json
@@ -19,12 +19,14 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 750
+      "blockTimeMS": 750,
+      "appName": "cmap-format-tests"
     }
   },
   "poolOptions": {
     "maxPoolSize": 10,
-    "waitQueueTimeoutMS": 50
+    "waitQueueTimeoutMS": 50,
+    "appName": "cmap-format-tests"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.json
@@ -20,13 +20,13 @@
       "closeConnection": false,
       "blockConnection": true,
       "blockTimeMS": 750,
-      "appName": "cmap-format-tests"
+      "appName": "PoolCheckoutMaxConnectingTimeout"
     }
   },
   "poolOptions": {
     "maxPoolSize": 10,
     "waitQueueTimeoutMS": 50,
-    "appName": "cmap-format-tests"
+    "appName": "PoolCheckoutMaxConnectingTimeout"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.yml
@@ -14,12 +14,14 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750
+    appName: "cmap-format-tests"
 poolOptions:
   maxPoolSize: 10
   # Drivers that limit connection establishment by waitQueueTimeoutMS may skip
   # this test. While waitQueueTimeoutMS is technically not supposed to limit establishment time,
   # it will soon be deprecated, so it is easier for those drivers to just skip this test.
   waitQueueTimeoutMS: 50
+  appName: "cmap-format-tests"
 operations:
   - name: ready
   # start creating two connections simultaneously.

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-maxConnecting-timeout.yml
@@ -14,14 +14,14 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750
-    appName: "cmap-format-tests"
+    appName: "PoolCheckoutMaxConnectingTimeout"
 poolOptions:
   maxPoolSize: 10
   # Drivers that limit connection establishment by waitQueueTimeoutMS may skip
   # this test. While waitQueueTimeoutMS is technically not supposed to limit establishment time,
   # it will soon be deprecated, so it is easier for those drivers to just skip this test.
   waitQueueTimeoutMS: 50
-  appName: "cmap-format-tests"
+  appName: "PoolCheckoutMaxConnectingTimeout"
 operations:
   - name: ready
   # start creating two connections simultaneously.

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-minPoolSize-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-minPoolSize-connection-maxConnecting.json
@@ -17,13 +17,15 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 500
+      "blockTimeMS": 500,
+      "appName": "cmap-format-tests"
     }
   },
   "poolOptions": {
     "minPoolSize": 2,
     "maxPoolSize": 3,
-    "waitQueueTimeoutMS": 5000
+    "waitQueueTimeoutMS": 5000,
+    "appName": "cmap-format-tests"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-minPoolSize-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-minPoolSize-connection-maxConnecting.json
@@ -18,14 +18,14 @@
       "closeConnection": false,
       "blockConnection": true,
       "blockTimeMS": 500,
-      "appName": "cmap-format-tests"
+      "appName": "PoolCheckoutMinPoolSizeConnectionMaxConnecting"
     }
   },
   "poolOptions": {
     "minPoolSize": 2,
     "maxPoolSize": 3,
     "waitQueueTimeoutMS": 5000,
-    "appName": "cmap-format-tests"
+    "appName": "PoolCheckoutMinPoolSizeConnectionMaxConnecting"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-minPoolSize-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-minPoolSize-connection-maxConnecting.yml
@@ -13,12 +13,14 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 500
+    appName: "cmap-format-tests"
 poolOptions:
   # allows both thread1 and the background thread to start opening connections concurrently
   minPoolSize: 2
   # gives opportunity for the checkout in thread2 to open a new connection, which it must not do nonetheless
   maxPoolSize: 3
   waitQueueTimeoutMS: 5000
+  appName: "cmap-format-tests"
 operations:
   - name: ready
   # thread1 exists to hold on one of the two permits to open a connection (the other one is initially held by the background thread),

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-minPoolSize-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-minPoolSize-connection-maxConnecting.yml
@@ -13,14 +13,14 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 500
-    appName: "cmap-format-tests"
+    appName: "PoolCheckoutMinPoolSizeConnectionMaxConnecting"
 poolOptions:
   # allows both thread1 and the background thread to start opening connections concurrently
   minPoolSize: 2
   # gives opportunity for the checkout in thread2 to open a new connection, which it must not do nonetheless
   maxPoolSize: 3
   waitQueueTimeoutMS: 5000
-  appName: "cmap-format-tests"
+  appName: "PoolCheckoutMinPoolSizeConnectionMaxConnecting"
 operations:
   - name: ready
   # thread1 exists to hold on one of the two permits to open a connection (the other one is initially held by the background thread),

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.json
@@ -19,13 +19,15 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 750
+      "blockTimeMS": 750,
+      "appName": "cmap-format-tests"
     }
   },
   "poolOptions": {
     "maxConnecting": 2,
     "maxPoolSize": 10,
-    "waitQueueTimeoutMS": 5000
+    "waitQueueTimeoutMS": 5000,
+    "appName": "cmap-format-tests"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.json
@@ -20,14 +20,14 @@
       "closeConnection": false,
       "blockConnection": true,
       "blockTimeMS": 750,
-      "appName": "cmap-format-tests"
+      "appName": "PoolCheckoutReturnedConnectionMaxConnecting"
     }
   },
   "poolOptions": {
     "maxConnecting": 2,
     "maxPoolSize": 10,
     "waitQueueTimeoutMS": 5000,
-    "appName": "cmap-format-tests"
+    "appName": "PoolCheckoutReturnedConnectionMaxConnecting"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
@@ -14,10 +14,12 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750
+    appName: "cmap-format-tests"
 poolOptions:
   maxConnecting: 2
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
+  appName: "cmap-format-tests"
 operations:
   - name: ready
   # check out a connection and hold on to it.

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-checkout-returned-connection-maxConnecting.yml
@@ -14,12 +14,12 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 750
-    appName: "cmap-format-tests"
+    appName: "PoolCheckoutReturnedConnectionMaxConnecting"
 poolOptions:
   maxConnecting: 2
   maxPoolSize: 10
   waitQueueTimeoutMS: 5000
-  appName: "cmap-format-tests"
+  appName: "PoolCheckoutReturnedConnectionMaxConnecting"
 operations:
   - name: ready
   # check out a connection and hold on to it.

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.json
@@ -17,11 +17,13 @@
       ],
       "closeConnection": false,
       "blockConnection": true,
-      "blockTimeMS": 10000
+      "blockTimeMS": 10000,
+      "appName": "cmap-format-tests"
     }
   },
   "poolOptions": {
-    "minPoolSize": 0
+    "minPoolSize": 0,
+    "appName": "cmap-format-tests"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.json
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.json
@@ -18,12 +18,12 @@
       "closeConnection": false,
       "blockConnection": true,
       "blockTimeMS": 10000,
-      "appName": "cmap-format-tests"
+      "appName": "PoolClearInterruptingPendingConnections"
     }
   },
   "poolOptions": {
     "minPoolSize": 0,
-    "appName": "cmap-format-tests"
+    "appName": "PoolClearInterruptingPendingConnections"
   },
   "operations": [
     {

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.yml
@@ -12,8 +12,10 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 10000
+    appName: "cmap-format-tests"
 poolOptions:
   minPoolSize: 0
+  appName: "cmap-format-tests"
 operations:
   - name: ready
   - name: start

--- a/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.yml
+++ b/source/connection-monitoring-and-pooling/tests/cmap-format/pool-clear-interrupting-pending-connections.yml
@@ -12,10 +12,10 @@ failPoint:
     closeConnection: false
     blockConnection: true
     blockTimeMS: 10000
-    appName: "cmap-format-tests"
+    appName: "PoolClearInterruptingPendingConnections"
 poolOptions:
   minPoolSize: 0
-  appName: "cmap-format-tests"
+  appName: "PoolClearInterruptingPendingConnections"
 operations:
   - name: ready
   - name: start


### PR DESCRIPTION
Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- [x] Test changes in at least one language driver (CSharp [custom patch](https://spruce.corp.mongodb.com/version/69f0f334b6c60b000713b50e/tasks)).
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).