### PR TITLE
DRIVERS-3321 update QE for `prefix` and `suffix`

### DIFF
--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -48,7 +48,10 @@ QEv1 and QEv2 are incompatible.
 MongoDB 8.0 dropped `queryType=rangePreview` and added `queryType=range`
 ([SPM-3583](https://jira.mongodb.org/browse/SPM-3583)).
 
-MongoDB 8.2 added unstable support for QE text queries ([SPM-2880](https://jira.mongodb.org/browse/SPM-2880))
+MongoDB 8.2 added unstable support for QE string queries ([SPM-2880](https://jira.mongodb.org/browse/SPM-2880))
+
+MongoDB 9.0 dropped `queryType=prefixPreview|suffixPreview` and added `queryType=prefix|suffix`
+([SPM-4539](https://jira.mongodb.org/browse/SPM-4539))
 
 ## META
 
@@ -1258,7 +1261,7 @@ class EncryptOpts {
    contentionFactor: Optional<Int64>,
    queryType: Optional<String>
    rangeOpts: Optional<RangeOpts>
-   textOpts: Optional<TextOpts>
+   stringOpts: Optional<StringOpts>
 }
 
 // RangeOpts specifies index options for a Queryable Encryption field supporting "range" queries.
@@ -1277,18 +1280,18 @@ class RangeOpts {
    precision: Optional<Int32>
 }
 
-// TextOpts specifies options for a Queryable Encryption field supporting text queries.
-// NOTE: TextOpts is currently unstable API and subject to backwards breaking changes.
-class TextOpts {
+// StringOpts specifies options for a Queryable Encryption field supporting string queries.
+class StringOpts {
    // substring contains further options to support substring queries.
+   // NOTE: substring is currently unstable API and subject to backwards breaking changes.
    substring: Optional<SubstringOpts>,
    // prefix contains further options to support prefix queries.
    prefix: Optional<PrefixOpts>,
    // suffix contains further options to support suffix queries.
    suffix: Optional<SuffixOpts>,
-   // caseSensitive determines whether text indexes for this field are case sensitive.
+   // caseSensitive determines whether string indexes for this field are case sensitive.
    caseSensitive: bool,
-   // diacriticSensitive determines whether text indexes for this field are diacritic sensitive.
+   // diacriticSensitive determines whether string indexes for this field are diacritic sensitive.
    diacriticSensitive: bool
 }
 
@@ -1302,7 +1305,6 @@ class SubstringOpts {
    strMaxQueryLength: Int32,
 }
 
-// NOTE: PrefixOpts is currently unstable API and subject to backwards breaking changes.
 class PrefixOpts {
    // strMinQueryLength is the minimum allowed query length. Querying with a shorter string will error.
    strMinQueryLength: Int32,
@@ -1310,7 +1312,6 @@ class PrefixOpts {
    strMaxQueryLength: Int32,
 }
 
-// NOTE: SuffixOpts is currently unstable API and subject to backwards breaking changes.
 class SuffixOpts {
    // strMinQueryLength is the minimum allowed query length. Querying with a shorter string will error.
    strMinQueryLength: Int32,
@@ -1340,20 +1341,20 @@ One of the strings:
 - "Indexed"
 - "Unindexed"
 - "Range"
-- "TextPreview"
+- "String"
 
-The result of explicit encryption with the "Indexed", "Range", or "TextPreview" algorithm must be processed by the
-server to insert or query. Drivers MUST document the following behavior:
+The result of explicit encryption with the "Indexed", "Range", or "String" algorithm must be processed by the server to
+insert or query. Drivers MUST document the following behavior:
 
-> To insert or query with an "Indexed", "Range", or "TextPreview" encrypted payload, use a `MongoClient` configured with
+> To insert or query with an "Indexed", "Range", or "String" encrypted payload, use a `MongoClient` configured with
 > `AutoEncryptionOpts`. `AutoEncryptionOpts.bypassQueryAnalysis` may be true. `AutoEncryptionOpts.bypassAutoEncryption`
-> must be false. The "TextPreview" algorithm is in preview and should be used for experimental workloads only. These
-> features are unstable and their security is not guaranteed until released as Generally Available (GA). The GA version
-> of these features may not be backwards compatible with the preview version.
+> must be false. The "substringPreview" query type is in preview and should be used for experimental workloads only.
+> This feature is unstable and its security is not guaranteed until released as Generally Available (GA). The GA version
+> of this feature may not be backwards compatible with the preview version.
 
 #### contentionFactor
 
-contentionFactor may be used to tune performance. Only applies when algorithm is "Indexed", "Range", or "TextPreview".
+contentionFactor may be used to tune performance. Only applies when algorithm is "Indexed", "Range", or "String".
 libmongocrypt returns an error if contentionFactor is set for a non-applicable algorithm.
 
 #### queryType
@@ -1362,24 +1363,24 @@ One of the strings:
 
 - "equality"
 - "range"
-- "prefixPreview"
+- "prefix"
     - Used for the `$encStrStartsWith` operator.
-- "suffixPreview"
+- "suffix"
     - Used for the `$encStrEndsWith` operator.
 - "substringPreview"
     - Used for the `$encStrContains` operator.
 
-queryType only applies when algorithm is "Indexed", "Range", or "TextPreview". libmongocrypt returns an error if
-queryType is set for a non-applicable algorithm.
+queryType only applies when algorithm is "Indexed", "Range", or "String". libmongocrypt returns an error if queryType is
+set for a non-applicable algorithm.
 
 #### rangeOpts
 
 rangeOpts only applies when algorithm is "Range". libmongocrypt returns an error if rangeOpts is set for a
 non-applicable algorithm.
 
-#### textOpts
+#### stringOpts
 
-textOpts only applies when algorithm is "TextPreview". libmongocrypt returns an error if textOpts is set for a
+stringOpts only applies when algorithm is "String". libmongocrypt returns an error if stringOpts is set for a
 non-applicable algorithm.
 
 ## User facing API: When Auto Encryption Fails
@@ -2521,6 +2522,13 @@ on. To support concurrent access of the key vault collection, the key management
 explicit session parameter as described in the [Drivers Sessions Specification](../sessions/driver-sessions.md).
 
 ## Changelog
+
+- 2026-05-29: Add stable support for prefix and suffix queries
+
+    - Replace `prefixPreview` with `prefix`.
+    - Replace `suffixPreview` with `suffix`.
+    - Replace `TextPreview` with `String`.
+    - Replace `TextOpts` with `StringOpts`.
 
 - 2025-09-30: Update `$lookup` prose test to reflect changes in
     [MONGOCRYPT-793](https://jira.mongodb.org/browse/MONGOCRYPT-793).

--- a/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix-ci-di.json
+++ b/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix-ci-di.json
@@ -11,7 +11,7 @@
       "bsonType": "string",
       "queries": [
         {
-          "queryType": "prefixPreview",
+          "queryType": "prefix",
           "strMinQueryLength": {
             "$numberInt": "2"
           },
@@ -23,7 +23,7 @@
           "diacriticSensitive": false
         },
         {
-          "queryType": "suffixPreview",
+          "queryType": "suffix",
           "strMinQueryLength": {
             "$numberInt": "2"
           },

--- a/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix.json
+++ b/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix.json
@@ -1,6 +1,6 @@
 {
-  "fields": [
-    {
+    "fields": [
+        {
             "keyId": {
                 "$binary": {
                     "base64": "EjRWeBI0mHYSNBI0VniQEg==",
@@ -11,7 +11,7 @@
             "bsonType": "string",
             "queries": [
                 {
-                    "queryType": "prefixPreview",
+                    "queryType": "prefix",
                     "strMinQueryLength": {
                         "$numberInt": "2"
                     },
@@ -22,7 +22,7 @@
                     "diacriticSensitive": true
                 },
                 {
-                    "queryType": "suffixPreview",
+                    "queryType": "suffix",
                     "strMinQueryLength": {
                         "$numberInt": "2"
                     },
@@ -34,5 +34,5 @@
                 }
             ]
         }
-  ]
+    ]
 }

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3871,10 +3871,10 @@ expect(dk).to.be.a(Binary);
 expect(calledCount).to.be.greaterThan(0);
 ```
 
-### 27. Text Explicit Encryption
+### 27. String Explicit Encryption
 
-The Text Explicit Encryption tests utilize Queryable Encryption (QE) range protocol V2 and require MongoDB server 8.2.0+
-and libmongocrypt 1.15.1+. The tests must not run against a standalone.
+The String Explicit Encryption tests utilize Queryable Encryption (QE) and require MongoDB server 8.2.0+ and libmongocrypt
+1.18.1+. The tests must not run against a standalone.
 
 Before running each of the following test cases, perform the following Test Setup.
 
@@ -3885,10 +3885,10 @@ create the following collections with majority write concern:
 
 - `db.prefix-suffix` using the `encryptedFields` option set to the contents of
     [encryptedFields-prefix-suffix.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix.json).
-    Skip this step if testing server 9.0.0+.
+    This step requires server 9.0.0+.
 - `db.prefix-suffix-ci-di` using the `encryptedFields` option set to the contents of
     [encryptedFields-prefix-suffix-ci-di.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix-ci-di.json).
-    Skip this step if testing server 9.0.0+.
+    This step requires server 9.0.0+.
 - `db.substring` using the `encryptedFields` option set to the contents of
     [encryptedFields-substring.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-substring.json)
 - `db.substring-ci-di` using the `encryptedFields` option set to the contents of
@@ -3941,9 +3941,9 @@ Use `clientEncryption` to encrypt the string `"foobarbaz"` with the following `E
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: true,
       diacriticSensitive: true,
       prefix: PrefixOpts {
@@ -3969,9 +3969,9 @@ Use `clientEncryption` to encrypt the string `"foobarbaz"` with the following `E
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: true,
       diacriticSensitive: true,
       substring: SubstringOpts {
@@ -3991,17 +3991,17 @@ Use `explicitEncryptedClient` to insert the following document into `db.substrin
 
 #### Case 1: can find a document by prefix
 
-Skip this test case if testing MongoDB server 9.0.0+.
+This test case requires MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the following `EncryptOpts`:
 
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
-   queryType: "prefixPreview",
+   algorithm: "String",
+   queryType: "prefix",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: true,
       diacriticSensitive: true,
       prefix: PrefixOpts {
@@ -4026,17 +4026,17 @@ Assert the following document is returned:
 
 #### Case 2: can find a document by suffix
 
-Skip this test case if testing MongoDB server 9.0.0+.
+This test case requires MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"baz"` with the following `EncryptOpts`:
 
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
-   queryType: "suffixPreview",
+   algorithm: "String",
+   queryType: "suffix",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: true,
       diacriticSensitive: true,
       suffix: SuffixOpts {
@@ -4061,17 +4061,17 @@ Assert the following document is returned:
 
 #### Case 3: assert no document found by prefix
 
-Skip this test case if testing MongoDB server 9.0.0+.
+This test case requires MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"baz"` with the following `EncryptOpts`:
 
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
-   queryType: "prefixPreview",
+   algorithm: "String",
+   queryType: "prefix",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: true,
       diacriticSensitive: true,
       prefix: PrefixOpts {
@@ -4092,17 +4092,17 @@ Assert that no documents are returned.
 
 #### Case 4: assert no document found by suffix
 
-Skip this test case if testing MongoDB server 9.0.0+.
+This test case requires MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the following `EncryptOpts`:
 
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
-   queryType: "suffixPreview",
+   algorithm: "String",
+   queryType: "suffix",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: true,
       diacriticSensitive: true,
       suffix: SuffixOpts {
@@ -4128,10 +4128,10 @@ Use `clientEncryption.encrypt()` to encrypt the string `"bar"` with the followin
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    queryType: "substringPreview",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: true,
       diacriticSensitive: true,
       substring: SubstringOpts {
@@ -4162,10 +4162,10 @@ Use `clientEncryption.encrypt()` to encrypt the string `"qux"` with the followin
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    queryType: "substringPreview",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: true,
       diacriticSensitive: true,
       substring: SubstringOpts {
@@ -4187,16 +4187,16 @@ Assert that no documents are returned.
 
 #### Case 7: assert `contentionFactor` is required
 
-Skip this test case if testing MongoDB server 9.0.0+.
+This test case requires MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the following `EncryptOpts`:
 
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
-   queryType: "prefixPreview",
-   textOpts: TextOpts {
+   algorithm: "String",
+   queryType: "prefix",
+   stringOpts: StringOpts {
       caseSensitive: true,
       diacriticSensitive: true,
       prefix: PrefixOpts {
@@ -4207,13 +4207,13 @@ class EncryptOpts {
 }
 ```
 
-Expect an error from libmongocrypt with a message containing the string: "contention factor is required for textPreview
+Expect an error from libmongocrypt with a message containing the string: "contention factor is required for string
 algorithm".
 
 #### Case 8: can find an auto-encrypted case indexed document by prefix and suffix
 
-This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). Skip this test case if
-testing MongoDB server 9.0.0+. This test requires libmongocrypt 1.18.1+.
+This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). This test case requires
+MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
 
 Use `autoEncryptedClient` to insert the following document into `db.prefix-suffix-ci-di` with majority write concern.
 
@@ -4226,10 +4226,10 @@ Use `clientEncryption.encrypt()` to encrypt the string `"bing"` with the followi
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    queryType: "prefix",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: false,
       diacriticSensitive: false,
       prefix: PrefixOpts {
@@ -4258,10 +4258,10 @@ Use `clientEncryption.encrypt()` to encrypt the string `"lin"` with the followin
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    queryType: "suffix",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: false,
       diacriticSensitive: false,
       suffix: SuffixOpts {
@@ -4287,8 +4287,8 @@ Assert the following document is returned:
 
 #### Case 9: can find an auto-encrypted diacritic-insensitively indexed document by prefix and suffix
 
-This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). Skip this test case if
-testing MongoDB server 9.0.0+. This test requires libmongocrypt 1.18.1+.
+This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). This test case requires
+MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
 
 Use `autoEncryptedClient` to insert the following document into `db.prefix-suffix-ci-di` with majority write concern:
 
@@ -4301,10 +4301,10 @@ Use `clientEncryption.encrypt()` to encrypt the string `"cafe"` with the followi
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    queryType: "prefix",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: false,
       diacriticSensitive: false,
       prefix: PrefixOpts {
@@ -4333,10 +4333,10 @@ Use `clientEncryption.encrypt()` to encrypt the string `"baz"` with the followin
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    queryType: "suffix",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: false,
       diacriticSensitive: false,
       suffix: SuffixOpts {
@@ -4376,10 +4376,10 @@ Use `clientEncryption.encrypt()` to encrypt the string `"bar"` with the followin
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    queryType: "substringPreview",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: false,
       diacriticSensitive: false,
       substring: SubstringOpts {
@@ -4420,10 +4420,10 @@ Use `clientEncryption.encrypt()` to encrypt the string `"cafe"` with the followi
 ```typescript
 class EncryptOpts {
    keyId : <key1ID>,
-   algorithm: "TextPreview",
+   algorithm: "String",
    queryType: "substringPreview",
    contentionFactor: 0,
-   textOpts: TextOpts {
+   stringOpts: StringOpts {
       caseSensitive: false,
       diacriticSensitive: false,
       substring: SubstringOpts {

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3873,8 +3873,8 @@ expect(calledCount).to.be.greaterThan(0);
 
 ### 27. String Explicit Encryption
 
-The String Explicit Encryption tests utilize Queryable Encryption (QE) and require MongoDB server 8.2.0+ and libmongocrypt
-1.18.1+. The tests must not run against a standalone.
+The String Explicit Encryption tests utilize Queryable Encryption (QE) and require MongoDB server 8.2.0+ and
+libmongocrypt 1.18.1+. The tests must not run against a standalone.
 
 Before running each of the following test cases, perform the following Test Setup.
 

--- a/source/client-side-encryption/tests/unified/QE-Text-cleanupStructuredEncryptionData.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-cleanupStructuredEncryptionData.json
@@ -3,15 +3,14 @@
   "schemaVersion": "1.25",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.2.0",
-      "maxServerVersion": "8.99.99",
+      "minServerVersion": "9.0.0",
       "topologies": [
         "replicaset",
         "sharded",
         "load-balanced"
       ],
       "csfle": {
-        "minLibmongocryptVersion": "1.15.0"
+        "minLibmongocryptVersion": "1.19.0"
       }
     }
   ],
@@ -102,7 +101,7 @@
               "bsonType": "string",
               "queries": [
                 {
-                  "queryType": "suffixPreview",
+                  "queryType": "suffix",
                   "contention": {
                     "$numberLong": "0"
                   },

--- a/source/client-side-encryption/tests/unified/QE-Text-cleanupStructuredEncryptionData.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-cleanupStructuredEncryptionData.yml
@@ -1,11 +1,10 @@
 description: QE-Text-cleanupStructuredEncryptionData
 schemaVersion: "1.25"
 runOnRequirements:
-  - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
-    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
+  - minServerVersion: "9.0.0" # Server 9.0.0 adds stable support for QE text prefix and suffix queries.
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
-      minLibmongocryptVersion: 1.15.0 # For SPM-4158.
+      minLibmongocryptVersion: 1.19.0 # For MONGOCRYPT-870.
 createEntities:
   - client:
       id: &client "client"
@@ -61,7 +60,7 @@ initialData:
                 "bsonType": "string",
                 "queries": [
                     {
-                      "queryType": "suffixPreview",
+                      "queryType": "suffix",
                       "contention": { "$numberLong": "0" },
                       "strMinQueryLength": { "$numberLong": "3" },
                       "strMaxQueryLength": { "$numberLong": "30" },

--- a/source/client-side-encryption/tests/unified/QE-Text-compactStructuredEncryptionData.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-compactStructuredEncryptionData.json
@@ -3,15 +3,14 @@
   "schemaVersion": "1.25",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.2.0",
-      "maxServerVersion": "8.99.99",
+      "minServerVersion": "9.0.0",
       "topologies": [
         "replicaset",
         "sharded",
         "load-balanced"
       ],
       "csfle": {
-        "minLibmongocryptVersion": "1.15.0"
+        "minLibmongocryptVersion": "1.19.0"
       }
     }
   ],
@@ -102,7 +101,7 @@
               "bsonType": "string",
               "queries": [
                 {
-                  "queryType": "suffixPreview",
+                  "queryType": "suffix",
                   "contention": {
                     "$numberLong": "0"
                   },
@@ -210,7 +209,7 @@
                             "bsonType": "string",
                             "queries": [
                               {
-                                "queryType": "suffixPreview",
+                                "queryType": "suffix",
                                 "contention": {
                                   "$numberLong": "0"
                                 },

--- a/source/client-side-encryption/tests/unified/QE-Text-compactStructuredEncryptionData.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-compactStructuredEncryptionData.yml
@@ -1,11 +1,10 @@
 description: QE-Text-compactStructuredEncryptionData
 schemaVersion: "1.25"
 runOnRequirements:
-  - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
-    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
+  - minServerVersion: "9.0.0" # Server 9.0.0 adds stable support for QE text prefix and suffix queries.
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
-      minLibmongocryptVersion: 1.15.0 # For SPM-4158.
+      minLibmongocryptVersion: 1.19.0 # For MONGOCRYPT-870.
 createEntities:
   - client:
       id: &client "client"
@@ -61,7 +60,7 @@ initialData:
                 "bsonType": "string",
                 "queries": [
                     {
-                      "queryType": "suffixPreview",
+                      "queryType": "suffix",
                       "contention": { "$numberLong": "0" },
                       "strMinQueryLength": { "$numberLong": "3" },
                       "strMaxQueryLength": { "$numberLong": "30" },

--- a/source/client-side-encryption/tests/unified/QE-Text-prefix.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-prefix.json
@@ -1,17 +1,16 @@
 {
-  "description": "QE-Text-suffixPreview",
+  "description": "QE-Text-prefix",
   "schemaVersion": "1.25",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.2.0",
-      "maxServerVersion": "8.99.99",
+      "minServerVersion": "9.0.0",
       "topologies": [
         "replicaset",
         "sharded",
         "load-balanced"
       ],
       "csfle": {
-        "minLibmongocryptVersion": "1.15.0"
+        "minLibmongocryptVersion": "1.19.0"
       }
     }
   ],
@@ -102,7 +101,7 @@
               "bsonType": "string",
               "queries": [
                 {
-                  "queryType": "suffixPreview",
+                  "queryType": "prefix",
                   "contention": {
                     "$numberLong": "0"
                   },
@@ -124,7 +123,7 @@
   ],
   "tests": [
     {
-      "description": "Insert QE suffixPreview",
+      "description": "Insert QE prefix",
       "operations": [
         {
           "name": "insertOne",
@@ -224,9 +223,9 @@
           "arguments": {
             "filter": {
               "$expr": {
-                "$encStrEndsWith": {
+                "$encStrStartsWith": {
                   "input": "$encryptedText",
-                  "suffix": "bar"
+                  "prefix": "foo"
                 }
               }
             }
@@ -247,55 +246,55 @@
                 },
                 {
                   "$binary": {
-                    "base64": "uDCWsucUsJemUP7pmeb+Kd8B9qupVzI8wnLFqX1rkiU=",
+                    "base64": "fmUMXTMV/XRiN0IL3VXxSEn6SQG9E6Po30kJKB8JJlQ=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "W3E1x4bHZ8SEHFz4zwXM0G5Z5WSwBhnxE8x5/qdP6JM=",
+                    "base64": "vZIDMiFDgjmLNYVrrbnq1zT4hg7sGpe/PMtighSsnRc=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "6g/TXVDDf6z+ntResIvTKWdmIy4ajQ1rhwdNZIiEG7A=",
+                    "base64": "26Z5G+sHTzV3D7F8Y0m08389USZ2afinyFV3ez9UEBQ=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "hU+u/T3D6dHDpT3d/v5AlgtRoAufCXCAyO2jQlgsnCw=",
+                    "base64": "q/JEq8of7bE0QE5Id0XuOsNQ4qVpANYymcPQDUL2Ywk=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "vrPnq0AtBIURNgNGA6HJL+5/p5SBWe+qz8505TRo/dE=",
+                    "base64": "Uvvv46LkfbgLoPqZ6xTBzpgoYRTM6FUgRdqZ9eaVojI=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "W5pylBxdv2soY2NcBfPiHDVLTS6tx+0ULkI8gysBeFY=",
+                    "base64": "nMxdq2lladuBJA3lv3JC2MumIUtRJBNJVLp3PVE6nQk=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "oWO3xX3x0bYUJGK2S1aPAmlU3Xtfsgb9lTZ6flGAlsg=",
+                    "base64": "hS3V0qq5CF/SkTl3ZWWWgXcAJ8G5yGtkY2RwcHNc5Oc=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "SjZGucTEUbdpd86O8yj1pyMyBOOKxvAQ9C8ngZ9C5UE=",
+                    "base64": "McgwYUxfKj5+4D0vskZymy4KA82s71MR25iV/Enutww=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "CEaMZkxVDVbnXr+To0DOyvsva04UQkIYP3KtgYVVwf8=",
+                    "base64": "Ciqdk1b+t+Vrr6oIlFFk0Zdym5BPmwN3glQ0/VcsVdM=",
                     "subType": "00"
                   }
                 }
@@ -306,7 +305,7 @@
       ]
     },
     {
-      "description": "Query with non-matching $encStrEndsWith",
+      "description": "Query with non-matching $encStrStartsWith",
       "operations": [
         {
           "name": "insertOne",
@@ -323,9 +322,9 @@
           "arguments": {
             "filter": {
               "$expr": {
-                "$encStrEndsWith": {
+                "$encStrStartsWith": {
                   "input": "$encryptedText",
-                  "suffix": "foo"
+                  "prefix": "bar"
                 }
               }
             }

--- a/source/client-side-encryption/tests/unified/QE-Text-prefix.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-prefix.yml
@@ -1,11 +1,10 @@
-description: QE-Text-prefixPreview
+description: QE-Text-prefix
 schemaVersion: "1.25"
 runOnRequirements:
-  - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
-    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
+  - minServerVersion: "9.0.0" # Server 9.0.0 adds stable support for QE text prefix and suffix queries.
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
-      minLibmongocryptVersion: 1.15.0 # For SPM-4158.
+      minLibmongocryptVersion: 1.19.0 # For MONGOCRYPT-870.
 createEntities:
   - client:
       id: &client "client"
@@ -62,7 +61,7 @@ initialData:
                 "queries": [
                     # Use zero contention for deterministic __safeContent__:
                     {
-                      "queryType": "prefixPreview",
+                      "queryType": "prefix",
                       "contention": { "$numberLong": "0" },
                       "strMinQueryLength": { "$numberLong": "3" },
                       "strMaxQueryLength": { "$numberLong": "30" },
@@ -74,7 +73,7 @@ initialData:
             ],
         }
 tests:
-  - description: "Insert QE prefixPreview"
+  - description: "Insert QE prefix"
     operations:
       - name: insertOne
         arguments:

--- a/source/client-side-encryption/tests/unified/QE-Text-suffix.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-suffix.json
@@ -1,17 +1,16 @@
 {
-  "description": "QE-Text-prefixPreview",
+  "description": "QE-Text-suffix",
   "schemaVersion": "1.25",
   "runOnRequirements": [
     {
-      "minServerVersion": "8.2.0",
-      "maxServerVersion": "8.99.99",
+      "minServerVersion": "9.0.0",
       "topologies": [
         "replicaset",
         "sharded",
         "load-balanced"
       ],
       "csfle": {
-        "minLibmongocryptVersion": "1.15.0"
+        "minLibmongocryptVersion": "1.19.0"
       }
     }
   ],
@@ -102,7 +101,7 @@
               "bsonType": "string",
               "queries": [
                 {
-                  "queryType": "prefixPreview",
+                  "queryType": "suffix",
                   "contention": {
                     "$numberLong": "0"
                   },
@@ -124,7 +123,7 @@
   ],
   "tests": [
     {
-      "description": "Insert QE prefixPreview",
+      "description": "Insert QE suffix",
       "operations": [
         {
           "name": "insertOne",
@@ -207,7 +206,7 @@
       ]
     },
     {
-      "description": "Query with matching $encStrStartsWith",
+      "description": "Query with matching $encStrEndsWith",
       "operations": [
         {
           "name": "insertOne",
@@ -224,9 +223,9 @@
           "arguments": {
             "filter": {
               "$expr": {
-                "$encStrStartsWith": {
+                "$encStrEndsWith": {
                   "input": "$encryptedText",
-                  "prefix": "foo"
+                  "suffix": "bar"
                 }
               }
             }
@@ -247,55 +246,55 @@
                 },
                 {
                   "$binary": {
-                    "base64": "fmUMXTMV/XRiN0IL3VXxSEn6SQG9E6Po30kJKB8JJlQ=",
+                    "base64": "uDCWsucUsJemUP7pmeb+Kd8B9qupVzI8wnLFqX1rkiU=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "vZIDMiFDgjmLNYVrrbnq1zT4hg7sGpe/PMtighSsnRc=",
+                    "base64": "W3E1x4bHZ8SEHFz4zwXM0G5Z5WSwBhnxE8x5/qdP6JM=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "26Z5G+sHTzV3D7F8Y0m08389USZ2afinyFV3ez9UEBQ=",
+                    "base64": "6g/TXVDDf6z+ntResIvTKWdmIy4ajQ1rhwdNZIiEG7A=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "q/JEq8of7bE0QE5Id0XuOsNQ4qVpANYymcPQDUL2Ywk=",
+                    "base64": "hU+u/T3D6dHDpT3d/v5AlgtRoAufCXCAyO2jQlgsnCw=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "Uvvv46LkfbgLoPqZ6xTBzpgoYRTM6FUgRdqZ9eaVojI=",
+                    "base64": "vrPnq0AtBIURNgNGA6HJL+5/p5SBWe+qz8505TRo/dE=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "nMxdq2lladuBJA3lv3JC2MumIUtRJBNJVLp3PVE6nQk=",
+                    "base64": "W5pylBxdv2soY2NcBfPiHDVLTS6tx+0ULkI8gysBeFY=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "hS3V0qq5CF/SkTl3ZWWWgXcAJ8G5yGtkY2RwcHNc5Oc=",
+                    "base64": "oWO3xX3x0bYUJGK2S1aPAmlU3Xtfsgb9lTZ6flGAlsg=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "McgwYUxfKj5+4D0vskZymy4KA82s71MR25iV/Enutww=",
+                    "base64": "SjZGucTEUbdpd86O8yj1pyMyBOOKxvAQ9C8ngZ9C5UE=",
                     "subType": "00"
                   }
                 },
                 {
                   "$binary": {
-                    "base64": "Ciqdk1b+t+Vrr6oIlFFk0Zdym5BPmwN3glQ0/VcsVdM=",
+                    "base64": "CEaMZkxVDVbnXr+To0DOyvsva04UQkIYP3KtgYVVwf8=",
                     "subType": "00"
                   }
                 }
@@ -306,7 +305,7 @@
       ]
     },
     {
-      "description": "Query with non-matching $encStrStartsWith",
+      "description": "Query with non-matching $encStrEndsWith",
       "operations": [
         {
           "name": "insertOne",
@@ -323,9 +322,9 @@
           "arguments": {
             "filter": {
               "$expr": {
-                "$encStrStartsWith": {
+                "$encStrEndsWith": {
                   "input": "$encryptedText",
-                  "prefix": "bar"
+                  "suffix": "foo"
                 }
               }
             }

--- a/source/client-side-encryption/tests/unified/QE-Text-suffix.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-suffix.yml
@@ -1,11 +1,10 @@
-description: QE-Text-suffixPreview
+description: QE-Text-suffix
 schemaVersion: "1.25"
 runOnRequirements:
-  - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
-    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
+  - minServerVersion: "9.0.0" # Server 9.0.0 adds stable support for QE text prefix and suffix queries.
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
-      minLibmongocryptVersion: 1.15.0 # For SPM-4158.
+      minLibmongocryptVersion: 1.19.0 # For MONGOCRYPT-870.
 createEntities:
   - client:
       id: &client "client"
@@ -62,7 +61,7 @@ initialData:
                 "queries": [
                     # Use zero contention for deterministic __safeContent__:
                     {
-                      "queryType": "suffixPreview",
+                      "queryType": "suffix",
                       "contention": { "$numberLong": "0" },
                       "strMinQueryLength": { "$numberLong": "3" },
                       "strMaxQueryLength": { "$numberLong": "30" },
@@ -74,7 +73,7 @@ initialData:
             ],
         }
 tests:
-  - description: "Insert QE suffixPreview"
+  - description: "Insert QE suffix"
     operations:
       - name: insertOne
         arguments:
@@ -110,7 +109,7 @@ tests:
                   - { "_id": 1, "encryptedText": { $$type: "binData" } } # Sends encrypted payload
                 ordered: true
               commandName: insert
-  - description: "Query with matching $encStrStartsWith"
+  - description: "Query with matching $encStrEndsWith"
     operations:
       - name: insertOne
         arguments:


### PR DESCRIPTION
# Summary

Add stable support for the prefix and suffix in Queryable Encryption:
- `queryType=prefixPreview` is replaced with `queryType=prefix`.
- `queryType=suffixPreview` is replaced with `queryType=suffix`.
- `algorithm=TextPreview` is replaced with `algorithm=String`.
- `TextOpts` is replaced with `StringOpts`.

# Background & Motivation

"substringPreview" is still unstable pending [WRITING-37758](https://jira.mongodb.org/browse/WRITING-37758).

Renaming "text" to "string" was a product request in DRIVERS-3531.

The spec uses a leading uppercase for `algorithm` values (`Indexed`, `Range`, etc.). though the `queryType` values have a leading lowercase (`equality`, `range`). libmongocrypt accepts a case-insensitive value, but I kept the specified casing consistent with the current spec.

Tests require the not-yet-released libmongocrypt 1.19.0. I want to wait to release until making "substringPreview" GA is decided. To test now, the C driver builds libmongocrypt from commit https://github.com/mongodb/libmongocrypt/commit/0ea5b7449ac2c7e774827a04495f96af14586117. Other drivers can get pre-release binaries from [build-and-test-and-upload](https://spruce.corp.mongodb.com/version/libmongocrypt_0ea5b7449ac2c7e774827a04495f96af14586117/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&taskName=-upload) tasks on Evergreen.

---

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- [x] Update changelog.
- [x] Test changes in at least one language driver. (Tested in https://github.com/mongodb/mongo-c-driver/pull/2310)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
