### PR TITLE
DRIVERS-2944 Update handshake spec to allow using OP_MSG exclusively

### DIFF
--- a/source/message/OP_MSG.md
+++ b/source/message/OP_MSG.md
@@ -409,6 +409,7 @@ In the near future, this opcode is expected to be extended and include support f
 
 ### Changelog
 
+- 2026-05-07: Allow OP_MSG for all handshakes.
 - 2024-04-30: Convert from RestructuredText to Markdown.
 - 2022-10-05: Remove spec front matter.
 - 2022-01-13: Clarify that `OP_MSG` must be used when using stable API

--- a/source/message/OP_MSG.md
+++ b/source/message/OP_MSG.md
@@ -409,7 +409,7 @@ In the near future, this opcode is expected to be extended and include support f
 
 ### Changelog
 
-- 2026-05-07: Allow OP_MSG for all handshakes.
+- 2026-05-08: Allow OP_MSG for all handshakes.
 - 2024-04-30: Convert from RestructuredText to Markdown.
 - 2022-10-05: Remove spec front matter.
 - 2022-01-13: Clarify that `OP_MSG` must be used when using stable API

--- a/source/message/OP_MSG.md
+++ b/source/message/OP_MSG.md
@@ -20,7 +20,7 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 `OP_MSG` is only available in MongoDB 3.6 (`maxWireVersion >= 6`) and later. MongoDB drivers MUST perform the MongoDB
 handshake using `OP_MSG` if an API version was declared on the client.
 
-If no API version was declared, drivers that have historically supported MongoDB 3.4 and earlier MUST perform the
+If no API version was declared, drivers that have historically supported MongoDB 3.4 and earlier MAY perform the
 handshake using `OP_QUERY` to determine if the node supports `OP_MSG`. Drivers that have only ever supported MongoDB 3.6
 and newer MAY default to using `OP_MSG`.
 

--- a/source/message/OP_MSG.md
+++ b/source/message/OP_MSG.md
@@ -17,15 +17,11 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 
 #### Usage
 
-`OP_MSG` is only available in MongoDB 3.6 (`maxWireVersion >= 6`) and later. MongoDB drivers MUST perform the MongoDB
-handshake using `OP_MSG` if an API version was declared on the client.
-
-Refer to the
+All messages, including authentication messages, MUST use `OP_MSG`. Refer to the
 [handshake specification](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md)
-for the appropriate use of `OP_MSG`.
-
-If the node supports `OP_MSG`, any and all messages MUST use `OP_MSG`, optionally compressed with `OP_COMPRESSED`.
-Authentication messages MUST also use `OP_MSG` when it is supported, but MUST NOT use `OP_COMPRESSED`.
+for the appropriate use of `OP_MSG`. See also
+[OP_COMPRESSED specification](https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.md)
+for more details.
 
 #### OP_MSG
 
@@ -409,7 +405,7 @@ In the near future, this opcode is expected to be extended and include support f
 
 ### Changelog
 
-- 2026-06-03: Allow OP_MSG for all handshakes.
+- 2026-06-05: Use OP_MSG for all messages.
 - 2024-04-30: Convert from RestructuredText to Markdown.
 - 2022-10-05: Remove spec front matter.
 - 2022-01-13: Clarify that `OP_MSG` must be used when using stable API

--- a/source/message/OP_MSG.md
+++ b/source/message/OP_MSG.md
@@ -409,7 +409,7 @@ In the near future, this opcode is expected to be extended and include support f
 
 ### Changelog
 
-- 2026-05-08: Allow OP_MSG for all handshakes.
+- 2026-06-03: Allow OP_MSG for all handshakes.
 - 2024-04-30: Convert from RestructuredText to Markdown.
 - 2022-10-05: Remove spec front matter.
 - 2022-01-13: Clarify that `OP_MSG` must be used when using stable API

--- a/source/message/OP_MSG.md
+++ b/source/message/OP_MSG.md
@@ -20,7 +20,8 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 `OP_MSG` is only available in MongoDB 3.6 (`maxWireVersion >= 6`) and later. MongoDB drivers MUST perform the MongoDB
 handshake using `OP_MSG` if an API version was declared on the client.
 
