### PR TITLE
DRIVERS-3475 Add DBRef test fixtures for encoding and decoding

### DIFF
--- a/source/dbref/tests/README.md
+++ b/source/dbref/tests/README.md
@@ -1,0 +1,75 @@
+# DBRef Tests
+
+These tests cover driver-level DBRef **model** encoding and decoding behavior. They do not require a running MongoDB
+server.
+
+## Relationship with bson-corpus
+
+`source/bson-corpus/tests/dbref.json` already tests DBRef at the **BSON/Extended JSON layer**: it verifies that specific
+byte sequences round-trip correctly through a driver's BSON codec. Documents with missing `$id`, non-string `$ref`, etc.
+appear there as *valid BSON documents* — because they are valid BSON; the bson-corpus does not prescribe driver model
+behavior.
+
+The tests in this directory complement bson-corpus by testing the **driver model layer**:
+
+| Concern                                                                | bson-corpus | These tests |
+| ---------------------------------------------------------------------- | ----------- | ----------- |
+| BSON bytes ↔ Extended JSON round-trip                                  | ✓           | —           |
+| Driver decodes valid DBRef into a model object                         | —           | ✓           |
+| Driver exposes `$ref`, `$id`, `$db`, extra fields                      | —           | ✓           |
+| Driver rejects invalid documents (missing `$id`, wrong types)          | —           | ✓           |
+| Out-of-order fields decoded and re-encoded in canonical order          | —           | ✓           |
+| Encoding produces canonical field order (`$ref`, `$id`, `$db`, extras) | —           | ✓           |
+
+## Test files
+
+- `valid-documents.json` — Documents that MUST be decoded to a DBRef model.
+- `out-of-order.json` — Documents with fields in non-canonical order that MUST still decode to a DBRef model and MUST
+    re-encode with fields in canonical order.
+- `invalid-documents.json` — Documents that MUST NOT be decoded to a DBRef model.
+- `encoding.json` — DBRef models (constructed directly or via decoding) that MUST encode with fields in canonical order.
+
+## Format
+
+### Decoding tests (`valid-documents.json`, `out-of-order.json`, `invalid-documents.json`)
+
+```json
+{
+  "description": "...",
+  "tests": [
+    {
+      "description": "...",
+      "document": { ... },
+      "valid": true,
+      "decoded": {
+        "ref": "...",
+        "id": ...,
+        "db": null,
+        "extra": { ... }
+      }
+    }
+  ]
+}
+```
+
+`document` is the input, expressed as Extended JSON (Relaxed). When `valid` is `true`, `decoded` contains the expected
+field values of the resulting DBRef model. When `valid` is `false`, the document MUST NOT be decoded to a DBRef model.
+
+### Encoding tests (`encoding.json`, `out-of-order.json`)
+
+```json
+{
+  "description": "...",
+  "tests": [
+    {
+      "description": "...",
+      "input": { ... },
+      "encoded": { ... }
+    }
+  ]
+}
+```
+
+`input` is the document to decode into a DBRef model (possibly with out-of-order fields). `encoded` is the expected
+output when the DBRef model is re-encoded to BSON, expressed as Extended JSON in canonical field order (`$ref`, `$id`,
+`$db`, then extra fields).

--- a/source/dbref/tests/encoding.json
+++ b/source/dbref/tests/encoding.json
@@ -1,0 +1,130 @@
+{
+  "description": "DBRef models MUST encode with fields in canonical order: $ref, $id, $db (if present), then extra fields in their original relative order",
+  "tests": [
+    {
+      "description": "basic fields: $ref and ObjectId $id",
+      "input": {
+        "$ref": "coll0",
+        "$id": {
+          "$oid": "60a6fe9a54f4180c86309efa"
+        }
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": {
+          "$oid": "60a6fe9a54f4180c86309efa"
+        }
+      }
+    },
+    {
+      "description": "integer $id",
+      "input": {
+        "$ref": "coll0",
+        "$id": 1
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1
+      }
+    },
+    {
+      "description": "null $id",
+      "input": {
+        "$ref": "coll0",
+        "$id": null
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": null
+      }
+    },
+    {
+      "description": "with $db",
+      "input": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0"
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0"
+      }
+    },
+    {
+      "description": "extra field with string value",
+      "input": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0",
+        "foo": "bar"
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0",
+        "foo": "bar"
+      }
+    },
+    {
+      "description": "multiple extra fields preserve relative order",
+      "input": {
+        "$ref": "coll0",
+        "$id": 1,
+        "foo": true,
+        "bar": false
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "foo": true,
+        "bar": false
+      }
+    },
+    {
+      "description": "extra field with document value",
+      "input": {
+        "$ref": "coll0",
+        "$id": 1,
+        "meta": {
+          "foo": 1,
+          "bar": 2
+        }
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "meta": {
+          "foo": 1,
+          "bar": 2
+        }
+      }
+    },
+    {
+      "description": "extra field with dollar-prefixed name",
+      "input": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$foo": "bar"
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$foo": "bar"
+      }
+    },
+    {
+      "description": "extra field with dot-notation name",
+      "input": {
+        "$ref": "coll0",
+        "$id": 1,
+        "foo.bar": 0
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "foo.bar": 0
+      }
+    }
+  ]
+}

