### PR TITLE
DRIVERS-3597 Fix over-strict update assertion and missing initialData in OpenTelemetry spec tests

### DIFF
--- a/source/open-telemetry/open-telemetry.md
+++ b/source/open-telemetry/open-telemetry.md
@@ -425,6 +425,8 @@ A URI options can be added later if we realise our users need it, while the oppo
 
 ## Changelog
 
+- 2026-07-31: Allowed the `update` test to accept `multi` and `upsert` at their default values, and added `initialData`
+    to the operation tests that create or modify collections.
 - 2026-06-16: Clarified that the `db.query.text` attribute should be serialized to Relaxed Extended JSON.
 - 2026-02-09: Renamed `db.system` to `db.system.name` according to the corresponding update of OpenTelemetry semantic
     conventions.

--- a/source/open-telemetry/tests/operation/aggregate.json
+++ b/source/open-telemetry/tests/operation/aggregate.json
@@ -26,6 +26,13 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "operation-aggregate",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "aggregation",

--- a/source/open-telemetry/tests/operation/aggregate.yml
+++ b/source/open-telemetry/tests/operation/aggregate.yml
@@ -9,11 +9,16 @@ createEntities:
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: operation-aggregate
+      databaseName: &databaseName0 operation-aggregate
   - collection:
       id: &collection0 collection0
       database: *database0
       collectionName: &collectionName0 test
+
+initialData:
+  - collectionName: *collectionName0
+    databaseName: *databaseName0
+    documents: []
 
 tests:
   - description: aggregation

