### PR TITLE
DRIVERS-3321 Restore "prefixPreview" and "suffixPreview"

### DIFF
--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -1348,9 +1348,9 @@ insert or query. Drivers MUST document the following behavior:
 
 > To insert or query with an "Indexed", "Range", or "String" encrypted payload, use a `MongoClient` configured with
 > `AutoEncryptionOpts`. `AutoEncryptionOpts.bypassQueryAnalysis` may be true. `AutoEncryptionOpts.bypassAutoEncryption`
-> must be false. The "substringPreview" query type is in preview and should be used for experimental workloads only.
-> This feature is unstable and its security is not guaranteed until released as Generally Available (GA). The GA version
-> of this feature may not be backwards compatible with the preview version.
+> must be false. The "prefixPreview", "suffixPreview", and "substringPreview" query types are in preview and should be
+> used for experimental workloads only. This feature is unstable and its security is not guaranteed until released as
+> Generally Available (GA). The GA version of this feature may not be backwards compatible with the preview version.
 
 #### contentionFactor
 
@@ -1363,9 +1363,9 @@ One of the strings:
 
 - "equality"
 - "range"
-- "prefix"
+- "prefix" / "prefixPreview"
     - Used for the `$encStrStartsWith` operator.
-- "suffix"
+- "suffix" / "suffixPreview"
     - Used for the `$encStrEndsWith` operator.
 - "substringPreview"
     - Used for the `$encStrContains` operator.
@@ -2522,6 +2522,8 @@ on. To support concurrent access of the key vault collection, the key management
 explicit session parameter as described in the [Drivers Sessions Specification](../sessions/driver-sessions.md).
 
 ## Changelog