--- a/source/dbref/tests/encoding.yml
+++ b/source/dbref/tests/encoding.yml
@@ -1,0 +1,37 @@
+description: "DBRef models MUST encode with fields in canonical order: $ref, $id, $db (if present), then extra fields in their original relative order"
+tests:
+  - description: "basic fields: $ref and ObjectId $id"
+    input: { $ref: "coll0", $id: { $oid: "60a6fe9a54f4180c86309efa" } }
+    encoded: { $ref: "coll0", $id: { $oid: "60a6fe9a54f4180c86309efa" } }
+
+  - description: "integer $id"
+    input: { $ref: "coll0", $id: 1 }
+    encoded: { $ref: "coll0", $id: 1 }
+
+  - description: "null $id"
+    input: { $ref: "coll0", $id: ~ }
+    encoded: { $ref: "coll0", $id: ~ }
+
+  - description: "with $db"
+    input: { $ref: "coll0", $id: 1, $db: "db0" }
+    encoded: { $ref: "coll0", $id: 1, $db: "db0" }
+
+  - description: "extra field with string value"
+    input: { $ref: "coll0", $id: 1, $db: "db0", foo: "bar" }
+    encoded: { $ref: "coll0", $id: 1, $db: "db0", foo: "bar" }
+
+  - description: "multiple extra fields preserve relative order"
+    input: { $ref: "coll0", $id: 1, foo: true, bar: false }
+    encoded: { $ref: "coll0", $id: 1, foo: true, bar: false }
+
+  - description: "extra field with document value"
+    input: { $ref: "coll0", $id: 1, meta: { foo: 1, bar: 2 } }
+    encoded: { $ref: "coll0", $id: 1, meta: { foo: 1, bar: 2 } }
+
+  - description: "extra field with dollar-prefixed name"
+    input: { $ref: "coll0", $id: 1, $foo: "bar" }
+    encoded: { $ref: "coll0", $id: 1, $foo: "bar" }
+
+  - description: "extra field with dot-notation name"
+    input: { $ref: "coll0", $id: 1, "foo.bar": 0 }
+    encoded: { $ref: "coll0", $id: 1, "foo.bar": 0 }

--- a/source/dbref/tests/invalid-documents.json
+++ b/source/dbref/tests/invalid-documents.json
@@ -1,0 +1,45 @@
+{
+  "description": "Documents that MUST NOT be decoded to a DBRef model",
+  "tests": [
+    {
+      "description": "missing $id",
+      "document": {
+        "$ref": "coll0"
+      },
+      "valid": false
+    },
+    {
+      "description": "missing $ref",
+      "document": {
+        "$id": {
+          "$oid": "60a6fe9a54f4180c86309efa"
+        }
+      },
+      "valid": false
+    },
+    {
+      "description": "missing both $ref and $id",
+      "document": {
+        "$db": "db0"
+      },
+      "valid": false
+    },
+    {
+      "description": "$ref is not a string (boolean)",
+      "document": {
+        "$ref": true,
+        "$id": 1
+      },
+      "valid": false
+    },
+    {
+      "description": "$db is not a string (integer)",
+      "document": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": 1
+      },
+      "valid": false
+    }
+  ]
+}

--- a/source/dbref/tests/invalid-documents.yml
+++ b/source/dbref/tests/invalid-documents.yml
@@ -1,0 +1,21 @@
+description: "Documents that MUST NOT be decoded to a DBRef model"
+tests:
+  - description: "missing $id"
+    document: { $ref: "coll0" }
+    valid: false
+
+  - description: "missing $ref"
+    document: { $id: { $oid: "60a6fe9a54f4180c86309efa" } }
+    valid: false
+
+  - description: "missing both $ref and $id"
+    document: { $db: "db0" }
+    valid: false
+
+  - description: "$ref is not a string (boolean)"
+    document: { $ref: true, $id: 1 }
+    valid: false
+
+  - description: "$db is not a string (integer)"
+    document: { $ref: "coll0", $id: 1, $db: 1 }
+    valid: false

