### PR TITLE
DRIVERS-3540 remove skip of cases 10 and 11

### DIFF
--- a/source/client-side-encryption/tests/README.md
+++ b/source/client-side-encryption/tests/README.md
@@ -4395,10 +4395,8 @@ Assert the following document is returned:
 
 #### Case 10: can find an auto-encrypted case-insensitively indexed document by substring
 
-Skip this test on server 9.0.0+.
-
-This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). This test requires
-libmongocrypt 1.18.1+.
+This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). This test case requires
+MongoDB server 9.0.0+ and libmongocrypt 1.20.0+.
 
 Use `autoEncryptedClient` to insert the following document into `db.substring-ci-di` with majority write concern:
 
@@ -4441,10 +4439,8 @@ Assert the following document is returned:
 
 #### Case 11: can find an auto-encrypted diacritic-insensitively indexed document by substring
 
-Skip this test on server 9.0.0+.
-
-This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). This test requires
-libmongocrypt 1.18.1+.
+This is a regression test for [DRIVERS-3470](https://jira.mongodb.org/browse/DRIVERS-3470). This test case requires
+MongoDB server 9.0.0+ and libmongocrypt 1.20.0+.
 
 Use `autoEncryptedClient` to insert the following document into `db.substring-ci-di` with majority write concern:
 

--- a/source/client-side-encryption/tests/unified/QE-Text-substring.yml
+++ b/source/client-side-encryption/tests/unified/QE-Text-substring.yml
@@ -4,7 +4,7 @@ runOnRequirements:
   - minServerVersion: "9.0.0" # Server 9.0.0 adds stable support for QE text substring queries.
     topologies: ["replicaset", "sharded", "load-balanced"] # QE does not support standalone.
     csfle:
-      minLibmongocryptVersion: 1.20.0 # For MONOGCRYPT-936.
+      minLibmongocryptVersion: 1.20.0 # For MONGOCRYPT-936.
 createEntities:
   - client:
       id: &client "client"


### PR DESCRIPTION
Follow-up to https://github.com/mongodb/specifications/pull/1957. Test cases 10 and 11 use "substring" so require server 9.0.0 and libmongocrypt 1.20.0.

As a drive-by, fixes a comment typo.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

- ~~[ ] Update changelog.~~ Test changes only.
- [x] Test changes in at least one language driver. (Implemented in https://github.com/mongodb/mongo-c-driver/pull/2334/changes#diff-d363a5539f2fbabfadf2d7cc6cdb96a203fb63f2caa31bae731c3e12d97b204cR5311)
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