--- a/source/open-telemetry/tests/operation/atlas_search.json
+++ b/source/open-telemetry/tests/operation/atlas_search.json
@@ -26,6 +26,13 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "operation-atlas-search",
+      "documents": []
+    }
+  ],
   "runOnRequirements": [
     {
       "minServerVersion": "7.0.5",

--- a/source/open-telemetry/tests/operation/atlas_search.yml
+++ b/source/open-telemetry/tests/operation/atlas_search.yml
@@ -9,11 +9,16 @@ createEntities:
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: operation-atlas-search
+      databaseName: &databaseName0 operation-atlas-search
   - collection:
       id: &collection0 collection0
       database: *database0
-      collectionName: test
+      collectionName: &collectionName0 test
+
+initialData:
+  - collectionName: *collectionName0
+    databaseName: *databaseName0
+    documents: []
 
 runOnRequirements:
   # Skip server versions without fix of SERVER-83107 to avoid error message "BSON field 'createSearchIndexes.indexes.type' is an unknown field."

--- a/source/open-telemetry/tests/operation/create_collection.json
+++ b/source/open-telemetry/tests/operation/create_collection.json
@@ -19,10 +19,24 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "newlyCreatedCollection",
+      "databaseName": "operation-create-collection",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "create collection",
       "operations": [
+        {
+          "object": "database0",
+          "name": "dropCollection",
+          "arguments": {
+            "collection": "newlyCreatedCollection"
+          }
+        },
         {
           "object": "database0",
           "name": "createCollection",
@@ -36,6 +50,72 @@
           "client": "client0",
           "ignoreExtraSpans": false,
           "spans": [
+            {
+              "name": "dropCollection operation-create-collection.newlyCreatedCollection",
+              "attributes": {
+                "db.system.name": "mongodb",
+                "db.namespace": "operation-create-collection",
+                "db.collection.name": "newlyCreatedCollection",
+                "db.operation.name": "dropCollection",
+                "db.operation.summary": "dropCollection operation-create-collection.newlyCreatedCollection"
+              },
+              "nested": [
+                {
+                  "name": "drop",
+                  "attributes": {
+                    "db.system.name": "mongodb",
+                    "db.namespace": "operation-create-collection",
+                    "db.collection.name": "newlyCreatedCollection",
+                    "db.command.name": "drop",
+                    "network.transport": "tcp",
+                    "db.mongodb.cursor_id": {
+                      "$$exists": false
+                    },
+                    "db.response.status_code": {
+                      "$$exists": false
+                    },
+                    "exception.message": {
+                      "$$exists": false
+                    },
+                    "exception.type": {
+                      "$$exists": false
+                    },
+                    "exception.stacktrace": {
+                      "$$exists": false
+                    },
+                    "server.address": {
+                      "$$type": "string"
+                    },
+                    "server.port": {
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
+                    },
+                    "db.query.summary": "drop operation-create-collection.newlyCreatedCollection",
+                    "db.query.text": {
+                      "$$matchAsDocument": {
+                        "$$matchAsRoot": {
+                          "drop": "newlyCreatedCollection"
+                        }
+                      }
+                    },
+                    "db.mongodb.server_connection_id": {
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
+                    },
+                    "db.mongodb.driver_connection_id": {
+                      "$$type": [
+                        "int",
+                        "long"
+                      ]
+                    }
+                  }
+                }
+              ]
+            },
             {
               "name": "createCollection operation-create-collection.newlyCreatedCollection",
               "attributes": {

--- a/source/open-telemetry/tests/operation/create_collection.yml
+++ b/source/open-telemetry/tests/operation/create_collection.yml
@@ -10,18 +10,64 @@ createEntities:
       id: &database0 database0
       client: *client0
       databaseName: &database0Name operation-create-collection
+
+# initialData drops and re-creates the collection so that the dropCollection
+# operation below always has a collection to drop, and so that the fixture is
+# repeatable within a single process.
+initialData:
+  - collectionName: &collectionName newlyCreatedCollection
+    databaseName: *database0Name
+    documents: []
+
 tests:
   - description: create collection
     operations:
       - object: *database0
+        name: dropCollection
+        arguments:
+          collection: *collectionName
+
+      - object: *database0
         name: createCollection
         arguments:
-          collection: &collectionName newlyCreatedCollection
+          collection: *collectionName
 
     expectTracingMessages:
       - client: *client0
         ignoreExtraSpans: false
         spans:
+          - name: dropCollection operation-create-collection.newlyCreatedCollection
+            attributes:
+              db.system.name: mongodb
+              db.namespace: *database0Name
+              db.collection.name: *collectionName
+              db.operation.name: dropCollection
+              db.operation.summary: dropCollection operation-create-collection.newlyCreatedCollection
+            nested:
+              - name: drop
+                attributes:
+                  db.system.name: mongodb
+                  db.namespace: *database0Name
+                  db.collection.name: *collectionName
+                  db.command.name: drop
+                  network.transport: tcp
+                  db.mongodb.cursor_id: { $$exists: false }
+                  db.response.status_code: { $$exists: false }
+                  exception.message: { $$exists: false }
+                  exception.type: { $$exists: false }
+                  exception.stacktrace: { $$exists: false }
+                  server.address: { $$type: string }
+                  server.port: { $$type: [int, long] }
+                  db.query.summary: drop operation-create-collection.newlyCreatedCollection
+                  db.query.text:
+                    $$matchAsDocument:
+                      $$matchAsRoot:
+                        drop: *collectionName
+                  db.mongodb.server_connection_id:
+                    $$type: [ int, long ]
+                  db.mongodb.driver_connection_id:
+                    $$type: [ int, long ]
+
           - name: createCollection operation-create-collection.newlyCreatedCollection
             attributes:
               db.system.name: mongodb

--- a/source/open-telemetry/tests/operation/create_indexes.json
+++ b/source/open-telemetry/tests/operation/create_indexes.json
@@ -26,6 +26,13 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "operation-create-indexes",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "create indexes",

--- a/source/open-telemetry/tests/operation/create_indexes.yml
+++ b/source/open-telemetry/tests/operation/create_indexes.yml
@@ -14,6 +14,12 @@ createEntities:
       id: &collection0 collection0
       database: *database0
       collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
+
 tests:
   - description: create indexes
     operations:

--- a/source/open-telemetry/tests/operation/delete.json
+++ b/source/open-telemetry/tests/operation/delete.json
@@ -26,6 +26,13 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "operation-delete",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "delete elements",

--- a/source/open-telemetry/tests/operation/delete.yml
+++ b/source/open-telemetry/tests/operation/delete.yml
@@ -15,6 +15,11 @@ createEntities:
       database: *database0
       collectionName: &collectionName0 test
 
+initialData:
+  - collectionName: *collectionName0
+    databaseName: *databaseName0
+    documents: []
+
 tests:
   - description: delete elements
     operations:

--- a/source/open-telemetry/tests/operation/drop_collection.json
+++ b/source/open-telemetry/tests/operation/drop_collection.json
@@ -31,6 +31,13 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "operation-drop-collection",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "drop collection",

--- a/source/open-telemetry/tests/operation/drop_collection.yml
+++ b/source/open-telemetry/tests/operation/drop_collection.yml
@@ -13,12 +13,18 @@ createEntities:
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: operation-drop-collection
+      databaseName: &database0Name operation-drop-collection
 
   - collection:
       id: collection0
       database: *database0
       collectionName: &collection_name test
+
+initialData:
+  - collectionName: *collection_name
+    databaseName: *database0Name
+    documents: []
+
 tests:
   - description: drop collection
     operations:

--- a/source/open-telemetry/tests/operation/drop_indexes.json
+++ b/source/open-telemetry/tests/operation/drop_indexes.json
@@ -46,6 +46,13 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "operation-drop-indexes",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "drop indexes",

--- a/source/open-telemetry/tests/operation/drop_indexes.yml
+++ b/source/open-telemetry/tests/operation/drop_indexes.yml
@@ -9,11 +9,11 @@ createEntities:
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: operation-drop-indexes
+      databaseName: &database0Name operation-drop-indexes
   - collection:
       id: &collection0 collection0
       database: *database0
-      collectionName: test
+      collectionName: &collection0Name test
   - client:
       id: &clientWithoutTracing clientWithoutTracing
       useMultipleMongoses: false
@@ -25,6 +25,11 @@ createEntities:
       id: &collectionWithoutTracing collectionWithoutTracing
       database: *databaseWithoutTracing
       collectionName: test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents: []
 
 tests:
   - description: drop indexes

--- a/source/open-telemetry/tests/operation/find_and_modify.json
+++ b/source/open-telemetry/tests/operation/find_and_modify.json
@@ -26,6 +26,13 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "operation-find-one-and-update",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "findOneAndUpdate",

--- a/source/open-telemetry/tests/operation/find_and_modify.yml
+++ b/source/open-telemetry/tests/operation/find_and_modify.yml
@@ -9,11 +9,16 @@ createEntities:
   - database:
       id: &database0 database0
       client: *client0
-      databaseName: operation-find-one-and-update
+      databaseName: &databaseName0 operation-find-one-and-update
   - collection:
       id: &collection0 collection0
       database: *database0
-      collectionName: test
+      collectionName: &collectionName0 test
+
+initialData:
+  - collectionName: *collectionName0
+    databaseName: *databaseName0
+    documents: []
 
 tests:
   - description: findOneAndUpdate

--- a/source/open-telemetry/tests/operation/update.json
+++ b/source/open-telemetry/tests/operation/update.json
@@ -26,6 +26,13 @@
       }
     }
   ],
+  "initialData": [
+    {
+      "collectionName": "test",
+      "databaseName": "operation-update",
+      "documents": []
+    }
+  ],
   "tests": [
     {
       "description": "update one element",
@@ -122,6 +129,12 @@
                                 "$inc": {
                                   "x": 1
                                 }
+                              },
+                              "multi": {
+                                "$$unsetOrMatches": false
+                              },
+                              "upsert": {
+                                "$$unsetOrMatches": false
                               }
                             }
                           ]

--- a/source/open-telemetry/tests/operation/update.yml
+++ b/source/open-telemetry/tests/operation/update.yml
@@ -15,6 +15,11 @@ createEntities:
       database: *database0
       collectionName: &collectionName0 test
 
+initialData:
+  - collectionName: *collectionName0
+    databaseName: *databaseName0
+    documents: []
+
 tests:
   - description: update one element
     operations:
@@ -63,4 +68,10 @@ tests:
                         update: test
                         ordered: true
                         txnNumber: { $$unsetOrMatches: 1 }
-                        updates: [ { "q": { "_id": 1 }, "u": { "$inc": { "x": 1 } } } ]
+                        # multi and upsert are optional: drivers may either omit them or send
+                        # them at their default values.
+                        updates:
+                          - q: { _id: 1 }
+                            u: { $inc: { x: 1 } }
+                            multi: { $$unsetOrMatches: false }
+                            upsert: { $$unsetOrMatches: false }


### PR DESCRIPTION
[DRIVERS-3597](https://jira.mongodb.org/browse/DRIVERS-3597)

Two problems in the OpenTelemetry operation fixtures forced drivers to carry local patches or skips instead of running the shared tests as written. Both are test-only.

- The `update` assertion required the update statement to contain exactly a query and an update document, so drivers that also send `multi` and `upsert` at their default values failed it. It now accepts either shape, as the CRUD spec's own tests do.
- Fixtures that create or modify collections declared no initial data, so the runner never cleaned up beforehand and they were not repeatable within a single process. They now declare it.

`list_collections` and `list_databases` are unchanged, since neither creates or modifies a collection.

Python implementation: https://github.com/mongodb/mongo-python-driver/pull/2964

PyMongo currently skips the `update` test and adds its own cleanup to work around these two problems. [PYTHON-5979](https://jira.mongodb.org/browse/PYTHON-5979) removes both workarounds once this merges.

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- [x] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded
    clusters).

The full Evergreen matrix is still running on the PyMongo PR; I will confirm it before merge.