### PR TITLE
DRIVERS-3556 skip change stream iterate-again CSOT test on 9.0+ sharded

### DIFF
--- a/source/client-side-operations-timeout/tests/change-streams.json
+++ b/source/client-side-operations-timeout/tests/change-streams.json
@@ -405,6 +405,21 @@
     },
     {
       "description": "change stream can be iterated again if previous iteration times out",
+      "runOnRequirements": [
+        {
+          "minServerVersion": "4.4",
+          "topologies": [
+            "replicaset"
+          ]
+        },
+        {
+          "minServerVersion": "4.4",
+          "maxServerVersion": "8.99",
+          "topologies": [
+            "sharded"
+          ]
+        }
+      ],
       "operations": [
         {
           "name": "createChangeStream",

--- a/source/client-side-operations-timeout/tests/change-streams.yml
+++ b/source/client-side-operations-timeout/tests/change-streams.yml
@@ -226,6 +226,13 @@ tests:
                 maxTimeMS: { $$type: ["int", "long"] }
 
   - description: "change stream can be iterated again if previous iteration times out"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+        topologies: ["replicaset"]
+      - minServerVersion: "4.4"
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: createChangeStream
         object: *collection


### PR DESCRIPTION
<!-- Thanks for contributing! -->

Please complete the following before merging:

- [ ] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

- [ ] Update changelog.
- [ ] Test changes in at least one language driver.
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