--- a/source/dbref/tests/out-of-order.json
+++ b/source/dbref/tests/out-of-order.json
@@ -1,0 +1,109 @@
+{
+  "description": "Documents with out-of-order fields MUST decode to a DBRef model and MUST re-encode with fields in canonical order ($ref, $id, $db, then extra fields)",
+  "tests": [
+    {
+      "description": "$id before $ref",
+      "input": {
+        "$id": 1,
+        "$ref": "coll0"
+      },
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": null
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1
+      }
+    },
+    {
+      "description": "$db before $ref",
+      "input": {
+        "$db": "db0",
+        "$ref": "coll0",
+        "$id": 1
+      },
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": "db0"
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0"
+      }
+    },
+    {
+      "description": "extra field before $ref",
+      "input": {
+        "foo": 1,
+        "$id": 1,
+        "$ref": "coll0"
+      },
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": null,
+        "extra": {
+          "foo": 1
+        }
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "foo": 1
+      }
+    },
+    {
+      "description": "extra field before $ref, with $db",
+      "input": {
+        "foo": 1,
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0"
+      },
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": "db0",
+        "extra": {
+          "foo": 1
+        }
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0",
+        "foo": 1
+      }
+    },
+    {
+      "description": "extra fields surrounding required fields",
+      "input": {
+        "foo": 1,
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0",
+        "bar": 1
+      },
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": "db0",
+        "extra": {
+          "foo": 1,
+          "bar": 1
+        }
+      },
+      "encoded": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0",
+        "foo": 1,
+        "bar": 1
+      }
+    }
+  ]
+}

--- a/source/dbref/tests/out-of-order.yml
+++ b/source/dbref/tests/out-of-order.yml
@@ -1,0 +1,48 @@
+description: "Documents with out-of-order fields MUST decode to a DBRef model and MUST re-encode with fields in canonical order ($ref, $id, $db, then extra fields)"
+tests:
+  - description: "$id before $ref"
+    input: { $id: 1, $ref: "coll0" }
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: ~
+    encoded: { $ref: "coll0", $id: 1 }
+
+  - description: "$db before $ref"
+    input: { $db: "db0", $ref: "coll0", $id: 1 }
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: "db0"
+    encoded: { $ref: "coll0", $id: 1, $db: "db0" }
+
+  - description: "extra field before $ref"
+    input: { foo: 1, $id: 1, $ref: "coll0" }
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: ~
+      extra:
+        foo: 1
+    encoded: { $ref: "coll0", $id: 1, foo: 1 }
+
+  - description: "extra field before $ref, with $db"
+    input: { foo: 1, $ref: "coll0", $id: 1, $db: "db0" }
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: "db0"
+      extra:
+        foo: 1
+    encoded: { $ref: "coll0", $id: 1, $db: "db0", foo: 1 }
+
+  - description: "extra fields surrounding required fields"
+    input: { foo: 1, $ref: "coll0", $id: 1, $db: "db0", bar: 1 }
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: "db0"
+      extra:
+        foo: 1
+        bar: 1
+    encoded: { $ref: "coll0", $id: 1, $db: "db0", foo: 1, bar: 1 }

--- a/source/dbref/tests/valid-documents.json
+++ b/source/dbref/tests/valid-documents.json
@@ -1,0 +1,156 @@
+{
+  "description": "Valid documents that MUST be decoded to a DBRef model",
+  "tests": [
+    {
+      "description": "ObjectId $id",
+      "document": {
+        "$ref": "coll0",
+        "$id": {
+          "$oid": "60a6fe9a54f4180c86309efa"
+        }
+      },
+      "valid": true,
+      "decoded": {
+        "ref": "coll0",
+        "id": {
+          "$oid": "60a6fe9a54f4180c86309efa"
+        },
+        "db": null
+      }
+    },
+    {
+      "description": "integer $id",
+      "document": {
+        "$ref": "coll0",
+        "$id": 1
+      },
+      "valid": true,
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": null
+      }
+    },
+    {
+      "description": "null $id",
+      "document": {
+        "$ref": "coll0",
+        "$id": null
+      },
+      "valid": true,
+      "decoded": {
+        "ref": "coll0",
+        "id": null,
+        "db": null
+      }
+    },
+    {
+      "description": "with $db",
+      "document": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0"
+      },
+      "valid": true,
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": "db0"
+      }
+    },
+    {
+      "description": "extra field with string value",
+      "document": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$db": "db0",
+        "foo": "bar"
+      },
+      "valid": true,
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": "db0",
+        "extra": {
+          "foo": "bar"
+        }
+      }
+    },
+    {
+      "description": "multiple extra fields with boolean values",
+      "document": {
+        "$ref": "coll0",
+        "$id": 1,
+        "foo": true,
+        "bar": false
+      },
+      "valid": true,
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": null,
+        "extra": {
+          "foo": true,
+          "bar": false
+        }
+      }
+    },
+    {
+      "description": "extra field with document value",
+      "document": {
+        "$ref": "coll0",
+        "$id": 1,
+        "meta": {
+          "foo": 1,
+          "bar": 2
+        }
+      },
+      "valid": true,
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": null,
+        "extra": {
+          "meta": {
+            "foo": 1,
+            "bar": 2
+          }
+        }
+      }
+    },
+    {
+      "description": "extra field with dollar-prefixed name",
+      "document": {
+        "$ref": "coll0",
+        "$id": 1,
+        "$foo": "bar"
+      },
+      "valid": true,
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": null,
+        "extra": {
+          "$foo": "bar"
+        }
+      }
+    },
+    {
+      "description": "extra field with dot-notation name",
+      "document": {
+        "$ref": "coll0",
+        "$id": 1,
+        "foo.bar": 0
+      },
+      "valid": true,
+      "decoded": {
+        "ref": "coll0",
+        "id": 1,
+        "db": null,
+        "extra": {
+          "foo.bar": 0
+        }
+      }
+    }
+  ]
+}

