### PR TITLE
DRIVERS-3476 clarify the `queryType` intended for each QE text operator

### DIFF
--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -1363,8 +1363,11 @@ One of the strings:
 - "equality"
 - "range"
 - "prefixPreview"
+   - Used for the `$encStrStartsWith` operator.
 - "suffixPreview"
+   - Used for the `$encStrEndsWith` operator.
 - "substringPreview"
+   - Used for the `$encStrContains` operator.
 
 queryType only applies when algorithm is "Indexed", "Range", or "TextPreview". libmongocrypt returns an error if
 queryType is set for a non-applicable algorithm.

--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -1363,11 +1363,11 @@ One of the strings:
 - "equality"
 - "range"
 - "prefixPreview"
-   - Used for the `$encStrStartsWith` operator.
+    - Used for the `$encStrStartsWith` operator.
 - "suffixPreview"
-   - Used for the `$encStrEndsWith` operator.
+    - Used for the `$encStrEndsWith` operator.
 - "substringPreview"
-   - Used for the `$encStrContains` operator.
+    - Used for the `$encStrContains` operator.
 
 queryType only applies when algorithm is "Indexed", "Range", or "TextPreview". libmongocrypt returns an error if
 queryType is set for a non-applicable algorithm.


### PR DESCRIPTION
This PR is related to, but does not resolve DRIVERS-3476. It is intended to clarify which QE Text `queryType` corresponds to which QE Text operator.


<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- ~~[ ] Update changelog.~~
- ~~[ ] Test changes in at least one language driver.~~
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