+
+- 2026-06-17: Restore `prefixPreview` and `suffixPreview` as experimental.
 
 - 2026-06-16: Update tests in response to server-side validation of payloads
     ([SERVER-91887](https://jira.mongodb.org/browse/SERVER-91887))

--- a/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix-preview.json
+++ b/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix-preview.json
@@ -1,0 +1,44 @@
+{
+    "fields": [
+        {
+            "keyId": {
+                "$binary": {
+                    "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                    "subType": "04"
+                }
+            },
+            "path": "encryptedText",
+            "bsonType": "string",
+            "queries": [
+                {
+                    "queryType": "prefixPreview",
+                    "strMinQueryLength": {
+                        "$numberInt": "2"
+                    },
+                    "strMaxQueryLength": {
+                        "$numberInt": "10"
+                    },
+                    "contention": {
+                        "$numberLong": "0"
+                    },
+                    "caseSensitive": true,
+                    "diacriticSensitive": true
+                },
+                {
+                    "queryType": "suffixPreview",
+                    "strMinQueryLength": {
+                        "$numberInt": "2"
+                    },
+                    "strMaxQueryLength": {
+                        "$numberInt": "10"
+                    },
+                    "contention": {
+                        "$numberLong": "0"
+                    },
+                    "caseSensitive": true,
+                    "diacriticSensitive": true
+                }
+            ]
+        }
+    ]
+}

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3878,6 +3878,9 @@ create the following collections with majority write concern:
 - `db.prefix-suffix-ci-di` using the `encryptedFields` option set to the contents of
     [encryptedFields-prefix-suffix-ci-di.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix-ci-di.json).
     This step requires server 9.0.0+.
+- `db.prefix-suffix-preview` using the `encryptedFields` option set to the contents of
+    [encryptedFields-prefix-suffix-preview.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-prefix-suffix-preview.json).
+    This step requires server pre-9.0.0.
 - `db.substring` using the `encryptedFields` option set to the contents of
     [encryptedFields-substring.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-substring.json)
 - `db.substring-ci-di` using the `encryptedFields` option set to the contents of
@@ -3947,7 +3950,8 @@ class EncryptOpts {
 }
 ```
 
-Use `explicitEncryptedClient` to insert the following document into `db.prefix-suffix` with majority write concern:
+Use `explicitEncryptedClient` to insert the following document into `db.prefix-suffix` (if created) and
+`db.prefix-suffix-preview` (if created) with majority write concern:
 
 ```javascript
 { "_id": 0, "encryptedText": <encrypted 'foobarbaz'> }
@@ -3980,7 +3984,12 @@ Use `explicitEncryptedClient` to insert the following document into `db.substrin
 
 #### Case 1: can find a document by prefix
 
-This test case requires MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
+Run this case multiple times with the following sets of parameters:
+
+- `queryType=prefix` and `collection=prefix-suffix`
+    - Require server 9.0.0+ and libmongocrypt 1.19.0+.
+- `queryType=prefixPreview` and `collection=prefix-suffix-preview`
+    - Require server pre-9.0.0 and libmongocrypt 1.19.1+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the following `EncryptOpts`:
 
@@ -3988,7 +3997,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the followin
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "prefix",
+   queryType: "<queryType>",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: true,
@@ -4001,7 +4010,7 @@ class EncryptOpts {
 }
 ```
 
-Use `explicitEncryptedClient` to run a "find" operation on the `db.prefix-suffix` collection with the following filter:
+Use `explicitEncryptedClient` to run a "find" operation on the `db.<collection>` collection with the following filter:
 
 ```javascript
 { $expr: { $encStrStartsWith: {input: '$encryptedText', prefix: <encrypted 'foo'>} } }
@@ -4015,7 +4024,12 @@ Assert the following document is returned:
 
 #### Case 2: can find a document by suffix
 
-This test case requires MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
+Run this case multiple times with the following sets of parameters:
+
+- `queryType=suffix` and `collection=prefix-suffix`
+    - Require server 9.0.0+ and libmongocrypt 1.19.0+.
+- `queryType=suffixPreview` and `collection=prefix-suffix-preview`
+    - Require server pre-9.0.0 and libmongocrypt 1.19.1+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"baz"` with the following `EncryptOpts`:
 
@@ -4023,7 +4037,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"baz"` with the followin
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "suffix",
+   queryType: "<queryType>",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: true,
@@ -4036,7 +4050,7 @@ class EncryptOpts {
 }
 ```
 
-Use `explicitEncryptedClient` to run a "find" operation on the `db.prefix-suffix` collection with the following filter:
+Use `explicitEncryptedClient` to run a "find" operation on the `db.<collection>` collection with the following filter:
 
 ```javascript
 { $expr: { $encStrEndsWith: {input: '$encryptedText', suffix: <encrypted 'baz'>} } }
@@ -4050,7 +4064,12 @@ Assert the following document is returned:
 
 #### Case 3: assert no document found by prefix
 
-This test case requires MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
+Run this case multiple times with the following sets of parameters:
+
+- `queryType=prefix` and `collection=prefix-suffix`
+    - Require server 9.0.0+ and libmongocrypt 1.19.0+.
+- `queryType=prefixPreview` and `collection=prefix-suffix-preview`
+    - Require server pre-9.0.0 and libmongocrypt 1.19.1+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"baz"` with the following `EncryptOpts`:
 
@@ -4058,7 +4077,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"baz"` with the followin
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "prefix",
+   queryType: "<queryType>",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: true,
@@ -4071,7 +4090,7 @@ class EncryptOpts {
 }
 ```
 
-Use `explicitEncryptedClient` to run a "find" operation on the `db.prefix-suffix` collection with the following filter:
+Use `explicitEncryptedClient` to run a "find" operation on the `db.<collection>` collection with the following filter:
 
 ```javascript
 { $expr: { $encStrStartsWith: {input: '$encryptedText', prefix: <encrypted 'baz'>} } }
@@ -4081,7 +4100,12 @@ Assert that no documents are returned.
 
 #### Case 4: assert no document found by suffix
 
-This test case requires MongoDB server 9.0.0+ and libmongocrypt 1.19.0+.
+Run this case multiple times with the following sets of parameters:
+
+- `queryType=suffix` and `collection=prefix-suffix`
+    - Require server 9.0.0+ and libmongocrypt 1.19.0+.
+- `queryType=suffixPreview` and `collection=prefix-suffix-preview`
+    - Require server pre-9.0.0 and libmongocrypt 1.19.1+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the following `EncryptOpts`:
 
@@ -4089,7 +4113,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"foo"` with the followin
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "suffix",
+   queryType: "<queryType>",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: true,
@@ -4102,7 +4126,7 @@ class EncryptOpts {
 }
 ```
 
-Use `explicitEncryptedClient` to run a "find" operation on the `db.prefix-suffix` collection with the following filter:
+Use `explicitEncryptedClient` to run a "find" operation on the `db.<collection>` collection with the following filter:
 
 ```javascript
 { $expr: { $encStrEndsWith: {input: '$encryptedText', suffix: <encrypted 'foo'>} } }

--- a/source/client-side-encryption/tests/unified/QE-Text-prefixPreview.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-prefixPreview.json
@@ -1,0 +1,339 @@
+{
+  "description": "QE-Text-prefixPreview",
+  "schemaVersion": "1.25",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ],
+      "csfle": {
+        "minLibmongocryptVersion": "1.19.1"
+      }
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "autoEncryptOpts": {
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "local": {
+              "key": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
+            }
+          }
+        },
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "db",
+        "client": "client",
+        "databaseName": "db"
+      }
+    },
+    {
+      "collection": {
+        "id": "coll",
+        "database": "db",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": [
+        {
+          "_id": {
+            "$binary": {
+              "base64": "q83vqxI0mHYSNBI0VniQEg==",
+              "subType": "04"
+            }
+          },
+          "keyMaterial": {
+            "$binary": {
+              "base64": "HBk9BWihXExNDvTp1lUxOuxuZK2Pe2ZdVdlsxPEBkiO1bS4mG5NNDsQ7zVxJAH8BtdOYp72Ku4Y3nwc0BUpIKsvAKX4eYXtlhv5zUQxWdeNFhg9qK7qb8nqhnnLeT0f25jFSqzWJoT379hfwDeu0bebJHr35QrJ8myZdPMTEDYF08QYQ48ShRBli0S+QzBHHAQiM2iJNr4svg2WR8JSeWQ==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1648914851981"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1648914851981"
+            }
+          },
+          "status": {
+            "$numberInt": "0"
+          },
+          "masterKey": {
+            "provider": "local"
+          }
+        }
+      ]
+    },
+    {
+      "databaseName": "db",
+      "collectionName": "coll",
+      "documents": [],
+      "createOptions": {
+        "encryptedFields": {
+          "fields": [
+            {
+              "keyId": {
+                "$binary": {
+                  "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                  "subType": "04"
+                }
+              },
+              "path": "encryptedText",
+              "bsonType": "string",
+              "queries": [
+                {
+                  "queryType": "prefixPreview",
+                  "contention": {
+                    "$numberLong": "0"
+                  },
+                  "strMinQueryLength": {
+                    "$numberLong": "3"
+                  },
+                  "strMaxQueryLength": {
+                    "$numberLong": "30"
+                  },
+                  "caseSensitive": true,
+                  "diacriticSensitive": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Insert QE prefixPreview",
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encryptedText": "foobar"
+            }
+          },
+          "object": "coll"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "filter": {
+                    "name": "coll"
+                  }
+                },
+                "commandName": "listCollections"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "$or": [
+                      {
+                        "_id": {
+                          "$in": [
+                            {
+                              "$binary": {
+                                "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                                "subType": "04"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "keyAltNames": {
+                          "$in": []
+                        }
+                      }
+                    ]
+                  },
+                  "$db": "keyvault",
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "encryptedText": {
+                        "$$type": "binData"
+                      }
+                    }
+                  ],
+                  "ordered": true
+                },
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Query with matching $encStrStartsWith",
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encryptedText": "foobar"
+            }
+          },
+          "object": "coll"
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "$expr": {
+                "$encStrStartsWith": {
+                  "input": "$encryptedText",
+                  "prefix": "foo"
+                }
+              }
+            }
+          },
+          "object": "coll",
+          "expectResult": [
+            {
+              "_id": {
+                "$numberInt": "1"
+              },
+              "encryptedText": "foobar",
+              "__safeContent__": [
+                {
+                  "$binary": {
+                    "base64": "wpaMBVDjL4bHf9EtSP52PJFzyNn1R19+iNI/hWtvzdk=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "fmUMXTMV/XRiN0IL3VXxSEn6SQG9E6Po30kJKB8JJlQ=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "vZIDMiFDgjmLNYVrrbnq1zT4hg7sGpe/PMtighSsnRc=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "26Z5G+sHTzV3D7F8Y0m08389USZ2afinyFV3ez9UEBQ=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "q/JEq8of7bE0QE5Id0XuOsNQ4qVpANYymcPQDUL2Ywk=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "Uvvv46LkfbgLoPqZ6xTBzpgoYRTM6FUgRdqZ9eaVojI=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "nMxdq2lladuBJA3lv3JC2MumIUtRJBNJVLp3PVE6nQk=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "hS3V0qq5CF/SkTl3ZWWWgXcAJ8G5yGtkY2RwcHNc5Oc=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "McgwYUxfKj5+4D0vskZymy4KA82s71MR25iV/Enutww=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "Ciqdk1b+t+Vrr6oIlFFk0Zdym5BPmwN3glQ0/VcsVdM=",
+                    "subType": "00"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Query with non-matching $encStrStartsWith",
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encryptedText": "foobar"
+            }
+          },
+          "object": "coll"
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "$expr": {
+                "$encStrStartsWith": {
+                  "input": "$encryptedText",
+                  "prefix": "bar"
+                }
+              }
+            }
+          },
+          "object": "coll",
+          "expectResult": []
+        }
+      ]
+    }
+  ]
+}

