### PR TITLE
DRIVERS-3535 - Client Backpressure with baseBackoffMS

### DIFF
--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -134,9 +134,11 @@ rules:
     1. `jitter` is a random jitter value between 0 and 1.
     2. `MAX_BACKOFF` is 10000ms.
     3. `BASE_BACKOFF` is constant 100ms.
-    4. This results in delays of 100ms and 200ms before accounting for jitter.
-    5. If `retryAfterMS` is present on the error and has a positive value, the client MUST use that value instead of
-        `BASE_BACKOFF`.
+    4. `attempt` is the retry number. The first retry is `attempt = 1`, the second is `attempt = 2`, and so on.
+    5. This results in delays of 100ms and 200ms before accounting for jitter.
+    6. If `retryAfterMS` is present on the error and has a positive value, the client MUST use that value instead of
+        `BASE_BACKOFF`. `retryAfterMS` represents a server-supplied base backoff to use in place of the driver's
+        default.
 4. If the request is eligible for retry (as outlined in step 2 above) and `enableOverloadRetargeting` is enabled, the
     client MUST add the previously used server's address to the list of deprioritized server addresses for
     [server selection](../server-selection/server-selection.md). Drivers MUST expose `enableOverloadRetargeting` as a

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -446,6 +446,8 @@ to understand and configure.
 
 ## Changelog
 
+- 2026-06-16: Add support for retryAfterMS backoff calculation.
+
 - 2026-04-14: Clarify correct retry behavior when a mix of overload and non-overload errors are encountered.
 
 - 2026-03-30: Introduce phase 1 support without token buckets.

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -218,14 +218,11 @@ def execute_command_retryable(command, ...):
 
             if is_overload:
                 jitter = random.random() # Random float between [0.0, 1.0).
-                # If present on the error, retryAfterMS sets the base backoff
-                retry_after_ms = exc.retry_after_ms
-                if retry_after_ms:
-                    retry_after = retry_after / 1000 # Convert from milliseconds to seconds
-                    backoff = jitter * min(MAX_BACKOFF, retry_after * 2 ** (attempt - 1))
-                # Otherwise fall back to BASE_BACKOFF
-                else:
-                    backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2 ** (attempt - 1))
+                retry_after = BASE_BACKOFF
+                # If present on the error, retryAfterMS overrides the base backoff
+                if exc.retry_after_ms:
+                    retry_after = exc.retry_after_ms / 1000 # Convert from milliseconds to seconds
+                backoff = jitter * min(MAX_BACKOFF, retry_after * 2 ** (attempt - 1))
                 # If the delay exceeds the deadline, bail early.
                 if _csot.get_timeout():
                     if time.monotonic() + backoff > _csot.get_deadline():

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -217,13 +217,12 @@ def execute_command_retryable(command, ...):
                 deprioritized_servers.append(server.address)
 
             if is_overload:
-                # If present on the error, retryAfterMS sets the backoff
+                # If present on the error, retryAfterMS sets the base backoff
                 retry_after_ms = exc.retry_after_ms
                 if retry_after_ms:
                     retry_after = retry_after / 1000 # Convert from milliseconds to seconds
-                    jitter = random.uniform(-0.5, 0.5) # Random float between [-0.5, 0.5].
-                    backoff = (jitter * retry_after) + retry_after
-                # Otherwise fall back to exponential
+                    backoff = jitter * min(MAX_BACKOFF, retry_after * 2 ** (attempt - 1))
+                # Otherwise fall back to BASE_BACKOFF
                 else:
                     jitter = random.random() # Random float between [0.0, 1.0).
                     backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2 ** (attempt - 1))

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -217,6 +217,7 @@ def execute_command_retryable(command, ...):
                 deprioritized_servers.append(server.address)
 
             if is_overload:
+                jitter = random.random() # Random float between [0.0, 1.0).
                 # If present on the error, retryAfterMS sets the base backoff
                 retry_after_ms = exc.retry_after_ms
                 if retry_after_ms:
@@ -224,7 +225,6 @@ def execute_command_retryable(command, ...):
                     backoff = jitter * min(MAX_BACKOFF, retry_after * 2 ** (attempt - 1))
                 # Otherwise fall back to BASE_BACKOFF
                 else:
-                    jitter = random.random() # Random float between [0.0, 1.0).
                     backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2 ** (attempt - 1))
                 # If the delay exceeds the deadline, bail early.
                 if _csot.get_timeout():

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -132,7 +132,7 @@ rules:
 3. If the request is eligible for retry (as outlined in step 2 above), the client MUST apply backoff according to the
     following rules:
     1. If `retryAfterMS` is present on the error and has a positive value, apply backoff according to the following
