### PR TITLE
DRIVERS-3480 Clarify that the operationTime MUST save rule excludes unacknowledged writes

### DIFF
--- a/source/causal-consistency/causal-consistency.md
+++ b/source/causal-consistency/causal-consistency.md
@@ -196,9 +196,9 @@ started with `causalConsistency = true` then all operations using that session w
 
 There are no new server commands related to causal consistency. Instead, causal consistency is implemented by:
 
-1. Saving the `operationTime` returned by 3.6+ servers for all operations in a property of the `ClientSession` object.
-    The server reports the `operationTime` whether the operation succeeded or not and drivers MUST save the
-    `operationTime` in the `ClientSession` whether the operation succeeded or not.
+1. Saving the `operationTime` returned by 3.6+ servers for all acknowledged operations in a property of the
+    `ClientSession` object. The server reports the `operationTime` whether the operation succeeded or not, and drivers
+    MUST save the `operationTime` in the `ClientSession` whether the operation succeeded or not.
 2. Passing that `operationTime` in the `afterClusterTime` field of the `readConcern` field for subsequent causally
     consistent read operations (for all commands that support a `readConcern`)
 3. Gossiping clusterTime (described in the Driver Session Specification)
@@ -402,6 +402,9 @@ resolving many discussions of spec details. A final reference implementation mus
 ## Q&A
 
 ## Changelog
+
+- 2026-05-13: Clarify that the "MUST save operationTime" rule applies only to acknowledged operations; unacknowledged
+    writes receive no server response and do not update the session's `operationTime`.
 
 - 2024-02-08: Migrated from reStructuredText to Markdown.
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DRIVERS-3480

The implementation section stated:

> drivers MUST save the `operationTime` in the `ClientSession` whether the operation succeeded or not

The "Unacknowledged writes" section then stated:

> Since unacknowledged writes don't receive a response from the server (or don't wait for a response) the `ClientSession`'s `operationTime` is not updated after an unacknowledged write.

These two requirements directly contradict each other: saving `operationTime` requires a server response, but unacknowledged writes produce none.

The fix adds "acknowledged" to the general rule and adds a cross-reference to the Unacknowledged writes section, making clear the exception applies there.

No behaviour change intended.