### PR TITLE
DRIVERS-3481 Clarify enumerate-collections Replica Sets section

### DIFF
--- a/source/enumerate-collections/enumerate-collections.md
+++ b/source/enumerate-collections/enumerate-collections.md
@@ -243,10 +243,8 @@ method
 
 #### Replica Sets
 
-- `listCollections` can be run on a secondary node.
-- Querying `system.indexes` on a secondary node requires secondaryOk to be set.
-- Drivers MUST run `listCollections` on the primary node when in a replica set topology, unless directly connected to a
-    secondary node in Single topology.
+The server supports running `listCollections` on a secondary node. Drivers MUST however run `listCollections` on the
+primary node when in a replica set topology, unless directly connected to a secondary node in Single topology.
 
 ## Test Plan
 
@@ -291,6 +289,9 @@ The shell implements the first algorithm for falling back if the `listCollection
 (<https://github.com/mongodb/mongo/blob/f32ba54f971c045fb589fe4c3a37da77dc486cee/src/mongo/shell/db.js#L550>).
 
 ## Changelog
+
+- 2026-05-13: Clarify "Replica Sets" section: reword to distinguish server capability from driver routing rule; remove
+    stale `system.indexes` bullet (2.x behavior).
 
 - 2024-07-26: Migrated from reStructuredText to Markdown. Drop description of behavior for MongoDB 2.x servers.
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DRIVERS-3481

The "Replica Sets" section contained two bullets followed by the normative MUST rule:

```
- `listCollections` can be run on a secondary node.
- Querying `system.indexes` on a secondary node requires secondaryOk to be set.
- Drivers MUST run `listCollections` on the primary node when in a replica set topology, unless directly connected to a secondary node in Single topology.
```

Two problems:

**1.** The first bullet ("can be run on a secondary") reads as a driver permission, directly contradicting the MUST that immediately follows. Reworded to make clear it describes a server capability, not a driver routing policy.

**2.** The `system.indexes` bullet is stale. Verified on MongoDB 4.4.29 — even after creating a collection and an index, `system.indexes` is empty and absent from `listCollections`:

```js
> db = db.getSiblingDB("test")
> db.col.insertMany([{a: 1}, {a: 2}, {a: 3}])
> db.col.createIndex({a: 1})
> db.getCollectionNames()
[ "col" ]
> db.col.getIndexes()
[ { "v" : 2, "key" : { "_id" : 1 }, "name" : "_id_" },
  { "v" : 2, "key" : { "a" : 1 },   "name" : "a_1"  } ]
> db.system.indexes.find().toArray()
[ ]
> db.getCollectionNames().includes("system.indexes")
false
```

`system.indexes` no longer exists as a collection in MongoDB 4.4+. The bullet has no remaining scope and is removed.