### PR TITLE
DRIVERS-3556 skip affected CSOT change stream tests on 9.0+ sharded

### DIFF
--- a/source/client-side-operations-timeout/etc/templates/retryability-timeoutMS.yml.template
+++ b/source/client-side-operations-timeout/etc/templates/retryability-timeoutMS.yml.template
@@ -91,7 +91,16 @@ tests:
           isTimeoutError: true
   - description: "operation is retried multiple times for non-zero timeoutMS - {{operation.operation_name}} on {{operation.object}}"
     runOnRequirements:
+    {%- if operation.operation_name == 'createChangeStream' %}
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
+    {%- else %}
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+    {%- endif %}
     operations:
       - name: failPoint
         object: testRunner

--- a/source/client-side-operations-timeout/tests/override-operation-timeoutMS.json
+++ b/source/client-side-operations-timeout/tests/override-operation-timeoutMS.json
@@ -269,6 +269,21 @@
     },
     {
       "description": "timeoutMS can be configured for an operation - createChangeStream on client",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -824,6 +839,21 @@
     },
     {
       "description": "timeoutMS can be configured for an operation - createChangeStream on database",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",
@@ -1890,6 +1920,21 @@
     },
     {
       "description": "timeoutMS can be configured for an operation - createChangeStream on collection",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "failPoint",

--- a/source/client-side-operations-timeout/tests/override-operation-timeoutMS.yml
+++ b/source/client-side-operations-timeout/tests/override-operation-timeoutMS.yml
@@ -164,7 +164,8 @@ tests:
     - minServerVersion: "4.4"
       topologies: ["replicaset"]
     - minServerVersion: "4.4"
-      maxServerVersion: "8.99" # Skip server 9.0+ due to reasons noted in DRIVERS-3556.
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
       topologies: ["sharded"]
     operations:
       - name: failPoint
@@ -462,7 +463,8 @@ tests:
     - minServerVersion: "4.4"
       topologies: ["replicaset"]
     - minServerVersion: "4.4"
-      maxServerVersion: "8.99" # Skip server 9.0+ due to reasons noted in DRIVERS-3556.
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
       topologies: ["sharded"]
     operations:
       - name: failPoint
@@ -1044,7 +1046,8 @@ tests:
     - minServerVersion: "4.4"
       topologies: ["replicaset"]
     - minServerVersion: "4.4"
-      maxServerVersion: "8.99" # Skip server 9.0+ due to reasons noted in DRIVERS-3556.
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
       topologies: ["sharded"]
     operations:
       - name: failPoint

--- a/source/client-side-operations-timeout/tests/override-operation-timeoutMS.yml
+++ b/source/client-side-operations-timeout/tests/override-operation-timeoutMS.yml
@@ -160,6 +160,12 @@ tests:
                 listDatabases: 1
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured for an operation - createChangeStream on client"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip server 9.0+ due to reasons noted in DRIVERS-3556.
+      topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -452,6 +458,12 @@ tests:
                 ping: 1
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured for an operation - createChangeStream on database"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip server 9.0+ due to reasons noted in DRIVERS-3556.
+      topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1028,6 +1040,12 @@ tests:
                 listIndexes: *collectionName
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured for an operation - createChangeStream on collection"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip server 9.0+ due to reasons noted in DRIVERS-3556.
+      topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner

--- a/source/client-side-operations-timeout/tests/retryability-timeoutMS.json
+++ b/source/client-side-operations-timeout/tests/retryability-timeoutMS.json
@@ -2626,7 +2626,17 @@
       "description": "operation is retried multiple times for non-zero timeoutMS - createChangeStream on client",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.3.1"
+          "minServerVersion": "4.3.1",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.3.1",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
         }
       ],
       "operations": [
@@ -3531,7 +3541,17 @@
       "description": "operation is retried multiple times for non-zero timeoutMS - createChangeStream on database",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.3.1"
+          "minServerVersion": "4.3.1",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.3.1",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
         }
       ],
       "operations": [
@@ -5513,7 +5533,17 @@
       "description": "operation is retried multiple times for non-zero timeoutMS - createChangeStream on collection",
       "runOnRequirements": [
         {
-          "minServerVersion": "4.3.1"
+          "minServerVersion": "4.3.1",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.3.1",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
         }
       ],
       "operations": [

--- a/source/client-side-operations-timeout/tests/retryability-timeoutMS.yml
+++ b/source/client-side-operations-timeout/tests/retryability-timeoutMS.yml
@@ -1315,6 +1315,11 @@ tests:
   - description: "operation is retried multiple times for non-zero timeoutMS - createChangeStream on client"
     runOnRequirements:
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1755,6 +1760,11 @@ tests:
   - description: "operation is retried multiple times for non-zero timeoutMS - createChangeStream on database"
     runOnRequirements:
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -2740,6 +2750,11 @@ tests:
   - description: "operation is retried multiple times for non-zero timeoutMS - createChangeStream on collection"
     runOnRequirements:
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner


### PR DESCRIPTION
# Summary

Skip time-sensitive CSOT change stream tests on 9.0+ sharded clusters.

# Details

Motivated by DRIVERS-3556. See [comment](https://jira.mongodb.org/browse/DRIVERS-3556?focusedCommentId=8635862&focusedId=8635862&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-8635862) for motivation to skip rather than try to workaround.

`override-operation-timeoutMS.yml.template` is not modified since it is [not used](https://github.com/mongodb/specifications/blob/ea6be202feb255242077cbc53527559e79e5cd00/source/client-side-operations-timeout/etc/generate-basic-tests.py#L116-L117) to generate the test file pending DRIVERS-3266.

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- ~~[ ] Update changelog.~~ (Test changes only)
- [x] Test changes in at least one language driver. (Tested locally with Go)
- ~~[ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).~~ (Skipping. This only adds a test skip)

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
