### PR TITLE
DRIVERS-3600 Validate database and collection names against "." and NUL

### DIFF
--- a/source/crud/crud.md
+++ b/source/crud/crud.md
@@ -97,6 +97,19 @@ A non-exhaustive list of acceptable naming deviations are as follows:
 - Using "isOrdered" rather than "ordered". Some languages idioms prefer the use of "is", "has", or "was" and this is
     acceptable.
 
+#### Database and Collection Name Validation
+
+An operation on a database whose name contains a period (`.`) MUST result in an error, client-side or server-side.
+Periods inside collection names remain legal.
+
+Where the driver itself combines a database and a collection name into a single namespace string, the driver MUST reject
+a period in the database component with a client-side error, because the server cannot tell it apart from a valid
+namespace. This applies, for example, to an API such as `renameCollection` that takes a namespace as an argument instead
+of a separate database name.
+
+An operation on a database or collection whose name contains a NUL byte (`U+0000`) MUST result in an error, client-side
+or server-side. A driver MUST NOT silently truncate the name.
+
 #### Timeouts
 
 Drivers MUST enforce timeouts for all operations per the
@@ -2615,6 +2628,8 @@ the Stable API, it was decided that this change was acceptable to make in minor 
 aforementioned allowance in the SemVer spec.
 
 ## Changelog
+
+- 2026-08-17: Require an error for a period in a database name and for a NUL byte in database and collection names.
 
 - 2026-06-17: Remove pre-4.2 version references.
 

--- a/source/crud/tests/README.md
+++ b/source/crud/tests/README.md
@@ -678,3 +678,25 @@ CommandStartedEvents. For each of `insertOne`, client `bulkWrite`, and collectio
     field of `request.documents[0]` is `_id`.
 - Otherwise, capture the CommandStartedEvent (referred to as `event`) emitted by the command and assert that the first
     field of `event.command.documents[0]` is `_id`.
+
+### 17. Ensure database and collection names are validated
+
+Construct a `MongoClient` (referred to as `client`).
+
+A period (`.`) in a database name would silently retarget the operation to another database. Assert that each of the
+following operations raises an error, either client-side or server-side:
+
+```javascript
+client.getDatabase("foo.bar").getCollection("coll").insertOne({})
+client.getCollection("foo.bar", "coll").insertOne({})
+```
+
+A NUL byte (`U+0000`) in a database or collection name truncates or invalidates the name. Drivers MUST NOT silently
+truncate the name. Assert that each of the following operations raises an error, either client-side or server-side:
+
+```javascript
+client.getDatabase("foo\0bar").getCollection("coll").insertOne({})
+client.getDatabase("db").getCollection("foo\0bar").insertOne({})
+client.bulkWrite([InsertOne { "namespace": "foo\0bar.coll", "document": {} }])
+client.bulkWrite([InsertOne { "namespace": "db.foo\0bar", "document": {} }])
+```


### PR DESCRIPTION
Reject a period in database names and a NUL byte in database and collection names at the API surface, since the driver's own encoding (db + "." + coll concatenation, cstring truncation) prevents the server from validating them. Add prose tests covering these cases for `getDatabase`/`getCollection` and `clientBulkWrite` namespaces.

Please complete the following before merging:

- [x] Is the relevant DRIVERS ticket in the PR title?
- [x] Update changelog.
- [x] Test changes in at least one language driver.
- [x] Test these changes against all server versions and topologies (including standalone, replica set, and sharded clusters).
