### PR TITLE
DRIVERS-3555 skip "substringPreview" on 9.0+

### DIFF
--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -3883,8 +3883,10 @@ create the following collections with majority write concern:
     This step requires server pre-9.0.0.
 - `db.substring` using the `encryptedFields` option set to the contents of
     [encryptedFields-substring.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-substring.json)
+    This step requires server pre-9.0.0.
 - `db.substring-ci-di` using the `encryptedFields` option set to the contents of
     [encryptedFields-substring-ci-di.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/encryptedFields-substring-ci-di.json)
+    This step requires server pre-9.0.0.
 
 Load the file
 [key1-document.json](https://github.com/mongodb/specifications/tree/master/source/client-side-encryption/etc/data/keys/key1-document.json)
@@ -3976,7 +3978,8 @@ class EncryptOpts {
 }
 ```
 
-Use `explicitEncryptedClient` to insert the following document into `db.substring` with majority write concern:
+Use `explicitEncryptedClient` to insert the following document into `db.substring` (if created) with majority write
+concern:
 
 ```javascript
 { "_id": 0, "encryptedText": <encrypted 'foobarbaz'> }
@@ -4136,6 +4139,8 @@ Assert that no documents are returned.
 
 #### Case 5: can find a document by substring
 
+Skip this test on server 9.0.0+.
+
 Use `clientEncryption.encrypt()` to encrypt the string `"bar"` with the following `EncryptOpts`:
 
 ```typescript
@@ -4169,6 +4174,8 @@ Assert the following document is returned:
 ```
 
 #### Case 6: assert no document found by substring
+
+Skip this test on server 9.0.0+.
 
 Use `clientEncryption.encrypt()` to encrypt the string `"qux"` with the following `EncryptOpts`:
 
@@ -4375,6 +4382,8 @@ Assert the following document is returned:
 
 #### Case 10: can find an auto-encrypted case-insensitively indexed document by substring
 
+Skip this test on server 9.0.0+.
+
 This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). This test requires
 libmongocrypt 1.18.1+.
 
@@ -4418,6 +4427,8 @@ Assert the following document is returned:
 ```
 
 #### Case 11: can find an auto-encrypted diacritic-insensitively indexed document by substring
+
+Skip this test on server 9.0.0+.
 
 This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). This test requires
 libmongocrypt 1.18.1+.

--- a/source/client-side-encryption/tests/unified/QE-Text-substringPreview.json
+++ b/source/client-side-encryption/tests/unified/QE-Text-substringPreview.json
@@ -4,6 +4,7 @@
   "runOnRequirements": [
     {
       "minServerVersion": "8.2.0",
+      "maxServerVersion": "8.99.99",
       "topologies": [
         "replicaset",
         "sharded",

--- a/source/client-side-encryption/tests/unified/QE-Text-substringPreview.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-substringPreview.yml
@@ -2,6 +2,7 @@ description: QE-Text-substringPreview
 schemaVersion: "1.25"
 runOnRequirements:
   - minServerVersion: "8.2.0" # Server 8.2.0 adds preview support for QE text queries.
+    maxServerVersion: "8.99.99" # Server 9.0.0 will remove support for "substringPreview": SERVER-129158
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
       minLibmongocryptVersion: 1.15.0 # For SPM-4158.


### PR DESCRIPTION
# Summary

Skip "substringPreview" on server 9.0+ since "substringPreview" is dropped in SERVER-129158.

# Details

SERVER-129158 drops "substringPreview" and adds "substring". This PR skips "substringPreview" separately from the addition of "substring" planned in DRIVERS-3540. "substring" is not-yet added since not all latest server builds appear updated (macOS arm64 is not). And supporting "substring" requires libmongocrypt 1.20.0+.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

- ~~[ ] Update changelog.~~ (Test changes only.)
- [x] Test changes in at least one language driver. (Tested in https://github.com/mongodb/mongo-c-driver/pull/2335)
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).~~ (Skipped to expedite.)

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
