### PR TITLE
DRIVERS-3377: Update deep_bson benchmark data size

### DIFF
--- a/source/benchmarking/benchmarking.md
+++ b/source/benchmarking/benchmarking.md
@@ -200,8 +200,8 @@ subdocuments, strings, integers, doubles and booleans.
 
 Dataset: The dataset, designated DEEP_BSON (disk file `deep_bson.json`), will be synthetically generated and consist of
 an extended JSON document representing a balanced binary tree of depth 6, with "left" and "right" keys at each level
-containing a sub-document until the final level, where each leaf contains two string fields, "leftValue" and "rightValue",
-each holding a random 8-character ASCII string (126 total key/value pairs).
+containing a sub-document until the final level, where each leaf contains two string fields, "leftValue" and
+"rightValue", each holding a random 8-character ASCII string (126 total key/value pairs).
 
 Dataset size: For score purposes, the dataset size for a task is the size of the single-document source file (2284
 bytes) times 10,000 operations, which equals 22,840,000 bytes or 22.84 MB.
@@ -221,8 +221,8 @@ subdocuments, strings, integers, doubles and booleans.
 
 Dataset: The dataset, designated DEEP_BSON, will be synthetically generated and consist of an extended JSON document
 representing a balanced binary tree of depth 6, with "left" and "right" keys at each level containing a sub-document
-until the final level, where each leaf contains two string fields, "leftValue" and "rightValue",
-each holding a random 8-character ASCII string (126 total key/value pairs).
+until the final level, where each leaf contains two string fields, "leftValue" and "rightValue", each holding a random
+8-character ASCII string (126 total key/value pairs).
 
 Dataset size: For score purposes, the dataset size for a task is the size of the single-document source file (2284
 bytes) times 10,000 operations, which equals 22,840,000 bytes or 22.84 MB.

--- a/source/benchmarking/benchmarking.md
+++ b/source/benchmarking/benchmarking.md
@@ -200,11 +200,11 @@ subdocuments, strings, integers, doubles and booleans.
 
 Dataset: The dataset, designated DEEP_BSON (disk file `deep_bson.json`), will be synthetically generated and consist of
 an extended JSON document representing a balanced binary tree of depth 6, with "left" and "right" keys at each level
-containing a sub-document until the final level, which will contain a random ASCII string of length 8 (126 total
-key/value pairs).
+containing a sub-document until the final level, where each leaf contains two string fields, "leftValue" and "rightValue",
+each holding a random 8-character ASCII string (126 total key/value pairs).
 
-Dataset size: For score purposes, the dataset size for a task is the size of the single-document source file (1964
-bytes) times 10,000 operations, which equals 19,640,000 bytes or 19.64 MB.
+Dataset size: For score purposes, the dataset size for a task is the size of the single-document source file (2284
+bytes) times 10,000 operations, which equals 22,840,000 bytes or 22.84 MB.
 
 | Phase       | Description                                                                                                                                                                                 |
 | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -221,10 +221,11 @@ subdocuments, strings, integers, doubles and booleans.
 
 Dataset: The dataset, designated DEEP_BSON, will be synthetically generated and consist of an extended JSON document
 representing a balanced binary tree of depth 6, with "left" and "right" keys at each level containing a sub-document
-until the final level, which will contain a random ASCII string of length 8 (126 total key/value pairs).
+until the final level, where each leaf contains two string fields, "leftValue" and "rightValue",
+each holding a random 8-character ASCII string (126 total key/value pairs).
 
-Dataset size: For score purposes, the dataset size for a task is the size of the single-document source file (1964
-bytes) times 10,000 operations, which equals 19,640,000 bytes or 19.64 MB.
+Dataset size: For score purposes, the dataset size for a task is the size of the single-document source file (2284
+bytes) times 10,000 operations, which equals 22,840,000 bytes or 22.84 MB.
 
 | Phase       | Description                                                                                                                                                                                                                   |
 | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -731,6 +732,8 @@ TBD: spec system to hold scores over time
 TBD: generated datasets should be park in S3 or somewhere for retrieval by URL
 
 ## Changelog
+
+- 2026-06-02: Correct DEEP_BSON dataset size to 2284 bytes (22,840,000 bytes / 22.84 MB)
 
 - 2026-01-21: Update `deep_bson.json` for compatibility with strong typed benchmarks.
 


### PR DESCRIPTION
# Summary


Updating the the DEEP_BSON dataset size to 22,840,000 bytes.

---

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

- [x] Update changelog.
- [x] Test changes in at least one language driver.

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
