### PR TITLE
DRIVERS-3274 Require readConcern.level is not sent for writes in causally-consistent sessions.

### DIFF
--- a/source/transactions/tests/unified/commit.json
+++ b/source/transactions/tests/unified/commit.json
@@ -209,6 +209,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {
@@ -870,6 +873,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {
@@ -1042,6 +1048,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {
@@ -1200,6 +1209,9 @@
                   "readConcern": {
                     "afterClusterTime": {
                       "$$exists": true
+                    },
+                    "level": {
+                      "$$exists": false
                     }
                   },
                   "lsid": {

--- a/source/transactions/tests/unified/commit.yml
+++ b/source/transactions/tests/unified/commit.yml
@@ -136,6 +136,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session0 }
                 txnNumber: { $numberLong: '2' }
                 startTransaction: true
@@ -522,6 +523,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session0 }
                 # txnNumber 2 was skipped
                 txnNumber: { $numberLong: '3' }
@@ -617,6 +619,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session1 }
                 txnNumber: { $$exists: false }
                 startTransaction: { $$exists: false }
@@ -701,6 +704,7 @@ tests:
                 ordered: true
                 readConcern:
                   afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
                 lsid: { $$sessionLsid: *session1 }
                 txnNumber: { $$exists: false }
                 startTransaction: { $$exists: false }


### PR DESCRIPTION
<!-- Thanks for contributing! -->

[DRIVERS-3274](https://jira.mongodb.org/browse/DRIVERS-3274)

https://github.com/mongodb/specifications/pull/1930 updated Transaction tests in [commit.yml](https://github.com/mongodb/specifications/blob/05ca6b36b95b0b331a18ad1fdb0460eeb394270a/source/transactions/tests/unified/commit.yml) to require that non-transaction write operations in causally-consistent session send `readConcern.afterClusterTime`. This PR requires that the same write operations _do not_ send `readConcern.level`, which is invalid for write commands.

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

- [x] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