--- a/source/client-side-encryption/tests/unified/QE-Text-prefixPreview.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-prefixPreview.yml
@@ -1,0 +1,226 @@
+description: QE-Text-prefixPreview
+schemaVersion: "1.25"
+runOnRequirements:
+  - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
+    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
+    topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
+    csfle:
+      minLibmongocryptVersion: 1.19.1 # For MONGOCRYPT-937.
+createEntities:
+  - client:
+      id: &client "client"
+      autoEncryptOpts:
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          local:
+            key: Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &db "db"
+      client: *client
+      databaseName: *db
+  - collection:
+      id: &coll "coll"
+      database: *db
+      collectionName: *coll
+initialData:
+  # Insert data encryption key:
+  - databaseName: keyvault
+    collectionName: datakeys
+    documents:
+      [
+        {
+          "_id": &keyid { "$binary": { "base64": "q83vqxI0mHYSNBI0VniQEg==", "subType": "04" } },
+          "keyMaterial":
+            {
+              "$binary":
+                {
+                  "base64": "HBk9BWihXExNDvTp1lUxOuxuZK2Pe2ZdVdlsxPEBkiO1bS4mG5NNDsQ7zVxJAH8BtdOYp72Ku4Y3nwc0BUpIKsvAKX4eYXtlhv5zUQxWdeNFhg9qK7qb8nqhnnLeT0f25jFSqzWJoT379hfwDeu0bebJHr35QrJ8myZdPMTEDYF08QYQ48ShRBli0S+QzBHHAQiM2iJNr4svg2WR8JSeWQ==",
+                  "subType": "00",
+                },
+            },
+          "creationDate": { "$date": { "$numberLong": "1648914851981" } },
+          "updateDate": { "$date": { "$numberLong": "1648914851981" } },
+          "status": { "$numberInt": "0" },
+          "masterKey": { "provider": "local" },
+        },
+      ]
+  # Create encrypted collection:
+  - databaseName: *db
+    collectionName: *coll
+    documents: []
+    createOptions:
+      encryptedFields:
+        {
+          "fields":
+            [
+              {
+                "keyId": *keyid,
+                "path": "encryptedText",
+                "bsonType": "string",
+                "queries": [
+                    # Use zero contention for deterministic __safeContent__:
+                    {
+                      "queryType": "prefixPreview",
+                      "contention": { "$numberLong": "0" },
+                      "strMinQueryLength": { "$numberLong": "3" },
+                      "strMaxQueryLength": { "$numberLong": "30" },
+                      "caseSensitive": true,
+                      "diacriticSensitive": true,
+                    },
+                  ],
+              },
+            ],
+        }
+tests:
+  - description: "Insert QE prefixPreview"
+    operations:
+      - name: insertOne
+        arguments:
+          document: { _id: 1, encryptedText: "foobar" }
+        object: *coll
+    expectEvents:
+      - client: "client"
+        events:
+          - commandStartedEvent:
+              command:
+                listCollections: 1
+                filter:
+                  name: *coll
+              commandName: listCollections
+          - commandStartedEvent:
+              command:
+                find: datakeys
+                filter:
+                  {
+                    "$or":
+                      [
+                        "_id": { "$in": [ *keyid ] },
+                        "keyAltNames": { "$in": [] },
+                      ],
+                  }
+                $db: keyvault
+                readConcern: { level: "majority" }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                insert: *coll
+                documents:
+                  - { "_id": 1, "encryptedText": { $$type: "binData" } } # Sends encrypted payload
+                ordered: true
+              commandName: insert
+  - description: "Query with matching $encStrStartsWith"
+    operations:
+      - name: insertOne
+        arguments:
+          document: { _id: 1, encryptedText: "foobar" }
+        object: *coll
+      - name: find
+        arguments:
+          filter:
+            {
+              $expr:
+                {
+                  $encStrStartsWith: { input: "$encryptedText", prefix: "foo" },
+                },
+            }
+        object: *coll
+        expectResult:
+          [
+            {
+              "_id": { "$numberInt": "1" },
+              "encryptedText": "foobar",
+              "__safeContent__":
+                [
+                  {
+                    "$binary":
+                      {
+                        "base64": "wpaMBVDjL4bHf9EtSP52PJFzyNn1R19+iNI/hWtvzdk=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "fmUMXTMV/XRiN0IL3VXxSEn6SQG9E6Po30kJKB8JJlQ=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "vZIDMiFDgjmLNYVrrbnq1zT4hg7sGpe/PMtighSsnRc=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "26Z5G+sHTzV3D7F8Y0m08389USZ2afinyFV3ez9UEBQ=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "q/JEq8of7bE0QE5Id0XuOsNQ4qVpANYymcPQDUL2Ywk=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "Uvvv46LkfbgLoPqZ6xTBzpgoYRTM6FUgRdqZ9eaVojI=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "nMxdq2lladuBJA3lv3JC2MumIUtRJBNJVLp3PVE6nQk=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "hS3V0qq5CF/SkTl3ZWWWgXcAJ8G5yGtkY2RwcHNc5Oc=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "McgwYUxfKj5+4D0vskZymy4KA82s71MR25iV/Enutww=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "Ciqdk1b+t+Vrr6oIlFFk0Zdym5BPmwN3glQ0/VcsVdM=",
+                        "subType": "00",
+                      },
+                  },
+                ],
+            },
+          ]
+
+  - description: "Query with non-matching $encStrStartsWith"
+    operations:
+      - name: insertOne
+        arguments:
+          document: { _id: 1, encryptedText: "foobar" }
+        object: *coll
+      - name: find
+        arguments:
+          filter:
+            {
+              $expr:
+                {
+                  $encStrStartsWith: { input: "$encryptedText", prefix: "bar" },
+                },
+            }
+        object: *coll
+        expectResult: []

