### PR TITLE
DRIVERS-3578 Use correct sum of backoffs for convenient transactions …

### DIFF
--- a/source/transactions-convenient-api/tests/README.md
+++ b/source/transactions-convenient-api/tests/README.md
@@ -105,14 +105,15 @@ Drivers should test that retries within `withTransaction` do not occur immediate
         ```
 5. Compare the durations of the two runs.
     ```python
-    assertTrue(absolute_value(with_backoff_time - (no_backoff_time + 3.6 seconds)) < 0.5 seconds)
+    assertTrue(absolute_value(with_backoff_time - (no_backoff_time + 2.3 seconds)) < 0.5 seconds)
     ```
-    The sum of 13 backoffs is roughly 3.6 seconds. There is a half-second window to account for potential variance
+    The sum of 13 backoffs is roughly 2.3 seconds. There is a half-second window to account for potential variance
     between the two runs.
 
 ## Changelog
 
-- 2206-07-08: Update Backoff test to use updated exponential formula.
+- 2026-07-22: Fix Backoff test to use the correct sum of backoffs.
+- 2026-07-08: Update Backoff test to use updated exponential formula.
 - 2026-04-02: [DRIVERS-3436](https://github.com/mongodb/specifications/pull/1920) Refine withTransaction timeout error
     wrapping semantics and label propagation in spec and prose tests
 - 2026-03-03: Clarify exponential backoff jitter upper bound.


### PR DESCRIPTION
…API backoff test

<!-- Thanks for contributing! -->

Please complete the following before merging:

- [X] Is the relevant DRIVERS ticket in the PR title?

<!--  All repo changes beyond typos now require a DRIVERS ticket; if you do not check the above box supply your reasoning below REASON BEGIN -->

<!--  REASON END -->

[DRIVERS-3578](https://jira.mongodb.org/browse/DRIVERS-3578). Updates the convenient transactions API backoff prose test to use the correct sum of the expected 13 backoffs. 

- [X] Update changelog.
- [X] Test changes in at least one language driver. [Python](https://github.com/mongodb/mongo-python-driver/pull/2877).
- [X] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

<!-- See also: https://wiki.corp.mongodb.com/pages/viewpage.action?pageId=80806719 -->