-Refer to the [handshake specification](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md) 
+Refer to the
+[handshake specification](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md)
 for the appropriate use of `OP_MSG` and `OP_QUERY`.
 
 If the node supports `OP_MSG`, any and all messages MUST use `OP_MSG`, optionally compressed with `OP_COMPRESSED`.

--- a/source/message/OP_MSG.md
+++ b/source/message/OP_MSG.md
@@ -20,9 +20,8 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 `OP_MSG` is only available in MongoDB 3.6 (`maxWireVersion >= 6`) and later. MongoDB drivers MUST perform the MongoDB
 handshake using `OP_MSG` if an API version was declared on the client.
 
-If no API version was declared, drivers that have historically supported MongoDB 3.4 and earlier MAY perform the
-handshake using `OP_QUERY` to determine if the node supports `OP_MSG`. Drivers that have only ever supported MongoDB 3.6
-and newer MAY default to using `OP_MSG`.
+Refer to the [handshake specification](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md) 
+for the appropriate use of `OP_MSG` and `OP_QUERY`.
 
 If the node supports `OP_MSG`, any and all messages MUST use `OP_MSG`, optionally compressed with `OP_COMPRESSED`.
 Authentication messages MUST also use `OP_MSG` when it is supported, but MUST NOT use `OP_COMPRESSED`.

--- a/source/message/OP_MSG.md
+++ b/source/message/OP_MSG.md
@@ -22,7 +22,7 @@ handshake using `OP_MSG` if an API version was declared on the client.
 
 Refer to the
 [handshake specification](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md)
-for the appropriate use of `OP_MSG` and `OP_QUERY`.
+for the appropriate use of `OP_MSG`.
 
 If the node supports `OP_MSG`, any and all messages MUST use `OP_MSG`, optionally compressed with `OP_COMPRESSED`.
 Authentication messages MUST also use `OP_MSG` when it is supported, but MUST NOT use `OP_COMPRESSED`.

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -101,7 +101,7 @@ reply = conn.send_command("admin", cmd)
 
 if reply["maxWireVersion"] < 6:
     # Server is reporting that it doesn't support OpMSG
-    raise Error()
+    raise Error("wire version check failed")
 
 # Store the negotiated compressor, see OP_COMPRESSED spec.
 if reply.get("compression"):
@@ -564,7 +564,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
-- 2026-05-07: Allow OP_MSG for all handshakes.
+- 2026-05-08: Allow OP_MSG for all handshakes.
 - 2025-09-04: Clarify that drivers do not append the same metadata multiple times.
 - 2025-06-09: Add requirement to allow appending to client metadata after `MongoClient` initialization.
 - 2024-11-05: Move handshake prose tests from spec file to prose test file.

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -51,10 +51,10 @@ and is maintained for backwards compatibility with servers that do not support t
 
 Drivers SHOULD use the `OP_MSG` protocol for all handshakes if their minWireVersion is 6 (MongoDB 3.6) or higher. If a
 [server API version](../versioned-api/versioned-api.md) is requested or `loadBalanced: True`, drivers MUST also use the
-`hello` command for the initial handshake. If server API version is not requested and
-`loadBalanced: False`, drivers MUST use legacy hello for the first message of the initial handshake, and include 
-`helloOk:true` in the handshake request. If the server does not understand `OP_MSG`, drivers MUST show the same error 
-message as when wire version checks fail (e.g. because the server's maxWireVersion is lower than the driver's minWireVersion).
+`hello` command for the initial handshake. If server API version is not requested and `loadBalanced: False`, drivers
+MUST use legacy hello for the first message of the initial handshake, and include `helloOk:true` in the handshake
+request. If the server does not understand `OP_MSG`, drivers MUST show the same error message as when wire version
+checks fail (e.g. because the server's maxWireVersion is lower than the driver's minWireVersion).
 
 ASIDE: If the legacy handshake response includes `helloOk: true`, then subsequent topology monitoring commands MUST use
 the `hello` command. If the legacy handshake response does not include `helloOk: true`, then subsequent topology

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -49,11 +49,12 @@ MongoDB uses the `hello` or `isMaster` commands for handshakes and topology moni
 preferred command. `hello` must always be sent using the `OP_MSG` protocol. `isMaster` is referred to as "legacy hello"
 and is maintained for backwards compatibility with servers that do not support the `hello` command.
 
