### PR TITLE
DRIVERS-3542 Clarify that partial cursor results must be preserved in BulkWriteException on getMore error

### DIFF
--- a/source/crud/bulk-write.md
+++ b/source/crud/bulk-write.md
@@ -831,6 +831,10 @@ When a top-level error is encountered and individual results and/or errors have 
 embed the top-level error within a `BulkWriteException` as the `error` field to retain this information. Otherwise,
 drivers MAY throw an exception containing only the top-level error.
 
+When a top-level error occurs during `getMore` iteration of the results cursor, any individual results already retrieved
+from the cursor prior to the error MUST be preserved and included in the `partialResult` field of the
+`BulkWriteException`. Drivers MUST NOT discard these partial cursor results.
+
 Encountering a top-level error MUST halt execution of a bulk write for both ordered and unordered bulk writes. This
 means that drivers MUST NOT attempt to retrieve more responses from the cursor or execute any further `bulkWrite`
 batches and MUST immediately throw an exception. If the results cursor has not been exhausted on the server when a


### PR DESCRIPTION
Clarifies the "Top-Level Errors" section of the client bulk write spec to explicitly state that individual results already retrieved from the results cursor before a `getMore` error must be preserved in `BulkWriteException.partialResult`.

The previous wording — "individual results and/or errors have already been observed" — was ambiguous: it could be read as covering only results from previously completed batches, not documents already read from the current (partially iterated) cursor. This ambiguity led to a bug in the Java driver where those partial cursor results were discarded.

This clarification aligns the spec with the existing behavior of the Go and C/C++ drivers, which already preserve partial cursor results correctly.

Jira: https://jira.mongodb.org/browse/DRIVERS-3542