### PR TITLE
DRIVERS-3461 skip QE "prefixPreview" and "suffixPreview" tests on server 9.0.0+

### DIFF
--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3884,7 +3884,8 @@ Using [QE CreateCollection() and Collection.Drop()](../client-side-encryption.md
 create the following collections with majority write concern:
 
 - `db.prefix-suffix` using the `encryptedFields` option set to the contents of
-    [encryptedFields-prefix-suffix.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix.json)
+    [encryptedFields-prefix-suffix.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix.json).
+    Skip this step if testing server 9.0.0+.
 - `db.substring` using the `encryptedFields` option set to the contents of
     [encryptedFields-substring.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-substring.json)
 
@@ -3975,6 +3976,8 @@ Use `encryptedClient` to insert the following document into `db.substring` with 
 
 #### Case 1: can find a document by prefix
 
+Skip this test case if testing MongoDB server 9.0.0+.
+
 Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the following `EncryptOpts`:
 
 ```typescript
@@ -4007,6 +4010,8 @@ Assert the following document is returned:
 ```
 
 #### Case 2: can find a document by suffix
+
+Skip this test case if testing MongoDB server 9.0.0+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"baz"` with the following `EncryptOpts`:
 
@@ -4041,6 +4046,8 @@ Assert the following document is returned:
 
 #### Case 3: assert no document found by prefix
 
+Skip this test case if testing MongoDB server 9.0.0+.
+
 Use `clientEncryption.encrypt()` to encrypt the string `"baz"` with the following `EncryptOpts`:
 
 ```typescript
@@ -4069,6 +4076,8 @@ Use `encryptedClient` to run a "find" operation on the `db.prefix-suffix` collec
 Assert that no documents are returned.
 
 #### Case 4: assert no document found by suffix
+
+Skip this test case if testing MongoDB server 9.0.0+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the following `EncryptOpts`:
 
@@ -4162,6 +4171,8 @@ Use `encryptedClient` to run a "find" operation on the `db.substring` collection
 Assert that no documents are returned.
 
 #### Case 7: assert `contentionFactor` is required
+
+Skip this test case if testing MongoDB server 9.0.0+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the following `EncryptOpts`:
 

--- a/source/client-side-encryption/tests/unified/QE-Text-cleanupStructuredEncryptionData.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-cleanupStructuredEncryptionData.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
       "topologies": [
         "replicaset",
         "sharded",

--- a/source/client-side-encryption/tests/unified/QE-Text-cleanupStructuredEncryptionData.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-cleanupStructuredEncryptionData.yml
@@ -2,6 +2,7 @@ description: QE-Text-cleanupStructuredEncryptionData
 schemaVersion: "1.25"
 runOnRequirements:
   - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
+    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
       minLibmongocryptVersion: 1.15.0 # For SPM-4158.

--- a/source/client-side-encryption/tests/unified/QE-Text-compactStructuredEncryptionData.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-compactStructuredEncryptionData.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
       "topologies": [
         "replicaset",
         "sharded",

--- a/source/client-side-encryption/tests/unified/QE-Text-compactStructuredEncryptionData.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-compactStructuredEncryptionData.yml
@@ -2,6 +2,7 @@ description: QE-Text-compactStructuredEncryptionData
 schemaVersion: "1.25"
 runOnRequirements:
   - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
+    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
       minLibmongocryptVersion: 1.15.0 # For SPM-4158.

--- a/source/client-side-encryption/tests/unified/QE-Text-prefixPreview.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-prefixPreview.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
       "topologies": [
         "replicaset",
         "sharded",

--- a/source/client-side-encryption/tests/unified/QE-Text-prefixPreview.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-prefixPreview.yml
@@ -2,6 +2,7 @@ description: QE-Text-prefixPreview
 schemaVersion: "1.25"
 runOnRequirements:
   - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
+    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
       minLibmongocryptVersion: 1.15.0 # For SPM-4158.

--- a/source/client-side-encryption/tests/unified/QE-Text-substringPreview.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-substringPreview.json
@@ -126,7 +126,7 @@
   ],
   "tests": [
     {
-      "description": "Insert QE suffixPreview",
+      "description": "Insert QE substringPreview",
       "operations": [
         {
           "name": "insertOne",

--- a/source/client-side-encryption/tests/unified/QE-Text-substringPreview.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-substringPreview.yml
@@ -74,7 +74,7 @@ initialData:
             ],
         }
 tests:
-  - description: "Insert QE suffixPreview"
+  - description: "Insert QE substringPreview"
     operations:
       - name: insertOne
         arguments:

--- a/source/client-side-encryption/tests/unified/QE-Text-suffixPreview.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-suffixPreview.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
       "topologies": [
         "replicaset",
         "sharded",

--- a/source/client-side-encryption/tests/unified/QE-Text-suffixPreview.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-suffixPreview.yml
@@ -2,6 +2,7 @@ description: QE-Text-suffixPreview
 schemaVersion: "1.25"
 runOnRequirements:
   - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
+    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
       minLibmongocryptVersion: 1.15.0 # For SPM-4158.


### PR DESCRIPTION
# Summary

Skip Queryable Encryption (QE) tests of "prefixPreview" and "suffixPreview" on server 9.0.0+.

# Background & Motivation
Following SERVER-123416, creating a collection with "suffixPreview" and "prefixPreview" is rejected by 9.0.0-rc0 servers, resulting in an error:

```
Cannot create a collection with an encrypted field with query type prefixPreview, as it is deprecated
```

This PR skips tests of "suffixPreview" and "prefixPreview" tests on 9.0.0+ servers. "substringPreview" is still supported and tested on 9.0.0+ servers.

As a drive-by fix, a typo is fixed in a test description of QE-Text-substringPreview: "suffixPreview" => "substringPreview".

This PR is intended as a short-term test fix. Upcoming spec changes of DRIVERS-3321 will update to use and test "suffix" and "prefix".

---
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- ~~[ ] Update changelog.~~ (N/A. Test changes only)
- [x] Test changes in at least one language driver. (Tested in C driver: https://github.com/mongodb/mongo-c-driver/pull/2284)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