-If a [server API version](../versioned-api/versioned-api.md) is requested or `loadBalanced: True`, drivers MUST use the
-`hello` command for the initial handshake and use the `OP_MSG` protocol. If server API version is not requested and
-`loadBalanced: False`, drivers MUST use legacy hello for the first message of the initial handshake with the `OP_QUERY`
-protocol (before switching to `OP_MSG` if the `maxWireVersion` indicates compatibility), and include `helloOk:true` in
-the handshake request.
+Drivers SHOULD use the `OP_MSG` protocol for all handshakes if their minWireVersion is 6 (MongoDB 3.6) or higher. If a
+[server API version](../versioned-api/versioned-api.md) is requested or `loadBalanced: True`, drivers MUST also use the
+`hello` command for the initial handshake. If server API version is not requested and
+`loadBalanced: False`, drivers MUST use legacy hello for the first message of the initial handshake, and include 
+`helloOk:true` in the handshake request. If the server does not understand `OP_MSG`, drivers MUST show the same error 
+message as when wire version checks fail (e.g. because the server's maxWireVersion is lower than the driver's minWireVersion).
 
 ASIDE: If the legacy handshake response includes `helloOk: true`, then subsequent topology monitoring commands MUST use
 the `hello` command. If the legacy handshake response does not include `helloOk: true`, then subsequent topology