--- a/source/client-side-encryption/tests/unified/QE-Text-suffixPreview.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-suffixPreview.json
@@ -1,0 +1,339 @@
+{
+  "description": "QE-Text-suffixPreview",
+  "schemaVersion": "1.25",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ],
+      "csfle": {
+        "minLibmongocryptVersion": "1.19.1"
+      }
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "autoEncryptOpts": {
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "local": {
+              "key": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
+            }
+          }
+        },
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "db",
+        "client": "client",
+        "databaseName": "db"
+      }
+    },
+    {
+      "collection": {
+        "id": "coll",
+        "database": "db",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": [
+        {
+          "_id": {
+            "$binary": {
+              "base64": "q83vqxI0mHYSNBI0VniQEg==",
+              "subType": "04"
+            }
+          },
+          "keyMaterial": {
+            "$binary": {
+              "base64": "HBk9BWihXExNDvTp1lUxOuxuZK2Pe2ZdVdlsxPEBkiO1bS4mG5NNDsQ7zVxJAH8BtdOYp72Ku4Y3nwc0BUpIKsvAKX4eYXtlhv5zUQxWdeNFhg9qK7qb8nqhnnLeT0f25jFSqzWJoT379hfwDeu0bebJHr35QrJ8myZdPMTEDYF08QYQ48ShRBli0S+QzBHHAQiM2iJNr4svg2WR8JSeWQ==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1648914851981"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1648914851981"
+            }
+          },
+          "status": {
+            "$numberInt": "0"
+          },
+          "masterKey": {
+            "provider": "local"
+          }
+        }
+      ]
+    },
+    {
+      "databaseName": "db",
+      "collectionName": "coll",
+      "documents": [],
+      "createOptions": {
+        "encryptedFields": {
+          "fields": [
+            {
+              "keyId": {
+                "$binary": {
+                  "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                  "subType": "04"
+                }
+              },
+              "path": "encryptedText",
+              "bsonType": "string",
+              "queries": [
+                {
+                  "queryType": "suffixPreview",
+                  "contention": {
+                    "$numberLong": "0"
+                  },
+                  "strMinQueryLength": {
+                    "$numberLong": "3"
+                  },
+                  "strMaxQueryLength": {
+                    "$numberLong": "30"
+                  },
+                  "caseSensitive": true,
+                  "diacriticSensitive": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Insert QE suffixPreview",
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encryptedText": "foobar"
+            }
+          },
+          "object": "coll"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "filter": {
+                    "name": "coll"
+                  }
+                },
+                "commandName": "listCollections"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "$or": [
+                      {
+                        "_id": {
+                          "$in": [
+                            {
+                              "$binary": {
+                                "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                                "subType": "04"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "keyAltNames": {
+                          "$in": []
+                        }
+                      }
+                    ]
+                  },
+                  "$db": "keyvault",
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "encryptedText": {
+                        "$$type": "binData"
+                      }
+                    }
+                  ],
+                  "ordered": true
+                },
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Query with matching $encStrEndsWith",
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encryptedText": "foobar"
+            }
+          },
+          "object": "coll"
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "$expr": {
+                "$encStrEndsWith": {
+                  "input": "$encryptedText",
+                  "suffix": "bar"
+                }
+              }
+            }
+          },
+          "object": "coll",
+          "expectResult": [
+            {
+              "_id": {
+                "$numberInt": "1"
+              },
+              "encryptedText": "foobar",
+              "__safeContent__": [
+                {
+                  "$binary": {
+                    "base64": "wpaMBVDjL4bHf9EtSP52PJFzyNn1R19+iNI/hWtvzdk=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "uDCWsucUsJemUP7pmeb+Kd8B9qupVzI8wnLFqX1rkiU=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "W3E1x4bHZ8SEHFz4zwXM0G5Z5WSwBhnxE8x5/qdP6JM=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "6g/TXVDDf6z+ntResIvTKWdmIy4ajQ1rhwdNZIiEG7A=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "hU+u/T3D6dHDpT3d/v5AlgtRoAufCXCAyO2jQlgsnCw=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "vrPnq0AtBIURNgNGA6HJL+5/p5SBWe+qz8505TRo/dE=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "W5pylBxdv2soY2NcBfPiHDVLTS6tx+0ULkI8gysBeFY=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "oWO3xX3x0bYUJGK2S1aPAmlU3Xtfsgb9lTZ6flGAlsg=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "SjZGucTEUbdpd86O8yj1pyMyBOOKxvAQ9C8ngZ9C5UE=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "CEaMZkxVDVbnXr+To0DOyvsva04UQkIYP3KtgYVVwf8=",
+                    "subType": "00"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Query with non-matching $encStrEndsWith",
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encryptedText": "foobar"
+            }
+          },
+          "object": "coll"
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "$expr": {
+                "$encStrEndsWith": {
+                  "input": "$encryptedText",
+                  "suffix": "foo"
+                }
+              }
+            }
+          },
+          "object": "coll",
+          "expectResult": []
+        }
+      ]
+    }
+  ]
+}