--- a/source/dbref/tests/valid-documents.yml
+++ b/source/dbref/tests/valid-documents.yml
@@ -1,0 +1,84 @@
+description: "Valid documents that MUST be decoded to a DBRef model"
+tests:
+  - description: "ObjectId $id"
+    document: { $ref: "coll0", $id: { $oid: "60a6fe9a54f4180c86309efa" } }
+    valid: true
+    decoded:
+      ref: "coll0"
+      id: { $oid: "60a6fe9a54f4180c86309efa" }
+      db: ~
+
+  - description: "integer $id"
+    document: { $ref: "coll0", $id: 1 }
+    valid: true
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: ~
+
+  - description: "null $id"
+    document: { $ref: "coll0", $id: ~ }
+    valid: true
+    decoded:
+      ref: "coll0"
+      id: ~
+      db: ~
+
+  - description: "with $db"
+    document: { $ref: "coll0", $id: 1, $db: "db0" }
+    valid: true
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: "db0"
+
+  - description: "extra field with string value"
+    document: { $ref: "coll0", $id: 1, $db: "db0", foo: "bar" }
+    valid: true
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: "db0"
+      extra:
+        foo: "bar"
+
+  - description: "multiple extra fields with boolean values"
+    document: { $ref: "coll0", $id: 1, foo: true, bar: false }
+    valid: true
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: ~
+      extra:
+        foo: true
+        bar: false
+
+  - description: "extra field with document value"
+    document: { $ref: "coll0", $id: 1, meta: { foo: 1, bar: 2 } }
+    valid: true
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: ~
+      extra:
+        meta: { foo: 1, bar: 2 }
+
+  - description: "extra field with dollar-prefixed name"
+    document: { $ref: "coll0", $id: 1, $foo: "bar" }
+    valid: true
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: ~
+      extra:
+        $foo: "bar"
+
+  - description: "extra field with dot-notation name"
+    document: { $ref: "coll0", $id: 1, "foo.bar": 0 }
+    valid: true
+    decoded:
+      ref: "coll0"
+      id: 1
+      db: ~
+      extra:
+        "foo.bar": 0


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DRIVERS-3475

Converts the prose test plan from `dbref.md` into machine-readable YAML fixtures; covering the 4 behavioral areas described in the spec:

- `valid-documents` — 9 valid documents that MUST decode to a DBRef model (`$id` as ObjectId/integer/null, with `$db`, with extra fields including dollar-prefixed and dot-notation names)
- `invalid-documents` — 5 documents that MUST NOT decode (missing `$ref`, missing `$id`, wrong types for `$ref`/`$db`)
- `out-of-order` — 5 documents with non-canonical field order that MUST decode correctly and MUST re-encode in canonical order (`$ref`, `$id`, `$db`, then extra fields)
- `encoding` — 9 DBRef models that MUST encode with fields in canonical order, preserving relative order of extra fields

## Relationship with bson-corpus

`source/bson-corpus/tests/dbref.json` already tests DBRef at the **BSON/Extended JSON layer** (byte sequences ↔ Extended JSON round-trips). Documents with missing `$id`, non-string `$ref`, etc. appear there as *valid BSON* — which they are; bson-corpus does not prescribe driver model behavior.

These tests are **complementary**, not redundant:

| Concern | bson-corpus | These tests |
|---------|-------------|-------------|
| BSON bytes ↔ Extended JSON round-trip | ✓ | — |
| Driver decodes valid DBRef into a model object | — | ✓ |
| Driver exposes `$ref`, `$id`, `$db`, extra fields | — | ✓ |
| Driver rejects invalid documents (missing `$id`, wrong types) | — | ✓ |
| Out-of-order fields decoded and re-encoded in canonical order | — | ✓ |
| Encoding produces canonical field order | — | ✓ |