@@ -78,12 +79,11 @@ Consider the following pseudo-code for establishing a new connection:
 ```python
 conn = Connection()
 conn.connect()  # Connect via TCP / TLS
+conn.supports_op_msg = True  # Always send the initial command via OP_MSG.
 if stable_api_configured or client_options.load_balanced:
     cmd = {"hello": 1}
-    conn.supports_op_msg = True  # Send the initial command via OP_MSG.
 else:
     cmd = {"legacy hello": 1, "helloOk": 1}
-    conn.supports_op_msg = False  # Send the initial command via OP_QUERY.
 cmd["backpressure"] = True
 cmd["client"] = client_metadata
 if client_options.compressors:
@@ -99,9 +99,9 @@ if creds:
 
 reply = conn.send_command("admin", cmd)
 
-if reply["maxWireVersion"] >= 6:
-    # Use OP_MSG for all future commands, including authentication.
-    conn.supports_op_msg = True
+if reply["maxWireVersion"] < 6:
+    # Server is reporting that it doesn't support OpMSG
+    raise Error()
 
 # Store the negotiated compressor, see OP_COMPRESSED spec.
 if reply.get("compression"):
@@ -564,6 +564,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
+- 2026-05-06: Allow OP_MSG for all handshakes.
 - 2025-09-04: Clarify that drivers do not append the same metadata multiple times.
 - 2025-06-09: Add requirement to allow appending to client metadata after `MongoClient` initialization.
 - 2024-11-05: Move handshake prose tests from spec file to prose test file.

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -564,7 +564,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
-- 2026-05-06: Allow OP_MSG for all handshakes.
+- 2026-05-07: Allow OP_MSG for all handshakes.
 - 2025-09-04: Clarify that drivers do not append the same metadata multiple times.
 - 2025-06-09: Add requirement to allow appending to client metadata after `MongoClient` initialization.
 - 2024-11-05: Move handshake prose tests from spec file to prose test file.

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -53,8 +53,8 @@ Drivers MUST use the `OP_MSG` protocol for all handshakes if their minWireVersio
 [server API version](../versioned-api/versioned-api.md) is requested or `loadBalanced: True`, drivers MUST also use the
 `hello` command for the initial handshake. If server API version is not requested and `loadBalanced: False`, drivers
 MUST use legacy hello for the first message of the initial handshake, and include `helloOk:true` in the handshake
-request. If the server does not understand `OP_MSG`, the socket MAY be closed by the server and drivers MUST include the
-original error and indicate that incompatible server is likely the cause.
+request. If the server does not understand `OP_MSG`, the server will close the socket and drivers MUST include the
+original error.
 
 ASIDE: If the legacy handshake response includes `helloOk: true`, then subsequent topology monitoring commands MUST use
 the `hello` command. If the legacy handshake response does not include `helloOk: true`, then subsequent topology
@@ -97,11 +97,7 @@ if creds:
         cmd["saslSupportedMechs"] = ...
     cmd["speculativeAuthenticate"] = ...
 
-try:
-    reply = conn.send_command("admin", cmd)
-except AutoReconnect as exc:
-    # Socket was closed, OpMSG might not be supported
-    raise Error("wire version might not be supported") from exc
+reply = conn.send_command("admin", cmd)
 
 # Store the negotiated compressor, see OP_COMPRESSED spec.
 if reply.get("compression"):
@@ -564,7 +560,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
-- 2026-05-08: Allow OP_MSG for all handshakes.
+- 2026-06-03: Allow OP_MSG for all handshakes.
 - 2025-09-04: Clarify that drivers do not append the same metadata multiple times.
 - 2025-06-09: Add requirement to allow appending to client metadata after `MongoClient` initialization.
 - 2024-11-05: Move handshake prose tests from spec file to prose test file.

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -49,12 +49,12 @@ MongoDB uses the `hello` or `isMaster` commands for handshakes and topology moni
 preferred command. `hello` must always be sent using the `OP_MSG` protocol. `isMaster` is referred to as "legacy hello"
 and is maintained for backwards compatibility with servers that do not support the `hello` command.
 
-Drivers SHOULD use the `OP_MSG` protocol for all handshakes if their minWireVersion is 6 (MongoDB 3.6) or higher. If a
+Drivers MUST use the `OP_MSG` protocol for all handshakes if their minWireVersion is 6 (MongoDB 3.6) or higher. If a
 [server API version](../versioned-api/versioned-api.md) is requested or `loadBalanced: True`, drivers MUST also use the
 `hello` command for the initial handshake. If server API version is not requested and `loadBalanced: False`, drivers
 MUST use legacy hello for the first message of the initial handshake, and include `helloOk:true` in the handshake
-request. If the server does not understand `OP_MSG`, drivers MUST show the same error message as when wire version
-checks fail (e.g. because the server's maxWireVersion is lower than the driver's minWireVersion).
+request. If the server does not understand `OP_MSG`, the socket MAY be closed by the server and drivers MUST include the
+original error and indicate that incompatible server is likely the cause.
 
 ASIDE: If the legacy handshake response includes `helloOk: true`, then subsequent topology monitoring commands MUST use
 the `hello` command. If the legacy handshake response does not include `helloOk: true`, then subsequent topology
@@ -97,11 +97,11 @@ if creds:
         cmd["saslSupportedMechs"] = ...
     cmd["speculativeAuthenticate"] = ...
 
-reply = conn.send_command("admin", cmd)
-
-if reply["maxWireVersion"] < 6:
-    # Server is reporting that it doesn't support OpMSG
-    raise Error("wire version check failed")
+try:
+    reply = conn.send_command("admin", cmd)
+except AutoReconnect as exc:
+    # Socket was closed, OpMSG might not be supported
+    raise AutoReconnect("wire version might not be supported") from exc
 
 # Store the negotiated compressor, see OP_COMPRESSED spec.
 if reply.get("compression"):

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -53,14 +53,14 @@ Drivers MUST use the `OP_MSG` protocol for all handshakes if their minWireVersio
 [server API version](../versioned-api/versioned-api.md) is requested or `loadBalanced: True`, drivers MUST also use the
 `hello` command for the initial handshake. If server API version is not requested and `loadBalanced: False`, drivers
 MUST use legacy hello for the first message of the initial handshake, and include `helloOk:true` in the handshake
-request. If the server does not understand `OP_MSG`, the server will close the socket and drivers MUST include the
-original error.
+request.
 
 ASIDE: If the legacy handshake response includes `helloOk: true`, then subsequent topology monitoring commands MUST use
 the `hello` command. If the legacy handshake response does not include `helloOk: true`, then subsequent topology
 monitoring commands MUST use the legacy hello command. See the
 [Server Discovery and Monitoring spec](../server-discovery-and-monitoring/server-discovery-and-monitoring-summary.md)
-for further information.
+for further information. Additionally, note that if the server does not understand `OP_MSG`, the server will close the
+socket.
 
 The initial handshake MUST be performed on every socket to any and all servers upon establishing the connection to
 MongoDB, including reconnects of dropped connections and newly discovered members of a cluster. It MUST be the first
@@ -79,7 +79,6 @@ Consider the following pseudo-code for establishing a new connection:
 ```python
 conn = Connection()
 conn.connect()  # Connect via TCP / TLS
