### PR TITLE
DRIVERS-3540 add "substring"

### DIFF
--- a/source/client-side-encryption/client-side-encryption.md
+++ b/source/client-side-encryption/client-side-encryption.md
@@ -1367,7 +1367,7 @@ One of the strings:
     - Used for the `$encStrStartsWith` operator.
 - "suffix" / "suffixPreview"
     - Used for the `$encStrEndsWith` operator.
-- "substringPreview"
+- "substring" / "substringPreview"
     - Used for the `$encStrContains` operator.
 
 queryType only applies when algorithm is "Indexed", "Range", or "String". libmongocrypt returns an error if queryType is
@@ -2522,6 +2522,8 @@ on. To support concurrent access of the key vault collection, the key management
 explicit session parameter as described in the [Drivers Sessions Specification](../sessions/driver-sessions.md).
 
 ## Changelog
+
+- 2026-06-22: Add stable support for substring queries
 
 - 2026-06-17: Restore `prefixPreview` and `suffixPreview` as experimental.
 

--- a/source/client-side-encryption/etc/data/encryptedFields-substring-ci-di.json
+++ b/source/client-side-encryption/etc/data/encryptedFields-substring-ci-di.json
@@ -19,7 +19,7 @@
             "$numberInt": "2"
           },
           "strMaxQueryLength": {
-            "$numberInt": "10"
+            "$numberInt": "6"
           },
           "contention": 0,
           "caseSensitive": false,

