### PR TITLE
DRIVERS-3529 Add env.agent to handshake metadata for agentic client identification

### DIFF
--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -148,6 +148,7 @@ the following structure:
                 timeout_sec: 42,          /* OPTIONAL */
                 memory_mb: 1024,          /* OPTIONAL */
                 region: "<string>",       /* OPTIONAL */
+                agent: "<string>",        /* OPTIONAL */
                 /* OPTIONAL */
                 container: {
                     runtime: "<string>",  /* OPTIONAL */
@@ -291,8 +292,8 @@ Example:
 
 This value is optional and is not application configurable.
 
-Information about the execution environment, including Function-as-a-Service (FaaS) identification and container
-runtime.
+Information about the execution environment, including Function-as-a-Service (FaaS) identification, container runtime,
+and agentic client (agent) identification.
 
 The contents of `client.env` MUST be adjusted to keep the handshake below the size limit; see
 [Limitations](#limitations) for specifics.
@@ -328,6 +329,36 @@ Depending on which `client.env.name` has been selected, other FaaS fields in `cl
 
 Missing variables or variables with values not matching the expected type MUST cause the corresponding `client.env`
 field to be omitted and MUST NOT cause a user-visible error.
+
+##### Agent
+
+Many AI coding assistants and agentic clients ("agents", e.g. Claude Code, Cursor, Gemini CLI) set an environment
+variable in the process environment when they execute shell commands or code on a user's behalf. `client.env.agent`
+captures which agent, if any, is driving the client, so that agent-mediated usage of MongoDB can be distinguished from
+direct human usage.
+
+`client.env.agent` is a single string, determined by which of the following environment variables are populated. The
+list MUST be evaluated in order, and the first match determines the value; subsequent entries MUST NOT be considered:
+
+| Order | Environment Variable | `client.env.agent` value |
+| ----- | -------------------- | ------------------------ |
+| 1     | `AI_AGENT`           | The value of `AI_AGENT`  |
+| 2     | `AGENT`              | The value of `AGENT`     |
+| 3     | `CLAUDECODE`         | `claude-code`            |
+| 4     | `CURSOR_AGENT`       | `cursor`                 |
+| 5     | `GEMINI_CLI`         | `gemini-cli`             |
+| 6     | `CODEX_SANDBOX`      | `codex`                  |
+| 7     | `AUGMENT_AGENT`      | `augment`                |
+| 8     | `OPENCODE_CLIENT`    | `opencode`               |
+
+For entries 1 and 2 (`AI_AGENT` and `AGENT`), the value of `client.env.agent` is the value of the environment variable.
+For entries 3 through 8, the value of `client.env.agent` is the fixed string in the table above, regardless of the value
+of the environment variable.
+
+An environment variable is considered populated if it is present in the environment with a non-empty value. If none of
+the above environment variables are populated, `client.env.agent` MUST be entirely omitted.
+
+Determination of `client.env.agent` MUST NOT cause a user-visible error.
 
 ##### Container
 
@@ -475,7 +506,7 @@ which will result in handshake failure. Drivers MUST validate these values and t
 if necessary. Implementers SHOULD cumulatively update fields in the following order until the document is under the size
 limit:
 
-1. Omit fields from `env` except `env.name`.
+1. Omit fields from `env` except `env.name` and `env.agent`.
 2. Omit fields from `os` except `os.type`.
 3. Omit the `env` document entirely.
 4. Truncate `platform`.
@@ -565,6 +596,7 @@ support the `hello` command, the `helloOk: true` argument is ignored and the leg
 
 ## Changelog
 
+- 2026-07-22: Add `env.agent` to `client` document for agentic client identification.
 - 2026-06-25: Clarify the client backpressure component of the handshake.
 - 2026-06-11: Clarify that there is no new behavior as a result of only using OP_MSG for all handshakes.
 - 2026-06-05: Use OP_MSG for all handshakes.

--- a/source/mongodb-handshake/handshake.md
+++ b/source/mongodb-handshake/handshake.md
@@ -332,13 +332,12 @@ field to be omitted and MUST NOT cause a user-visible error.
 
 ##### Agent
 
-Many AI coding assistants and agentic clients ("agents", e.g. Claude Code, Cursor, Gemini CLI) set an environment
-variable in the process environment when they execute shell commands or code on a user's behalf. `client.env.agent`
-captures which agent, if any, is driving the client, so that agent-mediated usage of MongoDB can be distinguished from
-direct human usage.
+Agents are AI coding assistants and agentic clients, such as Claude Code, Cursor, and Gemini CLI. Most agents set an
+environment variable when they execute shell commands or code on a user's behalf. `client.env.agent` captures which
+agent, if any, is driving the client. This distinguishes agent-mediated usage of MongoDB from direct human usage.
 
-`client.env.agent` is a single string, determined by which of the following environment variables are populated. The
-list MUST be evaluated in order, and the first match determines the value; subsequent entries MUST NOT be considered:
+`client.env.agent` is a single string. Its value is determined by the environment variables below. Drivers MUST evaluate
+the list in order. The first populated variable determines the value, and subsequent entries MUST NOT be considered.
 
 | Order | Environment Variable | `client.env.agent` value |
 | ----- | -------------------- | ------------------------ |
@@ -351,12 +350,11 @@ list MUST be evaluated in order, and the first match determines the value; subse
 | 7     | `AUGMENT_AGENT`      | `augment`                |
 | 8     | `OPENCODE_CLIENT`    | `opencode`               |
 
-For entries 1 and 2 (`AI_AGENT` and `AGENT`), the value of `client.env.agent` is the value of the environment variable.
-For entries 3 through 8, the value of `client.env.agent` is the fixed string in the table above, regardless of the value
-of the environment variable.
+For entries 1 and 2, `client.env.agent` is the value of the environment variable. For entries 3 through 8,
+`client.env.agent` is the fixed string in the table above, regardless of the value of the environment variable.
 
-An environment variable is considered populated if it is present in the environment with a non-empty value. If none of
-the above environment variables are populated, `client.env.agent` MUST be entirely omitted.
+A variable is considered populated if it is present in the environment with a non-empty value. If none of the variables
+above are populated, `client.env.agent` MUST be entirely omitted.
 
 Determination of `client.env.agent` MUST NOT cause a user-visible error.
 

--- a/source/mongodb-handshake/tests/README.md
+++ b/source/mongodb-handshake/tests/README.md
@@ -74,7 +74,67 @@ the following sets of environment variables:
     | `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` | `1024`             |
     | `KUBERNETES_SERVICE_HOST`         | `1`                |
 
-### Test 2: Test that the driver accepts an arbitrary auth mechanism
+### Test 2: Test that agent metadata is properly captured
+
+Drivers that capture values for `client.env` should test that a connection and hello command succeeds in the presence of
+the following sets of environment variables, and that `client.env.agent` is populated (or omitted) as described.
+
+1. Generic agent via `AI_AGENT`. `client.env.agent` MUST equal `custom-agent`.
+
+    | Environment Variable | Value          |
+    | -------------------- | -------------- |
+    | `AI_AGENT`           | `custom-agent` |
+
+2. Generic agent via `AGENT`. `client.env.agent` MUST equal `custom-agent`.
+
+    | Environment Variable | Value          |
+    | -------------------- | -------------- |
+    | `AGENT`              | `custom-agent` |
+
+3. Known agent. `client.env.agent` MUST equal `claude-code`.
+
+    | Environment Variable | Value |
+    | -------------------- | ----- |
+    | `CLAUDECODE`         | `1`   |
+
+4. Precedence - generic wins over known. `client.env.agent` MUST equal `custom-agent` (the value of `AI_AGENT`), not
+    `claude-code`.
+
+    | Environment Variable | Value          |
+    | -------------------- | -------------- |
+    | `AI_AGENT`           | `custom-agent` |
+    | `CLAUDECODE`         | `1`            |
+
+5. Precedence - first known wins. `client.env.agent` MUST equal `cursor`.
+
+    | Environment Variable | Value |
+    | -------------------- | ----- |
+    | `CURSOR_AGENT`       | `1`   |
+    | `GEMINI_CLI`         | `1`   |
+
+6. Empty value is treated as unset. `client.env.agent` MUST be omitted. If no other `client.env` fields are populated,
+    `client.env` MUST be entirely omitted.
+
+    | Environment Variable | Value               |
+    | -------------------- | ------------------- |
+    | `AI_AGENT`           | \`\` (empty string) |
+
+7. No agent variables. `client.env.agent` MUST be omitted.
+
+    | Environment Variable | Value |
+    | -------------------- | ----- |
+    |                      |       |
+
+8. Agent alongside FaaS. This test MUST verify that both the AWS Lambda metadata and `client.env.agent` (equal to
+    `claude-code`) are present in `client.env`.
+
+    | Environment Variable | Value              |
+    | -------------------- | ------------------ |
+    | `AWS_EXECUTION_ENV`  | `AWS_Lambda_java8` |
+    | `AWS_REGION`         | `us-east-2`        |
+    | `CLAUDECODE`         | `1`                |
+
+### Test 3: Test that the driver accepts an arbitrary auth mechanism
 
 1. Mock the server response in a way that `saslSupportedMechs` array in the `hello` command response contains an
     arbitrary string.

--- a/source/mongodb-handshake/tests/README.md
+++ b/source/mongodb-handshake/tests/README.md
@@ -74,7 +74,16 @@ the following sets of environment variables:
     | `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` | `1024`             |
     | `KUBERNETES_SERVICE_HOST`         | `1`                |
 
-### Test 2: Test that agent metadata is properly captured
+### Test 2: Test that the driver accepts an arbitrary auth mechanism
+
+1. Mock the server response in a way that `saslSupportedMechs` array in the `hello` command response contains an
+    arbitrary string.
+
+2. Create and connect a `Connection` object that connects to the server that returns the mocked response.
+
+3. Assert that no error is raised.
+
+### Test 3: Test that agent metadata is properly captured
 
 Drivers that capture values for `client.env` should test that a connection and hello command succeeds in the presence of
 the following sets of environment variables, and that `client.env.agent` is populated (or omitted) as described.
@@ -133,15 +142,6 @@ the following sets of environment variables, and that `client.env.agent` is popu
     | `AWS_EXECUTION_ENV`  | `AWS_Lambda_java8` |
     | `AWS_REGION`         | `us-east-2`        |
     | `CLAUDECODE`         | `1`                |
-
-### Test 3: Test that the driver accepts an arbitrary auth mechanism
-
-1. Mock the server response in a way that `saslSupportedMechs` array in the `hello` command response contains an
-    arbitrary string.
-
-2. Create and connect a `Connection` object that connects to the server that returns the mocked response.
-
-3. Assert that no error is raised.
 
 ## Client Metadata Update Prose Tests
 

--- a/source/mongodb-handshake/tests/README.md
+++ b/source/mongodb-handshake/tests/README.md
@@ -4,7 +4,7 @@
 
 ### Test 1: Test that environment metadata is properly captured
 
-Drivers that capture values for `client.env` should test that a connection and hello command succeeds in the presence of
+Drivers that capture values for `client.env` should test that a connection and hello command succeed in the presence of
 the following sets of environment variables:
 
 1. Valid AWS
@@ -85,7 +85,7 @@ the following sets of environment variables:
 
 ### Test 3: Test that agent metadata is properly captured
 
-Drivers that capture values for `client.env` should test that a connection and hello command succeeds in the presence of
+Drivers that capture values for `client.env` should test that a connection and hello command succeed in the presence of
 the following sets of environment variables, and that `client.env.agent` is populated (or omitted) as described.
 
 1. Generic agent via `AI_AGENT`. `client.env.agent` MUST equal `custom-agent`.

--- a/source/mongodb-handshake/tests/README.md
+++ b/source/mongodb-handshake/tests/README.md
@@ -128,11 +128,8 @@ the following sets of environment variables, and that `client.env.agent` is popu
     | -------------------- | ------------------- |
     | `AI_AGENT`           | `""` (empty string) |
 
-7. No agent variables. `client.env.agent` MUST be omitted.
-
-    | Environment Variable | Value |
-    | -------------------- | ----- |
-    |                      |       |
+7. No agent variables. None of the environment variables in the `client.env.agent` table are set. `client.env.agent`
+    MUST be omitted.
 
 8. Agent alongside FaaS. This test MUST verify that both the AWS Lambda metadata and `client.env.agent` (equal to
     `claude-code`) are present in `client.env`.

--- a/source/mongodb-handshake/tests/README.md
+++ b/source/mongodb-handshake/tests/README.md
@@ -126,7 +126,7 @@ the following sets of environment variables, and that `client.env.agent` is popu
 
     | Environment Variable | Value               |
     | -------------------- | ------------------- |
-    | `AI_AGENT`           | \`\` (empty string) |
+    | `AI_AGENT`           | `""` (empty string) |
 
 7. No agent variables. `client.env.agent` MUST be omitted.
 


### PR DESCRIPTION
## Summary

Adds a `client.env.agent` field to the MongoDB Handshake metadata so that agent-mediated usage of MongoDB (AI coding assistants / agentic clients such as Claude Code, Cursor, Gemini CLI) can be distinguished from direct human usage. See [DRIVERS-3529](https://jira.mongodb.org/browse/DRIVERS-3529).

## Changes

- Add `env.agent` to the `client` document structure.
- New **Agent** subsection defining detection via an ordered environment-variable table (first populated match wins):

  | Order | Env var | `client.env.agent` value |
  |---|---|---|
  | 1 | `AI_AGENT` | raw value |
  | 2 | `AGENT` | raw value |
  | 3 | `CLAUDECODE` | `claude-code` |
  | 4 | `CURSOR_AGENT` | `cursor` |
  | 5 | `GEMINI_CLI` | `gemini-cli` |
  | 6 | `CODEX_SANDBOX` | `codex` |
  | 7 | `AUGMENT_AGENT` | `augment` |
  | 8 | `OPENCODE_CLIENT` | `opencode` |

  Generic vars (`AI_AGENT`/`AGENT`) report their raw value; the six known agents report a fixed label. Generic wins over known. "Populated" = present with a non-empty value. Omitted entirely when none are populated; determination MUST NOT raise a user-visible error.
- Preserve `env.agent` alongside `env.name` in the size-limit truncation cascade.
- Append prose **Test 3: Test that agent metadata is properly captured** at the end of the Client Metadata prose tests, leaving the existing Test 1 and Test 2 numbering unchanged.

## Open questions for reviewers

- **Fixed label taxonomy**: chose kebab-case (`claude-code`, `gemini-cli`) for a normalized, tool-agnostic taxonomy per the design memo. Product Analytics owns the taxonomy — happy to switch to the raw env-var forms if preferred.

## Notes

Per the aligned approach with @jkovacs, v1 targets the top-traffic drivers (Node, Python). The other language tickets are split from DRIVERS-3529 and blocked on this spec change. PyMongo implementation is tracked under PYTHON-5929.

---

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- [x] Update changelog.
- [ ] Test changes in at least one language driver. <!-- Pending: PyMongo (PYTHON-5929) and Node (NODE-7666) -->
- [ ] Test these changes against all server versions and topologies (including standalone, replica set, and sharded clusters).
