### PR TITLE
DRIVERS-3482 Remove stale secondaryOk=true requirement from getMore section

### DIFF
--- a/source/find_getmore_killcursors_commands/find_getmore_killcursors_commands.md
+++ b/source/find_getmore_killcursors_commands/find_getmore_killcursors_commands.md
@@ -264,8 +264,7 @@ to the value of the option **maxAwaitTimeMS**. If no **maxAwaitTimeMS** is speci
 ### getMore
 
 The [getMore](https://www.mongodb.com/docs/manual/reference/command/getMore/) command replaces the **OP_GET_MORE** wire
-protocol message. The query flags passed to OP_QUERY for a getMore command MUST be secondaryOk=true when sent to a
-secondary. The OP_QUERY namespace MUST be the same as for the **find** and **killCursors** commands.
+protocol message. The OP_QUERY namespace MUST be the same as for the **find** and **killCursors** commands.
 
 ```typescript
 interface GetMoreCommand {
@@ -455,6 +454,8 @@ More in depth information about passing read preferences to Mongos can be found 
 [Server Selection Specification](../server-selection/server-selection.md#passing-read-preference-to-mongos).
 
 ## Changelog
+
+- 2026-05-13: Remove stale `secondaryOk=true` requirement from getMore section.
 
 - 2024-07-30: Migrated from reStructuredText to Markdown.
 


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DRIVERS-3482

The `getMore` section contained this sentence:

> The query flags passed to OP_QUERY for a getMore command MUST be secondaryOk=true when sent to a secondary.

This directly contradicted the "Interactions with OP_QUERY" section of the same spec:

> The **secondaryOk** flag SHOULD not be set for all follow-up **getMore** and **killCursors** commands. The cursor on the server keeps the original **secondaryOk** value first set on the **find** command.

The two changelog entries tell the history:

- **2015-09-30**: "Legacy secondaryOk flag must be set to true on getMore and killCursors commands"
- **2015-10-13**: "Legacy secondaryOk flag SHOULD not be set on getMore and killCursors commands" ← reversal

Commit 1aabad46 (2015-10-17) applied the reversal by updating the spec body and the changelog, but missed the sentence in the `getMore` section. That sentence has been inconsistent with the rest of the spec for ten years.

No behaviour change intended — the SHOULD NOT rule in the "Interactions with OP_QUERY" section has been the stated intent since 2015-10-13.