--- a/source/client-side-encryption/tests/unified/QE-Text-suffixPreview.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-suffixPreview.yml
@@ -1,0 +1,222 @@
+description: QE-Text-suffixPreview
+schemaVersion: "1.25"
+runOnRequirements:
+  - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
+    maxServerVersion: "8.99.99" # Server 9.0.0-rc0 removes support for "prefixPreview" and "suffixPreview": SERVER-123416
+    topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
+    csfle:
+      minLibmongocryptVersion: 1.19.1 # For MONGOCRYPT-937.
+createEntities:
+  - client:
+      id: &client "client"
+      autoEncryptOpts:
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          local:
+            key: Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &db "db"
+      client: *client
+      databaseName: *db
+  - collection:
+      id: &coll "coll"
+      database: *db
+      collectionName: *coll
+initialData:
+  # Insert data encryption key:
+  - databaseName: keyvault
+    collectionName: datakeys
+    documents:
+      [
+        {
+          "_id": &keyid { "$binary": { "base64": "q83vqxI0mHYSNBI0VniQEg==", "subType": "04" } },
+          "keyMaterial":
+            {
+              "$binary":
+                {
+                  "base64": "HBk9BWihXExNDvTp1lUxOuxuZK2Pe2ZdVdlsxPEBkiO1bS4mG5NNDsQ7zVxJAH8BtdOYp72Ku4Y3nwc0BUpIKsvAKX4eYXtlhv5zUQxWdeNFhg9qK7qb8nqhnnLeT0f25jFSqzWJoT379hfwDeu0bebJHr35QrJ8myZdPMTEDYF08QYQ48ShRBli0S+QzBHHAQiM2iJNr4svg2WR8JSeWQ==",
+                  "subType": "00",
+                },
+            },
+          "creationDate": { "$date": { "$numberLong": "1648914851981" } },
+          "updateDate": { "$date": { "$numberLong": "1648914851981" } },
+          "status": { "$numberInt": "0" },
+          "masterKey": { "provider": "local" },
+        },
+      ]
+  # Create encrypted collection:
+  - databaseName: *db
+    collectionName: *coll
+    documents: []
+    createOptions:
+      encryptedFields:
+        {
+          "fields":
+            [
+              {
+                "keyId": *keyid,
+                "path": "encryptedText",
+                "bsonType": "string",
+                "queries": [
+                    # Use zero contention for deterministic __safeContent__:
+                    {
+                      "queryType": "suffixPreview",
+                      "contention": { "$numberLong": "0" },
+                      "strMinQueryLength": { "$numberLong": "3" },
+                      "strMaxQueryLength": { "$numberLong": "30" },
+                      "caseSensitive": true,
+                      "diacriticSensitive": true,
+                    },
+                  ],
+              },
+            ],
+        }
+tests:
+  - description: "Insert QE suffixPreview"
+    operations:
+      - name: insertOne
+        arguments:
+          document: { _id: 1, encryptedText: "foobar" }
+        object: *coll
+    expectEvents:
+      - client: "client"
+        events:
+          - commandStartedEvent:
+              command:
+                listCollections: 1
+                filter:
+                  name: *coll
+              commandName: listCollections
+          - commandStartedEvent:
+              command:
+                find: datakeys
+                filter:
+                  {
+                    "$or":
+                      [
+                        "_id": { "$in": [ *keyid ] },
+                        "keyAltNames": { "$in": [] },
+                      ],
+                  }
+                $db: keyvault
+                readConcern: { level: "majority" }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                insert: *coll
+                documents:
+                  - { "_id": 1, "encryptedText": { $$type: "binData" } } # Sends encrypted payload
+                ordered: true
+              commandName: insert
+  - description: "Query with matching $encStrEndsWith"
+    operations:
+      - name: insertOne
+        arguments:
+          document: { _id: 1, encryptedText: "foobar" }
+        object: *coll
+      - name: find
+        arguments:
+          filter:
+            {
+              $expr:
+                { $encStrEndsWith: { input: "$encryptedText", suffix: "bar" } },
+            }
+        object: *coll
+        expectResult:
+          [
+            {
+              "_id": { "$numberInt": "1" },
+              "encryptedText": "foobar",
+              "__safeContent__":
+                [
+                  {
+                    "$binary":
+                      {
+                        "base64": "wpaMBVDjL4bHf9EtSP52PJFzyNn1R19+iNI/hWtvzdk=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "uDCWsucUsJemUP7pmeb+Kd8B9qupVzI8wnLFqX1rkiU=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "W3E1x4bHZ8SEHFz4zwXM0G5Z5WSwBhnxE8x5/qdP6JM=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "6g/TXVDDf6z+ntResIvTKWdmIy4ajQ1rhwdNZIiEG7A=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "hU+u/T3D6dHDpT3d/v5AlgtRoAufCXCAyO2jQlgsnCw=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "vrPnq0AtBIURNgNGA6HJL+5/p5SBWe+qz8505TRo/dE=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "W5pylBxdv2soY2NcBfPiHDVLTS6tx+0ULkI8gysBeFY=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "oWO3xX3x0bYUJGK2S1aPAmlU3Xtfsgb9lTZ6flGAlsg=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "SjZGucTEUbdpd86O8yj1pyMyBOOKxvAQ9C8ngZ9C5UE=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "CEaMZkxVDVbnXr+To0DOyvsva04UQkIYP3KtgYVVwf8=",
+                        "subType": "00",
+                      },
+                  },
+                ],
+            },
+          ]
+
+  - description: "Query with non-matching $encStrEndsWith"
+    operations:
+      - name: insertOne
+        arguments:
+          document: { _id: 1, encryptedText: "foobar" }
+        object: *coll
+      - name: find
+        arguments:
+          filter:
+            {
+              $expr:
+                { $encStrEndsWith: { input: "$encryptedText", suffix: "foo" } },
+            }
+        object: *coll
+        expectResult: []


### PR DESCRIPTION
# Summary

Follow-up to https://github.com/mongodb/specifications/pull/1945 to restore support for "prefixPreview" and "suffixPreview".

# Details

This depends on libmongocrypt 1.19.1 to restore support for the preview query types ([MONGOCRYPT-937](https://jira.mongodb.org/browse/MONGOCRYPT-937))

# Motivation

This is intended to avoid dropping support for preview in drivers too early before a 9.0 stable release. Requested in this [slack thread](https://mongodb.slack.com/archives/C0668RJBA0J/p1781302046713039).

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- [x] Update changelog.
- [x] Test changes in at least one language driver. (Tested in https://github.com/mongodb/mongo-c-driver/pull/2322)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