-conn.supports_op_msg = True  # Always send the initial command via OP_MSG.
 if stable_api_configured or client_options.load_balanced:
     cmd = {"hello": 1}
 else:
@@ -560,7 +559,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
-- 2026-06-03: Allow OP_MSG for all handshakes.
+- 2026-06-05: Use OP_MSG for all handshakes.
 - 2025-09-04: Clarify that drivers do not append the same metadata multiple times.
 - 2025-06-09: Add requirement to allow appending to client metadata after `MongoClient` initialization.
 - 2024-11-05: Move handshake prose tests from spec file to prose test file.

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -101,7 +101,7 @@ try:
     reply = conn.send_command("admin", cmd)
 except AutoReconnect as exc:
     # Socket was closed, OpMSG might not be supported
-    raise AutoReconnect("wire version might not be supported") from exc
+    raise Error("wire version might not be supported") from exc
 
 # Store the negotiated compressor, see OP_COMPRESSED spec.
 if reply.get("compression"):

--- a/source/mongodb-handshake/tests/unified/opmsg-not-supported.json
+++ b/source/mongodb-handshake/tests/unified/opmsg-not-supported.json
@@ -1,0 +1,74 @@
+{
+  "description": "op_msg not supported",
+  "schemaVersion": "1.3",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "4.4"
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "setupClient",
+        "useMultipleMongoses": false
+      }
+    },
+    {
+      "client": {
+        "id": "client",
+        "useMultipleMongoses": false,
+        "uriOptions": {
+          "appName": "op-msg-handshake-test",
+          "serverSelectionTimeoutMS": 500
+        }
+      }
+    },
+    {
+      "database": {
+        "id": "database",
+        "client": "client",
+        "databaseName": "test"
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "server closing connection during initial hello produces an error",
+      "operations": [
+        {
+          "name": "failPoint",
+          "object": "testRunner",
+          "arguments": {
+            "client": "setupClient",
+            "failPoint": {
+              "configureFailPoint": "failCommand",
+              "mode": "alwaysOn",
+              "data": {
+                "failCommands": [
+                  "hello",
+                  "isMaster"
+                ],
+                "appName": "op-msg-handshake-test",
+                "closeConnection": true
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "object": "database",
+          "arguments": {
+            "commandName": "ping",
+            "command": {
+              "ping": 1
+            }
+          },
+          "expectError": {
+            "errorContains": "connection closed",
+            "isClientError": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/source/mongodb-handshake/tests/unified/opmsg-not-supported.yml
+++ b/source/mongodb-handshake/tests/unified/opmsg-not-supported.yml
@@ -1,0 +1,45 @@
+description: "op_msg not supported"
+schemaVersion: "1.3"
+runOnRequirements:
+  - minServerVersion: "4.4"
+createEntities:
+  - client:
+      id: "setupClient"
+      useMultipleMongoses: false
+  - client:
+      id: "client"
+      useMultipleMongoses: false
+      uriOptions:
+        appName: "op-msg-handshake-test"
+        serverSelectionTimeoutMS: 500
+  - database:
+      id: "database"
+      client: "client"
+      databaseName: "test"
+tests:
+  # If a server doesn't understand OP_MSG, it will just close the socket.
+  # This test ensures that the existing socket error is still propagated to the user.
+  - description: "server closing connection during initial hello produces an error"
+    operations:
+      - name: "failPoint"
+        object: "testRunner"
+        arguments:
+          client: "setupClient"
+          failPoint:
+            configureFailPoint: "failCommand"
+            mode: "alwaysOn"
+            data:
+              failCommands:
+                - "hello"
+                - "isMaster"
+              appName: "op-msg-handshake-test"
+              closeConnection: true
+      - name: "runCommand"
+        object: "database"
+        arguments:
+          commandName: "ping"
+          command:
+            ping: 1
+        expectError:
+          errorContains: "connection closed"
+          isClientError: false


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

- [x] Update changelog.
- [x] Test changes in at least one language driver. 
        Python driver PR: https://github.com/mongodb/mongo-python-driver/pull/2799
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