-        formula: `backoff = retryAfterMS.value + (jitter * retryAfterMS)`
+        formula: `backoff = retryAfterMS.value + (jitter * retryAfterMS.value)`
         - `jitter` is a random jitter value between -0.5 and 0.5.
         - `retryAfterMS.value` is the value of the error's `retryAfterMS` field.
     2. Otherwise, apply exponential backoff according to the following formula:

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -130,12 +130,12 @@ rules:
             [retryReads](../retryable-reads/retryable-reads.md#retryreads) MUST be enabled. See
             [Why must both `retryWrites` and `retryReads` be enabled to retry runCommand?](client-backpressure.md#why-must-both-retrywrites-and-retryreads-be-enabled-to-retry-runcommand)
 3. If the request is eligible for retry (as outlined in step 2 above), the client MUST apply backoff according to the
-    following formula: `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^(attempt - 1))`
-    1. `jitter` is a random jitter value between 0 and 1.
+    following formula: `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^attempt)`
+    1. `jitter` is a random jitter value between 0 and 1. This averages out to `0.5`.
     2. `MAX_BACKOFF` is 10000ms.
     3. `BASE_BACKOFF` is constant 100ms.
     4. `attempt` is the retry number. The first retry is `attempt = 1`, the second is `attempt = 2`, and so on.
-    5. This results in delays of 100ms and 200ms before accounting for jitter.
+    5. This results in delays of 100ms and 200ms after accounting for the average jitter.
     6. If `baseBackoffMS` is present on the error and has a positive value, the client MUST use that value instead of
         `BASE_BACKOFF`. `baseBackoffMS` represents a server-supplied base backoff to use in place of the driver's
         default.

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -131,16 +131,13 @@ rules:
             [Why must both `retryWrites` and `retryReads` be enabled to retry runCommand?](client-backpressure.md#why-must-both-retrywrites-and-retryreads-be-enabled-to-retry-runcommand)
 3. If the request is eligible for retry (as outlined in step 2 above), the client MUST apply backoff according to the
     following rules:
-    1. If `retryAfterMS` is present on the error and has a positive value, apply backoff according to the following
-        formula: `backoff = min(MAX_BACKOFF, retryAfterMS.value + (jitter * retryAfterMS.value))`
-        - `jitter` is a random jitter value between -0.5 and 0.5.
-        - `retryAfterMS.value` is the value of the error's `retryAfterMS` field.
-        - `MAX_BACKOFF` is 10000ms.
-    2. Otherwise, apply exponential backoff according to the following formula:
-        `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^(attempt - 1))`
+    1. If `retryAfterMS` is present on the error and has a positive value, use the following formula:
+        `backoff = jitter * min(MAX_BACKOFF, retryAfterMS.value * 2^(attempt - 1))`
         - `jitter` is a random jitter value between 0 and 1.
         - `BASE_BACKOFF` is constant 100ms.
         - `MAX_BACKOFF` is 10000ms.
+        - `retryAfterMS.value` is the value of the error's `retryAfterMS` field.
+    2. Otherwise, use `BASE_BACKOFF` instead of `retryAfterMS.value` in the same formula.
         - This results in delays of 100ms and 200ms before accounting for jitter.
 4. If the request is eligible for retry (as outlined in step 2 above) and `enableOverloadRetargeting` is enabled, the
     client MUST add the previously used server's address to the list of deprioritized server addresses for

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -135,7 +135,7 @@ rules:
         formula: `backoff = retryAfterMS.value + (jitter * retryAfterMS)`
         - `jitter` is a random jitter value between -0.5 and 0.5.
         - `retryAfterMS.value` is the value of the error's `retryAfterMS` field.
-    2. If `retryAfterMS` is not present, apply exponential backoff according to the following formula:
+    2. Otherwise, apply exponential backoff according to the following formula:
         `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^(attempt - 1))`
         - `jitter` is a random jitter value between 0 and 1.
         - `BASE_BACKOFF` is constant 100ms.

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -132,9 +132,10 @@ rules:
 3. If the request is eligible for retry (as outlined in step 2 above), the client MUST apply backoff according to the
     following rules:
     1. If `retryAfterMS` is present on the error and has a positive value, apply backoff according to the following
-        formula: `backoff = retryAfterMS.value + (jitter * retryAfterMS.value)`
+        formula: `backoff = min(MAX_BACKOFF, retryAfterMS.value + (jitter * retryAfterMS.value))`
         - `jitter` is a random jitter value between -0.5 and 0.5.
         - `retryAfterMS.value` is the value of the error's `retryAfterMS` field.
+        - `MAX_BACKOFF` is 10000ms.
     2. Otherwise, apply exponential backoff according to the following formula:
         `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^(attempt - 1))`
         - `jitter` is a random jitter value between 0 and 1.

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -136,8 +136,8 @@ rules:
     3. `BASE_BACKOFF` is constant 100ms.
     4. `attempt` is the retry number. The first retry is `attempt = 1`, the second is `attempt = 2`, and so on.
     5. This results in delays of 100ms and 200ms before accounting for jitter.
-    6. If `retryAfterMS` is present on the error and has a positive value, the client MUST use that value instead of
-        `BASE_BACKOFF`. `retryAfterMS` represents a server-supplied base backoff to use in place of the driver's
+    6. If `baseBackoffMS` is present on the error and has a positive value, the client MUST use that value instead of
+        `BASE_BACKOFF`. `baseBackoffMS` represents a server-supplied base backoff to use in place of the driver's
         default.
 4. If the request is eligible for retry (as outlined in step 2 above) and `enableOverloadRetargeting` is enabled, the
     client MUST add the previously used server's address to the list of deprioritized server addresses for
@@ -218,11 +218,11 @@ def execute_command_retryable(command, ...):
 
             if is_overload:
                 jitter = random.random() # Random float between [0.0, 1.0).
-                retry_after = BASE_BACKOFF
-                # If present on the error, retryAfterMS overrides the base backoff
-                if exc.retry_after_ms:
-                    retry_after = exc.retry_after_ms / 1000 # Convert from milliseconds to seconds
-                backoff = jitter * min(MAX_BACKOFF, retry_after * 2 ** (attempt - 1))
+                base_backoff = BASE_BACKOFF
+                # If present on the error, baseBackoffMS overrides the base backoff
+                if exc.base_backoff_ms:
+                    base_backoff = exc.base_backoff_ms / 1000 # Convert from milliseconds to seconds
+                backoff = jitter * min(MAX_BACKOFF, base_backoff * 2 ** (attempt - 1))
                 # If the delay exceeds the deadline, bail early.
                 if _csot.get_timeout():
                     if time.monotonic() + backoff > _csot.get_deadline():
@@ -440,7 +440,7 @@ to understand and configure.
 
 ## Changelog
 
-- 2026-06-16: Add support for retryAfterMS backoff calculation.
+- 2026-06-16: Add support for baseBackoffMS backoff calculation.
 
 - 2026-04-14: Clarify correct retry behavior when a mix of overload and non-overload errors are encountered.
 

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -222,7 +222,7 @@ def execute_command_retryable(command, ...):
                 # If present on the error, retryAfterMS sets the backoff
                 retry_after_ms = exc.retry_after_ms
                 if retry_after_ms:
-                    retry_after /= 1000 # Convert from milliseconds to seconds
+                    retry_after = retry_after / 1000 # Convert from milliseconds to seconds
                     jitter = random.uniform(-0.5, 0.5) # Random float between [-0.5, 0.5].
                     backoff = (jitter * retry_after) + retry_after
                 # Otherwise fall back to exponential

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -222,7 +222,7 @@ def execute_command_retryable(command, ...):
                 # If present on the error, baseBackoffMS overrides the base backoff
                 if exc.base_backoff_ms:
                     base_backoff = exc.base_backoff_ms / 1000 # Convert from milliseconds to seconds
-                backoff = jitter * min(MAX_BACKOFF, base_backoff * 2 ** (attempt - 1))
+                backoff = jitter * min(MAX_BACKOFF, base_backoff * 2 ** attempt)
                 # If the delay exceeds the deadline, bail early.
                 if _csot.get_timeout():
                     if time.monotonic() + backoff > _csot.get_deadline():
@@ -439,6 +439,9 @@ another dimension to read preference selection that users need to reason about. 
 to understand and configure.
 
 ## Changelog
+
+- 2026-07-08: Update exponential backoff formula to use the attempt number as the exponent instead of one less than the
+    attempt number.
 
 - 2026-06-16: Add support for baseBackoffMS backoff calculation.
 

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -130,15 +130,10 @@ rules:
             [retryReads](../retryable-reads/retryable-reads.md#retryreads) MUST be enabled. See
             [Why must both `retryWrites` and `retryReads` be enabled to retry runCommand?](client-backpressure.md#why-must-both-retrywrites-and-retryreads-be-enabled-to-retry-runcommand)
 3. If the request is eligible for retry (as outlined in step 2 above), the client MUST apply backoff according to the
-    following rules:
-    1. If `retryAfterMS` is present on the error and has a positive value, use the following formula:
-        `backoff = jitter * min(MAX_BACKOFF, retryAfterMS.value * 2^(attempt - 1))`
-        - `jitter` is a random jitter value between 0 and 1.
-        - `BASE_BACKOFF` is constant 100ms.
-        - `MAX_BACKOFF` is 10000ms.
-        - `retryAfterMS.value` is the value of the error's `retryAfterMS` field.
-    2. Otherwise, use `BASE_BACKOFF` instead of `retryAfterMS.value` in the same formula.
-        - This results in delays of 100ms and 200ms before accounting for jitter.
+    following formula: `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^(attempt - 1))` - `jitter` is a random
+    jitter value between 0 and 1. - `MAX_BACKOFF` is 10000ms. - `BASE_BACKOFF` is constant 100ms. - This results in
+    delays of 100ms and 200ms before accounting for jitter.
+    1. If `retryAfterMS` is present on the error and has a positive value, use that value instead of `BASE_BACKOFF`.
 4. If the request is eligible for retry (as outlined in step 2 above) and `enableOverloadRetargeting` is enabled, the
     client MUST add the previously used server's address to the list of deprioritized server addresses for
     [server selection](../server-selection/server-selection.md). Drivers MUST expose `enableOverloadRetargeting` as a

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -130,10 +130,13 @@ rules:
             [retryReads](../retryable-reads/retryable-reads.md#retryreads) MUST be enabled. See
             [Why must both `retryWrites` and `retryReads` be enabled to retry runCommand?](client-backpressure.md#why-must-both-retrywrites-and-retryreads-be-enabled-to-retry-runcommand)
 3. If the request is eligible for retry (as outlined in step 2 above), the client MUST apply backoff according to the
-    following formula: `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^(attempt - 1))` - `jitter` is a random
-    jitter value between 0 and 1. - `MAX_BACKOFF` is 10000ms. - `BASE_BACKOFF` is constant 100ms. - This results in
-    delays of 100ms and 200ms before accounting for jitter.
-    1. If `retryAfterMS` is present on the error and has a positive value, use that value instead of `BASE_BACKOFF`.
+    following formula: `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^(attempt - 1))`
+    1. `jitter` is a random jitter value between 0 and 1.
+    2. `MAX_BACKOFF` is 10000ms.
+    3. `BASE_BACKOFF` is constant 100ms.
+    4. This results in delays of 100ms and 200ms before accounting for jitter.
+    5. If `retryAfterMS` is present on the error and has a positive value, the client MUST use that value instead of
+        `BASE_BACKOFF`.
 4. If the request is eligible for retry (as outlined in step 2 above) and `enableOverloadRetargeting` is enabled, the
     client MUST add the previously used server's address to the list of deprioritized server addresses for
     [server selection](../server-selection/server-selection.md). Drivers MUST expose `enableOverloadRetargeting` as a

--- a/source/client-backpressure/client-backpressure.md
+++ b/source/client-backpressure/client-backpressure.md
@@ -129,12 +129,18 @@ rules:
         - To retry `runCommand`, both [retryWrites](../retryable-writes/retryable-writes.md#retrywrites) and
             [retryReads](../retryable-reads/retryable-reads.md#retryreads) MUST be enabled. See
             [Why must both `retryWrites` and `retryReads` be enabled to retry runCommand?](client-backpressure.md#why-must-both-retrywrites-and-retryreads-be-enabled-to-retry-runcommand)
-3. If the request is eligible for retry (as outlined in step 2 above), the client MUST apply exponential backoff
-    according to the following formula: `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^(attempt - 1))`
-    - `jitter` is a random jitter value between 0 and 1.
-    - `BASE_BACKOFF` is constant 100ms.
-    - `MAX_BACKOFF` is 10000ms.
-    - This results in delays of 100ms and 200ms before accounting for jitter.
+3. If the request is eligible for retry (as outlined in step 2 above), the client MUST apply backoff according to the
+    following rules:
+    1. If `retryAfterMS` is present on the error and has a positive value, apply backoff according to the following
+        formula: `backoff = retryAfterMS.value + (jitter * retryAfterMS)`
+        - `jitter` is a random jitter value between -0.5 and 0.5.
+        - `retryAfterMS.value` is the value of the error's `retryAfterMS` field.
+    2. If `retryAfterMS` is not present, apply exponential backoff according to the following formula:
+        `backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2^(attempt - 1))`
+        - `jitter` is a random jitter value between 0 and 1.
+        - `BASE_BACKOFF` is constant 100ms.
+        - `MAX_BACKOFF` is 10000ms.
+        - This results in delays of 100ms and 200ms before accounting for jitter.
 4. If the request is eligible for retry (as outlined in step 2 above) and `enableOverloadRetargeting` is enabled, the
     client MUST add the previously used server's address to the list of deprioritized server addresses for
     [server selection](../server-selection/server-selection.md). Drivers MUST expose `enableOverloadRetargeting` as a
@@ -213,9 +219,16 @@ def execute_command_retryable(command, ...):
                 deprioritized_servers.append(server.address)
 
             if is_overload:
-                jitter = random.random() # Random float between [0.0, 1.0).
-                backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2 ** (attempt - 1))
-          
+                # If present on the error, retryAfterMS sets the backoff
+                retry_after_ms = exc.retry_after_ms
+                if retry_after_ms:
+                    retry_after /= 1000 # Convert from milliseconds to seconds
+                    jitter = random.uniform(-0.5, 0.5) # Random float between [-0.5, 0.5].
+                    backoff = (jitter * retry_after) + retry_after
+                # Otherwise fall back to exponential
+                else:
+                    jitter = random.random() # Random float between [0.0, 1.0).
+                    backoff = jitter * min(MAX_BACKOFF, BASE_BACKOFF * 2 ** (attempt - 1))
                 # If the delay exceeds the deadline, bail early.
                 if _csot.get_timeout():
                     if time.monotonic() + backoff > _csot.get_deadline():

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -157,28 +157,25 @@ option.
        const end = performance.now();
     ```
 
-6. Configure the random number generator used for exponential backoff jitter to always return a number as close as
-    possible to `1`.
-
-7. Run the following command to set up `retryAfterMS` on overload errors.
+6. Run the following command to set up `retryAfterMS` on overload errors.
 
     ```python
     client.admin.command("setParameter", 1, overloadRetryAfterMS=50)
     ```
 
-8. Execute step 5 again.
+7. Execute step 5 again.
 
-9. Run the following command to disable `retryAfterMS` on overload errors.
+8. Run the following command to disable `retryAfterMS` on overload errors.
 
     ```python
     client.admin.command("setParameter", 1, overloadRetryAfterMS=0)
     ```
 
-10. Compare the time between the two runs.
+9. Compare the time between the two runs.
 
     ```python
     assertTrue(absolute_value(exponential_backoff_time - (with_retry_after_ms_time + 0.2 seconds)) < 0.2 seconds)
     ```
 
-    The difference in the backoffs is 0.2 seconds. There is a 0.2-second window to account for potential variance
-    between the two runs.
+    The difference in the backoffs is 0.2 seconds. There is a 0.2-second window to account for potential variance between
+    the two runs.

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -123,7 +123,7 @@ option.
 #### Test 5: Overload Errors with baseBackoffMS override base backoff
 
 Drivers SHOULD test that overload errors with `baseBackoffMS` override the default backoff duration. This test MUST be
-executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command with the `errorLabels` option.
+executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command.
 
 1. Let `client` be a `MongoClient`.
 
@@ -140,8 +140,7 @@ executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint`
             mode: 'alwaysOn',
             data: {
                 failCommands: ['insert'],
-                errorCode: 462,
-                errorLabels: ['SystemOverloadedError', 'RetryableError']
+                errorCode: 462, // IngressRequestRateLimitExceeded
             }
         }
     ```
@@ -164,17 +163,21 @@ executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint`
 
 7. Execute step 5 again.
 
-8. Run the following command to disable `baseBackoffMS` on overload errors.
+8. Assert that the server attached `baseBackoffMS` to the error and that the driver parsed it.
+
+9. Run the following command to disable `baseBackoffMS` on overload errors.
 
     ```python
     client.admin.command("setParameter", 1, externalClientBaseBackoffMS=0)
     ```
 
-9. Compare the time between the two runs.
+10. Assert absolute bounds on each run's duration.
 
     ```python
-    assertTrue(absolute_value(exponential_backoff_time - (with_retry_after_ms_time + 0.5 seconds)) < 0.5 seconds)
+    assertGreaterEqual(exponential_backoff_time, 0.6)
+    assertGreaterEqual(with_base_backoff_ms_time, 0.3)
+    assertLess(with_base_backoff_ms_time, 0.6)
     ```
 
-    The difference in the backoffs is 0.5 seconds. There is a 0.5-second window to account for potential variance between
-    the two runs.
+    A run can never be faster than the sum of its backoffs. With jitter pinned to 1, the default backoffs are
+    `0.2 + 0.4 = 0.6s` and the `baseBackoffMS=50` backoffs are `0.1 + 0.2 = 0.3s`.

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -122,7 +122,7 @@ option.
 
 #### Test 5: Overload Errors with retryAfterMS override exponential backoff
 
-Drivers should test that overload errors with `retryAfterMS` override the default exponential backoff policy. This test
+Drivers SHOULD test that overload errors with `retryAfterMS` override the default exponential backoff policy. This test
 MUST be executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command with the `errorLabels`
 option.
 

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -119,3 +119,65 @@ option.
 5. Assert that the raised error contains both the `RetryableError` and `SystemOverloadedError` error labels.
 
 6. Assert that the total number of started commands is `maxAdaptiveRetries` + 1 (2).
+
+#### Test 5: Overload Errors with retryAfterMS override exponential backoff
+
+Drivers should test that overload errors with `retryAfterMS` override the default exponential backoff policy. This test
+MUST be executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command with the `errorLabels`
+option.
+
+1. Let `client` be a `MongoClient`.
+
+2. Let `coll` be a collection.
+
+3. Configure the random number generator used for exponential backoff jitter to always return a number as close as
+    possible to `1`.
+
+4. Configure the following failPoint:
+
+    ```javascript
+        {
+            configureFailPoint: 'failCommand',
+            mode: 'alwaysOn',
+            data: {
+                failCommands: ['insert'],
+                errorCode: 462,
+                errorLabels: ['SystemOverloadedError', 'RetryableError']
+            }
+        }
+    ```
+
+5. Insert the document `{ a: 1 }`. Expect that the command errors. Measure the duration of the command execution.
+
+    ```javascript
+       const start = performance.now();
+       expect(
+        await coll.insertOne({ a: 1 }).catch(e => e)
+       ).to.be.an.instanceof(MongoServerError);
+       const end = performance.now();
+    ```
+
+6. Configure the random number generator used for `retryAfterMS` jitter to always return `0`.
+
+7. Run the following command to set up `retryAfterMS` on overload errors.
+
+    ```python
+    client.admin.command("setParameter", 1, overloadRetryAfterMS=50)
+    ```
+
+8. Execute step 5 again.
+
+9. Run the following command to disable `retryAfterMS` on overload errors.
+
+    ```python
+    client.admin.command("setParameter", 1, overloadRetryAfterMS=0)
+    ```
+
+10. Compare the time between the two runs.
+
+    ```python
+    assertTrue(absolute_value(exponential_backoff_time - (with_retry_after_ms_time + 0.2 seconds)) < 0.2 seconds)
+    ```
+
+    The difference in the backoffs is 0.2 seconds. There is a 0.2-second window to account for potential variance
+    between the two runs.

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -120,11 +120,10 @@ option.
 
 6. Assert that the total number of started commands is `maxAdaptiveRetries` + 1 (2).
 
-#### Test 5: Overload Errors with retryAfterMS override exponential backoff
+#### Test 5: Overload Errors with retryAfterMS override base backoff
 
-Drivers SHOULD test that overload errors with `retryAfterMS` override the default exponential backoff policy. This test
-MUST be executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command with the `errorLabels`
-option.
+Drivers SHOULD test that overload errors with `retryAfterMS` override the default backoff duration. This test MUST be
+executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command with the `errorLabels` option.
 
 1. Let `client` be a `MongoClient`.
 

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -53,10 +53,10 @@ executed against a MongoDB 4.4+ server that has enabled the `configureFailPoint`
     6. Compare the time between the two runs.
 
         ```python
-        assertTrue(absolute_value(with_backoff_time - (no_backoff_time + 0.3 seconds)) < 0.3 seconds)
+        assertTrue(absolute_value(with_backoff_time - (no_backoff_time + 0.6 seconds)) < 0.6 seconds)
         ```
 
-        The sum of 2 backoffs is 0.3 seconds. There is a 0.3-second window to account for potential variance between the
+        The sum of 2 backoffs is 0.6 seconds. There is a 0.6-second window to account for potential variance between the
         two runs.
 
 #### Test 2: REMOVED
@@ -173,8 +173,8 @@ executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint`
 9. Compare the time between the two runs.
 
     ```python
-    assertTrue(absolute_value(exponential_backoff_time - (with_retry_after_ms_time + 0.2 seconds)) < 0.2 seconds)
+    assertTrue(absolute_value(exponential_backoff_time - (with_retry_after_ms_time + 0.5 seconds)) < 0.5 seconds)
     ```
 
-    The difference in the backoffs is 0.2 seconds. There is a 0.2-second window to account for potential variance between
+    The difference in the backoffs is 0.5 seconds. There is a 0.5-second window to account for potential variance between
     the two runs.

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -157,7 +157,8 @@ option.
        const end = performance.now();
     ```
 
-6. Configure the random number generator used for `retryAfterMS` jitter to always return `0`.
+6. Configure the random number generator used for exponential backoff jitter to always return a number as close as
+    possible to `1`.
 
 7. Run the following command to set up `retryAfterMS` on overload errors.
 

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -123,7 +123,7 @@ option.
 #### Test 5: Overload Errors with baseBackoffMS override base backoff
 
 Drivers SHOULD test that overload errors with `baseBackoffMS` override the default backoff duration. This test MUST be
-executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command.
+executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command with the `errorLabels` option.
 
 1. Let `client` be a `MongoClient`.
 
@@ -141,6 +141,7 @@ executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint`
             data: {
                 failCommands: ['insert'],
                 errorCode: 462, // IngressRequestRateLimitExceeded
+                errorLabels: ['SystemOverloadedError', 'RetryableError']
             }
         }
     ```

--- a/source/client-backpressure/tests/README.md
+++ b/source/client-backpressure/tests/README.md
@@ -120,9 +120,9 @@ option.
 
 6. Assert that the total number of started commands is `maxAdaptiveRetries` + 1 (2).
 
-#### Test 5: Overload Errors with retryAfterMS override base backoff
+#### Test 5: Overload Errors with baseBackoffMS override base backoff
 
-Drivers SHOULD test that overload errors with `retryAfterMS` override the default backoff duration. This test MUST be
+Drivers SHOULD test that overload errors with `baseBackoffMS` override the default backoff duration. This test MUST be
 executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint` command with the `errorLabels` option.
 
 1. Let `client` be a `MongoClient`.
@@ -156,18 +156,18 @@ executed against a MongoDB 9.0+ server that has enabled the `configureFailPoint`
        const end = performance.now();
     ```
 
-6. Run the following command to set up `retryAfterMS` on overload errors.
+6. Run the following command to set up `baseBackoffMS` on overload errors.
 
     ```python
-    client.admin.command("setParameter", 1, overloadRetryAfterMS=50)
+    client.admin.command("setParameter", 1, externalClientBaseBackoffMS=50)
     ```
 
 7. Execute step 5 again.
 
-8. Run the following command to disable `retryAfterMS` on overload errors.
+8. Run the following command to disable `baseBackoffMS` on overload errors.
 
     ```python
-    client.admin.command("setParameter", 1, overloadRetryAfterMS=0)
+    client.admin.command("setParameter", 1, externalClientBaseBackoffMS=0)
     ```
 
 9. Compare the time between the two runs.

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -55,6 +55,10 @@ Drivers MUST use the `OP_MSG` protocol for all handshakes if their minWireVersio
 MUST use legacy hello for the first message of the initial handshake, and include `helloOk:true` in the handshake
 request.
 
+Drivers MUST include `backpressure: "2"` in their handshake request in order to explicitly version their supported
+version of the client backpressure specification. The value of `backpressure` MUST be the string `"2"` and not a literal
+number `2`.
+
 If the legacy handshake response includes `helloOk: true`, then subsequent topology monitoring commands MUST use the
 `hello` command. If the legacy handshake response does not include `helloOk: true`, then subsequent topology monitoring
 commands MUST use the legacy hello command. Additionally, note that if the server does not understand `OP_MSG`, the
@@ -561,6 +565,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
+- 2026-06-25: Clarify the client backpressure component of the handshake.
 - 2026-06-11: Clarify that there is no new behavior as a result of only using OP_MSG for all handshakes.
 - 2026-06-05: Use OP_MSG for all handshakes.
 - 2025-09-04: Clarify that drivers do not append the same metadata multiple times.

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -85,7 +85,7 @@ if stable_api_configured or client_options.load_balanced:
     cmd = {"hello": 1}
 else:
     cmd = {"legacy hello": 1, "helloOk": 1}
-cmd["backpressure"] = True
+cmd["backpressure"] = "2"
 cmd["client"] = client_metadata
 if client_options.compressors:
     cmd["compression"] = client_options.compressors

--- a/source/mongodb-handshake/tests/README.md
+++ b/source/mongodb-handshake/tests/README.md
@@ -499,7 +499,7 @@ Before each test case, perform the setup.
 
 8. Assert that `initialClientMetadata` is identical to `updatedClientMetadata`.
 
-### Test 9: Handshake documents include `backpressure: true`
+### Test 9: Handshake documents include `backpressure: 2`
 
 These tests require a mechanism for observing handshake documents sent to the server.
 
@@ -511,4 +511,4 @@ These tests require a mechanism for observing handshake documents sent to the se
 
 3. Assert that for every handshake document intercepted:
 
-    1. The document has a field `backpressure` whose value is `true`.
+    1. The document has a field `backpressure` whose value is `"2"`.

--- a/source/mongodb-handshake/tests/README.md
+++ b/source/mongodb-handshake/tests/README.md
@@ -499,7 +499,7 @@ Before each test case, perform the setup.
 
 8. Assert that `initialClientMetadata` is identical to `updatedClientMetadata`.
 
-### Test 9: Handshake documents include `backpressure: 2`
+### Test 9: Handshake documents include `backpressure: "2"`
 
 These tests require a mechanism for observing handshake documents sent to the server.
 

--- a/source/transactions-convenient-api/tests/README.md
+++ b/source/transactions-convenient-api/tests/README.md
@@ -105,13 +105,14 @@ Drivers should test that retries within `withTransaction` do not occur immediate
         ```
 5. Compare the durations of the two runs.
     ```python
-    assertTrue(absolute_value(with_backoff_time - (no_backoff_time + 1.8 seconds)) < 0.5 seconds)
+    assertTrue(absolute_value(with_backoff_time - (no_backoff_time + 3.6 seconds)) < 0.5 seconds)
     ```
-    The sum of 13 backoffs is roughly 1.8 seconds. There is a half-second window to account for potential variance
+    The sum of 13 backoffs is roughly 3.6 seconds. There is a half-second window to account for potential variance
     between the two runs.
 
 ## Changelog
 
+- 2206-07-08: Update Backoff test to use updated exponential formula.
 - 2026-04-02: [DRIVERS-3436](https://github.com/mongodb/specifications/pull/1920) Refine withTransaction timeout error
     wrapping semantics and label propagation in spec and prose tests
 - 2026-03-03: Clarify exponential backoff jitter upper bound.

--- a/source/transactions-convenient-api/transactions-convenient-api.md
+++ b/source/transactions-convenient-api/transactions-convenient-api.md
@@ -123,7 +123,7 @@ This method should perform the following sequence of actions:
 
 2. If `transactionAttempt` > 0:
 
-    1. Calculate `backoffMS` to be `jitter * min(BACKOFF_INITIAL * 1.5 ** (transactionAttempt - 1), BACKOFF_MAX)`. If
+    1. Calculate `backoffMS` to be `jitter * min(BACKOFF_INITIAL * 1.5 ** (transactionAttempt), BACKOFF_MAX)`. If
         elapsed time + `backoffMS` > `TIMEOUT_MS`, then propagate the previously encountered error to the caller of
         `withTransaction` as per [timeout error propagation](#timeout-error-propagation) and return immediately.
         Otherwise, sleep for `backoffMS`.
@@ -218,7 +218,7 @@ withTransaction(callback, options) {
 
     retryTransaction: while (true) {
         if (transactionAttempt > 0) {
-            var backoff = Math.random() * min(BACKOFF_INITIAL * 1.5 ** (transactionAttempt - 1), 
+            var backoff = Math.random() * min(BACKOFF_INITIAL * 1.5 ** (transactionAttempt), 
                                               BACKOFF_MAX);
 
             if (Date.now() + backoff - startTime >= timeout) {
@@ -445,6 +445,9 @@ provides an implementation of a technique already described in the MongoDB 4.0 d
 ([DRIVERS-488](https://jira.mongodb.org/browse/DRIVERS-488)).
 
 ## Changelog
+
+- 2026-07-08: Update exponential backoff formula to use the attempt number as the exponent instead of one less than the
+    attempt number.
 
 - 2026-04-02: [DRIVERS-3436](https://github.com/mongodb/specifications/pull/1920) Refine withTransaction timeout error
     wrapping semantics and label propagation in spec and prose tests.


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [X] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

- [X] Update changelog.
- [x] Test changes in at least one language driver. [Python](https://github.com/mongodb/mongo-python-driver/pull/2877).
- [X] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
