### PR TITLE
DRIVERS-3470 fix typo in test name

### DIFF
--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -4210,7 +4210,7 @@ class EncryptOpts {
 Expect an error from libmongocrypt with a message containing the string: "contention factor is required for string
 algorithm".
 
-#### Case 8: can find an auto-encrypted case indexed document by prefix and suffix
+#### Case 8: can find an auto-encrypted case-insensitively indexed document by prefix and suffix
 
 This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). This test case requires
 MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.


### PR DESCRIPTION
Minor follow-up to https://github.com/mongodb/specifications/issues/1931 to fix a typo "case indexed" to "case-insensitively indexed".

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

- ~~[ ] Update changelog.~~
- ~~[ ] Test changes in at least one language driver.~~
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).~~

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