--- a/source/client-side-encryption/etc/data/encryptedFields-substring-ci-di.json
+++ b/source/client-side-encryption/etc/data/encryptedFields-substring-ci-di.json
@@ -11,7 +11,7 @@
       "bsonType": "string",
       "queries": [
         {
-          "queryType": "substringPreview",
+          "queryType": "substring",
           "strMaxLength": {
             "$numberInt": "10"
           },

--- a/source/client-side-encryption/etc/data/encryptedFields-substring-preview.json
+++ b/source/client-side-encryption/etc/data/encryptedFields-substring-preview.json
@@ -1,6 +1,6 @@
 {
-    "fields": [
-        {
+  "fields": [
+    {
             "keyId": {
                 "$binary": {
                     "base64": "EjRWeBI0mHYSNBI0VniQEg==",
@@ -11,7 +11,7 @@
             "bsonType": "string",
             "queries": [
                 {
-                    "queryType": "substring",
+                    "queryType": "substringPreview",
                     "strMaxLength": {
                         "$numberInt": "10"
                     },
@@ -29,5 +29,5 @@
                 }
             ]
         }
-    ]
+  ]
 }

--- a/source/client-side-encryption/etc/data/encryptedFields-substring-preview.json
+++ b/source/client-side-encryption/etc/data/encryptedFields-substring-preview.json
@@ -19,7 +19,7 @@
                         "$numberInt": "2"
                     },
                     "strMaxQueryLength": {
-                        "$numberInt": "10"
+                        "$numberInt": "6"
                     },
                     "contention": {
                         "$numberLong": "0"

--- a/source/client-side-encryption/etc/data/encryptedFields-substring.json
+++ b/source/client-side-encryption/etc/data/encryptedFields-substring.json
@@ -19,7 +19,7 @@
                         "$numberInt": "2"
                     },
                     "strMaxQueryLength": {
-                        "$numberInt": "10"
+                        "$numberInt": "6"
                     },
                     "contention": {
                         "$numberLong": "0"

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3974,7 +3974,7 @@ class EncryptOpts {
       diacriticSensitive: true,
       substring: SubstringOpts {
        strMaxLength: 10,
-       strMaxQueryLength: 10,
+       strMaxQueryLength: 6,
        strMinQueryLength: 2,
       }
    },
@@ -4162,7 +4162,7 @@ class EncryptOpts {
       diacriticSensitive: true,
       substring: SubstringOpts {
        strMaxLength: 10,
-       strMaxQueryLength: 10,
+       strMaxQueryLength: 6,
        strMinQueryLength: 2,
       }
    },
@@ -4203,7 +4203,7 @@ class EncryptOpts {
       diacriticSensitive: true,
       substring: SubstringOpts {
        strMaxLength: 10,
-       strMaxQueryLength: 10,
+       strMaxQueryLength: 6,
        strMinQueryLength: 2,
       }
    },
@@ -4419,7 +4419,7 @@ class EncryptOpts {
       diacriticSensitive: false,
       substring: SubstringOpts {
         strMaxLength: 10,
-        strMaxQueryLength: 10,
+        strMaxQueryLength: 6,
         strMinQueryLength: 2,
       }
    },
@@ -4465,7 +4465,7 @@ class EncryptOpts {
       diacriticSensitive: false,
       substring: SubstringOpts {
         strMaxLength: 10,
-        strMaxQueryLength: 10,
+        strMaxQueryLength: 6,
         strMinQueryLength: 2,
       }
    },

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3883,9 +3883,12 @@ create the following collections with majority write concern:
     This step requires server pre-9.0.0.
 - `db.substring` using the `encryptedFields` option set to the contents of
     [encryptedFields-substring.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-substring.json)
-    This step requires server pre-9.0.0.
+    This step requires server 9.0.0+.
 - `db.substring-ci-di` using the `encryptedFields` option set to the contents of
     [encryptedFields-substring-ci-di.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-substring-ci-di.json)
+    This step requires server 9.0.0+.
+- `db.substring-preview` using the `encryptedFields` option set to the contents of
+    [encryptedFields-substring-preview.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-substring-preview.json)
     This step requires server pre-9.0.0.
 
 Load the file
@@ -3978,8 +3981,8 @@ class EncryptOpts {
 }
 ```
 
-Use `explicitEncryptedClient` to insert the following document into `db.substring` (if created) with majority write
-concern:
+Use `explicitEncryptedClient` to insert the following document into `db.substring` (if created) and
+`db.substring-preview` (if created) with majority write concern:
 
 ```javascript
 { "_id": 0, "encryptedText": <encrypted 'foobarbaz'> }
@@ -4139,7 +4142,12 @@ Assert that no documents are returned.
 
 #### Case 5: can find a document by substring
 
-Skip this test on server 9.0.0+.
+Run this case multiple times with the following sets of parameters:
+
+- `queryType=substring` and `collection=substring`
+    - Require server 9.0.0+ and libmongocrypt 1.20.0+.
+- `queryType=substringPreview` and `collection=substring-preview`
+    - Require server pre-9.0.0 and libmongocrypt 1.18.1+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"bar"` with the following `EncryptOpts`:
 
@@ -4147,7 +4155,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"bar"` with the followin
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "substring",
+   queryType: "<queryType>",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: true,
@@ -4161,7 +4169,7 @@ class EncryptOpts {
 }
 ```
 
-Use `explicitEncryptedClient` to run a "find" operation on the `db.substring` collection with the following filter:
+Use `explicitEncryptedClient` to run a "find" operation on the `db.<collection>` collection with the following filter:
 
 ```javascript
 { $expr: { $encStrContains: {input: '$encryptedText', substring: <encrypted 'bar'>} } }
@@ -4175,7 +4183,12 @@ Assert the following document is returned:
 
 #### Case 6: assert no document found by substring
 
-Skip this test on server 9.0.0+.
+Run this case multiple times with the following sets of parameters:
+
+- `queryType=substring` and `collection=substring`
+    - Require server 9.0.0+ and libmongocrypt 1.20.0+.
+- `queryType=substringPreview` and `collection=substring-preview`
+    - Require server pre-9.0.0 and libmongocrypt 1.18.1+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"qux"` with the following `EncryptOpts`:
 
@@ -4183,7 +4196,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"qux"` with the followin
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "substring",
+   queryType: "<queryType>",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: true,
@@ -4197,7 +4210,7 @@ class EncryptOpts {
 }
 ```
 
-Use `explicitEncryptedClient` to run a "find" operation on the `db.substring` collection with the following filter:
+Use `explicitEncryptedClient` to run a "find" operation on the `db.<collection>` collection with the following filter:
 
 ```javascript
 { $expr: { $encStrContains: {input: '$encryptedText', substring: <encrypted 'qux'>} } }

--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -4147,7 +4147,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"bar"` with the followin
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "substringPreview",
+   queryType: "substring",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: true,
@@ -4183,7 +4183,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"qux"` with the followin
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "substringPreview",
+   queryType: "substring",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: true,
@@ -4399,7 +4399,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"bar"` with the followin
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "substringPreview",
+   queryType: "substring",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: false,
@@ -4445,7 +4445,7 @@ Use `clientEncryption.encrypt()` to encrypt the string `"cafe"` with the followi
 class EncryptOpts {
    keyId : <key1ID>,
    algorithm: "String",
-   queryType: "substringPreview",
+   queryType: "substring",
    contentionFactor: 0,
    stringOpts: StringOpts {
       caseSensitive: false,

--- a/source/client-side-encryption/tests/unified/QE-Text-substring.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-substring.json
@@ -1,0 +1,551 @@
+{
+  "description": "QE-Text-substring",
+  "schemaVersion": "1.25",
+  "runOnRequirements": [
+    {
+      "minServerVersion": "9.0.0",
+      "topologies": [
+        "replicaset",
+        "sharded",
+        "load-balanced"
+      ],
+      "csfle": {
+        "minLibmongocryptVersion": "1.20.0"
+      }
+    }
+  ],
+  "createEntities": [
+    {
+      "client": {
+        "id": "client",
+        "autoEncryptOpts": {
+          "keyVaultNamespace": "keyvault.datakeys",
+          "kmsProviders": {
+            "local": {
+              "key": "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
+            }
+          }
+        },
+        "observeEvents": [
+          "commandStartedEvent"
+        ]
+      }
+    },
+    {
+      "database": {
+        "id": "db",
+        "client": "client",
+        "databaseName": "db"
+      }
+    },
+    {
+      "collection": {
+        "id": "coll",
+        "database": "db",
+        "collectionName": "coll"
+      }
+    }
+  ],
+  "initialData": [
+    {
+      "databaseName": "keyvault",
+      "collectionName": "datakeys",
+      "documents": [
+        {
+          "_id": {
+            "$binary": {
+              "base64": "q83vqxI0mHYSNBI0VniQEg==",
+              "subType": "04"
+            }
+          },
+          "keyMaterial": {
+            "$binary": {
+              "base64": "HBk9BWihXExNDvTp1lUxOuxuZK2Pe2ZdVdlsxPEBkiO1bS4mG5NNDsQ7zVxJAH8BtdOYp72Ku4Y3nwc0BUpIKsvAKX4eYXtlhv5zUQxWdeNFhg9qK7qb8nqhnnLeT0f25jFSqzWJoT379hfwDeu0bebJHr35QrJ8myZdPMTEDYF08QYQ48ShRBli0S+QzBHHAQiM2iJNr4svg2WR8JSeWQ==",
+              "subType": "00"
+            }
+          },
+          "creationDate": {
+            "$date": {
+              "$numberLong": "1648914851981"
+            }
+          },
+          "updateDate": {
+            "$date": {
+              "$numberLong": "1648914851981"
+            }
+          },
+          "status": {
+            "$numberInt": "0"
+          },
+          "masterKey": {
+            "provider": "local"
+          }
+        }
+      ]
+    },
+    {
+      "databaseName": "db",
+      "collectionName": "coll",
+      "documents": [],
+      "createOptions": {
+        "encryptedFields": {
+          "fields": [
+            {
+              "keyId": {
+                "$binary": {
+                  "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                  "subType": "04"
+                }
+              },
+              "path": "encryptedText",
+              "bsonType": "string",
+              "queries": [
+                {
+                  "queryType": "substring",
+                  "contention": {
+                    "$numberLong": "0"
+                  },
+                  "strMinQueryLength": {
+                    "$numberLong": "3"
+                  },
+                  "strMaxQueryLength": {
+                    "$numberLong": "10"
+                  },
+                  "strMaxLength": {
+                    "$numberLong": "20"
+                  },
+                  "caseSensitive": true,
+                  "diacriticSensitive": true
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "tests": [
+    {
+      "description": "Insert QE substring",
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encryptedText": "foobar"
+            }
+          },
+          "object": "coll"
+        }
+      ],
+      "expectEvents": [
+        {
+          "client": "client",
+          "events": [
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "listCollections": 1,
+                  "filter": {
+                    "name": "coll"
+                  }
+                },
+                "commandName": "listCollections"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "find": "datakeys",
+                  "filter": {
+                    "$or": [
+                      {
+                        "_id": {
+                          "$in": [
+                            {
+                              "$binary": {
+                                "base64": "q83vqxI0mHYSNBI0VniQEg==",
+                                "subType": "04"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "keyAltNames": {
+                          "$in": []
+                        }
+                      }
+                    ]
+                  },
+                  "$db": "keyvault",
+                  "readConcern": {
+                    "level": "majority"
+                  }
+                },
+                "commandName": "find"
+              }
+            },
+            {
+              "commandStartedEvent": {
+                "command": {
+                  "insert": "coll",
+                  "documents": [
+                    {
+                      "_id": 1,
+                      "encryptedText": {
+                        "$$type": "binData"
+                      }
+                    }
+                  ],
+                  "ordered": true
+                },
+                "commandName": "insert"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Query with matching $encStrContains",
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encryptedText": "foobar"
+            }
+          },
+          "object": "coll"
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "$expr": {
+                "$encStrContains": {
+                  "input": "$encryptedText",
+                  "substring": "oba"
+                }
+              }
+            }
+          },
+          "object": "coll",
+          "expectResult": [
+            {
+              "_id": {
+                "$numberInt": "1"
+              },
+              "encryptedText": "foobar",
+              "__safeContent__": [
+                {
+                  "$binary": {
+                    "base64": "wpaMBVDjL4bHf9EtSP52PJFzyNn1R19+iNI/hWtvzdk=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "IpY3x/jjm8j/74jAdUhgxdM5hk68zR0zv/lTKm/72Vg=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "G+ky260C6QiOfIxKz14FmaMbAxvui1BKJO/TnLOHlGk=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "7dv3gAKe9vwJMZmpB40pRCwRTmc7ds9UkGhxH8j084E=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "o0V+Efn6x8XQdE80F1tztNaT3qxHjcsd9DOQ47BtmQk=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "sJvrCjyVot7PIZFsdRehWFANKAj6fmBaj3FLbz/dZLE=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "e98auxFmu02h5MfBIARk29MI7hSmvN3F9DaQ0xjqoEM=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "US83krGNov/ezL6IhsY5eEOCxv1xUPDIEL/nmY0IKi0=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "P2Aq5+OHZPG0CWIdmZvWq9c/18ZKVYW3vbxd+WU/TXU=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "8AdPRPnSzcd5uhq4TZfNvNeF0XjLNVwAsJJMTtktw84=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "9O6u/G51I4ZHFLhL4ZLuudbr0s202A2QnPfThmOXPhI=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "N7AjYVyVlv6+lVSTM+cIxRL3SMgs3G5LgxSs+jrgDkI=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "RbGF7dQbPGYQFd9DDO1hPz1UlLOJ77FAC6NsjGwJeos=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "m7srHMgKm6kZwsNx8rc45pmw0/9Qro6xuQ8lZS3+RYk=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "K75CNU3JyKFqZWPiIsVi4+n7DhYmcPl/nEhQ3d88mVI=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "c7bwGpUZc/7JzEnMS7qQ/TPuXZyrmMihFaAV6zIqbZc=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "rDvEdUgEk8u4Srt3ETokWs2FXcnyJaRGQ+NbkFwi2rQ=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "VcdZj9zfveRBRlpCR2OYWau2+GokOFb73TE3gpElNiU=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "eOa9o2xfA6OgkbYUxd6wQJicaeN6guhy2V66W3ALsaA=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "1xGkJh+um70XiRd8lKLDtyHgDqrf7/59Mg7X0+KZh8k=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "OSvllqHxycbcZN4phR6NDujY3ttA59o7nQJ6V9eJpX0=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "ZTX1pyk8Vdw0BSbJx7GeJNcQf3tGKxbrrNSTqBqUWkg=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "cn7V05zb5iXwYrePGMHztC+GRq+Tj8IMpRDraauPhSE=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "E9bV9KyrZxHJSUmMg0HrDK4gGN+75ruelAnrM6hXQgY=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "WrssTNmdgXoTGpbaF0JLRCGH6cDQuz1XEFNTy98nrb0=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "jZmyOJP35dsxQ/OY5U4ISpVRIYr8iedNfcwZiKt29Qc=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "d2mocORMbX9MX+/itAW8r1kxVw2/uii4vzXtc+2CIRQ=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "JBnJy58eRPhDo3DuZvsHbvQDiHXxdtAx1Eif66k5SfA=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "OjbDulC8s62v0pgweBSsQqtJjJBwH5JinfJpj7nVr+A=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "85i7KT2GP9nSda3Gsil5LKubhq0LDtc22pxBxHpR+nE=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "u9Fvsclwrs9lwIcMPV/fMZD7L3d5anSfJQVjQb9mgLg=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "LZ32ttmLJGOIw9oFaUCn3Sx5uHPTYJPSFpeGRWNqlUc=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "mMsZvGEePTqtl0FJAL/jAdyWNQIlpwN61YIlZsSIZ6s=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "XZcu1a/ZGsIzAl3j4MXQlLo4v2p7kvIqRHtIQYFmL6k=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "Zse27LinlYCEnX6iTmJceI33mEJxFb0LdPxp0RiMOaQ=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "vOv2Hgb2/sBpnX9XwFbIN6yDxhjchwlmczUf82W2tp4=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "oQxZ9A6j3x5j6x1Jqw/N9tpP4rfWMjcV3y+a3PkrL7c=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "/D7ew3EijyUnmT22awVFspcuyo3JChJcDeCPwpljzVM=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "BEmmwqyamt9X3bcWDld61P01zquy8fBHAXq3SHAPP0M=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "wygD9/kAo1KsRvtr1v+9/lvqoWdKwgh6gDHvAQfXPPk=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "pRTKgF/uksrF1c1AcfSTY6ZhqBKVud1vIztQ4/36SLs=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "C4iUo8oNJsjJ37BqnBgIgSQpf99X2Bb4W5MZEAmakHU=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "icoE53jIq6Fu/YGKUiSUTYyZ8xdiTQY9jJiGxVJObpw=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "oubCwk0V6G2RFWtcOnYDU4uUBoXBrhBRi4nZgrYj9JY=",
+                    "subType": "00"
+                  }
+                },
+                {
+                  "$binary": {
+                    "base64": "IyqhQ9nGhzEi5YW2W6v1kGU5DY2u2qSqbM/qXdLdWVU=",
+                    "subType": "00"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Query with non-matching $encStrContains",
+      "operations": [
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1,
+              "encryptedText": "foobar"
+            }
+          },
+          "object": "coll"
+        },
+        {
+          "name": "find",
+          "arguments": {
+            "filter": {
+              "$expr": {
+                "$encStrContains": {
+                  "input": "$encryptedText",
+                  "substring": "blah"
+                }
+              }
+            }
+          },
+          "object": "coll",
+          "expectResult": []
+        }
+      ]
+    }
+  ]
+}

--- a/source/client-side-encryption/tests/unified/QE-Text-substring.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-substring.json
@@ -109,7 +109,7 @@
                     "$numberLong": "3"
                   },
                   "strMaxQueryLength": {
-                    "$numberLong": "10"
+                    "$numberLong": "6"
                   },
                   "strMaxLength": {
                     "$numberLong": "20"
@@ -424,90 +424,6 @@
                 {
                   "$binary": {
                     "base64": "u9Fvsclwrs9lwIcMPV/fMZD7L3d5anSfJQVjQb9mgLg=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "LZ32ttmLJGOIw9oFaUCn3Sx5uHPTYJPSFpeGRWNqlUc=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "mMsZvGEePTqtl0FJAL/jAdyWNQIlpwN61YIlZsSIZ6s=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "XZcu1a/ZGsIzAl3j4MXQlLo4v2p7kvIqRHtIQYFmL6k=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "Zse27LinlYCEnX6iTmJceI33mEJxFb0LdPxp0RiMOaQ=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "vOv2Hgb2/sBpnX9XwFbIN6yDxhjchwlmczUf82W2tp4=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "oQxZ9A6j3x5j6x1Jqw/N9tpP4rfWMjcV3y+a3PkrL7c=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "/D7ew3EijyUnmT22awVFspcuyo3JChJcDeCPwpljzVM=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "BEmmwqyamt9X3bcWDld61P01zquy8fBHAXq3SHAPP0M=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "wygD9/kAo1KsRvtr1v+9/lvqoWdKwgh6gDHvAQfXPPk=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "pRTKgF/uksrF1c1AcfSTY6ZhqBKVud1vIztQ4/36SLs=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "C4iUo8oNJsjJ37BqnBgIgSQpf99X2Bb4W5MZEAmakHU=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "icoE53jIq6Fu/YGKUiSUTYyZ8xdiTQY9jJiGxVJObpw=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "oubCwk0V6G2RFWtcOnYDU4uUBoXBrhBRi4nZgrYj9JY=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "IyqhQ9nGhzEi5YW2W6v1kGU5DY2u2qSqbM/qXdLdWVU=",
                     "subType": "00"
                   }
                 }

--- a/source/client-side-encryption/tests/unified/QE-Text-substring.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-substring.yml
@@ -1,0 +1,472 @@
+description: QE-Text-substring
+schemaVersion: "1.25"
+runOnRequirements:
+  - minServerVersion: "9.0.0" # Server 9.0.0 adds stable support for QE text substring queries.
+    topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
+    csfle:
+      minLibmongocryptVersion: 1.20.0 # For MONOGCRYPT-936.
+createEntities:
+  - client:
+      id: &client "client"
+      autoEncryptOpts:
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          local:
+            key: Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: &db "db"
+      client: *client
+      databaseName: *db
+  - collection:
+      id: &coll "coll"
+      database: *db
+      collectionName: *coll
+initialData:
+  # Insert data encryption key:
+  - databaseName: keyvault
+    collectionName: datakeys
+    documents:
+      [
+        {
+          "_id": &keyid { "$binary": { "base64": "q83vqxI0mHYSNBI0VniQEg==", "subType": "04" } },
+          "keyMaterial":
+            {
+              "$binary":
+                {
+                  "base64": "HBk9BWihXExNDvTp1lUxOuxuZK2Pe2ZdVdlsxPEBkiO1bS4mG5NNDsQ7zVxJAH8BtdOYp72Ku4Y3nwc0BUpIKsvAKX4eYXtlhv5zUQxWdeNFhg9qK7qb8nqhnnLeT0f25jFSqzWJoT379hfwDeu0bebJHr35QrJ8myZdPMTEDYF08QYQ48ShRBli0S+QzBHHAQiM2iJNr4svg2WR8JSeWQ==",
+                  "subType": "00",
+                },
+            },
+          "creationDate": { "$date": { "$numberLong": "1648914851981" } },
+          "updateDate": { "$date": { "$numberLong": "1648914851981" } },
+          "status": { "$numberInt": "0" },
+          "masterKey": { "provider": "local" },
+        },
+      ]
+  # Create encrypted collection:
+  - databaseName: *db
+    collectionName: *coll
+    documents: []
+    createOptions:
+      encryptedFields:
+        {
+          "fields":
+            [
+              {
+                "keyId": *keyid,
+                "path": "encryptedText",
+                "bsonType": "string",
+                "queries": [
+                    # Use zero contention for deterministic __safeContent__:
+                    {
+                      "queryType": "substring",
+                      "contention": { "$numberLong": "0" },
+                      "strMinQueryLength": { "$numberLong": "3" },
+                      "strMaxQueryLength": { "$numberLong": "10" },
+                      "strMaxLength": { "$numberLong": "20" },
+                      "caseSensitive": true,
+                      "diacriticSensitive": true,
+                    },
+                  ],
+              },
+            ],
+        }
+tests:
+  - description: "Insert QE substring"
+    operations:
+      - name: insertOne
+        arguments:
+          document: { _id: 1, encryptedText: "foobar" }
+        object: *coll
+    expectEvents:
+      - client: "client"
+        events:
+          - commandStartedEvent:
+              command:
+                listCollections: 1
+                filter:
+                  name: *coll
+              commandName: listCollections
+          - commandStartedEvent:
+              command:
+                find: datakeys
+                filter:
+                  {
+                    "$or":
+                      [
+                        "_id": { "$in": [ *keyid ] },
+                        "keyAltNames": { "$in": [] },
+                      ],
+                  }
+                $db: keyvault
+                readConcern: { level: "majority" }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                insert: *coll
+                documents:
+                  - { "_id": 1, "encryptedText": { $$type: "binData" } } # Sends encrypted payload
+                ordered: true
+              commandName: insert
+  - description: "Query with matching $encStrContains"
+    operations:
+      - name: insertOne
+        arguments:
+          document: { _id: 1, encryptedText: "foobar" }
+        object: *coll
+      - name: find
+        arguments:
+          filter:
+            {
+              $expr:
+                {
+                  $encStrContains:
+                    { input: "$encryptedText", substring: "oba" },
+                },
+            }
+        object: *coll
+        expectResult:
+          [
+            {
+              "_id": { "$numberInt": "1" },
+              "encryptedText": "foobar",
+              "__safeContent__":
+                [
+                  {
+                    "$binary":
+                      {
+                        "base64": "wpaMBVDjL4bHf9EtSP52PJFzyNn1R19+iNI/hWtvzdk=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "IpY3x/jjm8j/74jAdUhgxdM5hk68zR0zv/lTKm/72Vg=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "G+ky260C6QiOfIxKz14FmaMbAxvui1BKJO/TnLOHlGk=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "7dv3gAKe9vwJMZmpB40pRCwRTmc7ds9UkGhxH8j084E=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "o0V+Efn6x8XQdE80F1tztNaT3qxHjcsd9DOQ47BtmQk=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "sJvrCjyVot7PIZFsdRehWFANKAj6fmBaj3FLbz/dZLE=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "e98auxFmu02h5MfBIARk29MI7hSmvN3F9DaQ0xjqoEM=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "US83krGNov/ezL6IhsY5eEOCxv1xUPDIEL/nmY0IKi0=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "P2Aq5+OHZPG0CWIdmZvWq9c/18ZKVYW3vbxd+WU/TXU=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "8AdPRPnSzcd5uhq4TZfNvNeF0XjLNVwAsJJMTtktw84=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "9O6u/G51I4ZHFLhL4ZLuudbr0s202A2QnPfThmOXPhI=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "N7AjYVyVlv6+lVSTM+cIxRL3SMgs3G5LgxSs+jrgDkI=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "RbGF7dQbPGYQFd9DDO1hPz1UlLOJ77FAC6NsjGwJeos=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "m7srHMgKm6kZwsNx8rc45pmw0/9Qro6xuQ8lZS3+RYk=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "K75CNU3JyKFqZWPiIsVi4+n7DhYmcPl/nEhQ3d88mVI=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "c7bwGpUZc/7JzEnMS7qQ/TPuXZyrmMihFaAV6zIqbZc=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "rDvEdUgEk8u4Srt3ETokWs2FXcnyJaRGQ+NbkFwi2rQ=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "VcdZj9zfveRBRlpCR2OYWau2+GokOFb73TE3gpElNiU=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "eOa9o2xfA6OgkbYUxd6wQJicaeN6guhy2V66W3ALsaA=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "1xGkJh+um70XiRd8lKLDtyHgDqrf7/59Mg7X0+KZh8k=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "OSvllqHxycbcZN4phR6NDujY3ttA59o7nQJ6V9eJpX0=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "ZTX1pyk8Vdw0BSbJx7GeJNcQf3tGKxbrrNSTqBqUWkg=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "cn7V05zb5iXwYrePGMHztC+GRq+Tj8IMpRDraauPhSE=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "E9bV9KyrZxHJSUmMg0HrDK4gGN+75ruelAnrM6hXQgY=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "WrssTNmdgXoTGpbaF0JLRCGH6cDQuz1XEFNTy98nrb0=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "jZmyOJP35dsxQ/OY5U4ISpVRIYr8iedNfcwZiKt29Qc=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "d2mocORMbX9MX+/itAW8r1kxVw2/uii4vzXtc+2CIRQ=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "JBnJy58eRPhDo3DuZvsHbvQDiHXxdtAx1Eif66k5SfA=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "OjbDulC8s62v0pgweBSsQqtJjJBwH5JinfJpj7nVr+A=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "85i7KT2GP9nSda3Gsil5LKubhq0LDtc22pxBxHpR+nE=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "u9Fvsclwrs9lwIcMPV/fMZD7L3d5anSfJQVjQb9mgLg=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "LZ32ttmLJGOIw9oFaUCn3Sx5uHPTYJPSFpeGRWNqlUc=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "mMsZvGEePTqtl0FJAL/jAdyWNQIlpwN61YIlZsSIZ6s=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "XZcu1a/ZGsIzAl3j4MXQlLo4v2p7kvIqRHtIQYFmL6k=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "Zse27LinlYCEnX6iTmJceI33mEJxFb0LdPxp0RiMOaQ=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "vOv2Hgb2/sBpnX9XwFbIN6yDxhjchwlmczUf82W2tp4=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "oQxZ9A6j3x5j6x1Jqw/N9tpP4rfWMjcV3y+a3PkrL7c=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "/D7ew3EijyUnmT22awVFspcuyo3JChJcDeCPwpljzVM=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "BEmmwqyamt9X3bcWDld61P01zquy8fBHAXq3SHAPP0M=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "wygD9/kAo1KsRvtr1v+9/lvqoWdKwgh6gDHvAQfXPPk=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "pRTKgF/uksrF1c1AcfSTY6ZhqBKVud1vIztQ4/36SLs=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "C4iUo8oNJsjJ37BqnBgIgSQpf99X2Bb4W5MZEAmakHU=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "icoE53jIq6Fu/YGKUiSUTYyZ8xdiTQY9jJiGxVJObpw=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "oubCwk0V6G2RFWtcOnYDU4uUBoXBrhBRi4nZgrYj9JY=",
+                        "subType": "00",
+                      },
+                  },
+                  {
+                    "$binary":
+                      {
+                        "base64": "IyqhQ9nGhzEi5YW2W6v1kGU5DY2u2qSqbM/qXdLdWVU=",
+                        "subType": "00",
+                      },
+                  },
+                ],
+            },
+          ]
+
+  - description: "Query with non-matching $encStrContains"
+    operations:
+      - name: insertOne
+        arguments:
+          document: { _id: 1, encryptedText: "foobar" }
+        object: *coll
+      - name: find
+        arguments:
+          filter:
+            {
+              $expr:
+                {
+                  $encStrContains: { input: "$encryptedText", substring: "blah" },
+                },
+            }
+        object: *coll
+        expectResult: []

--- a/source/client-side-encryption/tests/unified/QE-Text-substring.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-substring.yml
@@ -64,7 +64,7 @@ initialData:
                       "queryType": "substring",
                       "contention": { "$numberLong": "0" },
                       "strMinQueryLength": { "$numberLong": "3" },
-                      "strMaxQueryLength": { "$numberLong": "10" },
+                      "strMaxQueryLength": { "$numberLong": "6" },
                       "strMaxLength": { "$numberLong": "20" },
                       "caseSensitive": true,
                       "diacriticSensitive": true,
@@ -348,104 +348,6 @@ tests:
                     "$binary":
                       {
                         "base64": "u9Fvsclwrs9lwIcMPV/fMZD7L3d5anSfJQVjQb9mgLg=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "LZ32ttmLJGOIw9oFaUCn3Sx5uHPTYJPSFpeGRWNqlUc=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "mMsZvGEePTqtl0FJAL/jAdyWNQIlpwN61YIlZsSIZ6s=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "XZcu1a/ZGsIzAl3j4MXQlLo4v2p7kvIqRHtIQYFmL6k=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "Zse27LinlYCEnX6iTmJceI33mEJxFb0LdPxp0RiMOaQ=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "vOv2Hgb2/sBpnX9XwFbIN6yDxhjchwlmczUf82W2tp4=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "oQxZ9A6j3x5j6x1Jqw/N9tpP4rfWMjcV3y+a3PkrL7c=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "/D7ew3EijyUnmT22awVFspcuyo3JChJcDeCPwpljzVM=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "BEmmwqyamt9X3bcWDld61P01zquy8fBHAXq3SHAPP0M=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "wygD9/kAo1KsRvtr1v+9/lvqoWdKwgh6gDHvAQfXPPk=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "pRTKgF/uksrF1c1AcfSTY6ZhqBKVud1vIztQ4/36SLs=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "C4iUo8oNJsjJ37BqnBgIgSQpf99X2Bb4W5MZEAmakHU=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "icoE53jIq6Fu/YGKUiSUTYyZ8xdiTQY9jJiGxVJObpw=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "oubCwk0V6G2RFWtcOnYDU4uUBoXBrhBRi4nZgrYj9JY=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "IyqhQ9nGhzEi5YW2W6v1kGU5DY2u2qSqbM/qXdLdWVU=",
                         "subType": "00",
                       },
                   },

--- a/source/client-side-encryption/tests/unified/QE-Text-substringPreview.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-substringPreview.json
@@ -110,7 +110,7 @@
                     "$numberLong": "3"
                   },
                   "strMaxQueryLength": {
-                    "$numberLong": "10"
+                    "$numberLong": "6"
                   },
                   "strMaxLength": {
                     "$numberLong": "20"
@@ -425,90 +425,6 @@
                 {
                   "$binary": {
                     "base64": "u9Fvsclwrs9lwIcMPV/fMZD7L3d5anSfJQVjQb9mgLg=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "LZ32ttmLJGOIw9oFaUCn3Sx5uHPTYJPSFpeGRWNqlUc=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "mMsZvGEePTqtl0FJAL/jAdyWNQIlpwN61YIlZsSIZ6s=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "XZcu1a/ZGsIzAl3j4MXQlLo4v2p7kvIqRHtIQYFmL6k=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "Zse27LinlYCEnX6iTmJceI33mEJxFb0LdPxp0RiMOaQ=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "vOv2Hgb2/sBpnX9XwFbIN6yDxhjchwlmczUf82W2tp4=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "oQxZ9A6j3x5j6x1Jqw/N9tpP4rfWMjcV3y+a3PkrL7c=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "/D7ew3EijyUnmT22awVFspcuyo3JChJcDeCPwpljzVM=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "BEmmwqyamt9X3bcWDld61P01zquy8fBHAXq3SHAPP0M=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "wygD9/kAo1KsRvtr1v+9/lvqoWdKwgh6gDHvAQfXPPk=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "pRTKgF/uksrF1c1AcfSTY6ZhqBKVud1vIztQ4/36SLs=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "C4iUo8oNJsjJ37BqnBgIgSQpf99X2Bb4W5MZEAmakHU=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "icoE53jIq6Fu/YGKUiSUTYyZ8xdiTQY9jJiGxVJObpw=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "oubCwk0V6G2RFWtcOnYDU4uUBoXBrhBRi4nZgrYj9JY=",
-                    "subType": "00"
-                  }
-                },
-                {
-                  "$binary": {
-                    "base64": "IyqhQ9nGhzEi5YW2W6v1kGU5DY2u2qSqbM/qXdLdWVU=",
                     "subType": "00"
                   }
                 }

--- a/source/client-side-encryption/tests/unified/QE-Text-substringPreview.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-substringPreview.yml
@@ -65,7 +65,7 @@ initialData:
                       "queryType": "substringPreview",
                       "contention": { "$numberLong": "0" },
                       "strMinQueryLength": { "$numberLong": "3" },
-                      "strMaxQueryLength": { "$numberLong": "10" },
+                      "strMaxQueryLength": { "$numberLong": "6" },
                       "strMaxLength": { "$numberLong": "20" },
                       "caseSensitive": true,
                       "diacriticSensitive": true,
@@ -349,104 +349,6 @@ tests:
                     "$binary":
                       {
                         "base64": "u9Fvsclwrs9lwIcMPV/fMZD7L3d5anSfJQVjQb9mgLg=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "LZ32ttmLJGOIw9oFaUCn3Sx5uHPTYJPSFpeGRWNqlUc=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "mMsZvGEePTqtl0FJAL/jAdyWNQIlpwN61YIlZsSIZ6s=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "XZcu1a/ZGsIzAl3j4MXQlLo4v2p7kvIqRHtIQYFmL6k=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "Zse27LinlYCEnX6iTmJceI33mEJxFb0LdPxp0RiMOaQ=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "vOv2Hgb2/sBpnX9XwFbIN6yDxhjchwlmczUf82W2tp4=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "oQxZ9A6j3x5j6x1Jqw/N9tpP4rfWMjcV3y+a3PkrL7c=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "/D7ew3EijyUnmT22awVFspcuyo3JChJcDeCPwpljzVM=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "BEmmwqyamt9X3bcWDld61P01zquy8fBHAXq3SHAPP0M=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "wygD9/kAo1KsRvtr1v+9/lvqoWdKwgh6gDHvAQfXPPk=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "pRTKgF/uksrF1c1AcfSTY6ZhqBKVud1vIztQ4/36SLs=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "C4iUo8oNJsjJ37BqnBgIgSQpf99X2Bb4W5MZEAmakHU=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "icoE53jIq6Fu/YGKUiSUTYyZ8xdiTQY9jJiGxVJObpw=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "oubCwk0V6G2RFWtcOnYDU4uUBoXBrhBRi4nZgrYj9JY=",
-                        "subType": "00",
-                      },
-                  },
-                  {
-                    "$binary":
-                      {
-                        "base64": "IyqhQ9nGhzEi5YW2W6v1kGU5DY2u2qSqbM/qXdLdWVU=",
                         "subType": "00",
                       },
                   },


### PR DESCRIPTION
# Summary

Add "substring" as a query type for QE.

# Background & Motivation

This is a continuation of an effort to mark QE String (formerly Text) support as GA.

Driver support for "substringPreview" is not removed. Removal of preview is planned in DRIVERS-3548.

## strMaxQueryLength limit

The GA "substring" added further [parameter limits](https://github.com/10gen/mongo/blob/c739b267ba2994608079109f820123aeed51f47c/src/mongo/db/modules/enterprise/docs/fle/fle_string_search.md#parameter-limits-for-substring) than "substringPreview":

> `strMaxQueryLength` cannot be greater than 6.

The "substringPreview" tests used `strMaxQueryLength=10`, triggering an error when switching to "substring":

```
strMaxQueryLength (10) must be <= 6 for substring query type of field encryptedText
```

Both "substring" and "substringPreview" tests are updated to `strMaxQueryLength=6` for consistency.

## Testing

Support for "substring" requires SERVER-129158. SERVER-129158 was merged and tested "latest" server builds are updated.

---

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- [x] Update changelog.
- [x] Test changes in at least one language driver. (Tested in https://github.com/mongodb/mongo-c-driver/pull/2334)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
